### PR TITLE
Lua command for setting initial TLM values

### DIFF
--- a/src/OMSimulatorLib/FMICompositeModel.h
+++ b/src/OMSimulatorLib/FMICompositeModel.h
@@ -98,6 +98,7 @@ namespace oms2
     oms_status_enu_t setRealInputDerivatives(const oms2::SignalRef& sr, int order, double value);
 
     oms_status_enu_t addTLMInterface(TLMInterface *ifc);
+    oms_status_enu_t setTLMInitialValues(std::string ifc, std::vector<double> value);
 
     double getCurrentTime() {return time;}
 
@@ -149,6 +150,7 @@ namespace oms2
     double communicationInterval;
 
     std::vector<SignalRef> tlmSigRefs;
+    std::map<std::string, std::vector<double> > tlmInitialValues;
   };
 }
 

--- a/src/OMSimulatorLib/Model.cpp
+++ b/src/OMSimulatorLib/Model.cpp
@@ -207,6 +207,18 @@ oms2::TLMCompositeModel* oms2::Model::getTLMCompositeModel()
   return NULL;
 }
 
+oms_status_enu_t oms2::Model::setTLMInitialValues(const oms2::SignalRef &ifc, std::vector<double> values)
+{
+  if(this->getType() != oms_component_tlm) {
+    logError("Can only set initial TLM values on TLM models.");
+    return oms_status_error;
+  }
+
+  TLMCompositeModel *tlmModel = this->getTLMCompositeModel();
+
+  return tlmModel->setTLMInitialValues(ifc, values);
+}
+
 oms_status_enu_t oms2::Model::initialize()
 {
   if (oms_modelState_instantiated != modelState)

--- a/src/OMSimulatorLib/Model.h
+++ b/src/OMSimulatorLib/Model.h
@@ -83,6 +83,8 @@ namespace oms2
     const ComRef getName() const {return compositeModel->getName();}
     void setName(const ComRef& name) {compositeModel->setName(name);}
 
+    oms_status_enu_t setTLMInitialValues(const SignalRef& ifc, std::vector<double> value);
+
     virtual oms_status_enu_t describe() { return compositeModel->describe(); }
     oms_status_enu_t initialize();
     oms_status_enu_t reset();

--- a/src/OMSimulatorLib/OMSimulator.cpp
+++ b/src/OMSimulatorLib/OMSimulator.cpp
@@ -393,6 +393,12 @@ oms_status_enu_t oms2_setTLMSocketData(const char* cref, const char* address,
                                                      managerPort, monitorPort);
 }
 
+oms_status_enu_t oms2_setTLMInitialValues(const char *cref, const char *ifc, const double values[], int nvalues)
+{
+  logTrace();
+  return oms2::Scope::GetInstance().setTLMInitialValues(oms2::ComRef(cref), oms2::SignalRef(ifc), std::vector<double>(values, values+nvalues));
+}
+
 oms_status_enu_t oms2_getStartTime(const char* cref, double* startTime)
 {
   logTrace();

--- a/src/OMSimulatorLib/OMSimulator.h
+++ b/src/OMSimulatorLib/OMSimulator.h
@@ -340,6 +340,15 @@ oms_status_enu_t oms2_setTLMSocketData(const char* cref, const char* address,
                                        int managerPort, int monitorPort);
 
 /**
+ * \brief Sets initial value for a TLM interface
+ *
+ * \param cref  [in] Identifier of TLM composite model.
+ * \param from  [in] TLM interface (format: submodel:interface)
+ * \param value [in] Initial variable value
+ */
+oms_status_enu_t oms2_setTLMInitialValues(const char *cref, const char *ifc, const double values[], int nvalues);
+
+/**
  * \brief Adds an external model to a TLM composite model
  *
  * \param cref         [in] Identifier of TLM composite model.

--- a/src/OMSimulatorLib/Scope.cpp
+++ b/src/OMSimulatorLib/Scope.cpp
@@ -1347,6 +1347,17 @@ oms_status_enu_t oms2::Scope::setTLMSocketData(oms2::ComRef modelIdent,
   return tlmModel->setSocketData(address, managerPort, monitorPort);
 }
 
+oms_status_enu_t oms2::Scope::setTLMInitialValues(const oms2::ComRef &cref, const oms2::SignalRef &ifc, std::vector<double> values)
+{
+  Model *model = getModel(cref);
+  if(!model) {
+    logError("In Scope::setTLMSocketData(): Model \""+cref.toString()+"\" not found.");
+    return oms_status_error;
+  }
+
+  return model->setTLMInitialValues(ifc, values);
+}
+
 oms_status_enu_t oms2::Scope::describeModel(const oms2::ComRef &cref)
 {
   oms2::Model* model = getModel(cref);

--- a/src/OMSimulatorLib/Scope.h
+++ b/src/OMSimulatorLib/Scope.h
@@ -125,6 +125,7 @@ namespace oms2
     oms_status_enu_t addTLMInterface(const ComRef& cref, const ComRef& subref, const ComRef& name, int dimensions, oms_causality_enu_t causality, std::string domain, oms_tlm_interpolation_t interpolation, std::vector<SignalRef> &sigrefs);
     oms_status_enu_t addTLMConnection(const ComRef& cref, const SignalRef& from, const SignalRef& to, double delay, double alpha, double Zf, double Zfr);
     oms_status_enu_t setTLMSocketData(ComRef modelIdent, const std::string &address, int managerPort, int monitorPort);
+    oms_status_enu_t setTLMInitialValues(const ComRef& cref, const SignalRef& ifc, std::vector<double> values);
     oms_status_enu_t describeModel(const ComRef& cref);
 
   private:

--- a/src/OMSimulatorLib/TLMCompositeModel.cpp
+++ b/src/OMSimulatorLib/TLMCompositeModel.cpp
@@ -291,6 +291,16 @@ oms_status_enu_t oms2::TLMCompositeModel::setSocketData(const std::string& addre
   return oms_status_ok;
 }
 
+oms_status_enu_t oms2::TLMCompositeModel::setTLMInitialValues(const SignalRef& ifc, std::vector<double> values)
+{
+  FMICompositeModel *pFMISubModel = Scope::GetInstance().getFMICompositeModel(ifc.getCref());
+  if(pFMISubModel) {
+    return pFMISubModel->setTLMInitialValues(ifc.getVar(), values);
+  }
+  logError("In TLMCompositeModel::setTLMInitialValues(): FMI submodel \""+ifc.getCref().toString()+"\" not found.");
+  return oms_status_error;
+}
+
 oms_status_enu_t oms2::TLMCompositeModel::describe()
 {
   omtlm_printModelStructure(model);

--- a/src/OMSimulatorLib/TLMCompositeModel.h
+++ b/src/OMSimulatorLib/TLMCompositeModel.h
@@ -73,6 +73,8 @@ namespace oms2
                                    int managerPort,
                                    int monitorPort);
 
+    oms_status_enu_t setTLMInitialValues(const SignalRef &ifc, std::vector<double> value);
+
     oms_status_enu_t describe();
 
     oms_status_enu_t initialize(double startTime, double tolerance);

--- a/src/OMSimulatorLua/OMSimulatorLua.c
+++ b/src/OMSimulatorLua/OMSimulatorLua.c
@@ -846,6 +846,48 @@ static int OMSimulatorLua_oms2_setTLMSocketData(lua_State *L)
   return 1;
 }
 
+
+//oms_status_enu_t oms2_setTLMInitialValues(const char *cref, const char *ifc, double value1, double value2...));
+static int OMSimulatorLua_oms2_setTLMInitialValues(lua_State *L)
+{
+  //First parse initial arguments (3 or 8)
+  if(lua_gettop(L) != 3 && lua_gettop(L) != 8) {
+    return luaL_error(L, "expecting exactly 3 or 8 arguments");
+  }
+
+  luaL_checktype(L, 1, LUA_TSTRING);
+  luaL_checktype(L, 2, LUA_TSTRING);
+  luaL_checktype(L, 3, LUA_TNUMBER);
+  if(lua_gettop(L) > 3) {
+    luaL_checktype(L, 4, LUA_TNUMBER);
+    luaL_checktype(L, 5, LUA_TNUMBER);
+    luaL_checktype(L, 6, LUA_TNUMBER);
+    luaL_checktype(L, 7, LUA_TNUMBER);
+    luaL_checktype(L, 8, LUA_TNUMBER);
+  }
+
+  oms_status_enu_t status;
+  const char *cref =    lua_tostring(L, 1);
+  const char *subref =  lua_tostring(L, 2);
+  if(lua_gettop(L) == 3) {
+    double values[1];
+    values[0] = lua_tonumber(L,3);
+    status = oms2_setTLMInitialValues(cref, subref, values, 1);
+  }
+  else if(lua_gettop(L) == 3) {
+    double values[6];
+    values[0] = lua_tonumber(L,3);
+    values[1] = lua_tonumber(L,4);
+    values[2] = lua_tonumber(L,5);
+    values[3] = lua_tonumber(L,6);
+    values[4] = lua_tonumber(L,7);
+    values[5] = lua_tonumber(L,8);
+    status = oms2_setTLMInitialValues(cref, subref, values, 6);
+  }
+  lua_pushinteger(L, status);
+  return 1;
+}
+
 /* **************************************************** */
 /* OMSysIdent API                                       */
 /* **************************************************** */
@@ -1118,6 +1160,7 @@ DLLEXPORT int luaopen_OMSimulatorLua(lua_State *L)
   REGISTER_LUA_CALL(oms2_addTable);
   REGISTER_LUA_CALL(oms2_addTLMConnection);
   REGISTER_LUA_CALL(oms2_addTLMInterface);
+  REGISTER_LUA_CALL(oms2_setTLMInitialValues);
   REGISTER_LUA_CALL(oms2_compareSimulationResults);
   REGISTER_LUA_CALL(oms2_deleteConnection);
   REGISTER_LUA_CALL(oms2_deleteSubModel);


### PR DESCRIPTION
## Related Issues

Fixes #175 

## Purpose

API function for setting intial value/effort in TLM interfaces

## Approach

Added a Lua function, which inserts variables in a map. When sockets are initialized, initial values are taken from the map if they exist, otherwise from the FMI modelDescription.

## Type of Change

- New feature (non-breaking change which adds functionality)

## Checklist

- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings

---

## Open Questions and Pre-Merge TODOs
