### PR TITLE
Fix array size for initial TLM values

### DIFF
--- a/src/OMSimulatorLua/OMSimulatorLua.c
+++ b/src/OMSimulatorLua/OMSimulatorLua.c
@@ -1177,7 +1177,7 @@ static int OMSimulatorLua_oms2_setTLMInitialValues(lua_State *L)
     status = oms2_setTLMInitialValues(cref, subref, values, 2);
   }
   else {
-    double values[6];
+    double values[12];
     values[0] = lua_tonumber(L,3);
     values[1] = lua_tonumber(L,4);
     values[2] = lua_tonumber(L,5);


### PR DESCRIPTION
### Related Issues
#258
#289
#298

### Purpose

An array was too small for 3D interfaces, causing a crash.

### Approach

Resize the array.

### Type of Change

- Bug fix (non-breaking change which fixes an issue)

### Checklist

- I have performed a self-review of my own code
- My changes generate no new warnings