### PR TITLE
Fix short filenames of result files

### DIFF
--- a/src/OMSimulatorLib/Model.cpp
+++ b/src/OMSimulatorLib/Model.cpp
@@ -236,7 +236,7 @@ oms_status_enu_t oms2::Model::initialize()
   if (!resultFilename.empty())
   {
     std::string resulttype;
-    if (resultFilename.length() > 5)
+    if (resultFilename.length() > 4)
       resulttype = resultFilename.substr(resultFilename.length() - 4);
 
     if (".csv" == resulttype)
@@ -294,7 +294,7 @@ oms_status_enu_t oms2::Model::reset()
   if (!resultFilename.empty())
   {
     std::string resulttype;
-    if (resultFilename.length() > 5)
+    if (resultFilename.length() > 4)
       resulttype = resultFilename.substr(resultFilename.length() - 4);
 
     if (".csv" == resulttype)
@@ -404,7 +404,7 @@ void oms2::Model::setResultFile(const std::string& value)
     if (!resultFilename.empty())
     {
       std::string resulttype;
-      if (resultFilename.length() > 5)
+      if (resultFilename.length() > 4)
         resulttype = resultFilename.substr(resultFilename.length() - 4);
 
       if (".csv" == resulttype)


### PR DESCRIPTION
### Purpose

Allow short filenames of result files (e.g. a.mat).

### Type of Change

<!--- Please delete options that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)

### Checklist

<!--- Please delete options that are not relevant. -->

- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings