### PR TITLE
Add a Jenkins pipeline

### DIFF
--- a/.CI/cache-32/Dockerfile
+++ b/.CI/cache-32/Dockerfile
@@ -1,0 +1,6 @@
+# Cannot be parametrized in Jenkins...
+FROM docker.openmodelica.org/build-deps:v1.13-i386
+
+# We don't know the uid of the user who will build, so make the /cache directories world writable
+
+RUN mkdir -p /cache/runtest/ /cache/omlibrary/ && chmod ugo+rwx /cache/runtest/ /cache/omlibrary/

--- a/.CI/cache-arm32/Dockerfile
+++ b/.CI/cache-arm32/Dockerfile
@@ -1,0 +1,6 @@
+# Cannot be parametrized in Jenkins...
+FROM docker.openmodelica.org/build-deps:v1.13-arm32
+
+# We don't know the uid of the user who will build, so make the /cache directories world writable
+
+RUN mkdir -p /cache/runtest/ /cache/omlibrary/ && chmod ugo+rwx /cache/runtest/ /cache/omlibrary/

--- a/.CI/cache/Dockerfile
+++ b/.CI/cache/Dockerfile
@@ -1,0 +1,6 @@
+# Cannot be parametrized in Jenkins...
+FROM docker.openmodelica.org/build-deps:v1.13
+
+# We don't know the uid of the user who will build, so make the /cache directories world writable
+
+RUN mkdir -p /cache/runtest/ /cache/omlibrary/ && chmod ugo+rwx /cache/runtest/ /cache/omlibrary/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,3 +170,5 @@ IF (Ceres_FOUND AND OMSYSIDENT)
   enable_testing()
   add_subdirectory(src/OMSysIdentLib)
 ENDIF()
+
+ADD_DEPENDENCIES(OMSimulator OMSimulatorLib)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,428 @@
+pipeline {
+  agent none
+  environment {
+    CACHE_DIR = "testsuite/cache/${env.CHANGE_TARGET ?: env.GIT_BRANCH}"
+  }
+  options {
+    newContainerPerStage()
+  }
+  stages {
+    stage('build') {
+      parallel {
+        stage('linux64') {
+          agent {
+            dockerfile {
+              additionalBuildArgs '--pull'
+              dir '.CI/cache'
+              /* The cache Dockerfile makes /cache/runtest, etc world writable
+               * This is necessary because we run the docker image as a user and need to
+               * be able to have a global caching of the omlibrary parts and the runtest database.
+               * Note that the database is stored in a volume on a per-node basis, so the first time
+               * the tests run on a particular node, they might execute slightly slower
+               */
+              label 'linux'
+              args "--mount type=volume,source=runtest-omsimulator-cache-linux64,target=/cache/runtest"
+            }
+          }
+          environment {
+            RUNTESTDB = "/cache/runtest/"
+            NPROC = "${numPhysicalCPU}"
+          }
+          steps {
+            buildOMS()
+            sh '''
+            # No so-files should ever exist in a bin/ folder
+            ! ls install/linux/bin/*.so 1> /dev/null 2>&1
+            (cd install/linux && tar czf "../../OMSimulator-linux-amd64-`git describe`.tar.gz" *)
+            '''
+
+            archiveArtifacts "OMSimulator-linux-amd64-*.tar.gz"
+
+            partest()
+
+            junit 'testsuite/partest/result.xml'
+
+            // Temporary debugging
+            // archiveArtifacts artifacts: 'testsuite/**/*.log', fingerprint: true
+
+            sh 'make doc doc-html doc-doxygen'
+            sh '(cd install/linux/doc && zip -r "../../../OMSimulator-doc-`git describe`.zip" *)'
+            archiveArtifacts artifacts: 'OMSimulator-doc*.zip', fingerprint: true
+            stash name: 'docs', includes: "install/linux/doc/**"
+          }
+        }
+        stage('linux64-asan') {
+          stages {
+            stage('build') {
+              agent {
+                docker {
+                  image 'docker.openmodelica.org/build-deps:v1.13'
+                  label 'linux'
+                  alwaysPull true
+                }
+              }
+              environment {
+                RUNTESTDB = "/cache/runtest/"
+                ASAN = "ON"
+              }
+              steps {
+                buildOMS()
+                stash name: 'asan', includes: "install/linux/**"
+              }
+            }
+            stage('test') {
+              agent {
+                dockerfile {
+                  additionalBuildArgs '--pull'
+                  dir '.CI/cache'
+                  /* The cache Dockerfile makes /cache/runtest, etc world writable
+                   * This is necessary because we run the docker image as a user and need to
+                   * be able to have a global caching of the omlibrary parts and the runtest database.
+                   * Note that the database is stored in a volume on a per-node basis, so the first time
+                   * the tests run on a particular node, they might execute slightly slower
+                   */
+                  label 'linux'
+                  args "--mount type=volume,source=runtest-omsimulator-cache-linux64-asan,target=/cache/runtest " +
+                       "--cap-add SYS_PTRACE " + // Needed for ASAN
+                       "--oom-kill-disable -m 1024m --memory-swap 1024m" // Needed for ASAN
+                }
+              }
+              environment {
+                RUNTESTDB = "/cache/runtest/"
+                ASAN = "ON"
+              }
+              steps {
+                unstash name: 'asan'
+                partest()
+                junit 'testsuite/partest/result.xml'
+              }
+            }
+          }
+        }
+        stage('linux32') {
+          agent {
+            dockerfile {
+              additionalBuildArgs '--pull'
+              dir '.CI/cache-32'
+              /* The cache Dockerfile makes /cache/runtest, etc world writable
+               * This is necessary because we run the docker image as a user and need to
+               * be able to have a global caching of the omlibrary parts and the runtest database.
+               * Note that the database is stored in a volume on a per-node basis, so the first time
+               * the tests run on a particular node, they might execute slightly slower
+               */
+              label 'linux'
+              args "--mount type=volume,source=runtest-omsimulator-cache-linux32,target=/cache/runtest"
+            }
+          }
+          environment {
+            RUNTESTDB = "/cache/runtest/"
+          }
+          steps {
+            buildOMS()
+            sh '''
+            # No so-files should ever exist in a bin/ folder
+            ! ls install/linux/bin/*.so 1> /dev/null 2>&1
+            (cd install/linux && tar czf "../../OMSimulator-linux-i386-`git describe`.tar.gz" *)
+            '''
+
+            archiveArtifacts "OMSimulator-linux-i386-*.tar.gz"
+
+            partest()
+
+            // Disable until working
+            // junit 'testsuite/partest/result.xml'
+          }
+        }
+        stage('linux-arm32') {
+          stages {
+            stage('cross-compile') {
+              agent {
+                docker {
+                  image 'docker.openmodelica.org/armcross-omsimulator:v2.0'
+                  label 'linux'
+                  alwaysPull true
+                }
+              }
+              environment {
+                CROSS_TRIPLE = "arm-linux-gnueabihf"
+                CC = "${env.CROSS_TRIPLE}-gcc"
+                CXX = "${env.CROSS_TRIPLE}-g++"
+                AR = "${env.CROSS_TRIPLE}-ar"
+                RANLIB = "${env.CROSS_TRIPLE}-ranlib"
+                FMIL_FLAGS = '-DFMILIB_FMI_PLATFORM=arm-linux-gnueabihf'
+                detected_OS = 'Linux'
+                VERBOSE = '1'
+              }
+              steps {
+                sh 'printenv'
+                buildOMS()
+                sh '''
+                # No so-files should ever exist in a bin/ folder
+                ! ls install/linux/bin/*.so 1> /dev/null 2>&1
+                (cd install/linux && tar czf "../../OMSimulator-linux-arm32-`git describe`.tar.gz" *)
+                '''
+
+                archiveArtifacts "OMSimulator-linux-arm32-*.tar.gz"
+                stash name: 'arm32-install', includes: "install/linux/**"
+              }
+            }
+
+            stage('test') {
+              /* when {
+                beforeAgent true
+                expression { return false }
+              } */
+              agent {
+                dockerfile {
+                  additionalBuildArgs '--pull'
+                  dir '.CI/cache-arm32'
+                  /* The cache Dockerfile makes /cache/runtest, etc world writable
+                   * This is necessary because we run the docker image as a user and need to
+                   * be able to have a global caching of the omlibrary parts and the runtest database.
+                   * Note that the database is stored in a volume on a per-node basis, so the first time
+                   * the tests run on a particular node, they might execute slightly slower
+                   */
+                  label 'linux-arm32'
+                  args '--memory=500m --memory-swap=500m ' +
+                       "--mount type=volume,source=runtest-omsimulator-cache-arm32,target=/cache/runtest"
+                }
+              }
+              environment {
+                RUNTESTDB = "/cache/runtest/"
+              }
+              steps {
+                unstash name: 'arm32-install'
+
+                // Work-around for deleting logs
+                sh 'find testsuite/ -name "*.lua" -exec sed -i /teardown_command/d {} ";"'
+
+                partest()
+
+                // Disable until working
+                // junit 'testsuite/partest/result.xml'
+              }
+            }
+          }
+        }
+
+        stage('osxcross') {
+          stages {
+            stage('cross-compile') {
+              agent {
+                docker {
+                  image 'docker.openmodelica.org/osxcross-omsimulator:v2.0'
+                  label 'linux'
+                  alwaysPull true
+                }
+              }
+              environment {
+                CROSS_TRIPLE = "x86_64-apple-darwin15"
+                CC = "${env.CROSS_TRIPLE}-cc"
+                CXX = "${env.CROSS_TRIPLE}-c++"
+                AR = "${env.CROSS_TRIPLE}-ar"
+                RANLIB = "${env.CROSS_TRIPLE}-ranlib"
+                FMIL_FLAGS = '-DFMILIB_FMI_PLATFORM=darwin64'
+                detected_OS = 'Darwin'
+                VERBOSE = '1'
+                BOOST_ROOT = '/opt/osxcross/macports/pkgs/opt/local/'
+              }
+              steps {
+                buildOMS()
+                sh '''
+                (cd install/mac && zip -r "../../OMSimulator-osx-`git describe`.zip" *)
+                '''
+
+                archiveArtifacts "OMSimulator-osx*.zip"
+                stash name: 'osx-install', includes: "install/mac/**"
+              }
+            }
+
+            stage('test') {
+              /* when {
+                beforeAgent true
+                expression { return false }
+              } */
+              agent {
+                label 'osx'
+              }
+              steps {
+                unstash name: 'osx-install'
+                withEnv(["RUNTESTDB=${env.HOME}/jenkins-cache/runtest/"]) {
+                  partest()
+                }
+                junit 'testsuite/partest/result.xml'
+              }
+            }
+          }
+        }
+        stage('mingw64-cross') {
+          agent {
+            docker {
+              image 'docker.openmodelica.org/msyscross-omsimulator:v2.0'
+              label 'linux'
+              alwaysPull true
+            }
+          }
+          environment {
+            CROSS_TRIPLE = "x86_64-w64-mingw32"
+            CC = "${env.CROSS_TRIPLE}-gcc-posix"
+            CXX = "${env.CROSS_TRIPLE}-g++-posix"
+            CPPFLAGS = '-I/opt/pacman/mingw64/include'
+            LDFLAGS = '-L/opt/pacman/mingw64/lib'
+            AR = "${env.CROSS_TRIPLE}-ar-posix"
+            RANLIB = "${env.CROSS_TRIPLE}-ranlib-posix"
+            detected_OS = 'MINGW64'
+            VERBOSE = '1'
+            BOOST_ROOT = '/opt/pacman/mingw64/'
+          }
+
+          steps {
+            buildOMS()
+            sh '''
+            (cd install/mingw && zip -r "../../OMSimulator-mingw64-`git describe`.zip" *)
+            '''
+
+            archiveArtifacts "OMSimulator-mingw64*.zip"
+            stash name: 'mingw64-install', includes: "install/mingw/**"
+          }
+        }
+
+        stage('msvc64') {
+          agent {
+            label 'omsimulator-windows'
+          }
+          environment {
+            PATH = "${env.PATH};C:\\bin\\git\\bin;C:\\bin\\git\\usr\\bin;C:\\OMDev\\tools\\msys\\mingw64\\bin\\"
+            OMDEV = "/c/OMDev"
+            MSYSTEM = "MINGW64"
+          }
+
+          steps {
+            writeFile file: "buildZip.sh", text: """#!/bin/sh
+set -x -e
+export PATH="/c/Program Files/TortoiseSVN/bin/:/c/bin/jdk/bin:/c/bin/nsis/:\$PATH:/c/bin/git/bin"
+cd "${env.WORKSPACE}/install/win"
+zip -r "../../OMSimulator-win64-`git describe`.zip" *
+"""
+
+            bat """
+set BOOST_ROOT=C:\\local\\boost_1_64_0
+set PATH=C:\\bin\\cmake\\bin;%PATH%
+
+call configWinVS.bat VS15-Win64
+IF NOT ["%ERRORLEVEL%"]==["0"] GOTO fail
+
+call buildWinVS.bat VS15-Win64
+IF NOT ["%ERRORLEVEL%"]==["0"] GOTO fail
+
+call install\\win\\bin\\OMSimulator.exe --version
+IF NOT ["%ERRORLEVEL%"]==["0"] GOTO fail
+
+C:\\OMDev\\tools\\msys\\usr\\bin\\sh --login -i '${env.WORKSPACE}/buildZip.sh'
+
+EXIT /b 0
+
+:fail
+ECHO Something went wrong!
+EXIT /b 1
+"""
+
+            archiveArtifacts "OMSimulator-win64*.zip"
+          }
+        }
+
+      }
+    }
+
+    stage('upload') {
+      parallel {
+
+        stage('upload-doc') {
+          when {
+            allOf {
+              not {
+                changeRequest()
+              }
+              anyOf {
+                buildingTag()
+                anyOf {
+                  branch 'master'
+                  branch 'jenkins' // For testing purposes
+                  branch 'maintenance/**'
+                }
+              }
+            }
+            beforeAgent true
+          }
+          agent {
+            label 'linux'
+          }
+          options {
+            skipDefaultCheckout()
+          }
+          steps {
+            unstash name: 'docs'
+            sh "test ! -z '${GIT_BRANCH}'"
+            sshPublisher(publishers: [sshPublisherDesc(configName: 'OMSimulator-doc', transfers: [sshTransfer(execCommand: "rm -rf .tmp/${env.GIT_BRANCH}"), sshTransfer(execCommand: "test ! -z '${env.GIT_BRANCH}' && rm -rf '/var/www/doc/OMSimulator/${env.GIT_BRANCH}' && mkdir -p `dirname '/var/www/doc/OMSimulator/.tmp/${env.GIT_BRANCH}'` && mv '/var/www/doc/OMSimulator/.tmp/${env.GIT_BRANCH}' '/var/www/doc/OMSimulator/${env.GIT_BRANCH}'", remoteDirectory: ".tmp/${env.GIT_BRANCH}", removePrefix: "install/linux/doc", sourceFiles: 'install/linux/doc/**')])])
+          }
+        }
+
+      }
+    }
+
+  }
+}
+
+def numPhysicalCPU() {
+  def uname = sh script: 'uname', returnStdout: true
+  if (uname.startsWith("Darwin")) {
+    return sh (
+      script: 'sysctl hw.physicalcpu_max | cut -d" " -f2',
+      returnStdout: true
+    ).trim().toInteger() ?: 1
+  } else {
+    return sh (
+      script: 'lscpu -p | egrep -v "^#" | sort -u -t, -k 2,4 | wc -l',
+      returnStdout: true
+    ).trim().toInteger() ?: 1
+  }
+}
+
+void partest(cache=true, extraArgs='') {
+  echo "cache: ${cache}, asan: ${env.ASAN}"
+  sh """
+  make -C testsuite difftool
+  cp -f "${env.RUNTESTDB}/"* testsuite/ || true
+  """
+
+  // Work-around for deleting logs
+  sh 'find testsuite/ -name "*.lua" -exec sed -i /teardown_command/d {} ";"'
+
+  sh ("""#!/bin/bash -x
+  ulimit -t 1500
+  ${env.ASAN ? "" : "ulimit -v 6291456" /* Max 6GB per process */}
+
+  cd testsuite/partest
+  ./runtests.pl ${env.ASAN ? "-asan -fast": ""} -j${numPhysicalCPU()} -nocolour -with-xml ${extraArgs}
+  CODE=\$?
+  test \$CODE = 0 -o \$CODE = 7 || exit 1
+  """
+  + (cache ?
+  """
+  if test \$CODE = 0; then
+    mkdir -p "${env.RUNTESTDB}/"
+    cp ../runtest.db.* "${env.RUNTESTDB}/"
+  fi
+  """ : ''))
+}
+
+void buildOMS() {
+  def nproc = numPhysicalCPU()
+  sh """
+  export HOME="${'$'}PWD"
+  git fetch --tags
+  make config-3rdParty ${env.CC ? "CC=" + env.CC : ""} ${env.CXX ? "CXX=" + env.CXX : ""} -j${nproc}
+  make config-OMSimulator -j${nproc} ${env.ASAN ? "ASAN=ON" : ""}
+  make OMSimulator -j${nproc} ${env.ASAN ? "DISABLE_RUN_OMSIMULATOR_VERSION=1" : ""}
+  """
+}

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ ROOT_DIR=$(shell pwd)
 # Option to build Ceres-Solver and its dependencies as part of the 3rdParty projects
 CERES ?= ON
 # Option to build LIBXML2 as part of the 3rdParty projects
-LIBXML2 ?= ON
+LIBXML2 ?= $(OMTLM)
 # Option to enable the OMSysIdent parameter estimation module within the OMSimulator project
 OMSYSIDENT ?= ON
 # Option to enable OMTLM
@@ -89,12 +89,23 @@ ifeq ($(detected_OS),Darwin)
 endif
 
 ifeq ($(CROSS_TRIPLE),)
+  CMAKE=cmake $(CMAKE_TARGET)
 else
-	LUA_EXTRA_FLAGS=CC=$(CC) CXX=$(CXX) RANLIB=$(CROSS_TRIPLE)-ranlib detected_OS=$(detected_OS)
-	OMTLM := OFF
-	CROSS_TRIPLE_DASH = $(CROSS_TRIPLE)-
-	HOST_CROSS_TRIPLE = "--host=$(CROSS_TRIPLE)"
-	FMIL_FLAGS ?=
+  LUA_EXTRA_FLAGS=CC=$(CC) CXX=$(CXX) RANLIB=$(CROSS_TRIPLE)-ranlib detected_OS=$(detected_OS)
+  OMTLM := OFF
+  CERES := OFF
+  OMSYSIDENT := OFF
+  LIBXML2 := OFF
+  CROSS_TRIPLE_DASH = $(CROSS_TRIPLE)-
+  HOST_CROSS_TRIPLE = "--host=$(CROSS_TRIPLE)"
+  FMIL_FLAGS ?=
+  AR ?= $(CROSS_TRIPLE)-ar
+  RANLIB ?= $(CROSS_TRIPLE)-ranlib
+  CMAKE=cmake $(CMAKE_TARGET)
+  ifeq (MINGW,$(findstring MINGW,$(detected_OS)))
+    CMAKE_TARGET=-G "Unix Makefiles" -DCMAKE_SYSTEM_NAME=Windows -DCMAKE_RC_COMPILER=$(CROSS_TRIPLE)-windres
+  endif
+  DISABLE_RUN_OMSIMULATOR_VERSION ?= 1
 endif
 
 ifeq ($(BOOST_ROOT),)
@@ -113,7 +124,7 @@ OMSimulator:
 	@echo
 	@$(MAKE) OMTLMSimulator
 	@$(MAKE) OMSimulatorCore
-	test ! -z "$(CROSS_TRIPLE)" || $(TOP_INSTALL_DIR)/bin/OMSimulator --version
+	test ! -z "$(DISABLE_RUN_OMSIMULATOR_VERSION)" || $(TOP_INSTALL_DIR)/bin/OMSimulator --version
 
 OMSimulatorCore:
 	@echo

--- a/buildWinVS.bat
+++ b/buildWinVS.bat
@@ -51,9 +51,13 @@ IF NOT ["%ERRORLEVEL%"]==["0"] GOTO fail
 :: -- build OMSimulator -------------------------------------------------------
 
 install\win\bin\OMSimulator.exe --version
-IF NOT ["%ERRORLEVEL%"]==["0"] GOTO fail
+IF NOT ["%ERRORLEVEL%"]==["0"] GOTO omsfail
 EXIT /B 0
 
 :fail
 ECHO Build failed!
+EXIT /B 1
+
+:omsfail
+ECHO OMSimulator.exe does not start!
 EXIT /B 1

--- a/configWinVS.bat
+++ b/configWinVS.bat
@@ -48,6 +48,12 @@ SET OMFIT
 ECHO.
 :: -- init ----------------------------
 
+IF NOT EXIST build\\ mkdir build
+IF NOT EXIST build\\win\\ mkdir build\\win
+IF NOT EXIST install\\ MKDIR install
+IF NOT EXIST install\\win MKDIR install\\win
+IF NOT EXIST install\\win\\lib MKDIR install\\win\\lib
+
 IF ["%TARGET%"]==["clean"] GOTO clean
 IF ["%TARGET%"]==["fmil"] GOTO fmil
 IF ["%TARGET%"]==["lua"] GOTO lua

--- a/src/OMSimulator/CMakeLists.txt
+++ b/src/OMSimulator/CMakeLists.txt
@@ -34,7 +34,6 @@ include_directories(${LUALibrary_INCLUDEDIR})
 include_directories(../OMSysIdentLib)
 include_directories(../OMSysIdentLua)
 
-
 link_directories(${FMILibrary_LIBRARYDIR})
 link_directories(${LUALibrary_LIBRARYDIR})
 link_directories(${CVODELibrary_LIBRARYDIR})

--- a/src/OMSimulatorLib/CMakeLists.txt
+++ b/src/OMSimulatorLib/CMakeLists.txt
@@ -129,7 +129,7 @@ ENDIF()
 
 # Shared library version
 add_library(OMSimulatorLib_shared SHARED ${OMSYSIDENT_OPTION} ${OMSIMULATORLIB_SOURCES})
-set_target_properties(OMSimulatorLib_shared PROPERTIES OUTPUT_NAME OMSimulatorLib)
+set_target_properties(OMSimulatorLib_shared PROPERTIES OUTPUT_NAME OMSimulator)
 IF(WIN32 AND MSVC)
   target_link_libraries(OMSimulatorLib_shared fmilib sundials_kinsol sundials_cvode sundials_nvecserial ${Boost_LIBRARIES} ${CERES_OPTION} ${OMTLM_LINKFLAGS})
 ELSEIF(WIN32 AND MINGW)
@@ -139,13 +139,14 @@ ELSE()
 ENDIF()
 
 install(TARGETS OMSimulatorLib_shared DESTINATION lib/${HOST_SHORT})
-IF(WIN32)
+IF(WIN32 AND MSVC)
+  # MinGW can statically link
   install(TARGETS OMSimulatorLib_shared DESTINATION bin)
 ENDIF()
 
 # Static library version
 add_library(OMSimulatorLib STATIC ${OMSIMULATORLIB_SOURCES})
-set_target_properties(OMSimulatorLib PROPERTIES OUTPUT_NAME OMSimulatorLib)
+set_target_properties(OMSimulatorLib PROPERTIES OUTPUT_NAME OMSimulator)
 set_target_properties(OMSimulatorLib PROPERTIES POSITION_INDEPENDENT_CODE ON)
 install(TARGETS OMSimulatorLib DESTINATION lib/${HOST_SHORT})
 install(FILES OMSimulator.h Types.h DESTINATION include)

--- a/src/OMSimulatorLua/CMakeLists.txt
+++ b/src/OMSimulatorLua/CMakeLists.txt
@@ -21,21 +21,22 @@ IF (Ceres_FOUND AND OMSYSIDENT)
 ENDIF()
 
 # Shared library version
-add_library(OMSimulatorLua SHARED OMSimulatorLua.c)
+add_library(OMSimulatorLua STATIC OMSimulatorLua.c)
+set_target_properties(OMSimulatorLua PROPERTIES POSITION_INDEPENDENT_CODE ON)
+
 IF(WIN32 AND MSVC)
-  target_link_libraries(OMSimulatorLua OMSimulatorLib_shared fmilib sundials_kinsol sundials_cvode sundials_nvecserial lua wsock32 ws2_32)
+  target_link_libraries(OMSimulatorLua OMSimulatorLib fmilib sundials_kinsol sundials_cvode sundials_nvecserial lua wsock32 ws2_32)
 ELSEIF (WIN32 AND MINGW)
-  target_link_libraries(OMSimulatorLua OMSimulatorLib_shared fmilib shlwapi sundials_kinsol sundials_cvode sundials_nvecserial lua wsock32 ws2_32)
+  target_link_libraries(OMSimulatorLua OMSimulatorLib fmilib shlwapi sundials_kinsol sundials_cvode sundials_nvecserial lua wsock32 ws2_32)
 ELSEIF (APPLE)
-  target_link_libraries(OMSimulatorLua OMSimulatorLib_shared fmilib sundials_kinsol sundials_cvode sundials_nvecserial lua)
+  target_link_libraries(OMSimulatorLua OMSimulatorLib fmilib sundials_kinsol sundials_cvode sundials_nvecserial lua)
 ELSE ()
-  target_link_libraries(OMSimulatorLua OMSimulatorLib_shared fmilib sundials_kinsol sundials_cvode sundials_nvecserial)
+  target_link_libraries(OMSimulatorLua OMSimulatorLib fmilib sundials_kinsol sundials_cvode sundials_nvecserial)
 ENDIF ()
 
-install(TARGETS OMSimulatorLua DESTINATION lib/${HOST_SHORT})
-
 # install the damn thing MacOS style
-IF(APPLE)
-  install(CODE "execute_process(COMMAND install_name_tool -id \"@rpath/libOMSimulatorLua.dylib\" \"${CMAKE_INSTALL_PREFIX}/lib/${HOST_SHORT}/libOMSimulatorLua.dylib\")")
-  install(CODE "execute_process(COMMAND install_name_tool -change \"libOMSimulatorLib.dylib\" \"@rpath/libOMSimulatorLib.dylib\" \"${CMAKE_INSTALL_PREFIX}/lib/${HOST_SHORT}/libOMSimulatorLua.dylib\")")
-ENDIF()
+#IF(APPLE)
+#  install(CODE "execute_process(COMMAND install_name_tool -id \"@rpath/libOMSimulatorLua.dylib\" \"${CMAKE_INSTALL_PREFIX}/lib/${HOST_SHORT}/libOMSimulatorLua.dylib\")")
+#  install(CODE "execute_process(COMMAND install_name_tool -change \"libOMSimulatorLib.dylib\" \"@rpath/libOMSimulatorLib.dylib\" \"${CMAKE_INSTALL_PREFIX}/lib/${HOST_SHORT}/libOMSimulatorLua.dylib\")")
+#ENDIF()
+# install(TARGETS OMSimulatorLua DESTINATION lib/${HOST_SHORT})

--- a/src/OMSimulatorPython/OMSimulator.py
+++ b/src/OMSimulatorPython/OMSimulator.py
@@ -4,9 +4,9 @@ import ctypes, sys
 class OMSimulator:
   def __init__(self):
     if (sys.platform == 'win32'):
-      self.obj=cdll.LoadLibrary("OMSimulatorLib.dll")
+      self.obj=cdll.LoadLibrary("OMSimulator.dll")
     else:
-      self.obj=cdll.LoadLibrary("libOMSimulatorLib.so")
+      self.obj=cdll.LoadLibrary("libOMSimulator.so")
 
     self.obj.oms2_addConnection.argtypes = [ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p]
     self.obj.oms2_addConnection.restype = ctypes.c_int

--- a/src/OMSimulatorPython/OMSysIdent.py
+++ b/src/OMSimulatorPython/OMSysIdent.py
@@ -45,9 +45,9 @@ class OMSysIdent:
 
         """
         if (sys.platform == 'win32'):
-            self.obj=cdll.LoadLibrary("OMSimulatorLib.dll")
+            self.obj=cdll.LoadLibrary("OMSimulator.dll")
         else:
-            self.obj=cdll.LoadLibrary("libOMSimulatorLib.so")
+            self.obj=cdll.LoadLibrary("libOMSimulator.so")
 
         self.obj.omsi_newSysIdentModel.argtypes = [ctypes.c_char_p]
         self.obj.omsi_newSysIdentModel.restype = ctypes.c_void_p


### PR DESCRIPTION
## Purpose

Started work on making a Jenkins pipeline for the OMSimulator workflow, to replace Hudson.

## Approach

By adding a Jenkinsfile that performs a parallel build with optional runs of test suites depending on if it is a branch, tag, or change request.

The documentation is always generated, but only uploaded for branches and tags, to location:
https://openmodelica.org/doc/OMSimulator/BRANCH_OR_TAG_NAME/

## Type of Change

- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- I have performed a self-review of my own code
- My changes generate no new warnings

---

## Open Questions and Pre-Merge TODOs

- [x] Run the test suites
- [x] Add cached runs of the test suites (to run the most expensive jobs first)
- [x] Add a Windows slave to Jenkins
- [x] Add an ARM slave to Jenkins
- [x] Create a 32-bit Linux docker image for testing that?
- [x] Should builds/tests run only on pull requests or always? This might mess up building documentation for tags...