### PR TITLE
Fixed `oms2_setIntegerParameter` and `oms2_setBooleanParameter`

### DIFF
--- a/src/OMSimulatorLib/FMUWrapper.cpp
+++ b/src/OMSimulatorLib/FMUWrapper.cpp
@@ -1019,7 +1019,11 @@ oms_status_enu_t oms2::FMUWrapper::setIntegerParameter(const std::string& var, i
     return logError("No such parameter: " + var);
 
   it->second = value;
-  return oms_status_ok;
+
+  oms2::Variable* v = getVariable(var);
+  if (!v)
+    return oms_status_error;
+  return setInteger(*v, value);
 }
 
 oms_status_enu_t oms2::FMUWrapper::getIntegerParameter(const std::string& var, int& value)
@@ -1050,7 +1054,11 @@ oms_status_enu_t oms2::FMUWrapper::setBooleanParameter(const std::string& var, b
     return logError("No such parameter: " + var);
 
   it->second = value;
-  return oms_status_ok;
+
+  oms2::Variable* v = getVariable(var);
+  if (!v)
+    return oms_status_error;
+  return setBoolean(*v, value);
 }
 
 oms_status_enu_t oms2::FMUWrapper::getBooleanParameter(const std::string& var, bool& value)


### PR DESCRIPTION
Fixes #206 

## Purpose

`oms2_setIntegerParameter` and `oms2_setBooleanParameter` doesn not call the actual FMU C-API functions.

## Approach

Call the FMU C-API functions so that the parameters values are set.

## Type of Change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas