### PR TITLE
Add support for VS 2017

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,11 @@
-cmake_minimum_required(VERSION 3.1)
+IF(WIN32)
+  # VS 2017 requires Boost 1.64 or newer
+  # Boost 1.64 requires CMake 3.8 or newer
+  cmake_minimum_required(VERSION 3.8)
+ELSE()
+  cmake_minimum_required(VERSION 3.1)
+ENDIF()
+
 project(OMSimulator)
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/config.cmake/")

--- a/README.md
+++ b/README.md
@@ -32,13 +32,20 @@ OpenModelica FMI &amp; TLM based simulator
 
 ### Windows
 
-The batch scripts are developed for *MS Visual Studio 14 2015 Win64*.
+The following versions of MS Visual Studio are supported:
+
+- MS Visual Studio 2015 [Win64]:
+  - configWinVS14.bat
+  - buildWinVS14.bat
+- MS Visual Studio 2017 [Win64]:
+  - configWinVS15.bat
+  - buildWinVS15.bat
 
 It is not strictly required to install the full Visual Studio IDE. The batch
 scripts only require the *Visual C++ 2015 Build Tools* which are also available
-as a leaner standalone package, which can be downloaded from Microsoft (http://landinghub.visualstudio.com/visual-cpp-build-tools).
+as a leaner standalone package, which can be downloaded from [Microsoft](http://landinghub.visualstudio.com/visual-cpp-build-tools).
 
-1. install boost 1.63
+1. install boost 1.63 (or 1.64 for VS 2017)
 
    - Download and install precompiled boost libs, e.g. from [this](https://sourceforge.net/projects/boost/files/boost-binaries/) source
    - Set environment variable `BOOST_ROOT` to install path, e.g:

--- a/buildWinVS14.bat
+++ b/buildWinVS14.bat
@@ -1,6 +1,7 @@
 @echo off
 REM run this on wsl using "cmd.exe /C buildWinVS14.bat"
 
+@call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86_amd64
+
 echo # build OMSimulator
-call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86_amd64
 msbuild.exe "build\win\INSTALL.vcxproj" /t:Build /p:configuration=Release

--- a/buildWinVS15.bat
+++ b/buildWinVS15.bat
@@ -1,0 +1,8 @@
+@echo off
+REM run this on wsl using "cmd.exe /C buildWinVS15.bat"
+
+SET "VSCMD_START_DIR=%CD%"
+@call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" x86_amd64
+
+echo # build OMSimulator
+msbuild.exe "build\win\INSTALL.vcxproj" /t:Build /p:configuration=Release

--- a/configWinVS15.bat
+++ b/configWinVS15.bat
@@ -1,0 +1,68 @@
+@echo off
+REM run this on wsl using "cmd.exe /C configWinVS15.bat"
+
+IF NOT DEFINED BOOST_ROOT SET BOOST_ROOT=C:\local\boost_1_64_0
+
+SET "VSCMD_START_DIR=%CD%"
+@call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" x86_amd64
+
+echo # config fmil
+if exist "3rdParty\FMIL\build\win\" RMDIR /S /Q 3rdParty\FMIL\build\win
+if exist "3rdParty\FMIL\install\win\" RMDIR /S /Q 3rdParty\FMIL\install\win
+MKDIR 3rdParty\FMIL\build\win
+CD 3rdParty\FMIL\build\win
+cmake -G "Visual Studio 15 2017 Win64" -DFMILIB_INSTALL_PREFIX=..\..\install\win -DFMILIB_BUILD_TESTS:BOOL="0" -DFMILIB_GENERATE_DOXYGEN_DOC:BOOL="0" -DFMILIB_BUILD_STATIC_LIB:BOOL="1" -DBUILD_TESTING:BOOL="0" -DFMILIB_BUILD_BEFORE_TESTS:BOOL="0" ..\..
+CD ..\..\..\..
+echo # build fmil
+msbuild.exe "3rdParty\FMIL\build\win\INSTALL.vcxproj" /t:Build /p:configuration=Release
+
+echo # build Lua
+CD 3rdParty\Lua
+if exist "install\win\" RMDIR /S /Q install\win
+call buildWinVS15.bat
+CD ..\..
+
+echo # config cvode
+if exist "3rdParty\cvode\build-win\" RMDIR /S /Q 3rdParty\cvode\build-win
+if exist "3rdParty\cvode\install\win\" RMDIR /S /Q 3rdParty\cvode\install\win
+MKDIR 3rdParty\cvode\build-win
+CD 3rdParty\cvode\build-win
+cmake -G "Visual Studio 15 2017 Win64" -DCMAKE_INSTALL_PREFIX=..\install\win .. -DEXAMPLES_ENABLE:BOOL="0" -DBUILD_SHARED_LIBS:BOOL="0"
+CD ..\..\..
+echo # build cvode
+msbuild.exe "3rdParty\cvode\build-win\INSTALL.vcxproj" /t:Build /p:configuration=Release
+
+echo # config kinsol
+if exist "3rdParty\kinsol\build-win\" RMDIR /S /Q 3rdParty\kinsol\build-win
+if exist "3rdParty\kinsol\install\win\" RMDIR /S /Q 3rdParty\kinsol\install\win
+MKDIR 3rdParty\kinsol\build-win
+CD 3rdParty\kinsol\build-win
+cmake -G "Visual Studio 15 2017 Win64" -DCMAKE_INSTALL_PREFIX=..\install\win .. -DEXAMPLES_ENABLE:BOOL="0" -DBUILD_SHARED_LIBS:BOOL="0"
+CD ..\..\..
+echo # build kinsol
+msbuild.exe "3rdParty\kinsol\build-win\INSTALL.vcxproj" /t:Build /p:configuration=Release
+
+echo # config OMSimulator
+if exist "build\win\" RMDIR /S /Q build\win
+MKDIR build\win
+CD build\win
+cmake -G "Visual Studio 15 2017 Win64" ..\.. -DBOOST_ROOT=%BOOST_ROOT%
+CD ..\..
+
+echo # create install\bin folder
+IF NOT EXIST "install\bin" MKDIR "install\bin"
+
+echo # copy boost
+COPY %BOOST_ROOT%\lib64-msvc-14.1\boost_filesystem-vc141-mt-1_64.dll install\bin
+COPY %BOOST_ROOT%\lib64-msvc-14.1\boost_filesystem-vc141-mt-gd-1_64.dll install\bin
+COPY %BOOST_ROOT%\lib64-msvc-14.1\boost_system-vc141-mt-1_64.dll install\bin
+COPY %BOOST_ROOT%\lib64-msvc-14.1\boost_system-vc141-mt-gd-1_64.dll install\bin
+COPY %BOOST_ROOT%\lib64-msvc-14.1\boost_program_options-vc141-mt-1_64.dll install\bin
+COPY %BOOST_ROOT%\lib64-msvc-14.1\boost_program_options-vc141-mt-gd-1_64.dll install\bin
+
+echo # copy fmil
+COPY 3rdParty\fmil\install\win\lib\fmilib_shared.dll install\bin
+
+echo # copy lua
+COPY 3rdParty\lua\install\win\lua.dll install\bin
+COPY 3rdParty\lua\install\win\lua.exe install\bin


### PR DESCRIPTION
Boost 1.63 doesn't fully support VS2017. I am not sure how to deal with it. Maybe we can get remove the dependency to Boost.