### PR TITLE
Point to the allocated char array

### DIFF
--- a/src/OMSimulatorLib/OMSimulator.cpp
+++ b/src/OMSimulatorLib/OMSimulator.cpp
@@ -578,7 +578,7 @@ oms_status_enu_t oms2_loadModel(const char* filename, char** ident)
   if (!model)
     return oms_status_error;
 
-  *ident = const_cast<char*>(model->getName().c_str());
+  *ident = model->getElement()->getSimpleName();
   return oms_status_ok;
 }
 

--- a/src/OMSimulatorLib/oms2/Element.h
+++ b/src/OMSimulatorLib/oms2/Element.h
@@ -53,6 +53,7 @@ namespace oms2
     ~Element();
 
     const oms_element_type_enu_t getType() const {return type;}
+    char* getSimpleName() const {return name;}
     const oms2::ComRef getName() const {return oms2::ComRef(name);}
     oms_connector_t** getInterfaces() const {return interfaces;}
     const oms2::ssd::ElementGeometry* getGeometry() const {return reinterpret_cast<oms2::ssd::ElementGeometry*>(geometry);}


### PR DESCRIPTION
`oms2_ComRef` is deleted when `oms2::ComRef::getName()` is finished so calling `const_cast` on it is dangerous and leads to undefined behavior.