### PR TITLE
Support cross-compiling OMSimulator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,8 @@ IF("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_BINARY_DIR}")
   message(FATAL_ERROR "No in-source builds supported. Change to 'build' sub-directory and do 'cmake ..'.")
 ENDIF()
 
+message(STATUS "Platform string: ${PLATFORM_STRING}")
+
 IF(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
   set(CMAKE_INSTALL_PREFIX ${PROJECT_SOURCE_DIR}/install/${PLATFORM_STRING} CACHE PATH "Library installation path (don't change)" FORCE)
 ENDIF()


### PR DESCRIPTION
Does not work with TLM. Tested using Darwin, which disables SysIdent as
well.

### Related Issues

#229 

### Purpose

Cross-compiling the binary allows us to use x86 Linux systems on the build servers (of which we have many) rather than slow Apple machines (of which we have only 1).

### Approach

Passes along variables to more places. Allows for more configuration. Hacked around Lua.

### Type of Change

- Build system

### Checklist

- I have performed a self-review of my own code
- My changes generate no new warnings