### PR TITLE
simulateTLM() function in Model class

### DIFF
--- a/src/OMSimulatorLib/Model.cpp
+++ b/src/OMSimulatorLib/Model.cpp
@@ -389,6 +389,19 @@ oms_status_enu_t oms2::Model::stepUntil(const double timeValue)
   return status;
 }
 
+oms_status_enu_t oms2::Model::simulateTLM(const double timeValue, const std::string server)
+{
+  if (oms_modelState_simulation != modelState)
+    return logError("[oms2::Model::stepUntil] Model cannot be simulated, because it isn't initialized.");
+
+  if(oms_component_fmi != getType())
+    return logError("[oms2::Model::simulateTLM] Can only be used for FMICompositeModels.");
+
+  oms_status_enu_t status = getFMICompositeModel()->simulateTLM(resultFile, timeValue, communicationInterval, loggingInterval, server);
+
+  return status;
+}
+
 oms_status_enu_t oms2::Model::simulate_asynchronous(void (*cb)(const char* ident, double time, oms_status_enu_t status))
 {
   if (oms_modelState_simulation != modelState)

--- a/src/OMSimulatorLib/Model.h
+++ b/src/OMSimulatorLib/Model.h
@@ -100,6 +100,7 @@ namespace oms2
     oms_status_enu_t simulate_realtime();
     oms_status_enu_t doSteps(const int numberOfSteps);
     oms_status_enu_t stepUntil(const double timeValue);
+    oms_status_enu_t simulateTLM(const double timeValue, const std::string server);
 
   private:
     Model(const oms2::ComRef& cref);

--- a/src/OMSimulatorLib/TLM/TLMCompositeModel.cpp
+++ b/src/OMSimulatorLib/TLM/TLMCompositeModel.cpp
@@ -415,11 +415,9 @@ oms_status_enu_t oms2::TLMCompositeModel::stepUntil(ResultWriter &resultWriter, 
   logInfo("Starting submodel threads.");
   std::string server = address + ":" + std::to_string(managerPort);
   std::vector<std::thread*> fmiModelThreads;
-  for(auto it = fmiModels.begin(); it!=fmiModels.end(); ++it)
-  {
+  for(auto it = fmiModels.begin(); it!=fmiModels.end(); ++it) {
     Model* pModel = oms2::Scope::GetInstance().getModel(it->second->getName());
-    ResultWriter *pWriter = pModel->getResultWriter();
-    std::thread *t = new std::thread(&FMICompositeModel::simulateTLM, it->second, pWriter, stopTime, communicationInterval, loggingInterval, server);
+    std::thread *t = new std::thread(&Model::simulateTLM, pModel, stopTime, server);
     fmiModelThreads.push_back(t);
   }
 


### PR DESCRIPTION
### Purpose

Instead of first obtaining variables from Model class and then calling simulateTLM() in FMICompositeModel class, there shall be a simulateTLM() function in Model class.

### Type of Change

- New feature (non-breaking change which adds functionality)

### Checklist

<!--- Please delete options that are not relevant. -->

- I have performed a self-review of my own code
- My changes generate no new warnings
