### PR TITLE
Fix memory leaks in TLMCompositeModel

### DIFF
--- a/src/OMSimulatorLib/TLMCompositeModel.cpp
+++ b/src/OMSimulatorLib/TLMCompositeModel.cpp
@@ -70,7 +70,7 @@ oms2::TLMCompositeModel::~TLMCompositeModel()
     }
     externalModels.clear();
 
-    delete model;
+    omtlm_unloadModel(model);
 }
 
 oms2::TLMCompositeModel* oms2::TLMCompositeModel::NewModel(const ComRef& name)
@@ -383,7 +383,11 @@ oms_status_enu_t oms2::TLMCompositeModel::reset()
 
 oms_status_enu_t oms2::TLMCompositeModel::terminate()
 {
-  return logError("oms2::TLMCompositeModel::terminate: not implemented yet");
+  for(auto it = fmiModels.begin(); it!=fmiModels.end(); ++it) {
+    Model* pSubModel = oms2::Scope::GetInstance().getModel(it->second->getName());
+    pSubModel->terminate();
+  }
+  return oms_status_ok;
 }
 
 oms_status_enu_t oms2::TLMCompositeModel::simulate(ResultWriter &resultWriter, double stopTime, double communicationInterval, oms2::MasterAlgorithm masterAlgorithm)


### PR DESCRIPTION
## Related Issues

Related to #147

## Purpose

ASan reports two direct memory leaks when simulating TLM models:
- TLM model object is created and deleted in different binaries
- Also, it is deleted as a void pointer
- FMI submodels are never terminated

## Approach

- Call omtlm_unload(model) instead of "delete model"
- Call terminate for submodels from terminate in TLM Composite Model

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Please delete options that are not relevant. -->

- I have performed a self-review of my own code
- My changes generate no new warnings

---

## Open Questions and Pre-Merge TODOs