### PR TITLE
Store integer and boolean types

### DIFF
--- a/src/OMSimulatorLib/FMUWrapper.cpp
+++ b/src/OMSimulatorLib/FMUWrapper.cpp
@@ -1243,6 +1243,16 @@ oms_status_enu_t oms2::FMUWrapper::registerSignalsForResultFile(ResultWriter& re
         getReal(var, value.realValue);
         resultWriter.addParameter(name, description, SignalType_REAL, value);
       }
+      else if (var.isTypeInteger())
+      {
+        getInteger(var, value.intValue);
+        resultWriter.addParameter(name, description, SignalType_INT, value);
+      }
+      else if (var.isTypeBoolean())
+      {
+        getBoolean(var, value.boolValue);
+        resultWriter.addParameter(name, description, SignalType_BOOL, value);
+      }
       else
         logInfo("Parameter " + name + " will not be stored in the result file, because the signal type is not supported");
     }
@@ -1251,6 +1261,16 @@ oms_status_enu_t oms2::FMUWrapper::registerSignalsForResultFile(ResultWriter& re
       if (var.isTypeReal())
       {
         unsigned int ID = resultWriter.addSignal(name, description, SignalType_REAL);
+        resultFileMapping[ID] = i;
+      }
+      else if (var.isTypeInteger())
+      {
+        unsigned int ID = resultWriter.addSignal(name, description, SignalType_INT);
+        resultFileMapping[ID] = i;
+      }
+      else if (var.isTypeBoolean())
+      {
+        unsigned int ID = resultWriter.addSignal(name, description, SignalType_BOOL);
         resultFileMapping[ID] = i;
       }
       else

--- a/src/OMSimulatorLib/Variable.h
+++ b/src/OMSimulatorLib/Variable.h
@@ -82,7 +82,7 @@ namespace oms2
     const std::string& getDescription() const { return description; }
 
     bool isTypeReal() const { return oms_signal_type_real == type; }
-    bool isTypeInteger() const { return oms_signal_type_integer == type; }
+    bool isTypeInteger() const { return oms_signal_type_integer == type || oms_signal_type_enum == type; }
     bool isTypeBoolean() const { return oms_signal_type_boolean == type; }
 
     std::string getCausalityString() { return std::string(fmi2_causality_to_string(causality)); }


### PR DESCRIPTION
Fixes #206 

## Purpose

Right now only type real is stored in the result file. Other types are not supported.

## Approach

Store the other types like Integer and Boolean to the result file.

## Type of Change

- New feature (non-breaking change which adds functionality)

## Checklist

- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas