### PR TITLE
Make logging level adjustable

### DIFF
--- a/src/OMSimulator/Options.cpp
+++ b/src/OMSimulator/Options.cpp
@@ -53,6 +53,7 @@ ProgramOptions::ProgramOptions(int argc, char** argv)
   useStartTime = false;
   useStopTime = false;
   useTolerance = false;
+  logLevel = 0;
 
   std::regex re_integer("(\\+|-)?[[:digit:]]+");
   std::regex re_double("((\\+|-)?[[:digit:]]+)(\\.(([[:digit:]]+)?))?((e|E)((\\+|-)?)[[:digit:]]+)?");
@@ -80,6 +81,10 @@ ProgramOptions::ProgramOptions(int argc, char** argv)
     else if (isOptionAndValue("--logfile", "-l", value, re_default))
     {
       logfile = value;
+    }
+    else if (isOptionAndValue("--logLevel", value, re_integer))
+    {
+      logLevel = atoi(value.c_str());
     }
     else if (isOptionAndValue("--resultFile", "-r", value, re_default))
     {
@@ -187,6 +192,7 @@ void ProgramOptions::printUsage()
   std::cout << "  -h [ --help ]             Displays the help text" << std::endl;
   std::cout << "  -i [ --interval ] arg     Specifies the communication interval size." << std::endl;
   std::cout << "  -l [ --logFile ] arg      Specifies the logfile (stdout is used if no log file is specified)." << std::endl;
+  std::cout << "  --logLevel arg            0 default, 1 default+debug, 2 default+debug+trace" << std::endl;
   std::cout << "  -r [ --resultFile ] arg   Specifies the name of the output result file" << std::endl;
   std::cout << "  -s [ --startTime ] arg    Specifies the start time." << std::endl;
   std::cout << "  -t [ --stopTime ] arg     Specifies the stop time." << std::endl;

--- a/src/OMSimulator/Options.h
+++ b/src/OMSimulator/Options.h
@@ -66,6 +66,7 @@ public:
   std::string workingDir;
   std::string logfile;
   double timeout;
+  int logLevel;
 
 private:
   int argi;

--- a/src/OMSimulator/main.cpp
+++ b/src/OMSimulator/main.cpp
@@ -98,6 +98,8 @@ int main(int argc, char *argv[])
     return 0;
   }
 
+  oms2_setLoggingLevel(options.logLevel);
+
   std::string filename = options.filename;
   std::string type = "";
   if (filename.length() > 4)

--- a/src/OMSimulatorLib/Logging.cpp
+++ b/src/OMSimulatorLib/Logging.cpp
@@ -56,7 +56,7 @@ Log::Log() : filename(""), cb(NULL)
 {
   numWarnings = 0;
   numErrors = 0;
-  useDebugLogging = false;
+  logLevel = false;
 }
 
 Log::~Log()
@@ -121,7 +121,7 @@ void Log::Debug(const std::string& msg)
   Log& log = getInstance();
   std::lock_guard<std::mutex> lock(log.m);
 
-  if (!log.useDebugLogging)
+  if (log.logLevel < 1)
     return;
 
   if (!log.logFile.is_open())
@@ -138,7 +138,7 @@ void Log::Trace(const std::string& function, const std::string& file, const long
   Log& log = getInstance();
   std::lock_guard<std::mutex> lock(log.m);
 
-  if (!log.useDebugLogging)
+  if (log.logLevel < 2)
     return;
 
   std::string msg = function + " (" + file + ":" + std::to_string(line) + ")";
@@ -189,11 +189,11 @@ oms_status_t Log::setLogFile(const std::string& filename)
   return oms_status_ok;
 }
 
-void Log::setDebugLogging(bool debugLogging)
+void Log::setLoggingLevel(int logLevel)
 {
 #ifdef OMS_DEBUG_LOGGING
   Log& log = getInstance();
-  log.useDebugLogging = debugLogging;
+  log.logLevel = logLevel;
 #else
   Warning("Log::setDebugLogging is not available.")
 #endif

--- a/src/OMSimulatorLib/Logging.h
+++ b/src/OMSimulatorLib/Logging.h
@@ -60,7 +60,7 @@ public:
   static oms_status_t setLogFile(const std::string& filename);
 
   static void setLoggingCallback(void (*cb)(oms_message_type_t type, const char* message)) {getInstance().cb = cb;}
-  static void setDebugLogging(bool debugLogging);
+  static void setLoggingLevel(int logLevel);
 
 private:
   Log();
@@ -73,7 +73,7 @@ private:
   Log& operator=(Log const& copy); // not implemented
 
 private:
-  bool useDebugLogging;
+  int logLevel;
   std::string filename;
   std::ofstream logFile;
   std::mutex m;

--- a/src/OMSimulatorLib/OMSimulator.cpp
+++ b/src/OMSimulatorLib/OMSimulator.cpp
@@ -638,7 +638,7 @@ void oms2_setLoggingCallback(void (*cb)(oms_message_type_t type, const char* mes
   Log::setLoggingCallback(cb);
 }
 
-void oms2_setDebugLogging(int useDebugLogging)
+void oms2_setLoggingLevel(int logLevel)
 {
-  Log::setDebugLogging(useDebugLogging);
+  Log::setLoggingLevel(logLevel);
 }

--- a/src/OMSimulatorLib/OMSimulator.h
+++ b/src/OMSimulatorLib/OMSimulator.h
@@ -352,9 +352,9 @@ void oms2_setLoggingCallback(void (*cb)(oms_message_type_t type, const char* mes
 /**
  * \brief Enables/Disables debug logging (logDebug and logTrace).
  *
- * @param useDebugLogging   [in] 0 to disable debug logging, all other values to enable debug logging
+ * @param logLevel   [in] 0 default, 1 default+debug, 2 default+debug+trace
  */
-void oms2_setDebugLogging(int useDebugLogging);
+void oms2_setLoggingLevel(int logLevel);
 
 /**
  * \brief Redirects logging output to file or std streams. The warning/error counters are reset.


### PR DESCRIPTION
* `OMSimulator --logLevel=1` enables debug output
* This changes `oms2_setDebugLogging` to `oms2_setLoggingLevel` to make it more flexible