### PR TITLE
Correct communication interval for TLM submodels

### DIFF
--- a/src/OMSimulatorLib/FMICompositeModel.cpp
+++ b/src/OMSimulatorLib/FMICompositeModel.cpp
@@ -1161,16 +1161,16 @@ void oms2::FMICompositeModel::simulate_asynchronous(ResultWriter& resultWriter, 
 }
 
 #if !defined(NO_TLM)
-oms_status_enu_t oms2::FMICompositeModel::simulateTLM(double startTime, double stopTime, double tolerance, double commInterval, double loggingInterval, std::string server)
+oms_status_enu_t oms2::FMICompositeModel::simulateTLM(double startTime, double stopTime, double tolerance, double loggingInterval, std::string server)
 {
   logTrace();
 
   this->tlmServer = server;
-  this->communicationInterval = commInterval;
 
   Model *model = oms2::Scope::GetInstance().getModel(getName());
   model->setStartTime(startTime);
   model->setTolerance(tolerance);
+  communicationInterval = model->getCommunicationInterval();
   model->initialize();
   ResultWriter *resultWriter = model->getResultWriter();
 

--- a/src/OMSimulatorLib/FMICompositeModel.h
+++ b/src/OMSimulatorLib/FMICompositeModel.h
@@ -90,7 +90,7 @@ namespace oms2
     oms_status_enu_t doSteps(ResultWriter& resultWriter, const int numberOfSteps, double communicationInterval, double loggingInterval);
     oms_status_enu_t stepUntil(ResultWriter& resultWriter, double stopTime, double communicationInterval, double loggingInterval, MasterAlgorithm masterAlgorithm, bool realtime_sync);
 #if !defined(NO_TLM)
-    oms_status_enu_t simulateTLM(double startTime, double stopTime, double tolerance, double communicationInterval, double loggingInterval, std::string address);
+    oms_status_enu_t simulateTLM(double startTime, double stopTime, double tolerance, double loggingInterval, std::string address);
 #endif
     void simulate_asynchronous(ResultWriter& resultWriter, double stopTime, double communicationInterval, double loggingInterval, void (*cb)(const char* ident, double time, oms_status_enu_t status));
 

--- a/src/OMSimulatorLib/TLM/TLMCompositeModel.cpp
+++ b/src/OMSimulatorLib/TLM/TLMCompositeModel.cpp
@@ -412,7 +412,7 @@ oms_status_enu_t oms2::TLMCompositeModel::stepUntil(ResultWriter &resultWriter, 
   {
     Model* pModel = oms2::Scope::GetInstance().getModel(it->second->getName());
     double tolerance = pModel->getTolerance();
-    std::thread *t = new std::thread(&FMICompositeModel::simulateTLM, it->second, startTime, stopTime, tolerance, communicationInterval, loggingInterval, server);
+    std::thread *t = new std::thread(&FMICompositeModel::simulateTLM, it->second, startTime, stopTime, tolerance, loggingInterval, server);
     fmiModelThreads.push_back(t);
   }
 


### PR DESCRIPTION
### Purpose

Individual communication intervals for TLM submodels were ignored. They always used the TLM composite model interval.

### Approach

Change code so that individual communication intervals are respected.

### Type of Change

- Bug fix (non-breaking change which fixes an issue)

### Checklist

- I have performed a self-review of my own code
- My changes generate no new warnings