### PR TITLE
ignore error if we cannot find git

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -222,7 +222,7 @@ config-libxml2:
 	@echo
 	$(MKDIR) 3rdParty/libxml2/$(INSTALL_DIR)
 	cd 3rdParty/libxml2 && ./autogen.sh --prefix="$(ROOT_DIR)/3rdParty/libxml2/$(INSTALL_DIR)" --without-python $(HOST_CROSS_TRIPLE) && $(MAKE) && $(MAKE) install
-	cd 3rdParty/libxml2 && git clean -fdx -e 'install/'
+	cd 3rdParty/libxml2 && git clean -fdx -e 'install/' || true
 endif
 
 distclean:


### PR DESCRIPTION
### Related Issues

### Purpose

During Linux nightly builds while compiling OMSimulator we don't have git available but is used in the Makefile to clean libxml2. 

### Approach

Just ignore the error if git is not found.

### Type of Change

- build change

### Checklist

- I have performed a self-review of my own code

<!--- Please delete section if not relevant. -->
