### PR TITLE
New API: oms2_rename()

### DIFF
--- a/src/OMSimulatorLib/OMSimulator.cpp
+++ b/src/OMSimulatorLib/OMSimulator.cpp
@@ -556,10 +556,10 @@ oms_status_enu_t oms2_instantiateFMU(const char* modelIdent, const char* fmuPath
   return oms2::Scope::instantiateFMU(oms2::ComRef(modelIdent), fmuPath, oms2::ComRef(fmuIdent));
 }
 
-oms_status_enu_t oms2_renameModel(const char* identOld, const char* identNew)
+oms_status_enu_t oms2_rename(const char* identOld, const char* identNew)
 {
   logTrace();
-  return oms2::Scope::renameModel(oms2::ComRef(identOld), oms2::ComRef(identNew));
+  return oms2::Scope::rename(oms2::ComRef(identOld), oms2::ComRef(identNew));
 }
 
 oms_status_enu_t oms2_loadModel(const char* filename, char** ident)

--- a/src/OMSimulatorLib/OMSimulator.h
+++ b/src/OMSimulatorLib/OMSimulator.h
@@ -333,13 +333,14 @@ oms_status_enu_t oms2_unloadModel(const char* ident);
 oms_status_enu_t oms2_instantiateFMU(const char* modelIdent, const char* fmuPath, const char* fmuIdent);
 
 /**
- * \brief Unloads a composite model (works for FMI and TLM).
+ * \brief Renames a composite model (works for FMI and TLM) or sub-model (e.g.
+ * FMU instance).
  *
- * @param identOld   [in] Name of the model instance to rename.
- * @param identNew   [in] New name of the model instance.
+ * @param identOld   [in] Name of the instance to rename.
+ * @param identNew   [in] New name of the instance.
  * @return           Error status.
  */
-oms_status_enu_t oms2_renameModel(const char* identOld, const char* identNew);
+oms_status_enu_t oms2_rename(const char* identOld, const char* identNew);
 
 /**
  * \brief Returns the type of a given component.

--- a/src/OMSimulatorLib/oms2/FMICompositeModel.cpp
+++ b/src/OMSimulatorLib/oms2/FMICompositeModel.cpp
@@ -212,3 +212,43 @@ oms_connection_t** oms2::FMICompositeModel::getOMSConnections()
   }
   return oms_connections;
 }
+
+oms_status_enu_t oms2::FMICompositeModel::renameSubModel(const oms2::ComRef& identOld, const oms2::ComRef& identNew)
+{
+  oms2::ComRef identOld_ = identOld.last();
+  oms2::ComRef identNew_ = identNew.last();
+
+  if (!identNew_.isValidIdent())
+  {
+    logError("Identifier \"" + identNew + "\" is invalid.");
+    return oms_status_error;
+  }
+
+  if (!identOld_.isValidIdent())
+  {
+    logError("Identifier \"" + identOld + "\" is invalid.");
+    return oms_status_error;
+  }
+
+  // check if identNew is in scope
+  auto it = subModels.find(identNew_);
+  if (it != subModels.end())
+  {
+    logError("A sub-model called \"" + identNew.toString() + "\" is already in scope.");
+    return oms_status_error;
+  }
+
+  // check if identOld is in scope
+  it = subModels.find(identOld_);
+  if (it == subModels.end())
+  {
+    logError("There is no sub-model called \"" + identOld.toString() + "\" in scope.");
+    return oms_status_error;
+  }
+
+  it->second->setName(identNew);
+  subModels[identNew_] = it->second;
+  subModels.erase(it);
+
+  return oms_status_ok;
+}

--- a/src/OMSimulatorLib/oms2/FMICompositeModel.h
+++ b/src/OMSimulatorLib/oms2/FMICompositeModel.h
@@ -66,6 +66,8 @@ namespace oms2
 
     void updateComponents();
 
+    oms_status_enu_t renameSubModel(const ComRef& identOld, const ComRef& identNew);
+
   private:
     FMICompositeModel(const ComRef& name);
     ~FMICompositeModel();

--- a/src/OMSimulatorLib/oms2/FMISubModel.cpp
+++ b/src/OMSimulatorLib/oms2/FMISubModel.cpp
@@ -34,13 +34,13 @@
 
 #include <cstring>
 
-oms2::FMISubModel::FMISubModel(const ComRef& cref)
-  : cref(cref), geometry()
+oms2::FMISubModel::FMISubModel(const ComRef& ident)
+  : ident(ident.last()), geometry()
 {
   logTrace();
 
-  component.name = new char[cref.toString().length()+1];
-  strcpy(component.name, cref.toString().c_str());
+  component.name = new char[ident.toString().length()+1];
+  strcpy(component.name, ident.toString().c_str());
 
   component.type = oms_component_none;
   component.interfaces = NULL;

--- a/src/OMSimulatorLib/oms2/FMISubModel.h
+++ b/src/OMSimulatorLib/oms2/FMISubModel.h
@@ -44,7 +44,8 @@ namespace oms2
     virtual oms_component_type_enu_t getType() const = 0;
     static void deleteSubModel(FMISubModel *model) {if (model) delete model;}
 
-    const ComRef& getName() const {return cref;}
+    const ComRef& getName() const {return ident;}
+    void setName(const ComRef& name) {this->ident = name;}
     void setGeometry(double x1, double y1, double x2, double y2) {this->geometry.setSizePosition(x1, y1, x2, y2);}
     void setGeometry(const oms2::ssd::ElementGeometry& geometry) {this->geometry = geometry;}
     oms2::ssd::ElementGeometry* getGeometry() {return &geometry;}
@@ -52,7 +53,7 @@ namespace oms2
     oms_component_t* getComponent() {return &component;}
 
   protected:
-    FMISubModel(const ComRef& cref);
+    FMISubModel(const ComRef& ident);
     virtual ~FMISubModel();
 
   private:
@@ -61,7 +62,7 @@ namespace oms2
     FMISubModel& operator=(FMISubModel const& copy); // not implemented
 
   protected:
-    ComRef cref;
+    ComRef ident;
     oms2::ssd::ElementGeometry geometry;
     oms_component_t component;
   };

--- a/src/OMSimulatorLib/oms2/Scope.h
+++ b/src/OMSimulatorLib/oms2/Scope.h
@@ -55,8 +55,7 @@ namespace oms2
     static oms_status_enu_t newTLMModel(const ComRef& name);
     static oms_status_enu_t unloadModel(const ComRef& name);
     static oms_status_enu_t instantiateFMU(const ComRef& modelIdent, const std::string& fmuPath, const ComRef& fmuIdent);
-    static oms_status_enu_t renameModel(const ComRef& identOld, const ComRef& identNew);
-    Model* getModel(const ComRef& name);
+    static oms_status_enu_t rename(const ComRef& identOld, const ComRef& identNew);
     static Model* loadModel(const std::string& filename);
     static oms_status_enu_t saveModel(const std::string& filename, const ComRef& name);
 
@@ -71,6 +70,10 @@ namespace oms2
 
     static oms_status_enu_t getComponents(const ComRef& cref, oms_component_t*** components);
     static oms_status_enu_t getConnections(const ComRef& cref, oms_connection_t*** connections);
+
+    oms_status_enu_t renameModel(const ComRef& identOld, const ComRef& identNew);
+    Model* getModel(const ComRef& name);
+
   private:
     Scope();
     ~Scope();


### PR DESCRIPTION
Renames a composite model (works for FMI and TLM) or sub-model (e.g. FMU instance).