### PR TITLE
Fix target VS15-Win32

### DIFF
--- a/configWinVS.bat
+++ b/configWinVS.bat
@@ -142,14 +142,14 @@ IF ["%CERES%"]==["OFF"] (
 :: -- config pthread ----------------------------------------------------------
 ECHO # config pthread
 CD 3rdParty\pthread
-CALL buildWinVS.bat
+CALL buildWinVS.bat "%OMS_VS_TARGET%"
 CD ..\..
 :: -- config pthread ----------------------------------------------------------
 
 :: -- config libxml2 ----------------------------------------------------------
 ECHO # config libxml2
 CD 3rdParty\libxml2
-CALL buildWinVS.bat
+CALL buildWinVS.bat "%OMS_VS_TARGET%"
 CD ..\..
 :: -- config libxml2 ----------------------------------------------------------
 


### PR DESCRIPTION
## Related Issues

#197

## Purpose

Use the correct compiler environment and stop if an error occurs.

## Approach

Pass the target specifier to all the bat files.

## Type of Change

<!--- Please delete options that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas