### PR TITLE
Make it possible to statically link OMSimulator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,14 +44,7 @@ OMSimulator:
 
 
 
-ifeq ($(CERES),OFF)
-config-3rdParty: config-fmil config-lua config-cvode config-kinsol
-	@echo
-	@echo "# CERES=OFF => Skipping build of 3rdParty library Ceres-Solver. Ceres-Solver is a dependency of the (optional) parameter estimation module."
-	@echo
-else
 config-3rdParty: config-fmil config-lua config-cvode config-kinsol config-gflags config-glog config-ceres-solver
-endif
 
 config-OMSimulator:
 	@echo
@@ -59,7 +52,7 @@ config-OMSimulator:
 	@echo
 	$(RM) $(BUILD_DIR)
 	$(MKDIR) $(BUILD_DIR)
-	@cd $(BUILD_DIR) && cmake $(CMAKE_TARGET) -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -DOMFIT=$(OMFIT) ../..
+	cd $(BUILD_DIR) && cmake $(CMAKE_TARGET) -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -DOMFIT=$(OMFIT) ../..
 
 config-fmil:
 	@echo
@@ -113,6 +106,12 @@ config-glog: config-gflags
 	$(MKDIR) 3rdParty/glog/$(BUILD_DIR)
 	cd 3rdParty/glog/$(BUILD_DIR) && cmake $(CMAKE_TARGET) -DCMAKE_INSTALL_PREFIX=../../$(INSTALL_DIR) ../../glog -DBUILD_SHARED_LIBS="OFF" -DBUILD_TESTING="OFF" -DCMAKE_C_FLAGS="-fPIC" -DCMAKE_CXX_FLAGS="-fPIC" -DCMAKE_BUILD_TYPE="Release" && $(MAKE) install
 
+ifeq ($(CERES),OFF)
+config-ceres-solver:
+	@echo
+	@echo "# CERES=OFF => Skipping build of 3rdParty library Ceres-Solver. Ceres-Solver is a dependency of the (optional) parameter estimation module."
+	@echo
+else
 config-ceres-solver: config-glog
 	@echo
 	@echo "# config ceres-solver"
@@ -121,6 +120,7 @@ config-ceres-solver: config-glog
 	$(RM) 3rdParty/ceres- solver/$(INSTALL_DIR)
 	$(MKDIR) 3rdParty/ceres-solver/$(BUILD_DIR)
 	cd 3rdParty/ceres-solver/$(BUILD_DIR) && cmake $(CMAKE_TARGET) -DCMAKE_INSTALL_PREFIX=../../$(INSTALL_DIR) -DCXX11="ON" -DEXPORT_BUILD_DIR="ON" -DEIGEN_INCLUDE_DIR_HINTS="../../eigen/eigen" -DBUILD_EXAMPLES="OFF" -DBUILD_TESTING="OFF" -DCMAKE_BUILD_TYPE="Release" ../../ceres-solver && $(MAKE) install
+endif
 
 distclean:
 	@echo

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ The latest documentation is avilable as [pdf](https://openmodelica.org/doc/OMSim
 - [Boost](http://www.boost.org/) (system, filesystem)
 - [cmake](http://www.cmake.org)
 - [Sphinx](http://www.sphinx-doc.org/en/stable/)
+- [readline (if using Lua)](http://git.savannah.gnu.org/cgit/readline.git)
 - [3rdParty subproject](https://github.com/OpenModelica/OMFMISimulator-3rdParty)
   - FMILibrary
   - Lua

--- a/src/OMSimulator/CMakeLists.txt
+++ b/src/OMSimulator/CMakeLists.txt
@@ -4,6 +4,23 @@ set(CMAKE_INSTALL_RPATH "$ORIGIN/../bin:$ORIGIN/")
 
 find_package(Threads)
 
+# Because the shared libraries cannot link to static boost on amd64,
+# we have a different set of options for finding the boost package
+# used for the executable itself.
+
+set(Boost_USE_STATIC_LIBS ON)
+set(Boost_USE_STATIC_RUNTIME ON)
+
+find_package(Boost 1.54.0 COMPONENTS system filesystem REQUIRED)
+IF(Boost_FOUND)
+  message(STATUS "Found Boost static libraries")
+  message(STATUS "  Boost_LIBRARIES:    " ${Boost_LIBRARIES})
+  message(STATUS "  Boost_LIBRARY_DIRS: " ${Boost_LIBRARY_DIRS})
+  message(STATUS "  Boost_INCLUDE_DIRS: " ${Boost_INCLUDE_DIRS})
+ELSE()
+  MESSAGE(WARNING, "Boost library not found, please give a hint by setting the cmake variable BOOST_ROOT either in the cmake-gui or the command line, e.g., 'cmake -DBOOST_ROOT=C:/local/boost_1_63_0'")
+ENDIF()
+
 include_directories(../OMSimulatorLib)
 include_directories(../OMSimulatorLua)
 include_directories(${Boost_INCLUDE_DIRS})
@@ -26,11 +43,17 @@ IF (Ceres_FOUND AND OMFIT)
 ENDIF()
 
 IF(WIN32 AND MSVC)
-  target_link_libraries(OMSimulator lua ${OMFIT_OPTION} OMSimulatorLib fmilib sundials_cvode sundials_nvecserial ${Boost_LIBRARIES} ${CERES_OPTION} ${CMAKE_DL_LIBS} ${CMAKE_THREAD_LIBS_INIT})
+  target_link_libraries(OMSimulator lua ${OMFIT_OPTION} OMSimulatorLib ${FMILibrary_LIBRARY} sundials_cvode sundials_nvecserial ${Boost_LIBRARIES} ${CERES_OPTION} ${CMAKE_DL_LIBS} ${CMAKE_THREAD_LIBS_INIT})
 ELSEIF (WIN32 AND MINGW)
-  target_link_libraries(OMSimulator lua ${OMFIT_OPTION} OMSimulatorLib fmilib shlwapi sundials_cvode sundials_nvecserial ${Boost_LIBRARIES} ${CERES_OPTION} ${CMAKE_DL_LIBS} ${CMAKE_THREAD_LIBS_INIT})
+  target_link_libraries(OMSimulator lua ${OMFIT_OPTION} OMSimulatorLib ${FMILibrary_LIBRARY} shlwapi sundials_cvode sundials_nvecserial ${Boost_LIBRARIES} ${CERES_OPTION} ${CMAKE_DL_LIBS} ${CMAKE_THREAD_LIBS_INIT})
 ELSE()
-  target_link_libraries(OMSimulator lua ${OMFIT_OPTION} OMSimulatorLib fmilib sundials_cvode sundials_nvecserial ${Boost_LIBRARIES} ${CERES_OPTION} ${CMAKE_DL_LIBS} ${CMAKE_THREAD_LIBS_INIT})
+  target_link_libraries(OMSimulator lua ${OMFIT_OPTION} OMSimulatorLib ${FMILibrary_LIBRARY} sundials_cvode sundials_nvecserial ${Boost_LIBRARIES} ${CERES_OPTION} ${CMAKE_DL_LIBS} ${CMAKE_THREAD_LIBS_INIT})
+ENDIF()
+
+IF (CMAKE_CXX_COMPILER_ID MATCHES "[Cc]lang|GNU")
+  # Avoid external dependencies; especially useful when cross-compiling
+  # embedded ARM Linux systems
+  target_link_libraries(OMSimulator -static-libgcc -static-libstdc++)
 ENDIF()
 
 install(TARGETS OMSimulator DESTINATION bin)


### PR DESCRIPTION
For the executable itself, we can statically link against boost.
This makes the only dynamically linked libraries:
- pthreads
- dl
- ceres (if OMFit is used)