### PR TITLE
Fixed setTolerance() call in TLMCompositeModel

### DIFF
--- a/src/OMSimulatorLib/TLMCompositeModel.cpp
+++ b/src/OMSimulatorLib/TLMCompositeModel.cpp
@@ -380,7 +380,6 @@ oms_status_enu_t oms2::TLMCompositeModel::initialize(double startTime, double to
   for(auto it = fmiModels.begin(); it!=fmiModels.end(); ++it) {
     Model* pSubModel = oms2::Scope::GetInstance().getModel(it->second->getName());
     pSubModel->setStartTime(startTime);
-    pModel->setTolerance(pModel->getTolerance());
     pSubModel->initialize();
   }
 


### PR DESCRIPTION
### Related Issues

Resolves #240.

### Purpose

Tolerance for sub-models should not be over-written in TLM simulations.

### Approach

Remove call to setTolerance().

### Type of Change

<!--- Please delete options that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)

### Checklist

<!--- Please delete options that are not relevant. -->

- I have performed a self-review of my own code
- My changes generate no new warnings
