### PR TITLE
Fix "invalid read"

### DIFF
--- a/src/OMSimulatorLib/Scope.cpp
+++ b/src/OMSimulatorLib/Scope.cpp
@@ -59,7 +59,7 @@ oms2::Scope::~Scope()
 
   // free memory if no one else does
   for (auto it=models.begin(); it != models.end(); it++)
-    unloadModel(it->first);
+    oms2::Model::DeleteModel(it->second);
 }
 
 oms2::Scope& oms2::Scope::GetInstance()


### PR DESCRIPTION
### Purpose

Fix crash if not calling `oms2_unloadModel` for each model in scope.

### Approach

The iterator gets invalid during the loop when calling `unloadModel()`. Therefore, we can just call ` oms2::Model::DeleteModel` directly.

### Type of Change

<!--- Please delete options that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)

### Checklist

<!--- Please delete options that are not relevant. -->

- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
