### PR TITLE
Fix simulating w/o generating a result file

### DIFF
--- a/src/OMSimulatorLib/Model.cpp
+++ b/src/OMSimulatorLib/Model.cpp
@@ -44,7 +44,7 @@
 #include <pugixml.hpp>
 
 oms2::Model::Model(const oms2::ComRef& cref)
-  : systemGeometry(), resultFilename(cref.toString() + "_res.mat")
+  : systemGeometry(), resultFilename(cref.toString() + "_res.mat"), resultFile(NULL)
 {
   logTrace();
   modelState = oms_modelState_instantiated;
@@ -246,6 +246,8 @@ oms_status_enu_t oms2::Model::initialize()
     else
       return logError("Unsupported format of the result file: " + resultFilename);
   }
+  else
+    resultFile = new VoidWriter(1);
 
   modelState = oms_modelState_initialization;
   oms_status_enu_t status = compositeModel->initialize(startTime, tolerance);
@@ -302,6 +304,8 @@ oms_status_enu_t oms2::Model::reset()
     else
       return logError("Unsupported format of the result file: " + resultFilename);
   }
+  else
+    resultFile = new VoidWriter(1);
 
   oms_status_enu_t status = compositeModel->reset();
 

--- a/src/OMSimulatorLib/ResultWriter.h
+++ b/src/OMSimulatorLib/ResultWriter.h
@@ -95,4 +95,17 @@ protected:
   unsigned int nEmits;
 };
 
+class VoidWriter :
+  public ResultWriter
+{
+public:
+  VoidWriter(unsigned int bufferSize) :ResultWriter(bufferSize) {}
+  ~VoidWriter() {}
+
+protected:
+  bool createFile(const std::string& filename, double startTime, double stopTime) {return true;}
+  void closeFile() {}
+  void writeFile() {}
+};
+
 #endif


### PR DESCRIPTION
### Related Issues

#169

### Purpose

Fix bug when providing an empty result filename.

### Approach

Provide a dummy result writer, that is actually doing nothing.

### Type of Change

<!--- Please delete options that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)

### Checklist

<!--- Please delete options that are not relevant. -->

- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
