### PR TITLE
Add support for ssd::ConnectorGeometry

### DIFF
--- a/src/OMSimulatorLib/Types.h
+++ b/src/OMSimulatorLib/Types.h
@@ -294,12 +294,12 @@ typedef struct {
 } oms_connector_t;
 
 /**
- * \brief Element
+ * \brief Element (aka ssd:Component)
  */
 typedef struct {
   oms_element_type_enu_t type;      ///< Element type, e.g. FMU
   char* name;                       ///< Name of the element
-  oms_connector_t** interfaces;     ///< List (null-terminated array) of all interface variables: inputs, outputs, and parameters.
+  oms_connector_t** connectors;     ///< List (null-terminated array) of all interface variables: inputs, outputs, and parameters.
   ssd_element_geometry_t* geometry; ///< Geometry information of the element
 } oms_element_t;
 

--- a/src/OMSimulatorLib/oms2/Connector.h
+++ b/src/OMSimulatorLib/oms2/Connector.h
@@ -47,7 +47,15 @@ namespace oms2
   class Connector : protected oms_connector_t
   {
   public:
+    /**
+     * This constructor creates a oms2::Connector without geometry information.
+     */
     Connector(oms_causality_enu_t causality, oms_signal_type_enu_t type, const oms2::SignalRef& name);
+    /**
+     * This constructor is used if the optional SSD element giving the geometry
+     * information of the connector is initialized as well.
+     */
+    Connector(oms_causality_enu_t causality, oms_signal_type_enu_t type, const oms2::SignalRef& name, double height);
     ~Connector();
 
     // methods to copy the object

--- a/src/OMSimulatorLib/oms2/Connector.h
+++ b/src/OMSimulatorLib/oms2/Connector.h
@@ -39,6 +39,8 @@
 
 #include <string>
 
+#include <pugixml.hpp>
+
 namespace oms2
 {
   /**
@@ -57,6 +59,8 @@ namespace oms2
      */
     Connector(oms_causality_enu_t causality, oms_signal_type_enu_t type, const oms2::SignalRef& name, double height);
     ~Connector();
+
+    oms_status_enu_t exportToSSD(pugi::xml_node& root) const;
 
     // methods to copy the object
     Connector(const Connector& rhs);

--- a/src/OMSimulatorLib/oms2/Element.cpp
+++ b/src/OMSimulatorLib/oms2/Element.cpp
@@ -44,7 +44,7 @@ oms2::Element::Element(oms_element_type_enu_t type, const oms2::ComRef& name)
   this->name = new char[str.size()+1];
   strcpy(this->name, str.c_str());
 
-  this->interfaces = NULL;
+  this->connectors = NULL;
 
   this->geometry = reinterpret_cast<ssd_element_geometry_t*>(new oms2::ssd::ElementGeometry());
 }
@@ -53,11 +53,11 @@ oms2::Element::~Element()
 {
   if (this->name)
     delete[] this->name;
-  if (this->interfaces)
+  if (this->connectors)
   {
-    for (int i=0; this->interfaces[i]; ++i)
-      delete this->interfaces[i];
-    delete[] this->interfaces;
+    for (int i=0; this->connectors[i]; ++i)
+      delete this->connectors[i];
+    delete[] this->connectors;
   }
   if (this->geometry)
     delete reinterpret_cast<oms2::ssd::ElementGeometry*>(this->geometry);
@@ -87,20 +87,20 @@ void oms2::Element::setGeometry(const oms2::ssd::ElementGeometry* newGeometry)
   }
 }
 
-void oms2::Element::setInterfaces(const std::vector<oms2::Connector> newInterfaces)
+void oms2::Element::setConnectors(const std::vector<oms2::Connector> newConnectors)
 {
   logTrace();
 
-  if (this->interfaces)
+  if (this->connectors)
   {
-    for (int i=0; this->interfaces[i]; ++i)
-      delete this->interfaces[i];
-    delete[] this->interfaces;
+    for (int i=0; this->connectors[i]; ++i)
+      delete this->connectors[i];
+    delete[] this->connectors;
   }
 
-  this->interfaces = reinterpret_cast<oms_connector_t**>(new oms2::Connector*[newInterfaces.size()+1]);
-  this->interfaces[newInterfaces.size()] = NULL;
+  this->connectors = reinterpret_cast<oms_connector_t**>(new oms2::Connector*[newConnectors.size()+1]);
+  this->connectors[newConnectors.size()] = NULL;
 
-  for (int i=0; i<newInterfaces.size(); ++i)
-    this->interfaces[i] = reinterpret_cast<oms_connector_t*>(new oms2::Connector(newInterfaces[i]));
+  for (int i=0; i<newConnectors.size(); ++i)
+    this->connectors[i] = reinterpret_cast<oms_connector_t*>(new oms2::Connector(newConnectors[i]));
 }

--- a/src/OMSimulatorLib/oms2/Element.h
+++ b/src/OMSimulatorLib/oms2/Element.h
@@ -54,12 +54,12 @@ namespace oms2
 
     const oms_element_type_enu_t getType() const {return type;}
     const oms2::ComRef getName() const {return oms2::ComRef(std::string(name));}
-    oms_connector_t** getInterfaces() const {return interfaces;}
+    oms_connector_t** getConnectors() const {return connectors;}
     const oms2::ssd::ElementGeometry* getGeometry() const {return reinterpret_cast<oms2::ssd::ElementGeometry*>(geometry);}
 
     void setName(const ComRef& name);
     void setGeometry(const oms2::ssd::ElementGeometry* newGeometry);
-    void setInterfaces(const std::vector<oms2::Connector> newInterfaces);
+    void setConnectors(const std::vector<oms2::Connector> newConnectors);
 
   private:
     // methods to copy the object

--- a/src/OMSimulatorLib/oms2/Element.h
+++ b/src/OMSimulatorLib/oms2/Element.h
@@ -54,7 +54,7 @@ namespace oms2
 
     const oms_element_type_enu_t getType() const {return type;}
     const oms2::ComRef getName() const {return oms2::ComRef(std::string(name));}
-    oms_connector_t** getConnectors() const {return connectors;}
+    oms2::Connector** getConnectors() const {return reinterpret_cast<oms2::Connector**>(connectors);}
     const oms2::ssd::ElementGeometry* getGeometry() const {return reinterpret_cast<oms2::ssd::ElementGeometry*>(geometry);}
 
     void setName(const ComRef& name);

--- a/src/OMSimulatorLib/oms2/FMUWrapper.cpp
+++ b/src/OMSimulatorLib/oms2/FMUWrapper.cpp
@@ -305,14 +305,14 @@ oms2::FMUWrapper* oms2::FMUWrapper::newSubModel(const oms2::ComRef& cref, const 
 
   std::vector<oms2::Connector> connectors;
   int i = 1;
-  int size = model->inputs.size();
+  int size = 1 + model->inputs.size();
   for (auto const &v : model->inputs)
   {
     oms2::Connector c(oms_causality_input, v.getType(), v.getSignalRef(), i++/(double)size);
     connectors.push_back(c);
   }
   i = 1;
-  size = model->outputs.size();
+  size = 1+ model->outputs.size();
   for (auto const &v : model->outputs)
   {
     oms2::Connector c(oms_causality_output, v.getType(), v.getSignalRef(), i++/(double)size);
@@ -347,6 +347,17 @@ oms_status_enu_t oms2::FMUWrapper::exportToSSD(pugi::xml_node& root) const
     return status;
 
   // export ssd:Connectors
+  oms2::Connector** connectors = element.getConnectors();
+  if (connectors)
+  {
+    pugi::xml_node connectorsNode = subModel.append_child("ssd:Connectors");
+    for (int i=0; connectors[i]; ++i)
+    {
+      status = connectors[i]->exportToSSD(connectorsNode);
+      if (oms_status_ok != status)
+        return status;
+    }
+  }
 
   // export ssd:ParameterBindings
   const std::map<std::string, oms2::Option<double>>& realParameters = getRealParameters();

--- a/src/OMSimulatorLib/oms2/FMUWrapper.h
+++ b/src/OMSimulatorLib/oms2/FMUWrapper.h
@@ -43,6 +43,7 @@
 #include <vector>
 
 #include <fmilib.h>
+#include <pugixml.hpp>
 
 namespace oms2
 {

--- a/src/OMSimulatorLib/oms2/ssd/ConnectorGeometry.cpp
+++ b/src/OMSimulatorLib/oms2/ssd/ConnectorGeometry.cpp
@@ -34,12 +34,12 @@
 
 #include <string.h>
 
-oms2::ssd::ConnectorGeometry::ConnectorGeometry()
+oms2::ssd::ConnectorGeometry::ConnectorGeometry(double x, double y)
 {
   logTrace();
 
-  this->x = 0.0;
-  this->y = 0.0;
+  this->x = x;
+  this->y = y;
 }
 
 oms2::ssd::ConnectorGeometry::ConnectorGeometry(const oms2::ssd::ConnectorGeometry& rhs)

--- a/src/OMSimulatorLib/oms2/ssd/ConnectorGeometry.cpp
+++ b/src/OMSimulatorLib/oms2/ssd/ConnectorGeometry.cpp
@@ -71,6 +71,9 @@ oms2::ssd::ConnectorGeometry& oms2::ssd::ConnectorGeometry::operator=(oms2::ssd:
 
 oms_status_enu_t oms2::ssd::ConnectorGeometry::exportToSSD(pugi::xml_node& root) const
 {
-  logError("oms2::ssd::ConnectorGeometry::exportToSSD not implemented yet");
-  return oms_status_error;
+  pugi::xml_node node = root.append_child("ssd:ConnectorGeometry");
+  node.append_attribute("x") = std::to_string(x).c_str();
+  node.append_attribute("y") = std::to_string(y).c_str();
+
+  return oms_status_ok;
 }

--- a/src/OMSimulatorLib/oms2/ssd/ConnectorGeometry.h
+++ b/src/OMSimulatorLib/oms2/ssd/ConnectorGeometry.h
@@ -45,7 +45,7 @@ namespace oms2
     class ConnectorGeometry : protected ssd_connector_geometry_t
     {
     public:
-      ConnectorGeometry();
+      ConnectorGeometry(double x, double y);
       ConnectorGeometry(const ConnectorGeometry& rhs);
       ~ConnectorGeometry();
 


### PR DESCRIPTION
* inputs will be displayed on the left of a component
* outputs will be displayed on the right of a component
* renamed `oms_element_t.interfaces` to `oms_element_t.connectors`