### PR TITLE
Make buffering of result data adjustable

### DIFF
--- a/src/OMSimulator/main.cpp
+++ b/src/OMSimulator/main.cpp
@@ -133,7 +133,7 @@ int main(int argc, char *argv[])
       oms2_loadModel(filename.c_str(), &name);
 
     if (options.resultFile != "")
-      oms2_setResultFile(name, options.resultFile.c_str());
+      oms2_setResultFile(name, options.resultFile.c_str(), 1);
     if (options.useStartTime)
       oms2_setStartTime(name, options.startTime);
     if (options.useStopTime)

--- a/src/OMSimulatorLib/Model.cpp
+++ b/src/OMSimulatorLib/Model.cpp
@@ -240,9 +240,9 @@ oms_status_enu_t oms2::Model::initialize()
       resulttype = resultFilename.substr(resultFilename.length() - 4);
 
     if (".csv" == resulttype)
-      resultFile = new CSVWriter(1);
+      resultFile = new CSVWriter(bufferSize);
     else if (".mat" == resulttype)
-      resultFile = new MATWriter(1024);
+      resultFile = new MATWriter(bufferSize);
     else
       return logError("Unsupported format of the result file: " + resultFilename);
   }
@@ -298,9 +298,9 @@ oms_status_enu_t oms2::Model::reset()
       resulttype = resultFilename.substr(resultFilename.length() - 4);
 
     if (".csv" == resulttype)
-      resultFile = new CSVWriter(1);
+      resultFile = new CSVWriter(bufferSize);
     else if (".mat" == resulttype)
-      resultFile = new MATWriter(1024);
+      resultFile = new MATWriter(bufferSize);
     else
       return logError("Unsupported format of the result file: " + resultFilename);
   }
@@ -390,9 +390,10 @@ oms_status_enu_t oms2::Model::simulate_realtime()
   return status;
 }
 
-void oms2::Model::setResultFile(const std::string& value)
+void oms2::Model::setResultFile(const std::string& value, unsigned int bufferSize)
 {
   resultFilename = value;
+  this->bufferSize = bufferSize;
   if (oms_modelState_instantiated != modelState)
   {
     if (resultFile)
@@ -408,9 +409,9 @@ void oms2::Model::setResultFile(const std::string& value)
         resulttype = resultFilename.substr(resultFilename.length() - 4);
 
       if (".csv" == resulttype)
-        resultFile = new CSVWriter(1);
+        resultFile = new CSVWriter(bufferSize);
       else if (".mat" == resulttype)
-        resultFile = new MATWriter(96);
+        resultFile = new MATWriter(bufferSize);
       else
       {
         logError("Unsupported format of the result file: " + resultFilename);

--- a/src/OMSimulatorLib/Model.h
+++ b/src/OMSimulatorLib/Model.h
@@ -67,8 +67,9 @@ namespace oms2
     double getStopTime() const {return stopTime;}
     void setCommunicationInterval(double value) {communicationInterval = value;}
     void setLoggingInterval(double value) {loggingInterval = value;}
+    double getLoggingInterval() const {return loggingInterval;}
     double getCommunicationInterval() const {return communicationInterval;}
-    void setResultFile(const std::string& value);
+    void setResultFile(const std::string& value, unsigned int bufferSize);
     const std::string& getResultFile() const {return resultFilename;}
     ResultWriter *getResultWriter() const {return resultFile;}
     void setMasterAlgorithm(MasterAlgorithm value) {masterAlgorithm = value;}
@@ -114,6 +115,7 @@ namespace oms2
     double communicationInterval = 1.0e-2;  ///< experiment, default 1.0e-2
     double loggingInterval = 0.0;           ///< experiment, default 0.0
     std::string resultFilename;             ///< experiment, default <name>_res.mat
+    unsigned int bufferSize = 1;
     ResultWriter *resultFile = NULL;
     MasterAlgorithm masterAlgorithm = MasterAlgorithm::STANDARD;  ///< master algorithm for FMI co-simulation, default MasterAlgorithm::STANDARD
 

--- a/src/OMSimulatorLib/OMSimulator.cpp
+++ b/src/OMSimulatorLib/OMSimulator.cpp
@@ -453,10 +453,10 @@ oms_status_enu_t oms2_setLoggingInterval(const char* cref, double loggingInterva
   return oms2::Scope::GetInstance().setLoggingInterval(oms2::ComRef(cref), loggingInterval);
 }
 
-oms_status_enu_t oms2_setResultFile(const char* cref, const char* filename)
+oms_status_enu_t oms2_setResultFile(const char* cref, const char* filename, int bufferSize)
 {
   logTrace();
-  return oms2::Scope::GetInstance().setResultFile(oms2::ComRef(cref), std::string(filename));
+  return oms2::Scope::GetInstance().setResultFile(oms2::ComRef(cref), std::string(filename), bufferSize);
 }
 
 oms_status_enu_t oms2_setMasterAlgorithm(const char* ident, const char* masterAlgorithm)

--- a/src/OMSimulatorLib/OMSimulator.h
+++ b/src/OMSimulatorLib/OMSimulator.h
@@ -612,7 +612,7 @@ oms_status_enu_t oms2_setLoggingInterval(const char* cref, double loggingInterva
  * \param filename   [in] Result file
  * \return           Error status
  */
-oms_status_enu_t oms2_setResultFile(const char* cref, const char* filename);
+oms_status_enu_t oms2_setResultFile(const char* cref, const char* filename, int bufferSize);
 
 
 /**

--- a/src/OMSimulatorLib/Scope.cpp
+++ b/src/OMSimulatorLib/Scope.cpp
@@ -1577,7 +1577,7 @@ oms_status_enu_t oms2::Scope::setLoggingInterval(const ComRef& cref, double logg
   return oms_status_error;
 }
 
-oms_status_enu_t oms2::Scope::setResultFile(const ComRef& cref, const std::string& filename)
+oms_status_enu_t oms2::Scope::setResultFile(const ComRef& cref, const std::string& filename, unsigned int bufferSize)
 {
   if (cref.isIdent())
   {
@@ -1588,7 +1588,7 @@ oms_status_enu_t oms2::Scope::setResultFile(const ComRef& cref, const std::strin
       logError("[oms2::Scope::setResultFile] failed");
       return oms_status_error;
     }
-    model->setResultFile(filename);
+    model->setResultFile(filename, bufferSize);
     return oms_status_ok;
   }
   return oms_status_error;

--- a/src/OMSimulatorLib/Scope.h
+++ b/src/OMSimulatorLib/Scope.h
@@ -104,7 +104,7 @@ namespace oms2
     oms_status_enu_t setStopTime(const ComRef& cref, double stopTime);
     oms_status_enu_t setCommunicationInterval(const ComRef& cref, double communicationInterval);
     oms_status_enu_t setLoggingInterval(const ComRef& cref, double loggingInterval);
-    oms_status_enu_t setResultFile(const ComRef& cref, const std::string& filename);
+    oms_status_enu_t setResultFile(const ComRef& cref, const std::string& filename, unsigned int bufferSize);
     oms_status_enu_t setMasterAlgorithm(const ComRef& cref, const std::string& masterAlgorithm);
     oms_status_enu_t setActivationRatio(const ComRef& cref, int k);
     oms_status_enu_t exportCompositeStructure(const ComRef& cref, const std::string& filename);

--- a/src/OMSimulatorLua/OMSimulatorLua.c
+++ b/src/OMSimulatorLua/OMSimulatorLua.c
@@ -144,7 +144,7 @@ static int OMSimulatorLua_oms2_addTable(lua_State *L)
 static int OMSimulatorLua_oms2_deleteSubModel(lua_State *L)
 {
   if (lua_gettop(L) != 2)
-    return luaL_error(L, "expecting exactly 2 argument");
+    return luaL_error(L, "expecting exactly 2 arguments");
   luaL_checktype(L, 1, LUA_TSTRING);
   luaL_checktype(L, 2, LUA_TSTRING);
 
@@ -159,7 +159,7 @@ static int OMSimulatorLua_oms2_deleteSubModel(lua_State *L)
 static int OMSimulatorLua_oms2_rename(lua_State *L)
 {
   if (lua_gettop(L) != 2)
-    return luaL_error(L, "expecting exactly 2 argument");
+    return luaL_error(L, "expecting exactly 2 arguments");
   luaL_checktype(L, 1, LUA_TSTRING);
   luaL_checktype(L, 2, LUA_TSTRING);
 
@@ -195,7 +195,7 @@ static int OMSimulatorLua_oms2_loadModel(lua_State *L)
 static int OMSimulatorLua_oms2_saveModel(lua_State *L)
 {
   if (lua_gettop(L) != 2)
-    return luaL_error(L, "expecting exactly 2 argument");
+    return luaL_error(L, "expecting exactly 2 arguments");
   luaL_checktype(L, 1, LUA_TSTRING);
   luaL_checktype(L, 2, LUA_TSTRING);
 
@@ -336,7 +336,7 @@ static int OMSimulatorLua_oms2_getStartTime(lua_State *L)
 static int OMSimulatorLua_oms2_setStartTime(lua_State *L)
 {
   if (lua_gettop(L) != 2)
-    return luaL_error(L, "expecting exactly 2 argument");
+    return luaL_error(L, "expecting exactly 2 arguments");
   luaL_checktype(L, 1, LUA_TSTRING);
   luaL_checktype(L, 2, LUA_TNUMBER);
 
@@ -366,7 +366,7 @@ static int OMSimulatorLua_oms2_getStopTime(lua_State *L)
 static int OMSimulatorLua_oms2_setStopTime(lua_State *L)
 {
   if (lua_gettop(L) != 2)
-    return luaL_error(L, "expecting exactly 2 argument");
+    return luaL_error(L, "expecting exactly 2 arguments");
   luaL_checktype(L, 1, LUA_TSTRING);
   luaL_checktype(L, 2, LUA_TNUMBER);
 
@@ -381,7 +381,7 @@ static int OMSimulatorLua_oms2_setStopTime(lua_State *L)
 static int OMSimulatorLua_oms2_setCommunicationInterval(lua_State *L)
 {
   if (lua_gettop(L) != 2)
-    return luaL_error(L, "expecting exactly 2 argument");
+    return luaL_error(L, "expecting exactly 2 arguments");
   luaL_checktype(L, 1, LUA_TSTRING);
   luaL_checktype(L, 2, LUA_TNUMBER);
 
@@ -396,7 +396,7 @@ static int OMSimulatorLua_oms2_setCommunicationInterval(lua_State *L)
 static int OMSimulatorLua_oms2_setLoggingInterval(lua_State *L)
 {
   if (lua_gettop(L) != 2)
-    return luaL_error(L, "expecting exactly 2 argument");
+    return luaL_error(L, "expecting exactly 2 arguments");
   luaL_checktype(L, 1, LUA_TSTRING);
   luaL_checktype(L, 2, LUA_TNUMBER);
 
@@ -407,17 +407,24 @@ static int OMSimulatorLua_oms2_setLoggingInterval(lua_State *L)
   return 1;
 }
 
-//oms_status_enu_t oms2_setResultFile(const char* cref, const char* filename);
+//oms_status_enu_t oms2_setResultFile(const char* cref, const char* filename, unsigned int bufferSize);
 static int OMSimulatorLua_oms2_setResultFile(lua_State *L)
 {
-  if (lua_gettop(L) != 2)
-    return luaL_error(L, "expecting exactly 2 argument");
+  if (lua_gettop(L) != 2 && lua_gettop(L) != 3)
+    return luaL_error(L, "expecting exactly 2 or 3 arguments");
   luaL_checktype(L, 1, LUA_TSTRING);
   luaL_checktype(L, 2, LUA_TSTRING);
 
   const char* cref = lua_tostring(L, 1);
   const char* filename = lua_tostring(L, 2);
-  oms_status_enu_t status = oms2_setResultFile(cref, filename);
+
+  unsigned int bufferSize = 1;
+  if (lua_gettop(L) == 3)
+  {
+    luaL_checktype(L, 3, LUA_TNUMBER);
+    bufferSize = lua_tonumber(L, 3);
+  }
+  oms_status_enu_t status = oms2_setResultFile(cref, filename, bufferSize);
   lua_pushinteger(L, status);
   return 1;
 }
@@ -426,7 +433,7 @@ static int OMSimulatorLua_oms2_setResultFile(lua_State *L)
 static int OMSimulatorLua_oms2_setMasterAlgorithm(lua_State *L)
 {
   if (lua_gettop(L) != 2)
-    return luaL_error(L, "expecting exactly 2 argument");
+    return luaL_error(L, "expecting exactly 2 arguments");
   luaL_checktype(L, 1, LUA_TSTRING);
   luaL_checktype(L, 2, LUA_TSTRING);
 
@@ -441,7 +448,7 @@ static int OMSimulatorLua_oms2_setMasterAlgorithm(lua_State *L)
 static int OMSimulatorLua_experimental_setActivationRatio(lua_State *L)
 {
   if (lua_gettop(L) != 2)
-    return luaL_error(L, "expecting exactly 2 argument");
+    return luaL_error(L, "expecting exactly 2 arguments");
   luaL_checktype(L, 1, LUA_TSTRING);
   luaL_checktype(L, 2, LUA_TNUMBER);
 
@@ -469,7 +476,7 @@ static int OMSimulatorLua_experimental_simulate_realtime(lua_State *L)
 static int OMSimulatorLua_oms2_exportCompositeStructure(lua_State *L)
 {
   if (lua_gettop(L) != 2)
-    return luaL_error(L, "expecting exactly 2 argument");
+    return luaL_error(L, "expecting exactly 2 arguments");
   luaL_checktype(L, 1, LUA_TSTRING);
   luaL_checktype(L, 2, LUA_TSTRING);
 
@@ -553,7 +560,7 @@ static int OMSimulatorLua_oms2_simulate(lua_State *L)
 static int OMSimulatorLua_oms2_doSteps(lua_State *L)
 {
   if (lua_gettop(L) != 2)
-    return luaL_error(L, "expecting exactly 2 argument");
+    return luaL_error(L, "expecting exactly 2 arguments");
   luaL_checktype(L, 1, LUA_TSTRING);
   luaL_checktype(L, 2, LUA_TNUMBER);
 
@@ -568,7 +575,7 @@ static int OMSimulatorLua_oms2_doSteps(lua_State *L)
 static int OMSimulatorLua_oms2_stepUntil(lua_State *L)
 {
   if (lua_gettop(L) != 2)
-    return luaL_error(L, "expecting exactly 2 argument");
+    return luaL_error(L, "expecting exactly 2 arguments");
   luaL_checktype(L, 1, LUA_TSTRING);
   luaL_checktype(L, 2, LUA_TNUMBER);
 
@@ -599,7 +606,7 @@ static int OMSimulatorLua_oms2_getReal(lua_State *L)
 static int OMSimulatorLua_oms2_setReal(lua_State *L)
 {
   if (lua_gettop(L) != 2)
-    return luaL_error(L, "expecting exactly 2 argument");
+    return luaL_error(L, "expecting exactly 2 arguments");
   luaL_checktype(L, 1, LUA_TSTRING);
   luaL_checktype(L, 2, LUA_TNUMBER);
 
@@ -630,7 +637,7 @@ static int OMSimulatorLua_oms2_getRealParameter(lua_State *L)
 static int OMSimulatorLua_oms2_setRealParameter(lua_State *L)
 {
   if (lua_gettop(L) != 2)
-    return luaL_error(L, "expecting exactly 2 argument");
+    return luaL_error(L, "expecting exactly 2 arguments");
   luaL_checktype(L, 1, LUA_TSTRING);
   luaL_checktype(L, 2, LUA_TNUMBER);
 
@@ -661,7 +668,7 @@ static int OMSimulatorLua_oms2_getInteger(lua_State *L)
 static int OMSimulatorLua_oms2_setInteger(lua_State *L)
 {
   if (lua_gettop(L) != 2)
-    return luaL_error(L, "expecting exactly 2 argument");
+    return luaL_error(L, "expecting exactly 2 arguments");
   luaL_checktype(L, 1, LUA_TSTRING);
   luaL_checktype(L, 2, LUA_TNUMBER);
 
@@ -692,7 +699,7 @@ static int OMSimulatorLua_oms2_getIntegerParameter(lua_State *L)
 static int OMSimulatorLua_oms2_setIntegerParameter(lua_State *L)
 {
   if (lua_gettop(L) != 2)
-    return luaL_error(L, "expecting exactly 2 argument");
+    return luaL_error(L, "expecting exactly 2 arguments");
   luaL_checktype(L, 1, LUA_TSTRING);
   luaL_checktype(L, 2, LUA_TNUMBER);
 
@@ -723,7 +730,7 @@ static int OMSimulatorLua_oms2_getBoolean(lua_State *L)
 static int OMSimulatorLua_oms2_setBoolean(lua_State *L)
 {
   if (lua_gettop(L) != 2)
-    return luaL_error(L, "expecting exactly 2 argument");
+    return luaL_error(L, "expecting exactly 2 arguments");
   luaL_checktype(L, 1, LUA_TSTRING);
   luaL_checktype(L, 2, LUA_TNUMBER);
 
@@ -754,7 +761,7 @@ static int OMSimulatorLua_oms2_getBooleanParameter(lua_State *L)
 static int OMSimulatorLua_oms2_setBooleanParameter(lua_State *L)
 {
   if (lua_gettop(L) != 2)
-    return luaL_error(L, "expecting exactly 2 argument");
+    return luaL_error(L, "expecting exactly 2 arguments");
   luaL_checktype(L, 1, LUA_TSTRING);
   luaL_checktype(L, 2, LUA_TNUMBER);
 

--- a/src/OMSimulatorPython/OMSimulator.py
+++ b/src/OMSimulatorPython/OMSimulator.py
@@ -116,7 +116,7 @@ class OMSimulator:
     self.obj.oms2_setRealParameter.argtypes = [ctypes.c_char_p, ctypes.c_double]
     self.obj.oms2_setRealParameter.restype = ctypes.c_int
 
-    self.obj.oms2_setResultFile.argtypes = [ctypes.c_char_p, ctypes.c_char_p]
+    self.obj.oms2_setResultFile.argtypes = [ctypes.c_char_p, ctypes.c_char_p, ctypes.c_uint]
     self.obj.oms2_setResultFile.restype = ctypes.c_int
 
     self.obj.oms2_getStartTime.argtypes = [ctypes.c_char_p]
@@ -239,8 +239,8 @@ class OMSimulator:
     return self.obj.oms2_setReal(str.encode(signal), value)
   def setRealParameter(self, signal, value):
     return self.obj.oms2_setRealParameter(str.encode(signal), value)
-  def setResultFile(self, cref, filename):
-    return self.obj.oms2_setResultFile(str.encode(cref), str.encode(filename))
+  def setResultFile(self, cref, filename, bufferSize=1):
+    return self.obj.oms2_setResultFile(str.encode(cref), str.encode(filename), bufferSize)
   def getStartTime(self, ident):
     startTime = ctypes.c_double()
     status = self.obj.oms2_getStartTime(str.encode(ident), ctypes.byref(startTime))


### PR DESCRIPTION
### Related Issues

#169

### Purpose

This makes the size of the buffer that is used to speedup writing the result file adjustable.

### Approach

Add new argument to CAPI. Lua and Python bindings got an optional argument with default value of 1.

### Type of Change

<!--- Please delete options that are not relevant. -->

- New feature (non-breaking change which adds functionality)

### Checklist

<!--- Please delete options that are not relevant. -->

- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
