### PR TITLE
Use relative names for sub components

### DIFF
--- a/src/OMSimulatorLib/CompositeModel.cpp
+++ b/src/OMSimulatorLib/CompositeModel.cpp
@@ -45,3 +45,14 @@ oms2::CompositeModel::CompositeModel(oms_element_type_enu_t type, const ComRef& 
 oms2::CompositeModel::~CompositeModel()
 {
 }
+
+void oms2::CompositeModel::setName(const ComRef& name)
+{
+  element.setName(name);
+  if (getType() == oms_component_fmi)
+  {
+    // update internal references to the parent FMI composite model
+    FMICompositeModel* fmiModel = dynamic_cast<FMICompositeModel*>(this);
+    fmiModel->setName(name);
+  }
+}

--- a/src/OMSimulatorLib/CompositeModel.h
+++ b/src/OMSimulatorLib/CompositeModel.h
@@ -56,7 +56,7 @@ namespace oms2
     const oms2::ssd::ElementGeometry* getGeometry() {return element.getGeometry();}
     oms2::Element* getElement() {return &element;}
 
-    void setName(const ComRef& name) {element.setName(name);}
+    void setName(const ComRef& name);
     void setGeometry(const oms2::ssd::ElementGeometry& geometry) {element.setGeometry(&geometry);}
 
     virtual oms_status_enu_t initialize(double startTime, double tolerance) = 0;
@@ -70,7 +70,7 @@ namespace oms2
     virtual oms_status_enu_t registerSignalsForResultFile(ResultWriter& resultWriter) = 0;
     virtual oms_status_enu_t emit(ResultWriter& resultWriter) = 0;
 
-    virtual oms_status_enu_t describe() { return oms_status_error; }
+    virtual oms_status_enu_t describe() = 0;
 
   protected:
     CompositeModel(oms_element_type_enu_t type, const ComRef& cref);

--- a/src/OMSimulatorLib/Connection.cpp
+++ b/src/OMSimulatorLib/Connection.cpp
@@ -34,6 +34,7 @@
 #include "Logging.h"
 
 #include <cstring>
+#include <iostream>
 
 oms2::Connection::Connection(const oms2::ComRef& parent, const oms2::SignalRef& conA, const oms2::SignalRef& conB)
 {
@@ -131,4 +132,18 @@ bool oms2::Connection::isEqual(const oms2::Connection& connection) const
   const oms2::SignalRef& conA_ = connection.getSignalA();
   const oms2::SignalRef& conB_ = connection.getSignalB();
   return isEqual(parent_, conA_, conB_);
+}
+
+void oms2::Connection::describe()
+{
+  std::cout << getParent().toString() << ": " << getSignalA().toString() << " -> " << getSignalB().toString() << std::endl;
+}
+
+void oms2::Connection::setParent(const oms2::ComRef& parent)
+{
+  std::string str = parent.toString();
+
+  if (this->parent) delete[] this->parent;
+  this->parent = new char[str.size()+1];
+  strcpy(this->parent, str.c_str());
 }

--- a/src/OMSimulatorLib/Connection.h
+++ b/src/OMSimulatorLib/Connection.h
@@ -55,6 +55,7 @@ namespace oms2
     Connection& operator=(const Connection& rhs);
 
     const oms2::ComRef getParent() const {return oms2::ComRef(parent);}
+    void setParent(const oms2::ComRef& parent);
     const oms2::SignalRef getSignalA() const {return oms2::SignalRef(conA);}
     const oms2::SignalRef getSignalB() const {return oms2::SignalRef(conB);}
 
@@ -63,6 +64,8 @@ namespace oms2
 
     bool isEqual(const oms2::Connection& connection) const;
     bool isEqual(const oms2::ComRef& parent, const oms2::SignalRef& signalA, const oms2::SignalRef& signalB) const;
+
+    void describe();
 
   private:
     friend bool operator==(const Connection& lhs, const Connection& rhs);

--- a/src/OMSimulatorLib/Element.cpp
+++ b/src/OMSimulatorLib/Element.cpp
@@ -35,6 +35,7 @@
 #include "Connector.h"
 
 #include <cstring>
+#include <iostream>
 
 oms2::Element::Element(oms_element_type_enu_t type, const oms2::ComRef& name)
 {
@@ -103,4 +104,21 @@ void oms2::Element::setConnectors(const std::vector<oms2::Connector> newConnecto
 
   for (int i=0; i<newConnectors.size(); ++i)
     this->connectors[i] = reinterpret_cast<oms_connector_t*>(new oms2::Connector(newConnectors[i]));
+}
+
+void oms2::Element::describe()
+{
+  std::cout << "FMI sub model \"" + getName() + "\"" << std::endl;
+
+  switch(getType())
+  {
+    case oms_component_none:
+    case oms_component_tlm:      std::cout << "type: TLM model" << std::endl; break;
+    case oms_component_fmi:      std::cout << "type: FMI model" << std::endl; break;
+    case oms_component_external: std::cout << "type: External model" << std::endl; break;
+    case oms_component_fmu:      std::cout << "type: FMU" << std::endl; break;
+    case oms_component_table:    std::cout << "type: lookup table" << std::endl; break;
+    case oms_component_port:     std::cout << "type: port" << std::endl; break;
+    default:                     std::cout << "type: unknown" << std::endl; break;
+  }
 }

--- a/src/OMSimulatorLib/Element.h
+++ b/src/OMSimulatorLib/Element.h
@@ -61,6 +61,8 @@ namespace oms2
     void setGeometry(const oms2::ssd::ElementGeometry* newGeometry);
     void setConnectors(const std::vector<oms2::Connector> newConnectors);
 
+    void describe();
+
   private:
     // methods to copy the object
     Element(const Element& rhs);            ///< not implemented

--- a/src/OMSimulatorLib/FMICompositeModel.cpp
+++ b/src/OMSimulatorLib/FMICompositeModel.cpp
@@ -428,7 +428,7 @@ oms_status_enu_t oms2::FMICompositeModel::addFMU(const std::string& filename, co
   }
 
   oms2::ComRef parent = getName();
-  oms2::FMUWrapper* subModel = oms2::FMUWrapper::newSubModel(parent + cref, filename);
+  oms2::FMUWrapper* subModel = oms2::FMUWrapper::newSubModel(cref, filename);
   if (!subModel)
     return oms_status_error;
 
@@ -452,7 +452,7 @@ oms_status_enu_t oms2::FMICompositeModel::addTable(const std::string& filename, 
   }
 
   oms2::ComRef parent = getName();
-  oms2::Table* subModel = oms2::Table::newSubModel(parent + cref, filename);
+  oms2::Table* subModel = oms2::Table::newSubModel(cref, filename);
   if (!subModel)
     return oms_status_error;
 
@@ -1605,4 +1605,36 @@ oms_status_enu_t oms2::FMICompositeModel::removeSignalsFromResults(const std::st
   for (const auto& it : subModels)
     it.second->removeSignalsFromResults(regex);
   return oms_status_ok;
+}
+
+oms_status_enu_t oms2::FMICompositeModel::describe()
+{
+  std::cout << "# FMI composite model \"" + getName() + "\"" << std::endl;
+
+  oms2::Element** elements = getElements();
+  while(*elements)
+  {
+    oms2::Element* element = *elements;
+    std::cout << "## ";
+    element->describe();
+    elements++;
+  }
+
+  oms2::Connection** connections = getConnections();
+  std::cout << "## Connections" << std::endl;
+  while(*connections)
+  {
+    oms2::Connection* connection = *connections;
+    connection->describe();
+    connections++;
+  }
+
+  return oms_status_ok;
+}
+
+void oms2::FMICompositeModel::setName(const oms2::ComRef& name)
+{
+  for (auto& connection : connections)
+    if (connection)
+      connection->setParent(name);
 }

--- a/src/OMSimulatorLib/FMICompositeModel.h
+++ b/src/OMSimulatorLib/FMICompositeModel.h
@@ -75,6 +75,7 @@ namespace oms2
     FMISubModel* getSubModel(const oms2::ComRef& cref);
     oms2::Connection** getConnections() {return &connections[0];}
 
+    void setName(const oms2::ComRef& name);
     oms_status_enu_t renameSubModel(const oms2::ComRef& identOld, const oms2::ComRef& identNew);
 
     oms2::Element** getElements();
@@ -108,6 +109,8 @@ namespace oms2
 
     oms_status_enu_t addSignalsToResults(const std::string& regex);
     oms_status_enu_t removeSignalsFromResults(const std::string& regex);
+
+    oms_status_enu_t describe();
 
   private:
     oms_status_enu_t loadElementGeometry(const pugi::xml_node& node);

--- a/src/OMSimulatorLib/FMUWrapper.cpp
+++ b/src/OMSimulatorLib/FMUWrapper.cpp
@@ -1268,9 +1268,7 @@ oms_status_enu_t oms2::FMUWrapper::registerSignalsForResultFile(ResultWriter& re
       continue;
 
     auto const &var = allVariables[i];
-    oms2::ComRef cref = var.getCref();
-    cref.popFirst();
-    std::string name = cref.toString() + "." + var.getName();
+    std::string name = var.getCref().toString() + "." + var.getName();
     const std::string& description = var.getDescription();
     if (var.isParameter())
     {

--- a/src/OMSimulatorLib/Model.h
+++ b/src/OMSimulatorLib/Model.h
@@ -89,7 +89,7 @@ namespace oms2
 
     oms_status_enu_t setTLMInitialValues(const SignalRef& ifc, std::vector<double> value);
 
-    virtual oms_status_enu_t describe() { return compositeModel->describe(); }
+    oms_status_enu_t describe() { return compositeModel->describe(); }
     oms_status_enu_t initialize();
     oms_status_enu_t reset();
     oms_status_enu_t terminate();

--- a/src/OMSimulatorLib/Scope.cpp
+++ b/src/OMSimulatorLib/Scope.cpp
@@ -1475,10 +1475,7 @@ oms_status_enu_t oms2::Scope::describeModel(const oms2::ComRef &cref)
 {
   oms2::Model* model = getModel(cref);
   if (!model)
-  {
-    logError("Model: "+cref.toString()+" not found.");
-    return oms_status_error;
-  }
+    return logError("Model: " + cref.toString() + " not found.");
 
   return model->describe();
 }

--- a/src/OMSimulatorLib/Types.h
+++ b/src/OMSimulatorLib/Types.h
@@ -76,8 +76,8 @@ typedef enum {
 
 typedef enum {
   oms_component_none,
-  oms_component_tlm,      ///< TLM model
-  oms_component_fmi,      ///< FMI model
+  oms_component_tlm,      ///< TLM composite model
+  oms_component_fmi,      ///< FMI composite model
   oms_component_external, ///< External model
   oms_component_fmu,      ///< FMU
   oms_component_table,    ///< lookup table

--- a/src/OMSimulatorLua/OMSimulatorLua.c
+++ b/src/OMSimulatorLua/OMSimulatorLua.c
@@ -46,6 +46,20 @@ static int OMSimulatorLua_oms2_getVersion(lua_State *L)
   return 1;
 }
 
+//oms_status_enu_t oms2_describe(const char* cref);
+static int OMSimulatorLua_oms2_describe(lua_State *L)
+{
+  if (lua_gettop(L) != 1)
+    return luaL_error(L, "expecting exactly 1 argument");
+  luaL_checktype(L, 1, LUA_TSTRING);
+
+  const char* cref = lua_tostring(L, 1);
+  oms_status_enu_t status = oms2_describe(cref);
+
+  lua_pushinteger(L, status);
+  return 1;
+}
+
 //int oms2_compareSimulationResults(const char* filenameA, const char* filenameB, const char* var, double relTol, double absTol);
 static int OMSimulatorLua_oms2_compareSimulationResults(lua_State *L)
 {
@@ -1369,7 +1383,6 @@ DLLEXPORT int luaopen_OMSimulatorLua(lua_State *L)
   REGISTER_LUA_CALL(experimental_setActivationRatio);
   REGISTER_LUA_CALL(experimental_simulate_realtime);
   REGISTER_LUA_CALL(oms2_addConnection);
-  REGISTER_LUA_CALL(oms2_addConnection);
   REGISTER_LUA_CALL(oms2_addExternalModel);
   REGISTER_LUA_CALL(oms2_addFMISubModel);
   REGISTER_LUA_CALL(oms2_addFMU);
@@ -1380,6 +1393,7 @@ DLLEXPORT int luaopen_OMSimulatorLua(lua_State *L)
   REGISTER_LUA_CALL(oms2_compareSimulationResults);
   REGISTER_LUA_CALL(oms2_deleteConnection);
   REGISTER_LUA_CALL(oms2_deleteSubModel);
+  REGISTER_LUA_CALL(oms2_describe);
   REGISTER_LUA_CALL(oms2_exportCompositeStructure);
   REGISTER_LUA_CALL(oms2_exportDependencyGraphs);
   REGISTER_LUA_CALL(oms2_getBoolean);


### PR DESCRIPTION
### Related Issues

#212

### Purpose

Fix refactoring issues when renaming FMI composite models.

### Approach

Use relative names inside FMI composite models for sub components.

### Type of Change

<!--- Please delete options that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)

### Checklist

<!--- Please delete options that are not relevant. -->

- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings
