### PR TITLE
Expose type information of fmu interface signals

### DIFF
--- a/src/OMSimulatorLib/Types.h
+++ b/src/OMSimulatorLib/Types.h
@@ -72,15 +72,24 @@ typedef enum {
   oms_component_port  /* port */
 } oms_component_type_t;
 
+typedef enum {
+  oms_signal_type_real,
+  oms_signal_type_integer,
+  oms_signal_type_boolean,
+  oms_signal_type_string,
+  oms_signal_type_enum
+} oms_signal_type_t;
+
 typedef struct {
   oms_causality_t causality;
+  oms_signal_type_t type;
   char* name;
-} oms_fmu_port_t;
+} oms_signal_t;
 
 typedef struct {
   oms_component_type_t type;
   char* name;
-  oms_fmu_port_t** interfaces;
+  oms_signal_t** interfaces;
 } oms_component_t;
 
 typedef enum {

--- a/src/OMSimulatorLib/oms2_FMUWrapper.cpp
+++ b/src/OMSimulatorLib/oms2_FMUWrapper.cpp
@@ -304,7 +304,7 @@ oms2::FMUWrapper* oms2::FMUWrapper::newSubModel(const oms2::ComRef& cref, const 
   // create some special variable maps
   for (auto const &v : model->allVariables)
   {
-    if (v.isParameter() && fmi2_base_type_real == v.getBaseType())
+    if (v.isParameter() && v.isTypeReal())
       model->realParameters[v.getName()] = oms2::Option<double>();
 
     if (v.isInput())
@@ -316,30 +316,33 @@ oms2::FMUWrapper* oms2::FMUWrapper::newSubModel(const oms2::ComRef& cref, const 
   }
 
   int nInterfaces = model->inputs.size() + model->outputs.size() + model->parameters.size();
-  model->component.interfaces = new oms_fmu_port_t*[nInterfaces + 1];
+  model->component.interfaces = new oms_signal_t*[nInterfaces + 1];
   model->component.interfaces[nInterfaces] = NULL;
   int i=0;
   for (int j=0; j<model->inputs.size(); ++i, ++j)
   {
     const oms2::Variable& v = model->inputs[j];
-    model->component.interfaces[i] = new oms_fmu_port_t;
+    model->component.interfaces[i] = new oms_signal_t;
     model->component.interfaces[i]->causality = oms_causality_input;
+    model->component.interfaces[i]->type = v.getType();
     model->component.interfaces[i]->name = new char[v.toString().length()+1];
     strcpy(model->component.interfaces[i]->name, v.toString().c_str());
   }
   for (int j=0; j<model->outputs.size(); ++i, ++j)
   {
     const oms2::Variable& v = model->outputs[j];
-    model->component.interfaces[i] = new oms_fmu_port_t;
+    model->component.interfaces[i] = new oms_signal_t;
     model->component.interfaces[i]->causality = oms_causality_output;
+    model->component.interfaces[i]->type = v.getType();
     model->component.interfaces[i]->name = new char[v.toString().length()+1];
     strcpy(model->component.interfaces[i]->name, v.toString().c_str());
   }
   for (int j=0; j<model->parameters.size(); ++i, ++j)
   {
     const oms2::Variable& v = model->parameters[j];
-    model->component.interfaces[i] = new oms_fmu_port_t;
+    model->component.interfaces[i] = new oms_signal_t;
     model->component.interfaces[i]->causality = oms_causality_parameter;
+    model->component.interfaces[i]->type = v.getType();
     model->component.interfaces[i]->name = new char[v.toString().length()+1];
     strcpy(model->component.interfaces[i]->name, v.toString().c_str());
   }
@@ -396,7 +399,7 @@ oms_status_t oms2::FMUWrapper::getRealParameter(const std::string& var, double& 
 oms_status_t oms2::FMUWrapper::setReal(const oms2::Variable& var, double realValue)
 {
   logTrace();
-  if (!fmu || fmi2_base_type_real != var.getBaseType())
+  if (!fmu || !var.isTypeReal())
   {
     logError("oms2::FMUWrapper::setReal failed");
     return oms_status_error;
@@ -412,7 +415,7 @@ oms_status_t oms2::FMUWrapper::setReal(const oms2::Variable& var, double realVal
 oms_status_t oms2::FMUWrapper::getReal(const oms2::Variable& var, double& realValue)
 {
   logTrace();
-  if (!fmu || fmi2_base_type_real != var.getBaseType())
+  if (!fmu || !var.isTypeReal())
   {
     logError("oms2::FMUWrapper::getReal failed");
     return oms_status_error;

--- a/src/OMSimulatorLib/oms2_Variable.cpp
+++ b/src/OMSimulatorLib/oms2_Variable.cpp
@@ -50,7 +50,28 @@ oms2::Variable::Variable(const oms2::ComRef& cref, fmi2_import_variable_t *var, 
   vr = fmi2_import_get_variable_vr(var);
   causality = fmi2_import_get_causality(var);
   initialProperty = fmi2_import_get_initial(var);
-  baseType = fmi2_import_get_variable_base_type(var);
+  switch (fmi2_import_get_variable_base_type(var))
+  {
+    case fmi2_base_type_real:
+      type = oms_signal_type_real;
+      break;
+    case fmi2_base_type_int:
+      type = oms_signal_type_integer;
+      break;
+    case fmi2_base_type_bool:
+      type = oms_signal_type_boolean;
+      break;
+    case fmi2_base_type_str:
+      type = oms_signal_type_string;
+      break;
+    case fmi2_base_type_enum:
+      type = oms_signal_type_enum;
+      break;
+    default:
+      logError("Unknown fmi base type");
+      type = oms_signal_type_real;
+      break;
+  }
 }
 
 oms2::Variable::~Variable()

--- a/src/OMSimulatorLib/oms2_Variable.h
+++ b/src/OMSimulatorLib/oms2_Variable.h
@@ -34,6 +34,7 @@
 
 #include "oms2_ComRef.h"
 #include "oms2_SignalRef.h"
+#include "Types.h"
 
 #include <fmilib.h>
 #include <string>
@@ -74,25 +75,25 @@ namespace oms2
     std::string toString() const { return sr.toString(); }
 
     fmi2_value_reference_t getValueReference() const { return vr; }
-    fmi2_base_type_enu_t getBaseType() const { return baseType; }
+    oms_signal_type_t getType() const { return type; }
     const std::string& getDescription() const { return description; }
 
-    bool isTypeReal() const { return fmi2_base_type_real == baseType; }
-    bool isTypeInteger() const { return fmi2_base_type_int == baseType; }
-    bool isTypeBoolean() const { return fmi2_base_type_bool == baseType; }
+    bool isTypeReal() const { return oms_signal_type_real == type; }
+    bool isTypeInteger() const { return oms_signal_type_integer == type; }
+    bool isTypeBoolean() const { return oms_signal_type_boolean == type; }
 
     std::string getCausalityString() { return std::string(fmi2_causality_to_string(causality)); }
 
     unsigned int getIndex() const { return index; }
 
   private:
-    SignalRef sr;
+    oms2::SignalRef sr;
     std::string description;
     fmi2_value_reference_t vr;
     fmi2_causality_enu_t causality;
     fmi2_initial_enu_t initialProperty;
     bool is_state;
-    fmi2_base_type_enu_t baseType;
+    oms_signal_type_t type;
     unsigned int index; ///< index origin = 1
 
     friend bool operator==(const oms2::Variable& v1, const oms2::Variable& v2);


### PR DESCRIPTION
@adeas31 `oms_fmu_port_t` is renamed to `oms_signal_t`