### PR TITLE
Lower requirements on boost

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ IF(WIN32)
   set(Boost_USE_STATIC_RUNTIME OFF)
 ENDIF()
 
-find_package(Boost 1.63.0 COMPONENTS system filesystem program_options REQUIRED)
+find_package(Boost 1.54.0 COMPONENTS system filesystem program_options REQUIRED)
 IF(Boost_FOUND)
   message(STATUS "Found Boost")
   message(STATUS "  Boost_LIBRARIES:    " ${Boost_LIBRARIES})

--- a/README.md
+++ b/README.md
@@ -17,21 +17,6 @@ OpenModelica FMI &amp; TLM based simulator
 
 ### Linux
 
-0. install boost 1.63
-
-```bash
-wget -O boost_1_63_0.tar.gz http://sourceforge.net/projects/boost/files/boost/1.63.0/boost_1_63_0.tar.gz/download
-tar xzvf boost_1_63_0.tar.gz
-cd boost_1_63_0/
-
-sudo apt update
-sudo apt install build-essential g++ python-dev autotools-dev libicu-dev build-essential libbz2-dev libboost-all-dev
-
-./bootstrap.sh --prefix=/usr/
-./b2
-sudo ./b2 install
-```
-
 1. configure OMSimulator
 
 ```bash
@@ -49,10 +34,9 @@ sudo ./b2 install
 
 0. install boost 1.63
 
-* Download and install precompiled boost libs, e.g. from this source:
-  * https://sourceforge.net/projects/boost/files/boost-binaries/
-* Set environment variable `BOOST_ROOT` to install path, e.g:
-  * `BOOST_ROOT=C:\local\boost_1_63_0`
+- Download and install precompiled boost libs, e.g. from [this](https://sourceforge.net/projects/boost/files/boost-binaries/) source
+- Set environment variable `BOOST_ROOT` to install path, e.g:
+  - `BOOST_ROOT=C:\local\boost_1_63_0`
 
 1. configure OMSimulator
 

--- a/src/OMSimulatorLib/CompositeModel.cpp
+++ b/src/OMSimulatorLib/CompositeModel.cpp
@@ -53,7 +53,7 @@
 #include <sstream>
 #include <stdlib.h>
 #include <string>
-#include <unordered_map>
+#include <map>
 #include <vector>
 
 #include <boost/filesystem.hpp>
@@ -704,7 +704,7 @@ void CompositeModel::describe()
 {
   logTrace();
 
-  std::unordered_map<std::string, FMUWrapper*>::iterator it;
+  std::map<std::string, FMUWrapper*>::iterator it;
 
   std::cout << "# FMU instances" << std::endl;
   for (it=fmuInstances.begin(); it != fmuInstances.end(); it++)
@@ -962,7 +962,7 @@ oms_status_t CompositeModel::doSteps(const int numberOfSteps)
   for(int step=0; step<numberOfSteps; step++)
   {
     // do_step
-    std::unordered_map<std::string, FMUWrapper*>::iterator it;
+    std::map<std::string, FMUWrapper*>::iterator it;
     for (it=fmuInstances.begin(); it != fmuInstances.end(); it++)
       it->second->doStep(tcur+communicationInterval);
     tcur += communicationInterval;
@@ -993,7 +993,7 @@ oms_status_t CompositeModel::stepUntil(const double timeValue)
       tcur = timeValue;
 
     // do_step
-    std::unordered_map<std::string, FMUWrapper*>::iterator it;
+    std::map<std::string, FMUWrapper*>::iterator it;
     for (it=fmuInstances.begin(); it != fmuInstances.end(); it++)
       it->second->doStep(tcur);
     emit();
@@ -1022,7 +1022,7 @@ void CompositeModel::initialize()
 
   // Enter initialization
   modelState = oms_modelState_initialization;
-  std::unordered_map<std::string, FMUWrapper*>::iterator it;
+  std::map<std::string, FMUWrapper*>::iterator it;
   for (it=fmuInstances.begin(); it != fmuInstances.end(); it++)
     it->second->enterInitialization(tcur);
 
@@ -1085,7 +1085,7 @@ void CompositeModel::terminate()
     return;
   }
 
-  std::unordered_map<std::string, FMUWrapper*>::iterator it;
+  std::map<std::string, FMUWrapper*>::iterator it;
   for (it=fmuInstances.begin(); it != fmuInstances.end(); it++)
     it->second->terminate();
 
@@ -1114,7 +1114,7 @@ void CompositeModel::reset()
   logTrace();
   OMS_TOC(globalClocks, GLOBALCLOCK_SIMULATION);
 
-  std::unordered_map<std::string, FMUWrapper*>::iterator it;
+  std::map<std::string, FMUWrapper*>::iterator it;
   for (it=fmuInstances.begin(); it != fmuInstances.end(); it++)
     it->second->reset();
 
@@ -1151,7 +1151,7 @@ void CompositeModel::setVariableFilter(const char* instanceFilter, const char* v
 {
   std::regex exp(instanceFilter);
 
-  std::unordered_map<std::string, FMUWrapper*>::iterator it;
+  std::map<std::string, FMUWrapper*>::iterator it;
   for (it=fmuInstances.begin(); it != fmuInstances.end(); it++)
     if (std::regex_match(it->first, exp))
       it->second->setVariableFilter(variableFilter);

--- a/src/OMSimulatorLib/CompositeModel.h
+++ b/src/OMSimulatorLib/CompositeModel.h
@@ -43,7 +43,7 @@
 
 #include <deque>
 #include <string>
-#include <unordered_map>
+#include <map>
 
 class CompositeModel
 {
@@ -98,12 +98,12 @@ private:
 private:
   Settings settings;
   ResultWriter *resultFile;
-  std::unordered_map<std::string, FMUWrapper*> fmuInstances;
-  std::unordered_map<std::string, LookupTable*> lookupTables;
+  std::map<std::string, FMUWrapper*> fmuInstances;
+  std::map<std::string, LookupTable*> lookupTables;
   std::vector< std::pair<std::string, Variable*> > lookupAssignments;
-  std::unordered_map<std::string, double> realParameterList;
-  std::unordered_map<std::string, int> integerParameterList;
-  std::unordered_map<std::string, bool> booleanParameterList;
+  std::map<std::string, double> realParameterList;
+  std::map<std::string, int> integerParameterList;
+  std::map<std::string, bool> booleanParameterList;
   DirectedGraph outputsGraph;
   DirectedGraph initialUnknownsGraph;
   double tcur;


### PR DESCRIPTION
- Ubuntu 14.04 provides with Boost 1.54
- Ubuntu 16.04 provides with Boost 1.58

Therefore, we lower the requirements on boost to 1.54. As a side-effect, this affects the ordering within some STL data types…

