### PR TITLE
APIs to get the start and stop time of the model

### DIFF
--- a/src/OMSimulatorLib/OMSimulator.cpp
+++ b/src/OMSimulatorLib/OMSimulator.cpp
@@ -393,10 +393,22 @@ oms_status_enu_t oms2_setTLMSocketData(const char* cref, const char* address,
                                                      managerPort, monitorPort);
 }
 
+oms_status_enu_t oms2_getStartTime(const char* cref, double *startTime)
+{
+  logTrace();
+  return oms2::Scope::GetInstance().getStartTime(oms2::ComRef(cref), startTime);
+}
+
 oms_status_enu_t oms2_setStartTime(const char* cref, double startTime)
 {
   logTrace();
   return oms2::Scope::GetInstance().setStartTime(oms2::ComRef(cref), startTime);
+}
+
+oms_status_enu_t oms2_getStopTime(const char* cref, double *stopTime)
+{
+  logTrace();
+  return oms2::Scope::GetInstance().getStopTime(oms2::ComRef(cref), stopTime);
 }
 
 oms_status_enu_t oms2_setStopTime(const char* cref, double stopTime)

--- a/src/OMSimulatorLib/OMSimulator.h
+++ b/src/OMSimulatorLib/OMSimulator.h
@@ -501,6 +501,15 @@ oms_status_enu_t oms2_getBooleanParameter(const char* signal, bool* value);
 oms_status_enu_t oms2_setBooleanParameter(const char* signal, bool value);
 
 /**
+ * \brief Get the start time from the model.
+ *
+ * \param cref        [in] Name of the model instance
+ * \param startTime   [out] Start time
+ * \return            Error status
+ */
+oms_status_enu_t oms2_getStartTime(const char* cref, double *startTime);
+
+/**
  * \brief Set the start time of the simulation.
  *
  * \param cref        [in] Name of the model instance
@@ -508,6 +517,15 @@ oms_status_enu_t oms2_setBooleanParameter(const char* signal, bool value);
  * \return            Error status
  */
 oms_status_enu_t oms2_setStartTime(const char* cref, double startTime);
+
+/**
+ * \brief Get the stop time from the model.
+ *
+ * \param cref       [in] Name of the model instance
+ * \param stopTime   [out] Stop time
+ * \return           Error status
+ */
+oms_status_enu_t oms2_getStopTime(const char* cref, double *stopTime);
 
 /**
  * \brief Set the stop time of the simulation.

--- a/src/OMSimulatorLib/Scope.cpp
+++ b/src/OMSimulatorLib/Scope.cpp
@@ -1359,6 +1359,23 @@ oms_status_enu_t oms2::Scope::describeModel(const oms2::ComRef &cref)
   return model->describe();
 }
 
+oms_status_enu_t oms2::Scope::getStartTime(const ComRef& cref, double *startTime)
+{
+  if (cref.isIdent())
+  {
+    // Model
+    Model* model = getModel(cref);
+    if (!model)
+    {
+      logError("[oms2::Scope::getStartTime] failed");
+      return oms_status_error;
+    }
+    *startTime = model->getStartTime();
+    return oms_status_ok;
+  }
+  return oms_status_error;
+}
+
 oms_status_enu_t oms2::Scope::setStartTime(const ComRef& cref, double startTime)
 {
   if (cref.isIdent())
@@ -1371,6 +1388,23 @@ oms_status_enu_t oms2::Scope::setStartTime(const ComRef& cref, double startTime)
       return oms_status_error;
     }
     model->setStartTime(startTime);
+    return oms_status_ok;
+  }
+  return oms_status_error;
+}
+
+oms_status_enu_t oms2::Scope::getStopTime(const ComRef& cref, double *stopTime)
+{
+  if (cref.isIdent())
+  {
+    // Model
+    Model* model = getModel(cref);
+    if (!model)
+    {
+      logError("[oms2::Scope::getStopTime] failed");
+      return oms_status_error;
+    }
+    *stopTime = model->getStopTime();
     return oms_status_ok;
   }
   return oms_status_error;

--- a/src/OMSimulatorLib/Scope.h
+++ b/src/OMSimulatorLib/Scope.h
@@ -97,7 +97,9 @@ namespace oms2
     oms_status_enu_t setBooleanParameter(const oms2::SignalRef& signal, bool value);
     oms_status_enu_t setTempDirectory(const std::string& newTempDir);
     oms_status_enu_t setWorkingDirectory(const std::string& path);
+    oms_status_enu_t getStartTime(const ComRef& cref, double *startTime);
     oms_status_enu_t setStartTime(const ComRef& cref, double startTime);
+    oms_status_enu_t getStopTime(const ComRef& cref, double *stopTime);
     oms_status_enu_t setStopTime(const ComRef& cref, double stopTime);
     oms_status_enu_t setCommunicationInterval(const ComRef& cref, double communicationInterval);
     oms_status_enu_t setResultFile(const ComRef& cref, const std::string& filename);


### PR DESCRIPTION
Fixes #151 

## Purpose

Required APIs to read the start and stop time of the model.

## Type of Change

- New feature (non-breaking change which adds functionality)

## Checklist

- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas