### PR TITLE
Add maximum log file size

### DIFF
--- a/doc/UsersGuide/source/api/setMaxLogFileSize.rst
+++ b/doc/UsersGuide/source/api/setMaxLogFileSize.rst
@@ -1,0 +1,30 @@
+#CAPTION#
+setMaxLogFileSize
+-----------------
+
+Sets maximum log file size in MB. If the file exceeds this limit, the logging will continue on stdout.
+#END#
+
+#LUA#
+.. code-block:: lua
+
+  oms2_setMaxLogFileSize(size)
+
+#END#
+
+#PYTHON#
+.. code-block:: python
+
+  # not yet available
+
+#END#
+
+#CAPI#
+.. code-block:: c
+
+  void oms2_setMaxLogFileSize(const unsigned long size);
+
+#END#
+
+#DESCRIPTION#
+#END#

--- a/src/OMSimulatorLib/Logging.h
+++ b/src/OMSimulatorLib/Logging.h
@@ -58,6 +58,7 @@ public:
   static void Trace(const std::string& function, const std::string& file, const long line);
 
   static oms_status_enu_t setLogFile(const std::string& filename);
+  static void setMaxLogFileSize(const unsigned long size) {getInstance().limit=1024*1024*size;}
 
   static void setLoggingCallback(void (*cb)(oms_message_type_enu_t type, const char* message)) {getInstance().cb = cb;}
   static void setLoggingLevel(int logLevel);
@@ -81,6 +82,9 @@ private:
   unsigned int numWarnings;
   unsigned int numErrors;
   unsigned int numMessages;
+
+  unsigned long limit = 1024*1024*50;
+  unsigned long size = 0;
 
   void (*cb)(oms_message_type_enu_t type, const char* message);
 };

--- a/src/OMSimulatorLib/OMSimulator.cpp
+++ b/src/OMSimulatorLib/OMSimulator.cpp
@@ -56,6 +56,11 @@ oms_status_enu_t oms2_setLogFile(const char* filename)
   return Log::setLogFile(filename);
 }
 
+void oms2_setMaxLogFileSize(const unsigned long size)
+{
+  Log::setMaxLogFileSize(size);
+}
+
 const char* oms2_getVersion()
 {
   return oms_git_version;

--- a/src/OMSimulatorLib/OMSimulator.h
+++ b/src/OMSimulatorLib/OMSimulator.h
@@ -428,6 +428,15 @@ oms_status_enu_t oms2_setLoggingSamples(const char* cref, const int loggingSampl
 oms_status_enu_t oms2_setLogFile(const char* filename);
 
 /**
+ * \brief Sets maximum log file size in MB. If the file exceeds this limit, the
+ * logging will continue on stdout.
+ *
+ * \param size   [in] maximum log file size in MB
+ * \return       Error status
+ */
+void oms2_setMaxLogFileSize(const unsigned long size);
+
+/**
  * \brief Set new temp directory
  *
  * \param path   [in] Path to new temp directory

--- a/src/OMSimulatorLua/OMSimulatorLua.c
+++ b/src/OMSimulatorLua/OMSimulatorLua.c
@@ -331,6 +331,18 @@ static int OMSimulatorLua_oms2_setLogFile(lua_State *L)
   return 1;
 }
 
+//void oms2_setMaxLogFileSize(const unsigned long size);
+static int OMSimulatorLua_oms2_setMaxLogFileSize(lua_State *L)
+{
+  if (lua_gettop(L) != 1)
+    return luaL_error(L, "expecting exactly 1 argument");
+  luaL_checktype(L, 1, LUA_TNUMBER);
+
+  unsigned long size = lua_tointeger(L, 1);
+  oms2_setMaxLogFileSize(size);
+  return 0;
+}
+
 //oms_status_enu_t oms2_getStartTime(const char* cref, double* startTime);
 static int OMSimulatorLua_oms2_getStartTime(lua_State *L)
 {
@@ -1424,14 +1436,15 @@ DLLEXPORT int luaopen_OMSimulatorLua(lua_State *L)
   REGISTER_LUA_CALL(oms2_setLogFile);
   REGISTER_LUA_CALL(oms2_setLoggingInterval);
   REGISTER_LUA_CALL(oms2_setLoggingLevel);
+  REGISTER_LUA_CALL(oms2_setLoggingSamples);
   REGISTER_LUA_CALL(oms2_setMasterAlgorithm);
+  REGISTER_LUA_CALL(oms2_setMaxLogFileSize);
   REGISTER_LUA_CALL(oms2_setReal);
   REGISTER_LUA_CALL(oms2_setRealParameter);
   REGISTER_LUA_CALL(oms2_setResultFile);
   REGISTER_LUA_CALL(oms2_setStartTime);
   REGISTER_LUA_CALL(oms2_setStopTime);
   REGISTER_LUA_CALL(oms2_setTempDirectory);
-  REGISTER_LUA_CALL(oms2_setLoggingSamples);
   REGISTER_LUA_CALL(oms2_setTLMInitialValues);
   REGISTER_LUA_CALL(oms2_setTLMLoggingLevel);
   REGISTER_LUA_CALL(oms2_setTLMPositionAndOrientation);


### PR DESCRIPTION
### Related Issues

#266, #227 

### Purpose

Stop writing to log file if a certain size is reached.

### Approach

```c
/**
 * \brief Sets maximum log file size in MB. If the file exceeds this limit, the
 * logging will continue on stdout.
 *
 * \param size   [in] maximum log file size in MB
 * \return       Error status
 */
void oms2_setMaxLogFileSize(const unsigned long size);
```

The default value is 50.

### Type of Change

<!--- Please delete options that are not relevant. -->

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update
