### PR TITLE
add a OMTLMSimulatorStandalone target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,14 @@ OMTLMSimulator:
 	test ! `uname` != Darwin || cp OMTLMSimulator/bin/FMIWrapper $(INSTALL_DIR)/bin/
 	test ! `uname` != Darwin || cp OMTLMSimulator/bin/StartTLMFmiWrapper $(INSTALL_DIR)/bin/
 
+OMTLMSimulatorStandalone: config-fmil
+	@echo
+	@echo "# make OMTLMSimulator Standalone"
+	@echo
+	@echo $(ABI)
+	@$(MAKE) -C OMTLMSimulator install
+
+
 config-3rdParty: config-fmil config-lua config-cvode config-kinsol config-gflags config-glog config-ceres-solver config-libxml2
 
 config-OMSimulator:


### PR DESCRIPTION
## Purpose

Need to build OMTLMSimulator standalone for OM release/nightly builds

## Type of Change

- New feature (non-breaking change which adds functionality)

## Checklist

- I have performed a self-review of my own code
