### PR TITLE
Added argument for specifying callback updating period

### DIFF
--- a/src/OMSimulatorLib/OMSimulator.cpp
+++ b/src/OMSimulatorLib/OMSimulator.cpp
@@ -666,10 +666,10 @@ oms_status_enu_t oms2_terminate(const char* ident)
   return oms2::Scope::GetInstance().terminate(oms2::ComRef(ident));
 }
 
-oms_status_enu_t oms2_simulate_asynchronous(const char* ident, void (*cb)(const char* ident, double time, oms_status_enu_t status))
+oms_status_enu_t oms2_simulate_asynchronous(const char* ident, double cbPeriod, void (*cb)(const char* ident, double time, oms_status_enu_t status))
 {
   logTrace();
-  return oms2::Scope::GetInstance().simulate_asynchronous(oms2::ComRef(ident), cb);
+  return oms2::Scope::GetInstance().simulate_asynchronous(oms2::ComRef(ident), cbPeriod, cb);
 }
 
 void oms2_setLoggingCallback(void (*cb)(oms_message_type_enu_t type, const char* message))

--- a/src/OMSimulatorLib/OMSimulator.h
+++ b/src/OMSimulatorLib/OMSimulator.h
@@ -480,7 +480,15 @@ oms_status_enu_t oms2_initialize(const char* ident);
  */
 oms_status_enu_t oms2_simulate(const char* ident);
 
-oms_status_enu_t oms2_simulate_asynchronous(const char* ident, void (*cb)(const char* ident, double time, oms_status_enu_t status));
+/**
+ * \brief Simulates a composite model in its own thread.
+ *
+ * \param ident            [in] Name of the model instance
+ * \param cbPeriod         [in] Period duration in seconds between calls to callback function cb
+ * \param cb               [in] Callback function which to be called periodically
+ * \return                 Error status
+ */
+oms_status_enu_t oms2_simulate_asynchronous(const char* ident, double cbPeriod, void (*cb)(const char* ident, double time, oms_status_enu_t status));
 
 /**
  * \brief Simulates a composite model for a given number of steps (works for both FMI and TLM).

--- a/src/OMSimulatorLib/oms2/CompositeModel.h
+++ b/src/OMSimulatorLib/oms2/CompositeModel.h
@@ -65,7 +65,7 @@ namespace oms2
 
     virtual oms_status_enu_t doSteps(ResultWriter& resultWriter, const int numberOfSteps, double communicationInterval) = 0;
     virtual oms_status_enu_t stepUntil(ResultWriter& resultWriter, double stopTime, double communicationInterval, MasterAlgorithm masterAlgorithm) = 0;
-    virtual void simulate_asynchronous(ResultWriter& resultWriter, double stopTime, double communicationInterval, void (*cb)(const char* ident, double time, oms_status_enu_t status)) = 0;
+    virtual void simulate_asynchronous(ResultWriter& resultWriter, double stopTime, double communicationInterval, double cbPeriod, void (*cb)(const char* ident, double time, oms_status_enu_t status)) = 0;
 
     virtual oms_status_enu_t registerSignalsForResultFile(ResultWriter& resultWriter) = 0;
     virtual oms_status_enu_t emit(ResultWriter& resultWriter) = 0;

--- a/src/OMSimulatorLib/oms2/FMICompositeModel.cpp
+++ b/src/OMSimulatorLib/oms2/FMICompositeModel.cpp
@@ -960,7 +960,7 @@ oms_status_enu_t oms2::FMICompositeModel::stepUntilPCTPL(ResultWriter& resultWri
   return oms_status_ok;
 }
 
-void oms2::FMICompositeModel::simulate_asynchronous(ResultWriter& resultWriter, double stopTime, double communicationInterval, void (*cb)(const char* ident, double time, oms_status_enu_t status))
+void oms2::FMICompositeModel::simulate_asynchronous(ResultWriter& resultWriter, double stopTime, double communicationInterval, double cbPeriod, void (*cb)(const char* ident, double time, oms_status_enu_t status))
 {
   logTrace();
 
@@ -986,7 +986,7 @@ void oms2::FMICompositeModel::simulate_asynchronous(ResultWriter& resultWriter, 
 
     now = std::chrono::system_clock::now();
     elapsed_seconds = now-start;
-    if ((elapsed_seconds - elapsed_seconds_previous) > std::chrono::duration<double>(1.0)) {
+    if ((elapsed_seconds - elapsed_seconds_previous) > std::chrono::duration<double>(cbPeriod)) {
       // bthiele: FIXME not meaningfull to always return oms_status_ok, but this is consistent with what `simulate` does. Behaviour should be (consistently) changed in `simulate` and `simulate_asynchronous`
       cb(this->getName().c_str(), time, oms_status_ok);
     }

--- a/src/OMSimulatorLib/oms2/FMICompositeModel.h
+++ b/src/OMSimulatorLib/oms2/FMICompositeModel.h
@@ -88,7 +88,7 @@ namespace oms2
     oms_status_enu_t doSteps(ResultWriter& resultWriter, const int numberOfSteps, double communicationInterval);
     oms_status_enu_t stepUntil(ResultWriter& resultWriter, double stopTime, double communicationInterval, MasterAlgorithm masterAlgorithm);
     oms_status_enu_t simulateTLM(ResultWriter *resultWriter, double stopTime, double communicationInterval, std::string address);
-    void simulate_asynchronous(ResultWriter& resultWriter, double stopTime, double communicationInterval, void (*cb)(const char* ident, double time, oms_status_enu_t status));
+    void simulate_asynchronous(ResultWriter& resultWriter, double stopTime, double communicationInterval, double cbPeriod, void (*cb)(const char* ident, double time, oms_status_enu_t status));
 
     oms_status_enu_t setReal(const oms2::SignalRef& sr, double value);
     oms_status_enu_t setReals(const std::vector<oms2::SignalRef> &sr, std::vector<double> values);

--- a/src/OMSimulatorLib/oms2/Model.cpp
+++ b/src/OMSimulatorLib/oms2/Model.cpp
@@ -295,7 +295,7 @@ oms_status_enu_t oms2::Model::reset()
 
   modelState = oms_modelState_instantiated;
 
-  return status; // 2018-04-24: Careful, return value is fixed to oms_status_ok 
+  return status; // 2018-04-24: Careful, return value is fixed to oms_status_ok
 }
 
 oms_status_enu_t oms2::Model::terminate()
@@ -352,7 +352,7 @@ oms_status_enu_t oms2::Model::stepUntil(const double timeValue)
   return status;
 }
 
-oms_status_enu_t oms2::Model::simulate_asynchronous(void (*cb)(const char* ident, double time, oms_status_enu_t status))
+oms_status_enu_t oms2::Model::simulate_asynchronous(double cbPeriod, void (*cb)(const char* ident, double time, oms_status_enu_t status))
 {
   if (oms_modelState_simulation != modelState)
   {
@@ -360,7 +360,7 @@ oms_status_enu_t oms2::Model::simulate_asynchronous(void (*cb)(const char* ident
     return oms_status_error;
   }
 
-  std::thread([=]{compositeModel->simulate_asynchronous(*resultFile, stopTime, communicationInterval, cb);}).detach();
+  std::thread([=]{compositeModel->simulate_asynchronous(*resultFile, stopTime, communicationInterval, cbPeriod, cb);}).detach();
 
   return oms_status_ok;
 }

--- a/src/OMSimulatorLib/oms2/Model.h
+++ b/src/OMSimulatorLib/oms2/Model.h
@@ -85,7 +85,7 @@ namespace oms2
     oms_status_enu_t reset();
     oms_status_enu_t terminate();
     oms_status_enu_t simulate();
-    oms_status_enu_t simulate_asynchronous(void (*cb)(const char* ident, double time, oms_status_enu_t status));
+    oms_status_enu_t simulate_asynchronous(double cbPeriod, void (*cb)(const char* ident, double time, oms_status_enu_t status));
     oms_status_enu_t doSteps(const int numberOfSteps);
     oms_status_enu_t stepUntil(const double timeValue);
 

--- a/src/OMSimulatorLib/oms2/Scope.cpp
+++ b/src/OMSimulatorLib/oms2/Scope.cpp
@@ -284,7 +284,7 @@ oms_status_enu_t oms2::Scope::simulate(const ComRef& name)
   return model->simulate();
 }
 
-oms_status_enu_t oms2::Scope::simulate_asynchronous(const ComRef& name, void (*cb)(const char* ident, double time, oms_status_enu_t status))
+oms_status_enu_t oms2::Scope::simulate_asynchronous(const ComRef& name,  double cbPeriod, void (*cb)(const char* ident, double time, oms_status_enu_t status))
 {
   logTrace();
 
@@ -292,7 +292,7 @@ oms_status_enu_t oms2::Scope::simulate_asynchronous(const ComRef& name, void (*c
   if (!model)
     return oms_status_error;
 
-  return model->simulate_asynchronous(cb);
+  return model->simulate_asynchronous(cbPeriod, cb);
 }
 
 oms_status_enu_t oms2::Scope::doSteps(const ComRef& name, const int numberOfSteps)

--- a/src/OMSimulatorLib/oms2/Scope.h
+++ b/src/OMSimulatorLib/oms2/Scope.h
@@ -64,7 +64,7 @@ namespace oms2
     oms_status_enu_t reset(const ComRef& name);
     oms_status_enu_t terminate(const ComRef& name);
     oms_status_enu_t simulate(const ComRef& name);
-    oms_status_enu_t simulate_asynchronous(const ComRef& name, void (*cb)(const char* ident, double time, oms_status_enu_t status));
+    oms_status_enu_t simulate_asynchronous(const ComRef& name, double cbPeriod, void (*cb)(const char* ident, double time, oms_status_enu_t status));
     oms_status_enu_t doSteps(const ComRef& name, const int numberOfSteps);
     oms_status_enu_t stepUntil(const ComRef& name, const double timeValue);
     oms_status_enu_t addFMU(const ComRef& modelIdent, const std::string& fmuPath, const ComRef& fmuIdent);

--- a/src/OMSimulatorLib/oms2/TLMCompositeModel.cpp
+++ b/src/OMSimulatorLib/oms2/TLMCompositeModel.cpp
@@ -375,7 +375,7 @@ oms_status_enu_t oms2::TLMCompositeModel::stepUntil(ResultWriter &resultWriter, 
   return oms_status_ok;
 }
 
-void oms2::TLMCompositeModel::simulate_asynchronous(ResultWriter& resultWriter, double stopTime, double communicationInterval, void (*cb)(const char* ident, double time, oms_status_enu_t status))
+void oms2::TLMCompositeModel::simulate_asynchronous(ResultWriter& resultWriter, double stopTime, double communicationInterval, double cbPeriod, void (*cb)(const char* ident, double time, oms_status_enu_t status))
 {
   logTrace();
 

--- a/src/OMSimulatorLib/oms2/TLMCompositeModel.h
+++ b/src/OMSimulatorLib/oms2/TLMCompositeModel.h
@@ -79,7 +79,7 @@ namespace oms2
     oms_status_enu_t reset();
     oms_status_enu_t terminate();
     oms_status_enu_t simulate(ResultWriter &resultWriter, double stopTime, double communicationInterval, oms2::MasterAlgorithm masterAlgorithm);
-    void simulate_asynchronous(ResultWriter& resultWriter, double stopTime, double communicationInterval, void (*cb)(const char* ident, double time, oms_status_enu_t status));
+    void simulate_asynchronous(ResultWriter& resultWriter, double stopTime, double communicationInterval, double cbPeriod, void (*cb)(const char* ident, double time, oms_status_enu_t status));
     oms_status_enu_t doSteps(ResultWriter& resultWriter, const int numberOfSteps, double communicationInterval);
     oms_status_enu_t stepUntil(ResultWriter &resultWriter, double stopTime, double communicationInterval, oms2::MasterAlgorithm masterAlgorithm);
 


### PR DESCRIPTION
Added argument cbPeriod to oms2_simulate_asynchronous function.
Allows to specify the period duration in which the provided callback
function is called (wall-clock time).

@adeas31 