### PR TITLE
Disabled port availability check on Windows

### DIFF
--- a/src/OMSimulatorLib/oms2/TLMCompositeModel.cpp
+++ b/src/OMSimulatorLib/oms2/TLMCompositeModel.cpp
@@ -275,8 +275,10 @@ oms_status_enu_t oms2::TLMCompositeModel::setSocketData(const std::string& addre
                                                         int managerPort,
                                                         int monitorPort)
 {
+#ifndef _WIN32
   omtlm_checkPortAvailability(&managerPort);
   omtlm_checkPortAvailability(&monitorPort);
+#endif
 
   omtlm_setAddress(model, address);
   omtlm_setManagerPort(model, managerPort);


### PR DESCRIPTION
The port check locks the port, so that it cannot be used in the actual simulation. We need to figure out a solution to this later.