### PR TITLE
Added API `oms2_loadModelFromString`

### DIFF
--- a/doc/UsersGuide/source/api/loadModel.rst
+++ b/doc/UsersGuide/source/api/loadModel.rst
@@ -2,20 +2,20 @@
 loadModel
 ---------
 
-Loads a FMI composite model from xml representation.
+Loads a FMI composite model from xml file.
 #END#
 
 #LUA#
 .. code-block:: lua
 
-  ident, status = oms2_loadModel(filename)
+  status, ident = oms2_loadModel(filename)
 
 #END#
 
 #PYTHON#
 .. code-block:: python
 
-  ident, status = session.loadModel(filename)
+  status, ident = session.loadModel(filename)
 
 #END#
 

--- a/doc/UsersGuide/source/api/loadModelFromString.rst
+++ b/doc/UsersGuide/source/api/loadModelFromString.rst
@@ -1,0 +1,30 @@
+#CAPTION#
+loadModelFromString
+-------------------
+
+Loads a FMI composite model from xml representation.
+#END#
+
+#LUA#
+.. code-block:: lua
+
+  status, ident = oms2_loadModelFromString(contents)
+
+#END#
+
+#PYTHON#
+.. code-block:: python
+
+  status, ident = session.loadModelFromString(filename)
+
+#END#
+
+#CAPI#
+.. code-block:: c
+
+  oms_status_enu_t oms2_loadModelFromString(const char* contents, char** ident);
+
+#END#
+
+#DESCRIPTION#
+#END#

--- a/src/OMSimulatorLib/OMSimulator.cpp
+++ b/src/OMSimulatorLib/OMSimulator.cpp
@@ -150,6 +150,20 @@ oms_status_enu_t oms2_loadModel(const char* filename, char** ident)
   return oms_status_ok;
 }
 
+oms_status_enu_t oms2_loadModelFromString(const char* contents, char** ident)
+{
+  logTrace();
+  oms2::Model* model = oms2::Scope::GetInstance().loadModel(contents);
+
+  if (!model) {
+    return oms_status_error;
+  }
+
+  oms_element_t* element = reinterpret_cast<oms_element_t*>(model->getElement());
+  *ident = element->name;
+  return oms_status_ok;
+}
+
 oms_status_enu_t oms2_saveModel(const char* filename, const char* ident)
 {
   logTrace();

--- a/src/OMSimulatorLib/OMSimulator.h
+++ b/src/OMSimulatorLib/OMSimulator.h
@@ -122,13 +122,22 @@ oms_status_enu_t oms2_deleteSubModel(const char* modelIdent, const char* subMode
 oms_status_enu_t oms2_rename(const char* identOld, const char* identNew);
 
 /**
- * \brief Loads a FMI composite model from xml representation.
+ * \brief Loads a FMI composite model from xml file.
  *
- * \param filename   [in] Path to the composite model xml representation
+ * \param filename   [in] Path to the composite model xml file
  * \param ident      [out] Name of the imported model
  * \return           Error status
  */
 oms_status_enu_t oms2_loadModel(const char* filename, char** ident);
+
+/**
+ * \brief Loads a FMI composite model from xml representation.
+ *
+ * \param contents   [in] Composite model xml contents
+ * \param ident      [out] Name of the imported model
+ * \return           Error status
+ */
+oms_status_enu_t oms2_loadModelFromString(const char* contents, char** ident);
 
 /**
  * \brief Loads a FMI composite model from xml representation.
@@ -682,7 +691,6 @@ oms_status_enu_t oms2_exportCompositeStructure(const char* cref, const char* fil
 /**
  * \brief Export the dependency graphs of a given model to a dot file.
  *
- * \param cref             [in] Name of the model instance
  * \param initialization   [in] Path to the dot file; An existing file will be overwritten
  * \param simulation       [in] Path to the dot file; An existing file will be overwritten
  * \return                 Error status

--- a/src/OMSimulatorLua/OMSimulatorLua.c
+++ b/src/OMSimulatorLua/OMSimulatorLua.c
@@ -205,6 +205,25 @@ static int OMSimulatorLua_oms2_loadModel(lua_State *L)
   return 2;
 }
 
+//oms_status_enu_t oms2_loadModelFromString(const char* contents, char** ident);
+static int OMSimulatorLua_oms2_loadModelFromString(lua_State *L)
+{
+  if (lua_gettop(L) != 1)
+    return luaL_error(L, "expecting exactly 1 argument");
+  luaL_checktype(L, 1, LUA_TSTRING);
+
+  const char* contents = lua_tostring(L, 1);
+  char* ident = NULL;
+  oms_status_enu_t status = oms2_loadModelFromString(contents, &ident);
+
+  lua_pushinteger(L, status);
+  if (ident)
+    lua_pushstring(L, ident);
+  else
+    lua_pushstring(L, "");
+  return 2;
+}
+
 //oms_status_enu_t oms2_saveModel(const char* filename, const char* ident);
 static int OMSimulatorLua_oms2_saveModel(lua_State *L)
 {
@@ -1449,6 +1468,7 @@ DLLEXPORT int luaopen_OMSimulatorLua(lua_State *L)
   REGISTER_LUA_CALL(oms2_getVersion);
   REGISTER_LUA_CALL(oms2_initialize);
   REGISTER_LUA_CALL(oms2_loadModel);
+  REGISTER_LUA_CALL(oms2_loadModelFromString);
   REGISTER_LUA_CALL(oms2_newFMIModel);
   REGISTER_LUA_CALL(oms2_newTLMModel);
   REGISTER_LUA_CALL(oms2_removeSignalsFromResults);

--- a/src/OMSimulatorPython/OMSimulator.py
+++ b/src/OMSimulatorPython/OMSimulator.py
@@ -77,6 +77,9 @@ class OMSimulator:
     self.obj.oms2_loadModel.argtypes = [ctypes.c_char_p]
     self.obj.oms2_loadModel.restype = ctypes.c_int
 
+    self.obj.oms2_loadModelFromString.argtypes = [ctypes.c_char_p]
+    self.obj.oms2_loadModelFromString.restype = ctypes.c_int
+
     self.obj.oms2_newFMIModel.argtypes = [ctypes.c_char_p]
     self.obj.oms2_newFMIModel.restype = ctypes.c_int
 
@@ -224,6 +227,10 @@ class OMSimulator:
   def loadModel(self, filename):
     ident = ctypes.c_char_p()
     status = self.obj.oms2_loadModel(str.encode(filename), ctypes.byref(ident))
+    return [status, ident.value]
+  def loadModelFromString(self, contents):
+    ident = ctypes.c_char_p()
+    status = self.obj.oms2_loadModelFromString(str.encode(contents), ctypes.byref(ident))
     return [status, ident.value]
   def newFMIModel(self, ident):
     return self.obj.oms2_newFMIModel(str.encode(ident))


### PR DESCRIPTION
### Purpose

Allow loading a model from a xml string buffer.

### Approach

Used the `oms2_loadModel` approach. The only difference is instead of loading from a file the string buffer is used.

### Type of Change

- Code refactoring (non-breaking change which improves maintainability)
- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

### Checklist

- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation