### PR TITLE
use boost::regex instead of std::regex for old and dumb compilers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,14 +34,16 @@ IF(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 ENDIF()
 
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
-  # require at least gcc 5.0
-  if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.0)
-    message(FATAL_ERROR "GCC version must be at least 5.0!")
+  # require at least gcc 4.9.2
+  if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.9.2)
+    message(WARNING, "Using boost::regex instead of std::regex due to old gcc compiler")
+    set(BOOST_REGEX regex)
   endif()
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-  # require at least clang 4.0
-  if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.0)
-    message(FATAL_ERROR "Clang version must be at least 4.0!")
+  # require at least clang 3.8.0
+  if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 3.9.0)
+    message(WARNING, "Using boost::regex instead of std::regex due to old clang compiler")
+    set(BOOST_REGEX regex)
   endif()
 endif()
 

--- a/src/OMSimulator/CMakeLists.txt
+++ b/src/OMSimulator/CMakeLists.txt
@@ -16,7 +16,7 @@ IF(NOT WIN32)
 set(Boost_USE_STATIC_RUNTIME ON)
 ENDIF()
 
-find_package(Boost 1.54.0 COMPONENTS system filesystem REQUIRED)
+find_package(Boost 1.54.0 COMPONENTS system filesystem ${BOOST_REGEX} REQUIRED)
 IF(Boost_FOUND)
   message(STATUS "Found Boost static libraries")
   message(STATUS "  Boost_LIBRARIES:    " ${Boost_LIBRARIES})

--- a/src/OMSimulator/Options.cpp
+++ b/src/OMSimulator/Options.cpp
@@ -32,7 +32,6 @@
 #include "Options.h"
 
 #include <iostream>
-#include <regex>
 #include <string>
 
 ProgramOptions::ProgramOptions(int argc, char** argv)
@@ -55,10 +54,10 @@ ProgramOptions::ProgramOptions(int argc, char** argv)
   useTolerance = false;
   logLevel = 0;
 
-  std::regex re_integer("(\\+|-)?[[:digit:]]+");
-  std::regex re_double("((\\+|-)?[[:digit:]]+)(\\.(([[:digit:]]+)?))?((e|E)((\\+|-)?)[[:digit:]]+)?");
-  std::regex re_default(".+");
-  std::regex re_solver("internal|euler|cvode");
+  oms_regex re_integer("(\\+|-)?[[:digit:]]+");
+  oms_regex re_double("((\\+|-)?[[:digit:]]+)(\\.(([[:digit:]]+)?))?((e|E)((\\+|-)?)[[:digit:]]+)?");
+  oms_regex re_default(".+");
+  oms_regex re_solver("internal|euler|cvode");
 
   validOptions = true;
   for (; argi<argc; ++argi)
@@ -152,7 +151,7 @@ bool ProgramOptions::isOption(const std::string& name1, const std::string& name2
   return isOption(name1) || isOption(name2);
 }
 
-bool ProgramOptions::isOptionAndValue(const std::string& name, std::string& value, std::regex re)
+bool ProgramOptions::isOptionAndValue(const std::string& name, std::string& value, oms_regex re)
 {
   std::string arg(argv[argi]);
   std::string _value;
@@ -183,7 +182,7 @@ bool ProgramOptions::isOptionAndValue(const std::string& name, std::string& valu
   return false;
 }
 
-bool ProgramOptions::isOptionAndValue(const std::string& name1, const std::string& name2, std::string& value, std::regex re)
+bool ProgramOptions::isOptionAndValue(const std::string& name1, const std::string& name2, std::string& value, oms_regex re)
 {
   return isOptionAndValue(name1, value, re) || isOptionAndValue(name2, value, re);
 }

--- a/src/OMSimulatorLib/ComRef.cpp
+++ b/src/OMSimulatorLib/ComRef.cpp
@@ -34,7 +34,7 @@
 
 #include <deque>
 #include <string>
-#include <regex>
+#include <RegEx.h>
 
 oms2::ComRef::ComRef()
 {
@@ -84,8 +84,8 @@ oms2::ComRef oms2::ComRef::operator+(const oms2::ComRef& rhs)
 
 bool oms2::ComRef::isValidIdent(const std::string& ident)
 {
-  std::regex re("^[a-zA-Z][a-zA-Z0-9_]*$");
-  return std::regex_match(ident, re);
+  oms_regex re("^[a-zA-Z][a-zA-Z0-9_]*$");
+  return oms_regex_match(ident, re);
 }
 
 bool oms2::ComRef::isValidIdent() const

--- a/src/OMSimulatorLib/FMUWrapper.cpp
+++ b/src/OMSimulatorLib/FMUWrapper.cpp
@@ -41,7 +41,7 @@
 #include "FMICompositeModel.h"
 
 #include <cmath>
-#include <regex>
+#include <RegEx.h>
 #include <fmilib.h>
 #include <JM/jm_portability.h>
 
@@ -969,7 +969,7 @@ oms_status_enu_t oms2::FMUWrapper::emit(ResultWriter& resultWriter)
 
 void oms2::FMUWrapper::addSignalsToResults(const std::string& regex)
 {
-  std::regex exp(regex);
+  oms_regex exp(regex);
   for (unsigned int i=0; i<allVariables.size(); ++i)
   {
     if (exportVariables[i])
@@ -986,7 +986,7 @@ void oms2::FMUWrapper::addSignalsToResults(const std::string& regex)
 
 void oms2::FMUWrapper::removeSignalsFromResults(const std::string& regex)
 {
-  std::regex exp(regex);
+  oms_regex exp(regex);
   for (unsigned int i=0; i<allVariables.size(); ++i)
   {
     if (!exportVariables[i])

--- a/src/OMSimulatorLib/RegEx.h
+++ b/src/OMSimulatorLib/RegEx.h
@@ -28,51 +28,36 @@
  * See the full OSMC Public License conditions for more details.
  *
  */
+ 
+#ifndef _OMS_REGEX_H_
+#define _OMS_REGEX_H_
+ 
+#include <regex>
 
-#ifndef _OMS_OPTIONS_H_
-#define _OMS_OPTIONS_H_
+// adrpo: crap regex handling
+#if __cplusplus >= 201103L &&                             \
+    (!defined(__GLIBCXX__) || (__cplusplus >= 201402L) || \
+        (defined(_GLIBCXX_REGEX_DFS_QUANTIFIERS_LIMIT) || \
+         defined(_GLIBCXX_REGEX_STATE_LIMIT)           || \
+             (defined(_GLIBCXX_RELEASE)                && \
+             _GLIBCXX_RELEASE > 4)))
 
-#include <RegEx.h>
-#include <string>
+#define OMS_GOOD_REGEX 1
+#else
+#define OMS_GOOD_REGEX 0
+#endif
 
-class ProgramOptions
-{
-public:
-  ProgramOptions(int argc, char** argv);
-  void printUsage();
+#if OMS_GOOD_REGEX || defined(_MSC_VER)
+#define oms_regex std::regex
+#define oms_regex_match std::regex_match
 
-private:
-  bool isOption(const std::string& name);
-  bool isOption(const std::string& name1, const std::string& name2);
-  bool isOptionAndValue(const std::string& name, std::string& value, oms_regex re);
-  bool isOptionAndValue(const std::string& name1, const std::string& name2, std::string& value, oms_regex re);
+#else
 
-public:
-  bool validOptions;
-  bool describe;
-  bool help;
-  bool version;
-  double startTime;
-  bool useStartTime;
-  double stopTime;
-  bool useStopTime;
-  double tolerance;
-  bool useTolerance;
-  double communicationInterval;
-  bool useCommunicationInterval;
-  std::string filename;
-  std::string resultFile;
-  std::string tempDir;
-  std::string workingDir;
-  std::string logfile;
-  std::string solver;
-  double timeout;
-  int logLevel;
-
-private:
-  int argi;
-  int argc;
-  char** argv;
-};
+#include <boost/regex.hpp>
+#define oms_regex boost::regex
+#define oms_regex_match boost::regex_match
 
 #endif
+
+
+#endif // #ifndef _OMS_REGEX_H_


### PR DESCRIPTION
### Purpose

use boost::regex instead of std::regex for older compilers

