### PR TITLE
Make dependency graphs independent from initialization

### DIFF
--- a/src/OMSimulatorLib/FMICompositeModel.h
+++ b/src/OMSimulatorLib/FMICompositeModel.h
@@ -126,6 +126,7 @@ namespace oms2
 
     oms_status_enu_t stepUntilStandard(ResultWriter& resultWriter, double stopTime, double communicationInterval, double loggingInterval, bool realtime_sync);
     oms_status_enu_t stepUntilPCTPL(ResultWriter& resultWriter, double stopTime, double communicationInterval, double loggingInterval, bool realtime_sync);
+    oms_status_enu_t updateDependencyGraphs();
 
 #if !defined(NO_TLM)
     oms_status_enu_t initializeSockets(double stopTime, double &communicationInterval, std::string server);

--- a/src/OMSimulatorLib/Logging.cpp
+++ b/src/OMSimulatorLib/Logging.cpp
@@ -131,7 +131,7 @@ void Log::Info(const std::string& msg)
     log.cb(oms_message_info, msg.c_str());
 }
 
-void Log::Warning(const std::string& msg)
+oms_status_enu_t Log::Warning(const std::string& msg)
 {
   Log& log = getInstance();
   std::lock_guard<std::mutex> lock(log.m);
@@ -143,6 +143,8 @@ void Log::Warning(const std::string& msg)
 
   if (log.cb)
     log.cb(oms_message_warning, msg.c_str());
+
+  return oms_status_warning;
 }
 
 oms_status_enu_t Log::Error(const std::string& msg)

--- a/src/OMSimulatorLib/Logging.h
+++ b/src/OMSimulatorLib/Logging.h
@@ -52,7 +52,7 @@ class Log
 {
 public:
   static void Info(const std::string& msg);
-  static void Warning(const std::string& msg);
+  static oms_status_enu_t Warning(const std::string& msg);
   static oms_status_enu_t Error(const std::string& msg);
   static void Debug(const std::string& msg);
   static void Trace(const std::string& function, const std::string& file, const long line);


### PR DESCRIPTION
### Purpose

Make dependency graphs independent from initialization. This is useful to debug model that fail during initialization.

### Type of Change

<!--- Please delete options that are not relevant. -->

- New feature (non-breaking change which adds functionality)

### Checklist

<!--- Please delete options that are not relevant. -->

- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
