### PR TITLE
catch the exception

### DIFF
--- a/src/OMSimulatorLib/Scope.cpp
+++ b/src/OMSimulatorLib/Scope.cpp
@@ -335,7 +335,15 @@ oms_status_enu_t oms2::Scope::setTempDirectory(const std::string& newTempDir)
   }
 
   boost::filesystem::path path(newTempDir.c_str());
-  path = boost::filesystem::canonical(path);
+  try
+  {
+    path = boost::filesystem::canonical(path);
+  }
+  catch(std::exception e)
+  {
+    // do nothing, canonical fails if the directory contains a junction or a symlink!
+    // https://svn.boost.org/trac10/ticket/11138
+  }
   tempDir = path.string();
 
   logInfo("New temp directory: \"" + std::string(tempDir) + "\"");


### PR DESCRIPTION
### Purpose

Fix boost issues with canonical on Windows when using directory junctions.
My `C:\OMDev is a mklink /J OMDev E:\OMDev`

### Approach

Catches the exception.

### Type of Change

- Bug fix (non-breaking change which fixes an issue)

### Checklist

- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
