### PR TITLE
Terminate the running simulation

### DIFF
--- a/src/OMSimulatorLib/CompositeModel.h
+++ b/src/OMSimulatorLib/CompositeModel.h
@@ -65,7 +65,7 @@ namespace oms2
 
     virtual oms_status_enu_t doSteps(ResultWriter& resultWriter, const int numberOfSteps, double communicationInterval) = 0;
     virtual oms_status_enu_t stepUntil(ResultWriter& resultWriter, double stopTime, double communicationInterval, MasterAlgorithm masterAlgorithm, bool realtime_sync) = 0;
-    virtual void simulate_asynchronous(ResultWriter& resultWriter, double stopTime, double communicationInterval, void (*cb)(const char* ident, double time, oms_status_enu_t status)) = 0;
+    virtual void simulate_asynchronous(ResultWriter& resultWriter, double stopTime, double communicationInterval, int *terminate, void (*cb)(const char* ident, double time, oms_status_enu_t status)) = 0;
 
     virtual oms_status_enu_t registerSignalsForResultFile(ResultWriter& resultWriter) = 0;
     virtual oms_status_enu_t emit(ResultWriter& resultWriter) = 0;

--- a/src/OMSimulatorLib/FMICompositeModel.cpp
+++ b/src/OMSimulatorLib/FMICompositeModel.cpp
@@ -993,13 +993,13 @@ oms_status_enu_t oms2::FMICompositeModel::stepUntilPCTPL(ResultWriter& resultWri
   return oms_status_ok;
 }
 
-void oms2::FMICompositeModel::simulate_asynchronous(ResultWriter& resultWriter, double stopTime, double communicationInterval, void (*cb)(const char* ident, double time, oms_status_enu_t status))
+void oms2::FMICompositeModel::simulate_asynchronous(ResultWriter& resultWriter, double stopTime, double communicationInterval, int *terminate, void (*cb)(const char* ident, double time, oms_status_enu_t status))
 {
   logTrace();
   oms_status_enu_t statusSubModel;
   oms_status_enu_t status;
 
-  while (time < stopTime)
+  while (time < stopTime && *terminate)
   {
     logDebug("doStep: " + std::to_string(time) + " -> " + std::to_string(time+communicationInterval));
     time += communicationInterval;

--- a/src/OMSimulatorLib/FMICompositeModel.h
+++ b/src/OMSimulatorLib/FMICompositeModel.h
@@ -88,7 +88,7 @@ namespace oms2
     oms_status_enu_t doSteps(ResultWriter& resultWriter, const int numberOfSteps, double communicationInterval);
     oms_status_enu_t stepUntil(ResultWriter& resultWriter, double stopTime, double communicationInterval, MasterAlgorithm masterAlgorithm, bool realtime_sync);
     oms_status_enu_t simulateTLM(ResultWriter *resultWriter, double stopTime, double communicationInterval, std::string address);
-    void simulate_asynchronous(ResultWriter& resultWriter, double stopTime, double communicationInterval, void (*cb)(const char* ident, double time, oms_status_enu_t status));
+    void simulate_asynchronous(ResultWriter& resultWriter, double stopTime, double communicationInterval, int *terminate, void (*cb)(const char* ident, double time, oms_status_enu_t status));
 
     oms_status_enu_t setReal(const oms2::SignalRef& sr, double value);
     oms_status_enu_t setReals(const std::vector<oms2::SignalRef> &sr, std::vector<double> values);

--- a/src/OMSimulatorLib/Model.cpp
+++ b/src/OMSimulatorLib/Model.cpp
@@ -352,7 +352,7 @@ oms_status_enu_t oms2::Model::stepUntil(const double timeValue)
   return status;
 }
 
-oms_status_enu_t oms2::Model::simulate_asynchronous(void (*cb)(const char* ident, double time, oms_status_enu_t status))
+oms_status_enu_t oms2::Model::simulate_asynchronous(int *terminate, void (*cb)(const char* ident, double time, oms_status_enu_t status))
 {
   if (oms_modelState_simulation != modelState)
   {
@@ -360,7 +360,7 @@ oms_status_enu_t oms2::Model::simulate_asynchronous(void (*cb)(const char* ident
     return oms_status_error;
   }
 
-  std::thread([=]{compositeModel->simulate_asynchronous(*resultFile, stopTime, communicationInterval, cb);}).detach();
+  std::thread([=]{compositeModel->simulate_asynchronous(*resultFile, stopTime, communicationInterval, terminate, cb);}).detach();
 
   return oms_status_ok;
 }

--- a/src/OMSimulatorLib/Model.h
+++ b/src/OMSimulatorLib/Model.h
@@ -88,7 +88,7 @@ namespace oms2
     oms_status_enu_t reset();
     oms_status_enu_t terminate();
     oms_status_enu_t simulate();
-    oms_status_enu_t simulate_asynchronous(void (*cb)(const char* ident, double time, oms_status_enu_t status));
+    oms_status_enu_t simulate_asynchronous(int *terminate, void (*cb)(const char* ident, double time, oms_status_enu_t status));
     oms_status_enu_t simulate_realtime();
     oms_status_enu_t doSteps(const int numberOfSteps);
     oms_status_enu_t stepUntil(const double timeValue);

--- a/src/OMSimulatorLib/OMSimulator.cpp
+++ b/src/OMSimulatorLib/OMSimulator.cpp
@@ -236,10 +236,10 @@ oms_status_enu_t oms2_terminate(const char* ident)
   return oms2::Scope::GetInstance().terminate(oms2::ComRef(ident));
 }
 
-oms_status_enu_t oms2_simulate_asynchronous(const char* ident, void (*cb)(const char* ident, double time, oms_status_enu_t status))
+oms_status_enu_t oms2_simulate_asynchronous(const char* ident, int *terminate, void (*cb)(const char* ident, double time, oms_status_enu_t status))
 {
   logTrace();
-  return oms2::Scope::GetInstance().simulate_asynchronous(oms2::ComRef(ident), cb);
+  return oms2::Scope::GetInstance().simulate_asynchronous(oms2::ComRef(ident), terminate, cb);
 }
 
 void oms2_setLoggingCallback(void (*cb)(oms_message_type_enu_t type, const char* message))

--- a/src/OMSimulatorLib/OMSimulator.h
+++ b/src/OMSimulatorLib/OMSimulator.h
@@ -246,7 +246,7 @@ oms_status_enu_t oms2_simulate(const char* ident);
  * \param cb               [in] Callback function which is called after every completed step of the composite model
  * \return                 Error status
  */
-oms_status_enu_t oms2_simulate_asynchronous(const char* ident, void (*cb)(const char* ident, double time, oms_status_enu_t status));
+oms_status_enu_t oms2_simulate_asynchronous(const char* ident, int *terminate, void (*cb)(const char* ident, double time, oms_status_enu_t status));
 
 /**
  * \brief Simulates a composite model for a given number of steps (works for both FMI and TLM).

--- a/src/OMSimulatorLib/Scope.cpp
+++ b/src/OMSimulatorLib/Scope.cpp
@@ -295,7 +295,7 @@ oms_status_enu_t oms2::Scope::simulate_realtime(const ComRef& name)
   return model->simulate_realtime();
 }
 
-oms_status_enu_t oms2::Scope::simulate_asynchronous(const ComRef& name, void (*cb)(const char* ident, double time, oms_status_enu_t status))
+oms_status_enu_t oms2::Scope::simulate_asynchronous(const ComRef& name, int *terminate, void (*cb)(const char* ident, double time, oms_status_enu_t status))
 {
   logTrace();
 
@@ -303,7 +303,7 @@ oms_status_enu_t oms2::Scope::simulate_asynchronous(const ComRef& name, void (*c
   if (!model)
     return oms_status_error;
 
-  return model->simulate_asynchronous(cb);
+  return model->simulate_asynchronous(terminate, cb);
 }
 
 oms_status_enu_t oms2::Scope::doSteps(const ComRef& name, const int numberOfSteps)

--- a/src/OMSimulatorLib/Scope.h
+++ b/src/OMSimulatorLib/Scope.h
@@ -64,7 +64,7 @@ namespace oms2
     oms_status_enu_t reset(const ComRef& name);
     oms_status_enu_t terminate(const ComRef& name);
     oms_status_enu_t simulate(const ComRef& name);
-    oms_status_enu_t simulate_asynchronous(const ComRef& name, void (*cb)(const char* ident, double time, oms_status_enu_t status));
+    oms_status_enu_t simulate_asynchronous(const ComRef& name, int *terminate, void (*cb)(const char* ident, double time, oms_status_enu_t status));
     oms_status_enu_t simulate_realtime(const ComRef& name);
     oms_status_enu_t doSteps(const ComRef& name, const int numberOfSteps);
     oms_status_enu_t stepUntil(const ComRef& name, const double timeValue);

--- a/src/OMSimulatorLib/TLMCompositeModel.cpp
+++ b/src/OMSimulatorLib/TLMCompositeModel.cpp
@@ -400,7 +400,7 @@ oms_status_enu_t oms2::TLMCompositeModel::stepUntil(ResultWriter &resultWriter, 
   return oms_status_ok;
 }
 
-void oms2::TLMCompositeModel::simulate_asynchronous(ResultWriter& resultWriter, double stopTime, double communicationInterval, void (*cb)(const char* ident, double time, oms_status_enu_t status))
+void oms2::TLMCompositeModel::simulate_asynchronous(ResultWriter& resultWriter, double stopTime, double communicationInterval, int *terminate, void (*cb)(const char* ident, double time, oms_status_enu_t status))
 {
   logTrace();
 

--- a/src/OMSimulatorLib/TLMCompositeModel.h
+++ b/src/OMSimulatorLib/TLMCompositeModel.h
@@ -79,7 +79,7 @@ namespace oms2
     oms_status_enu_t reset();
     oms_status_enu_t terminate();
     oms_status_enu_t simulate(ResultWriter &resultWriter, double stopTime, double communicationInterval, oms2::MasterAlgorithm masterAlgorithm);
-    void simulate_asynchronous(ResultWriter& resultWriter, double stopTime, double communicationInterval, void (*cb)(const char* ident, double time, oms_status_enu_t status));
+    void simulate_asynchronous(ResultWriter& resultWriter, double stopTime, double communicationInterval, int *terminate, void (*cb)(const char* ident, double time, oms_status_enu_t status));
     oms_status_enu_t doSteps(ResultWriter& resultWriter, const int numberOfSteps, double communicationInterval);
     oms_status_enu_t stepUntil(ResultWriter &resultWriter, double stopTime, double communicationInterval, oms2::MasterAlgorithm masterAlgorithm, bool realtime_sync);
 


### PR DESCRIPTION
Fixes #152 

## Purpose

An asynchronous simulation can be started using `oms2_simulate_asynchronous`. An API to cancel the running the simulation is required.

## Approach

There is no standard way to terminate a detached thread. The only way is to store the thread handles and then use the OS native techniques to kill the thread using the handle.

Use the int pointer as a flag to terminate the simulation. Set the pointer value to 1 and pass it to `oms2_simulate_asynchronous`. Set to 0 when you want to terminate the simulation.

I personally think we don't need to terminate or kill the thread via a new API. Just use the flag to get out of the simulation loop and let the thread finish.

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas