### PR TITLE
Make sure inputs were set correctly after initialization

### DIFF
--- a/src/OMSimulatorLib/FMICompositeModel.cpp
+++ b/src/OMSimulatorLib/FMICompositeModel.cpp
@@ -857,6 +857,8 @@ oms_status_enu_t oms2::FMICompositeModel::initialize(double startTime, double to
     if (oms_status_ok != it.second->exitInitialization())
       return logError("[oms2::FMICompositeModel::initialize] failed");
 
+  updateInputs(outputsGraph);
+
   return oms_status_ok;
 }
 
@@ -1483,7 +1485,7 @@ oms_status_enu_t oms2::FMICompositeModel::updateInputs(oms2::DirectedGraph& grap
       double value = 0.0;
       getReal(graph.nodes[output].getSignalRef(), value);
       setReal(graph.nodes[input].getSignalRef(), value);
-      //std::cout << inputFMU << "." << inputVar << " = " << outputFMU << "." << outputVar << std::endl;
+      //std::cout << "[time " << time << "] " << graph.nodes[output].getSignalRef().toString() << " -> " << graph.nodes[input].getSignalRef().toString() << " (value: " << value << ")" << std::endl;
     }
     else
     {


### PR DESCRIPTION
### Related Issues

There is no dedicated issue for this, but the problem was reported by @meek1.

### Purpose

Inputs were in some cases not updated during initialization.

### Approach

Now inputs will be updated twice during initialization: once before and once after `exitInitialization()` of the FMI interface.

### Type of Change

- Bug fix (non-breaking change which fixes an issue)

### Checklist

- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings