### PR TITLE
New API to set special flags, e.g. for workarounds

### DIFF
--- a/src/OMSimulatorLib/FMICompositeModel.cpp
+++ b/src/OMSimulatorLib/FMICompositeModel.cpp
@@ -1597,16 +1597,16 @@ oms_status_enu_t oms2::FMICompositeModel::emit(ResultWriter& resultWriter)
   return oms_status_ok;
 }
 
-oms_status_enu_t oms2::FMICompositeModel::addVariableFilter(const std::string& regex)
+oms_status_enu_t oms2::FMICompositeModel::addSignalsToResults(const std::string& regex)
 {
   for (const auto& it : subModels)
-    it.second->addVariableFilter(regex);
+    it.second->addSignalsToResults(regex);
   return oms_status_ok;
 }
 
-oms_status_enu_t oms2::FMICompositeModel::removeVariableFilter(const std::string& regex)
+oms_status_enu_t oms2::FMICompositeModel::removeSignalsFromResults(const std::string& regex)
 {
   for (const auto& it : subModels)
-    it.second->removeVariableFilter(regex);
+    it.second->removeSignalsFromResults(regex);
   return oms_status_ok;
 }

--- a/src/OMSimulatorLib/FMICompositeModel.h
+++ b/src/OMSimulatorLib/FMICompositeModel.h
@@ -106,8 +106,8 @@ namespace oms2
 
     double getCurrentTime() {return time;}
 
-    oms_status_enu_t addVariableFilter(const std::string& regex);
-    oms_status_enu_t removeVariableFilter(const std::string& regex);
+    oms_status_enu_t addSignalsToResults(const std::string& regex);
+    oms_status_enu_t removeSignalsFromResults(const std::string& regex);
 
   private:
     oms_status_enu_t loadElementGeometry(const pugi::xml_node& node);

--- a/src/OMSimulatorLib/FMISubModel.cpp
+++ b/src/OMSimulatorLib/FMISubModel.cpp
@@ -42,3 +42,14 @@ oms2::FMISubModel::FMISubModel(oms_element_type_enu_t type, const ComRef& cref)
 oms2::FMISubModel::~FMISubModel()
 {
 }
+
+oms_status_enu_t oms2::FMISubModel::setFlags(const std::string& flags)
+{
+  if (flags == "+fetchAllVars")
+    fetchAllVars = true;
+  else if (flags == "-fetchAllVars")
+    fetchAllVars = false;
+  else
+    return oms_status_error;
+  return oms_status_ok;
+}

--- a/src/OMSimulatorLib/FMISubModel.h
+++ b/src/OMSimulatorLib/FMISubModel.h
@@ -88,6 +88,8 @@ namespace oms2
     void setActivationRatio(int k) {eclock.k  = k;}
     int getActivationRatio() const {return eclock.k;}
 
+    oms_status_enu_t setFlags(const std::string& flags);
+
   protected:
     FMISubModel(oms_element_type_enu_t type, const ComRef& cref);
     virtual ~FMISubModel();
@@ -104,6 +106,8 @@ namespace oms2
     DirectedGraph outputsGraph;
 
     Experimental_Clock eclock;
+
+    bool fetchAllVars = false;
   };
 }
 

--- a/src/OMSimulatorLib/FMISubModel.h
+++ b/src/OMSimulatorLib/FMISubModel.h
@@ -82,8 +82,8 @@ namespace oms2
     virtual oms_status_enu_t registerSignalsForResultFile(ResultWriter& resultWriter) = 0;
     virtual oms_status_enu_t emit(ResultWriter& resultWriter) = 0;
 
-    virtual void addVariableFilter(const std::string& regex) = 0;
-    virtual void removeVariableFilter(const std::string& regex) = 0;
+    virtual void addSignalsToResults(const std::string& regex) = 0;
+    virtual void removeSignalsFromResults(const std::string& regex) = 0;
 
     void setActivationRatio(int k) {eclock.k  = k;}
     int getActivationRatio() const {return eclock.k;}

--- a/src/OMSimulatorLib/FMUWrapper.cpp
+++ b/src/OMSimulatorLib/FMUWrapper.cpp
@@ -328,7 +328,6 @@ oms2::FMUWrapper* oms2::FMUWrapper::newSubModel(const oms2::ComRef& cref, const 
   // create some special variable maps
   for (auto const &v : model->allVariables)
   {
-    bool filter = true;
     if (v.isParameter() && v.isTypeReal())
       model->realParameters[v.getName()] = oms2::Option<double>();
     else if (v.isParameter() && v.isTypeInteger())
@@ -339,13 +338,11 @@ oms2::FMUWrapper* oms2::FMUWrapper::newSubModel(const oms2::ComRef& cref, const 
     if (v.isInput())
     {
       model->inputs.push_back(v);
-      filter = false;
     }
     else if (v.isOutput())
     {
       model->outputs.push_back(v);
       model->outputsGraph.addVariable(v);
-      filter = false;
     }
     else if (v.isParameter())
       model->parameters.push_back(v);
@@ -353,7 +350,7 @@ oms2::FMUWrapper* oms2::FMUWrapper::newSubModel(const oms2::ComRef& cref, const 
     if (v.isInitialUnknown())
       model->initialUnknownsGraph.addVariable(v);
 
-    model->varFilter.push_back(filter);
+    model->exportVariables.push_back(v.isInput() || v.isOutput());
   }
 
   std::vector<oms2::Connector> connectors;
@@ -1253,7 +1250,7 @@ oms_status_enu_t oms2::FMUWrapper::registerSignalsForResultFile(ResultWriter& re
 {
   for (unsigned int i=0; i<allVariables.size(); ++i)
   {
-    if (varFilter[i])
+    if (!exportVariables[i])
       continue;
 
     auto const &var = allVariables[i];
@@ -1337,36 +1334,36 @@ oms_status_enu_t oms2::FMUWrapper::emit(ResultWriter& resultWriter)
   return oms_status_ok;
 }
 
-void oms2::FMUWrapper::addVariableFilter(const std::string& regex)
+void oms2::FMUWrapper::addSignalsToResults(const std::string& regex)
 {
   std::regex exp(regex);
   for (unsigned int i=0; i<allVariables.size(); ++i)
   {
-    if (!varFilter[i])
+    if (exportVariables[i])
       continue;
 
     auto const &var = allVariables[i];
     if(regex_match(var.toString(), exp))
     {
-      logInfo("added to variable filter: " + var.toString());
-      varFilter[i] = false;
+      logInfo("added \"" + var.toString() + "\" to results");
+      exportVariables[i] = true;
     }
   }
 }
 
-void oms2::FMUWrapper::removeVariableFilter(const std::string& regex)
+void oms2::FMUWrapper::removeSignalsFromResults(const std::string& regex)
 {
   std::regex exp(regex);
   for (unsigned int i=0; i<allVariables.size(); ++i)
   {
-    if (varFilter[i])
+    if (!exportVariables[i])
       continue;
 
     auto const &var = allVariables[i];
     if(regex_match(var.toString(), exp))
     {
-      logInfo("removed from variable filter: " + var.toString());
-      varFilter[i] = true;
+      logInfo("removed \"" + var.toString() + "\" from results");
+      exportVariables[i] = false;
     }
   }
 }

--- a/src/OMSimulatorLib/FMUWrapper.cpp
+++ b/src/OMSimulatorLib/FMUWrapper.cpp
@@ -770,6 +770,20 @@ oms_status_enu_t oms2::FMUWrapper::doStep(double stopTime)
   fmi2_status_t fmistatus;
   double hdef = (stopTime-time) / 1.0;
 
+  // HACK for certain FMUs
+  if (fetchAllVars)
+  {
+    for (auto &v : allVariables)
+    {
+      if (v.isTypeReal())
+      {
+        double realValue;
+        if (oms_status_ok != getReal(v, realValue))
+          return logError("failed to fetch variable " + v.toString());
+      }
+    }
+  }
+
   if (oms_fmi_kind_me == fmuInfo.getKind())
   {
     // main simulation loop

--- a/src/OMSimulatorLib/FMUWrapper.h
+++ b/src/OMSimulatorLib/FMUWrapper.h
@@ -95,8 +95,8 @@ namespace oms2
     oms_status_enu_t registerSignalsForResultFile(ResultWriter& resultWriter);
     oms_status_enu_t emit(ResultWriter& resultWriter);
 
-    void addVariableFilter(const std::string& regex);
-    void removeVariableFilter(const std::string& regex);
+    void addSignalsToResults(const std::string& regex);
+    void removeSignalsFromResults(const std::string& regex);
 
   private:
     oms_status_enu_t initializeDependencyGraph_initialUnknowns();
@@ -143,7 +143,7 @@ namespace oms2
     std::vector<oms2::Variable> outputs;
     std::vector<oms2::Variable> parameters;
     std::vector<oms2::Variable> allVariables;
-    std::vector<bool> varFilter;
+    std::vector<bool> exportVariables;
 
     std::map<std::string, oms2::Option<double>> realParameters;
     std::map<std::string, oms2::Option<int>> integerParameters;

--- a/src/OMSimulatorLib/OMSimulator.cpp
+++ b/src/OMSimulatorLib/OMSimulator.cpp
@@ -546,14 +546,14 @@ oms_status_enu_t oms2_setTLMDataSamples(const char *cref, const int samples)
 #endif
 }
 
-oms_status_enu_t oms2_addVariableFilter(const char* cref, const char* regex)
+oms_status_enu_t oms2_addSignalsToResults(const char* cref, const char* regex)
 {
   logTrace();
-  return oms2::Scope::GetInstance().addVariableFilter(oms2::ComRef(cref), std::string(regex));
+  return oms2::Scope::GetInstance().addSignalsToResults(oms2::ComRef(cref), std::string(regex));
 }
 
-oms_status_enu_t oms2_removeVariableFilter(const char* cref, const char* regex)
+oms_status_enu_t oms2_removeSignalsFromResults(const char* cref, const char* regex)
 {
   logTrace();
-  return oms2::Scope::GetInstance().removeVariableFilter(oms2::ComRef(cref), std::string(regex));
+  return oms2::Scope::GetInstance().removeSignalsFromResults(oms2::ComRef(cref), std::string(regex));
 }

--- a/src/OMSimulatorLib/OMSimulator.cpp
+++ b/src/OMSimulatorLib/OMSimulator.cpp
@@ -557,3 +557,9 @@ oms_status_enu_t oms2_removeSignalsFromResults(const char* cref, const char* reg
   logTrace();
   return oms2::Scope::GetInstance().removeSignalsFromResults(oms2::ComRef(cref), std::string(regex));
 }
+
+oms_status_enu_t oms2_setFlags(const char* cref, const char* flags)
+{
+  logTrace();
+  return oms2::Scope::GetInstance().setFlags(oms2::ComRef(cref), std::string(flags));
+}

--- a/src/OMSimulatorLib/OMSimulator.h
+++ b/src/OMSimulatorLib/OMSimulator.h
@@ -700,6 +700,15 @@ oms_status_enu_t oms2_addSignalsToResults(const char* cref, const char* regex);
  */
 oms_status_enu_t oms2_removeSignalsFromResults(const char* cref, const char* regex);
 
+/**
+ * \brief Sets special flags.
+ *
+ * \param cref  [in] Name of the model instance
+ * \param flags [in] flags
+ * \return Error status
+ */
+oms_status_enu_t oms2_setFlags(const char* cref, const char* flags);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/OMSimulatorLib/OMSimulator.h
+++ b/src/OMSimulatorLib/OMSimulator.h
@@ -689,7 +689,7 @@ oms_status_enu_t oms2_getCurrentTime(const char* model, double* time);
  * \param regex [in] Regular expression
  * \return Error status
  */
-oms_status_enu_t oms2_addVariableFilter(const char* cref, const char* regex);
+oms_status_enu_t oms2_addSignalsToResults(const char* cref, const char* regex);
 
 /**
  * \brief Add all variables that match the given regex to the result file.
@@ -698,7 +698,7 @@ oms_status_enu_t oms2_addVariableFilter(const char* cref, const char* regex);
  * \param regex [in] Regular expression
  * \return Error status
  */
-oms_status_enu_t oms2_removeVariableFilter(const char* cref, const char* regex);
+oms_status_enu_t oms2_removeSignalsFromResults(const char* cref, const char* regex);
 
 #ifdef __cplusplus
 }

--- a/src/OMSimulatorLib/Scope.cpp
+++ b/src/OMSimulatorLib/Scope.cpp
@@ -1814,3 +1814,37 @@ oms_status_enu_t oms2::Scope::removeSignalsFromResults(const ComRef& cref, const
   }
   return oms_status_error;
 }
+
+oms_status_enu_t oms2::Scope::setFlags(const ComRef& cref, const std::string& flags)
+{
+  if (!cref.isIdent())
+  {
+    // Sub-model
+    ComRef modelCref = cref.first();
+    Model* model = getModel(modelCref);
+    if (!model)
+    {
+      logError("[oms2::Scope::setFlags] failed");
+      return oms_status_error;
+    }
+
+    // FMI model?
+    if (oms_component_fmi == model->getType())
+    {
+      FMICompositeModel* fmiModel = model->getFMICompositeModel();
+      FMISubModel* subModel = fmiModel->getSubModel(cref);
+      if (!subModel)
+      {
+        logError("[oms2::Scope::setFlags] failed");
+        return oms_status_error;
+      }
+      return subModel->setFlags(flags);
+    }
+    else
+    {
+      logError("[oms2::Scope::setFlags] is only implemented for FMI models yet");
+      return oms_status_error;
+    }
+  }
+  return oms_status_error;
+}

--- a/src/OMSimulatorLib/Scope.cpp
+++ b/src/OMSimulatorLib/Scope.cpp
@@ -1765,7 +1765,7 @@ oms_status_enu_t oms2::Scope::getCurrentTime(const oms2::ComRef& cref, double* t
   return oms_status_error;
 }
 
-oms_status_enu_t oms2::Scope::addVariableFilter(const ComRef& cref, const std::string& regex)
+oms_status_enu_t oms2::Scope::addSignalsToResults(const ComRef& cref, const std::string& regex)
 {
   if (cref.isIdent())
   {
@@ -1773,7 +1773,7 @@ oms_status_enu_t oms2::Scope::addVariableFilter(const ComRef& cref, const std::s
     Model* model = getModel(cref);
     if (!model)
     {
-      logError("[oms2::Scope::addVariableFilter] failed");
+      logError("[oms2::Scope::addSignalsToResults] failed");
       return oms_status_error;
     }
 
@@ -1781,16 +1781,16 @@ oms_status_enu_t oms2::Scope::addVariableFilter(const ComRef& cref, const std::s
     if (oms_component_fmi == model->getType())
     {
       FMICompositeModel* fmiModel = model->getFMICompositeModel();
-      return fmiModel->addVariableFilter(regex);
+      return fmiModel->addSignalsToResults(regex);
     }
 
-    logError("[oms2::Scope::addVariableFilter] is only implemented for FMI models yet");
+    logError("[oms2::Scope::addSignalsToResults] is only implemented for FMI models yet");
     return oms_status_error;
   }
   return oms_status_error;
 }
 
-oms_status_enu_t oms2::Scope::removeVariableFilter(const ComRef& cref, const std::string& regex)
+oms_status_enu_t oms2::Scope::removeSignalsFromResults(const ComRef& cref, const std::string& regex)
 {
   if (cref.isIdent())
   {
@@ -1798,7 +1798,7 @@ oms_status_enu_t oms2::Scope::removeVariableFilter(const ComRef& cref, const std
     Model* model = getModel(cref);
     if (!model)
     {
-      logError("[oms2::Scope::removeVariableFilter] failed");
+      logError("[oms2::Scope::removeSignalsFromResults] failed");
       return oms_status_error;
     }
 
@@ -1806,10 +1806,10 @@ oms_status_enu_t oms2::Scope::removeVariableFilter(const ComRef& cref, const std
     if (oms_component_fmi == model->getType())
     {
       FMICompositeModel* fmiModel = model->getFMICompositeModel();
-      return fmiModel->removeVariableFilter(regex);
+      return fmiModel->removeSignalsFromResults(regex);
     }
 
-    logError("[oms2::Scope::removeVariableFilter] is only implemented for FMI models yet");
+    logError("[oms2::Scope::removeSignalsFromResults] is only implemented for FMI models yet");
     return oms_status_error;
   }
   return oms_status_error;

--- a/src/OMSimulatorLib/Scope.h
+++ b/src/OMSimulatorLib/Scope.h
@@ -114,6 +114,7 @@ namespace oms2
     oms_status_enu_t getCurrentTime(const ComRef& cref, double* time);
     oms_status_enu_t addSignalsToResults(const ComRef& cref, const std::string& regex);
     oms_status_enu_t removeSignalsFromResults(const ComRef& cref, const std::string& regex);
+    oms_status_enu_t setFlags(const ComRef& cref, const std::string& flags);
 
     const std::string& getTempDirectory() {return GetInstance().tempDir;}
     const std::string& getWorkingDirectory() {return GetInstance().workingDir;}

--- a/src/OMSimulatorLib/Scope.h
+++ b/src/OMSimulatorLib/Scope.h
@@ -112,8 +112,8 @@ namespace oms2
     oms_status_enu_t exportCompositeStructure(const ComRef& cref, const std::string& filename);
     oms_status_enu_t exportDependencyGraphs(const ComRef& cref, const std::string& initialization, const std::string& simulation);
     oms_status_enu_t getCurrentTime(const ComRef& cref, double* time);
-    oms_status_enu_t addVariableFilter(const ComRef& cref, const std::string& regex);
-    oms_status_enu_t removeVariableFilter(const ComRef& cref, const std::string& regex);
+    oms_status_enu_t addSignalsToResults(const ComRef& cref, const std::string& regex);
+    oms_status_enu_t removeSignalsFromResults(const ComRef& cref, const std::string& regex);
 
     const std::string& getTempDirectory() {return GetInstance().tempDir;}
     const std::string& getWorkingDirectory() {return GetInstance().workingDir;}

--- a/src/OMSimulatorLib/Table.h
+++ b/src/OMSimulatorLib/Table.h
@@ -83,8 +83,8 @@ namespace oms2
     oms_status_enu_t registerSignalsForResultFile(ResultWriter& resultWriter) {return oms_status_ok;}
     oms_status_enu_t emit(ResultWriter& resultWriter) {return oms_status_ok;}
 
-    void addVariableFilter(const std::string& regex) {logWarning("addVariableFilter not implemented for tables");}
-    void removeVariableFilter(const std::string& regex) {logWarning("removeVariableFilter not implemented for tables");}
+    void addSignalsToResults(const std::string& regex) {logWarning("addSignalsToResults not implemented for tables");}
+    void removeSignalsFromResults(const std::string& regex) {logWarning("removeSignalsFromResults not implemented for tables");}
 
   private:
     Table(const ComRef& cref, const std::string& filename);

--- a/src/OMSimulatorLua/OMSimulatorLua.c
+++ b/src/OMSimulatorLua/OMSimulatorLua.c
@@ -530,8 +530,8 @@ static int OMSimulatorLua_oms2_reset(lua_State *L)
   return 1;
 }
 
-//oms_status_enu_t oms2_addVariableFilter(const char* cref, const char* regex);
-static int OMSimulatorLua_oms2_addVariableFilter(lua_State *L)
+//oms_status_enu_t oms2_addSignalsToResults(const char* cref, const char* regex);
+static int OMSimulatorLua_oms2_addSignalsToResults(lua_State *L)
 {
   if (lua_gettop(L) != 2)
     return luaL_error(L, "expecting exactly 2 argument");
@@ -539,13 +539,13 @@ static int OMSimulatorLua_oms2_addVariableFilter(lua_State *L)
 
   const char* cref = lua_tostring(L, 1);
   const char* regex = lua_tostring(L, 2);
-  oms_status_enu_t status = oms2_addVariableFilter(cref, regex);
+  oms_status_enu_t status = oms2_addSignalsToResults(cref, regex);
   lua_pushinteger(L, status);
   return 1;
 }
 
-//oms_status_enu_t oms2_removeVariableFilter(const char* cref, const char* regex);
-static int OMSimulatorLua_oms2_removeVariableFilter(lua_State *L)
+//oms_status_enu_t oms2_removeSignalsFromResults(const char* cref, const char* regex);
+static int OMSimulatorLua_oms2_removeSignalsFromResults(lua_State *L)
 {
   if (lua_gettop(L) != 2)
     return luaL_error(L, "expecting exactly 2 argument");
@@ -553,7 +553,7 @@ static int OMSimulatorLua_oms2_removeVariableFilter(lua_State *L)
 
   const char* cref = lua_tostring(L, 1);
   const char* regex = lua_tostring(L, 2);
-  oms_status_enu_t status = oms2_removeVariableFilter(cref, regex);
+  oms_status_enu_t status = oms2_removeSignalsFromResults(cref, regex);
   lua_pushinteger(L, status);
   return 1;
 }
@@ -1362,7 +1362,7 @@ DLLEXPORT int luaopen_OMSimulatorLua(lua_State *L)
   REGISTER_LUA_CALL(oms2_addTable);
   REGISTER_LUA_CALL(oms2_addTLMConnection);
   REGISTER_LUA_CALL(oms2_addTLMInterface);
-  REGISTER_LUA_CALL(oms2_addVariableFilter);
+  REGISTER_LUA_CALL(oms2_addSignalsToResults);
   REGISTER_LUA_CALL(oms2_compareSimulationResults);
   REGISTER_LUA_CALL(oms2_deleteConnection);
   REGISTER_LUA_CALL(oms2_deleteSubModel);
@@ -1383,7 +1383,7 @@ DLLEXPORT int luaopen_OMSimulatorLua(lua_State *L)
   REGISTER_LUA_CALL(oms2_loadModel);
   REGISTER_LUA_CALL(oms2_newFMIModel);
   REGISTER_LUA_CALL(oms2_newTLMModel);
-  REGISTER_LUA_CALL(oms2_removeVariableFilter);
+  REGISTER_LUA_CALL(oms2_removeSignalsFromResults);
   REGISTER_LUA_CALL(oms2_rename);
   REGISTER_LUA_CALL(oms2_reset);
   REGISTER_LUA_CALL(oms2_saveModel);

--- a/src/OMSimulatorLua/OMSimulatorLua.c
+++ b/src/OMSimulatorLua/OMSimulatorLua.c
@@ -544,6 +544,20 @@ static int OMSimulatorLua_oms2_addSignalsToResults(lua_State *L)
   return 1;
 }
 
+//oms_status_enu_t oms2_setFlags(const char* cref, const char* flags);
+static int OMSimulatorLua_oms2_setFlags(lua_State *L)
+{
+  if (lua_gettop(L) != 2)
+    return luaL_error(L, "expecting exactly 2 argument");
+  luaL_checktype(L, 1, LUA_TSTRING);
+
+  const char* cref = lua_tostring(L, 1);
+  const char* flags = lua_tostring(L, 2);
+  oms_status_enu_t status = oms2_setFlags(cref, flags);
+  lua_pushinteger(L, status);
+  return 1;
+}
+
 //oms_status_enu_t oms2_removeSignalsFromResults(const char* cref, const char* regex);
 static int OMSimulatorLua_oms2_removeSignalsFromResults(lua_State *L)
 {
@@ -1359,10 +1373,10 @@ DLLEXPORT int luaopen_OMSimulatorLua(lua_State *L)
   REGISTER_LUA_CALL(oms2_addExternalModel);
   REGISTER_LUA_CALL(oms2_addFMISubModel);
   REGISTER_LUA_CALL(oms2_addFMU);
+  REGISTER_LUA_CALL(oms2_addSignalsToResults);
   REGISTER_LUA_CALL(oms2_addTable);
   REGISTER_LUA_CALL(oms2_addTLMConnection);
   REGISTER_LUA_CALL(oms2_addTLMInterface);
-  REGISTER_LUA_CALL(oms2_addSignalsToResults);
   REGISTER_LUA_CALL(oms2_compareSimulationResults);
   REGISTER_LUA_CALL(oms2_deleteConnection);
   REGISTER_LUA_CALL(oms2_deleteSubModel);
@@ -1390,6 +1404,7 @@ DLLEXPORT int luaopen_OMSimulatorLua(lua_State *L)
   REGISTER_LUA_CALL(oms2_setBoolean);
   REGISTER_LUA_CALL(oms2_setBooleanParameter);
   REGISTER_LUA_CALL(oms2_setCommunicationInterval);
+  REGISTER_LUA_CALL(oms2_setFlags);
   REGISTER_LUA_CALL(oms2_setInteger);
   REGISTER_LUA_CALL(oms2_setIntegerParameter);
   REGISTER_LUA_CALL(oms2_setLogFile);

--- a/src/OMSimulatorPython/OMSimulator.py
+++ b/src/OMSimulatorPython/OMSimulator.py
@@ -17,8 +17,8 @@ class OMSimulator:
     self.obj.oms2_addTable.argtypes = [ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p]
     self.obj.oms2_addTable.restype = ctypes.c_int
 
-    self.obj.oms2_addVariableFilter.argtypes = [ctypes.c_char_p, ctypes.c_char_p]
-    self.obj.oms2_addVariableFilter.restype = ctypes.c_int
+    self.obj.oms2_addSignalsToResults.argtypes = [ctypes.c_char_p, ctypes.c_char_p]
+    self.obj.oms2_addSignalsToResults.restype = ctypes.c_int
 
     self.obj.oms2_compareSimulationResults.argtypes = [ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p, ctypes.c_double, ctypes.c_double]
     self.obj.oms2_compareSimulationResults.restype = ctypes.c_int
@@ -77,8 +77,8 @@ class OMSimulator:
     self.obj.oms2_newFMIModel.argtypes = [ctypes.c_char_p]
     self.obj.oms2_newFMIModel.restype = ctypes.c_int
 
-    self.obj.oms2_removeVariableFilter.argtypes = [ctypes.c_char_p, ctypes.c_char_p]
-    self.obj.oms2_removeVariableFilter.restype = ctypes.c_int
+    self.obj.oms2_removeSignalsFromResults.argtypes = [ctypes.c_char_p, ctypes.c_char_p]
+    self.obj.oms2_removeSignalsFromResults.restype = ctypes.c_int
 
     self.obj.oms2_rename.argtypes = [ctypes.c_char_p, ctypes.c_char_p]
     self.obj.oms2_rename.restype = ctypes.c_int
@@ -161,8 +161,8 @@ class OMSimulator:
     return self.obj.oms2_addFMU(str.encode(modelIdent), str.encode(fmuPath), str.encode(fmuIdent))
   def addTable(self, modelIdent, tablePath, tableIdent):
     return self.obj.oms2_addTable(str.encode(modelIdent), str.encode(tablePath), str.encode(tableIdent))
-  def addVariableFilter(self, cref, regex):
-    return self.obj.oms2_addVariableFilter(str.encode(cref), str.encode(regex))
+  def addSignalsToResults(self, cref, regex):
+    return self.obj.oms2_addSignalsToResults(str.encode(cref), str.encode(regex))
   def compareSimulationResults(self, filenameA, filenameB, var, relTol, absTol):
     return self.obj.oms2_compareSimulationResults(str.encode(filenameA), str.encode(filenameB), str.encode(var), relTol, absTol)
   def deleteConnection(self, cref, conA, conB):
@@ -221,8 +221,8 @@ class OMSimulator:
     return self.obj.oms2_newFMIModel(str.encode(ident))
   def rename(self, identOld, identNew):
     return self.obj.oms2_rename(str.encode(identOld), str.encode(identNew))
-  def removeVariableFilter(self, cref, regex):
-    return self.obj.oms2_removeVariableFilter(str.encode(cref), str.encode(regex))
+  def removeSignalsFromResults(self, cref, regex):
+    return self.obj.oms2_removeSignalsFromResults(str.encode(cref), str.encode(regex))
   def reset(self, ident):
     return self.obj.oms2_reset(str.encode(ident))
   def saveModel(self, filename, ident):


### PR DESCRIPTION
### Related Issues

https://github.com/OpenModelica/OMSimulator/issues/169#issuecomment-397446497

### Purpose

Add special flag to fetch all variables of a given FMU.

### Approach

New API `oms2_setFlags(const char* cref, const char* flags);`.

### Type of Change

<!--- Please delete options that are not relevant. -->

- Code refactoring (non-breaking change which improves maintainability)
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

### Checklist

<!--- Please delete options that are not relevant. -->

- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
