### PR TITLE
API function simulate_asynchronous for FMUs

### DIFF
--- a/src/OMSimulatorLib/OMSimulator.cpp
+++ b/src/OMSimulatorLib/OMSimulator.cpp
@@ -651,8 +651,7 @@ oms_status_enu_t oms2_terminate(const char* ident)
 oms_status_enu_t oms2_simulate_asynchronous(const char* ident, void (*cb)(const char* ident, double time, oms_status_enu_t status))
 {
   logTrace();
-  logError("oms2_simulate_asynchronous: not implemented yet");
-  return oms_status_error;
+  return oms2::Scope::GetInstance().simulate_asynchronous(oms2::ComRef(ident), cb);
 }
 
 void oms2_setLoggingCallback(void (*cb)(oms_message_type_enu_t type, const char* message))

--- a/src/OMSimulatorLib/oms2/CompositeModel.h
+++ b/src/OMSimulatorLib/oms2/CompositeModel.h
@@ -62,6 +62,7 @@ namespace oms2
     virtual oms_status_enu_t initialize(double startTime, double tolerance) = 0;
     virtual oms_status_enu_t terminate() = 0;
     virtual oms_status_enu_t simulate(ResultWriter& resultWriter, double stopTime, double communicationInterval, MasterAlgorithm masterAlgorithm) = 0;
+    virtual void simulate_asynchronous(ResultWriter& resultWriter, double stopTime, double communicationInterval, void (*cb)(const char* ident, double time, oms_status_enu_t status)) = 0;
 
     virtual oms_status_enu_t registerSignalsForResultFile(ResultWriter& resultWriter) = 0;
     virtual oms_status_enu_t emit(ResultWriter& resultWriter) = 0;

--- a/src/OMSimulatorLib/oms2/FMICompositeModel.h
+++ b/src/OMSimulatorLib/oms2/FMICompositeModel.h
@@ -86,6 +86,7 @@ namespace oms2
     oms_status_enu_t terminate();
     oms_status_enu_t simulate(ResultWriter& resultWriter, double stopTime, double communicationInterval, MasterAlgorithm masterAlgorithm);
     oms_status_enu_t simulateTLM(ResultWriter *resultWriter, double stopTime, double communicationInterval, std::string address);
+    void simulate_asynchronous(ResultWriter& resultWriter, double stopTime, double communicationInterval, void (*cb)(const char* ident, double time, oms_status_enu_t status));
 
     oms_status_enu_t setReal(const oms2::SignalRef& sr, double value);
     oms_status_enu_t getReal(const oms2::SignalRef& sr, double& value);

--- a/src/OMSimulatorLib/oms2/Model.cpp
+++ b/src/OMSimulatorLib/oms2/Model.cpp
@@ -39,6 +39,7 @@
 #include "ssd/Tags.h"
 
 #include <regex>
+#include <thread>
 
 #include <pugixml.hpp>
 
@@ -303,4 +304,17 @@ oms_status_enu_t oms2::Model::simulate()
 
   oms_status_enu_t status = compositeModel->simulate(*resultFile, stopTime, communicationInterval, masterAlgorithm);
   return status;
+}
+
+oms_status_enu_t oms2::Model::simulate_asynchronous(void (*cb)(const char* ident, double time, oms_status_enu_t status))
+{
+  if (oms_modelState_simulation != modelState)
+  {
+    logError("[oms2::Model::simulate_asynchronous] Model cannot be simulated, because it isn't initialized.");
+    return oms_status_error;
+  }
+
+  std::thread([=]{compositeModel->simulate_asynchronous(*resultFile, stopTime, communicationInterval, cb);}).detach();
+
+  return oms_status_ok;
 }

--- a/src/OMSimulatorLib/oms2/Model.h
+++ b/src/OMSimulatorLib/oms2/Model.h
@@ -84,6 +84,7 @@ namespace oms2
     oms_status_enu_t initialize();
     oms_status_enu_t terminate();
     oms_status_enu_t simulate();
+    oms_status_enu_t simulate_asynchronous(void (*cb)(const char* ident, double time, oms_status_enu_t status));
 
   private:
     Model(const oms2::ComRef& cref);

--- a/src/OMSimulatorLib/oms2/Scope.cpp
+++ b/src/OMSimulatorLib/oms2/Scope.cpp
@@ -273,6 +273,17 @@ oms_status_enu_t oms2::Scope::simulate(const ComRef& name)
   return model->simulate();
 }
 
+oms_status_enu_t oms2::Scope::simulate_asynchronous(const ComRef& name, void (*cb)(const char* ident, double time, oms_status_enu_t status))
+{
+  logTrace();
+
+  oms2::Model* model = getModel(name);
+  if (!model)
+    return oms_status_error;
+
+  return model->simulate_asynchronous(cb);
+}
+
 oms_status_enu_t oms2::Scope::setTempDirectory(const std::string& newTempDir)
 {
   logTrace();

--- a/src/OMSimulatorLib/oms2/Scope.h
+++ b/src/OMSimulatorLib/oms2/Scope.h
@@ -63,6 +63,7 @@ namespace oms2
     oms_status_enu_t initialize(const ComRef& name);
     oms_status_enu_t terminate(const ComRef& name);
     oms_status_enu_t simulate(const ComRef& name);
+    oms_status_enu_t simulate_asynchronous(const ComRef& name, void (*cb)(const char* ident, double time, oms_status_enu_t status));
     oms_status_enu_t addFMU(const ComRef& modelIdent, const std::string& fmuPath, const ComRef& fmuIdent);
     oms_status_enu_t addTable(const ComRef& modelIdent, const std::string& tablePath, const ComRef& tableIdent);
     oms_status_enu_t deleteSubModel(const ComRef& modelIdent, const ComRef& subModelIdent);

--- a/src/OMSimulatorLib/oms2/TLMCompositeModel.cpp
+++ b/src/OMSimulatorLib/oms2/TLMCompositeModel.cpp
@@ -349,3 +349,11 @@ oms_status_enu_t oms2::TLMCompositeModel::simulate(ResultWriter &resultWriter, d
 
   return oms_status_ok;
 }
+
+void oms2::TLMCompositeModel::simulate_asynchronous(ResultWriter& resultWriter, double stopTime, double communicationInterval, void (*cb)(const char* ident, double time, oms_status_enu_t status))
+{
+  logTrace();
+
+  logError("oms2::TLMCompositeModel::simulate_asynchronous: Function is not implemented, yet.");
+  cb(this->getName().c_str(), 0, oms_status_error);
+}

--- a/src/OMSimulatorLib/oms2/TLMCompositeModel.h
+++ b/src/OMSimulatorLib/oms2/TLMCompositeModel.h
@@ -78,6 +78,7 @@ namespace oms2
     oms_status_enu_t initialize(double startTime, double tolerance);
     oms_status_enu_t terminate();
     oms_status_enu_t simulate(ResultWriter &resultWriter, double stopTime, double communicationInterval, MasterAlgorithm masterAlgorithm);
+    void simulate_asynchronous(ResultWriter& resultWriter, double stopTime, double communicationInterval, void (*cb)(const char* ident, double time, oms_status_enu_t status));
 
     oms_status_enu_t registerSignalsForResultFile(ResultWriter& resultWriter) {return oms_status_ok;}
     oms_status_enu_t emit(ResultWriter& resultWriter) {return oms_status_ok;}


### PR DESCRIPTION
The PR contains an implementation for the `simulate_asynchronous` API function for FMI composites. The TLM models are not supported (yet) and only the stubs are provided.

There is currently no test that exercises this function. Since this API call is introduced for OMEditor, there is no Lua or Python scripting interface for `simulate_asynchronous`. Should there be also a scripting interface for this function?