### PR TITLE
Fix number of arguments for setTLMInitialValues()

### DIFF
--- a/src/OMSimulatorLib/FMICompositeModel.cpp
+++ b/src/OMSimulatorLib/FMICompositeModel.cpp
@@ -1579,16 +1579,23 @@ oms_status_enu_t oms2::FMICompositeModel::setTLMInitialValues(std::string ifcnam
   for(TLMInterface* ifc: tlmInterfaces) {
     if(ifc->getName() == ifcname) {
       found = true;
-      if(ifc->getDimensions() == 1) {
+      if(ifc->getDimensions() == 1 && ifc->getCausality() != oms_causality_bidir) {
         if(values.size() < 1) {
           logError("No initial TLM value specified.");
           return oms_status_error;
         }
         tlmInitialValues.insert(std::make_pair(ifcname, values));
       }
+      else if(ifc->getDimensions() == 1 && ifc->getCausality() == oms_causality_bidir) {
+        if(values.size() < 2) {
+          logError("Too few initial TLM values specified for 1D interface (should be 2, effort and flow).");
+          return oms_status_error;
+        }
+        tlmInitialValues.insert(std::make_pair(ifcname, values));
+      }
       else if(ifc->getDimensions() == 3) {
-        if(values.size() < 6) {
-          logError("Too few initial TLM values specified for 3D interface (should be 6).");
+        if(values.size() < 12) {
+          logError("Too few initial TLM values specified for 3D interface (should be 12, 3 forces, 3 torques, 3 velocities and 3 angular velocities).");
           return oms_status_error;
         }
         tlmInitialValues.insert(std::make_pair(ifcname, values));

--- a/src/OMSimulatorLua/OMSimulatorLua.c
+++ b/src/OMSimulatorLua/OMSimulatorLua.c
@@ -1139,8 +1139,8 @@ static int OMSimulatorLua_oms2_setTLMSocketData(lua_State *L)
 static int OMSimulatorLua_oms2_setTLMInitialValues(lua_State *L)
 {
   //First parse initial arguments (3 or 8)
-  if(lua_gettop(L) != 3 && lua_gettop(L) != 8) {
-    return luaL_error(L, "expecting exactly 3 or 8 arguments");
+  if(lua_gettop(L) != 3 && lua_gettop(L) != 4 && lua_gettop(L) != 14) {
+    return luaL_error(L, "expecting exactly 3, 4 or 14 arguments");
   }
 
   luaL_checktype(L, 1, LUA_TSTRING);
@@ -1148,10 +1148,18 @@ static int OMSimulatorLua_oms2_setTLMInitialValues(lua_State *L)
   luaL_checktype(L, 3, LUA_TNUMBER);
   if(lua_gettop(L) > 3) {
     luaL_checktype(L, 4, LUA_TNUMBER);
+  }
+  if(lua_gettop(L) > 4) {
     luaL_checktype(L, 5, LUA_TNUMBER);
     luaL_checktype(L, 6, LUA_TNUMBER);
     luaL_checktype(L, 7, LUA_TNUMBER);
     luaL_checktype(L, 8, LUA_TNUMBER);
+    luaL_checktype(L, 9, LUA_TNUMBER);
+    luaL_checktype(L, 10, LUA_TNUMBER);
+    luaL_checktype(L, 11, LUA_TNUMBER);
+    luaL_checktype(L, 12, LUA_TNUMBER);
+    luaL_checktype(L, 13, LUA_TNUMBER);
+    luaL_checktype(L, 14, LUA_TNUMBER);
   }
 
   oms_status_enu_t status;
@@ -1162,6 +1170,12 @@ static int OMSimulatorLua_oms2_setTLMInitialValues(lua_State *L)
     values[0] = lua_tonumber(L,3);
     status = oms2_setTLMInitialValues(cref, subref, values, 1);
   }
+  else if(lua_gettop(L) == 4) {
+    double values[2];
+    values[0] = lua_tonumber(L,3);
+    values[1] = lua_tonumber(L,4);
+    status = oms2_setTLMInitialValues(cref, subref, values, 2);
+  }
   else {
     double values[6];
     values[0] = lua_tonumber(L,3);
@@ -1170,7 +1184,13 @@ static int OMSimulatorLua_oms2_setTLMInitialValues(lua_State *L)
     values[3] = lua_tonumber(L,6);
     values[4] = lua_tonumber(L,7);
     values[5] = lua_tonumber(L,8);
-    status = oms2_setTLMInitialValues(cref, subref, values, 6);
+    values[6] = lua_tonumber(L,9);
+    values[7] = lua_tonumber(L,10);
+    values[8] = lua_tonumber(L,11);
+    values[9] = lua_tonumber(L,12);
+    values[10] = lua_tonumber(L,13);
+    values[11] = lua_tonumber(L,14);
+    status = oms2_setTLMInitialValues(cref, subref, values, 12);
   }
   lua_pushinteger(L, status);
   return 1;


### PR DESCRIPTION
### Related Issues

#258
#289

### Purpose

Number of argument checks were wrong for initial TLM values API function.

### Approach

Correct the number of argument checks.

### Type of Change

<!--- Please delete options that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)

### Checklist

- I have performed a self-review of my own code
- My changes generate no new warnings