### PR TITLE
Start stop time lua

### DIFF
--- a/src/OMSimulatorLib/OMSimulator.cpp
+++ b/src/OMSimulatorLib/OMSimulator.cpp
@@ -393,7 +393,7 @@ oms_status_enu_t oms2_setTLMSocketData(const char* cref, const char* address,
                                                      managerPort, monitorPort);
 }
 
-oms_status_enu_t oms2_getStartTime(const char* cref, double *startTime)
+oms_status_enu_t oms2_getStartTime(const char* cref, double* startTime)
 {
   logTrace();
   return oms2::Scope::GetInstance().getStartTime(oms2::ComRef(cref), startTime);
@@ -405,7 +405,7 @@ oms_status_enu_t oms2_setStartTime(const char* cref, double startTime)
   return oms2::Scope::GetInstance().setStartTime(oms2::ComRef(cref), startTime);
 }
 
-oms_status_enu_t oms2_getStopTime(const char* cref, double *stopTime)
+oms_status_enu_t oms2_getStopTime(const char* cref, double* stopTime)
 {
   logTrace();
   return oms2::Scope::GetInstance().getStopTime(oms2::ComRef(cref), stopTime);

--- a/src/OMSimulatorLib/OMSimulator.h
+++ b/src/OMSimulatorLib/OMSimulator.h
@@ -507,7 +507,7 @@ oms_status_enu_t oms2_setBooleanParameter(const char* signal, bool value);
  * \param startTime   [out] Start time
  * \return            Error status
  */
-oms_status_enu_t oms2_getStartTime(const char* cref, double *startTime);
+oms_status_enu_t oms2_getStartTime(const char* cref, double* startTime);
 
 /**
  * \brief Set the start time of the simulation.
@@ -525,7 +525,7 @@ oms_status_enu_t oms2_setStartTime(const char* cref, double startTime);
  * \param stopTime   [out] Stop time
  * \return           Error status
  */
-oms_status_enu_t oms2_getStopTime(const char* cref, double *stopTime);
+oms_status_enu_t oms2_getStopTime(const char* cref, double* stopTime);
 
 /**
  * \brief Set the stop time of the simulation.

--- a/src/OMSimulatorLib/Scope.cpp
+++ b/src/OMSimulatorLib/Scope.cpp
@@ -1359,7 +1359,7 @@ oms_status_enu_t oms2::Scope::describeModel(const oms2::ComRef &cref)
   return model->describe();
 }
 
-oms_status_enu_t oms2::Scope::getStartTime(const ComRef& cref, double *startTime)
+oms_status_enu_t oms2::Scope::getStartTime(const ComRef& cref, double* startTime)
 {
   if (cref.isIdent())
   {
@@ -1393,7 +1393,7 @@ oms_status_enu_t oms2::Scope::setStartTime(const ComRef& cref, double startTime)
   return oms_status_error;
 }
 
-oms_status_enu_t oms2::Scope::getStopTime(const ComRef& cref, double *stopTime)
+oms_status_enu_t oms2::Scope::getStopTime(const ComRef& cref, double* stopTime)
 {
   if (cref.isIdent())
   {

--- a/src/OMSimulatorLib/Scope.h
+++ b/src/OMSimulatorLib/Scope.h
@@ -97,9 +97,9 @@ namespace oms2
     oms_status_enu_t setBooleanParameter(const oms2::SignalRef& signal, bool value);
     oms_status_enu_t setTempDirectory(const std::string& newTempDir);
     oms_status_enu_t setWorkingDirectory(const std::string& path);
-    oms_status_enu_t getStartTime(const ComRef& cref, double *startTime);
+    oms_status_enu_t getStartTime(const ComRef& cref, double* startTime);
     oms_status_enu_t setStartTime(const ComRef& cref, double startTime);
-    oms_status_enu_t getStopTime(const ComRef& cref, double *stopTime);
+    oms_status_enu_t getStopTime(const ComRef& cref, double* stopTime);
     oms_status_enu_t setStopTime(const ComRef& cref, double stopTime);
     oms_status_enu_t setCommunicationInterval(const ComRef& cref, double communicationInterval);
     oms_status_enu_t setResultFile(const ComRef& cref, const std::string& filename);

--- a/src/OMSimulatorLua/OMSimulatorLua.c
+++ b/src/OMSimulatorLua/OMSimulatorLua.c
@@ -332,6 +332,21 @@ static int OMSimulatorLua_oms2_setRealParameter(lua_State *L)
   return 1;
 }
 
+//oms_status_enu_t oms2_getStartTime(const char* cref, double* startTime);
+static int OMSimulatorLua_oms2_getStartTime(lua_State *L)
+{
+  if (lua_gettop(L) != 1)
+    return luaL_error(L, "expecting exactly 1 argument");
+  luaL_checktype(L, 1, LUA_TSTRING);
+
+  const char* cref = lua_tostring(L, 1);
+  double startTime = 0.0;
+  oms_status_enu_t status = oms2_getStartTime(cref, &startTime);
+  lua_pushnumber(L, startTime);
+  lua_pushinteger(L, status);
+  return 2;
+}
+
 //oms_status_enu_t oms2_setStartTime(const char* cref, double startTime);
 static int OMSimulatorLua_oms2_setStartTime(lua_State *L)
 {
@@ -345,6 +360,21 @@ static int OMSimulatorLua_oms2_setStartTime(lua_State *L)
   oms_status_enu_t status = oms2_setStartTime(cref, startTime);
   lua_pushinteger(L, status);
   return 1;
+}
+
+//oms_status_enu_t oms2_getStopTime(const char* cref, double* stopTime);
+static int OMSimulatorLua_oms2_getStopTime(lua_State *L)
+{
+  if (lua_gettop(L) != 1)
+    return luaL_error(L, "expecting exactly 1 argument");
+  luaL_checktype(L, 1, LUA_TSTRING);
+
+  const char* cref = lua_tostring(L, 1);
+  double stopTime = 1.0;
+  oms_status_enu_t status = oms2_getStopTime(cref, &stopTime);
+  lua_pushnumber(L, stopTime);
+  lua_pushinteger(L, status);
+  return 2;
 }
 
 //oms_status_enu_t oms2_setStopTime(const char* cref, double stopTime);
@@ -1115,7 +1145,9 @@ DLLEXPORT int luaopen_OMSimulatorLua(lua_State *L)
   REGISTER_LUA_CALL(oms2_setReal);
   REGISTER_LUA_CALL(oms2_setRealParameter);
   REGISTER_LUA_CALL(oms2_setResultFile);
+  REGISTER_LUA_CALL(oms2_getStartTime);
   REGISTER_LUA_CALL(oms2_setStartTime);
+  REGISTER_LUA_CALL(oms2_getStopTime);
   REGISTER_LUA_CALL(oms2_setStopTime);
   REGISTER_LUA_CALL(oms2_setTempDirectory);
   REGISTER_LUA_CALL(oms2_setTLMSocketData);

--- a/src/OMSimulatorPython/OMSimulator.py
+++ b/src/OMSimulatorPython/OMSimulator.py
@@ -116,8 +116,14 @@ class OMSimulator:
     self.obj.oms2_setResultFile.argtypes = [ctypes.c_char_p, ctypes.c_char_p]
     self.obj.oms2_setResultFile.restype = ctypes.c_int
 
+    self.obj.oms2_getStartTime.argtypes = [ctypes.c_char_p]
+    self.obj.oms2_getStartTime.restype = ctypes.c_int
+
     self.obj.oms2_setStartTime.argtypes = [ctypes.c_char_p, ctypes.c_double]
     self.obj.oms2_setStartTime.restype = ctypes.c_int
+
+    self.obj.oms2_getStopTime.argtypes = [ctypes.c_char_p]
+    self.obj.oms2_getStopTime.restype = ctypes.c_int
 
     self.obj.oms2_setStopTime.argtypes = [ctypes.c_char_p, ctypes.c_double]
     self.obj.oms2_setStopTime.restype = ctypes.c_int
@@ -230,8 +236,16 @@ class OMSimulator:
     return self.obj.oms2_setRealParameter(str.encode(signal), value)
   def setResultFile(self, cref, filename):
     return self.obj.oms2_setResultFile(str.encode(cref), str.encode(filename))
+  def getStartTime(self, ident):
+    startTime = ctypes.c_double()
+    status = self.obj.oms2_getStartTime(str.encode(ident), ctypes.byref(startTime))
+    return [status, startTime.value]
   def setStartTime(self, cref, startTime):
     return self.obj.oms2_setStartTime(str.encode(cref), startTime)
+  def getStopTime(self, ident):
+    stopTime = ctypes.c_double()
+    status = self.obj.oms2_getStopTime(str.encode(ident), ctypes.byref(stopTime))
+    return [status, stopTime.value]
   def setStopTime(self, cref, stopTime):
     return self.obj.oms2_setStopTime(str.encode(cref), stopTime)
   def setTempDirectory(self, filename):


### PR DESCRIPTION
Fixes #151 

## Purpose

Add bindings to the Python and Lua interface for `getStartTime` and `getStopTime`.

## Type of Change

- New feature (non-breaking change which adds functionality)

## Checklist

- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas