### PR TITLE
update clang check to 3.8.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,7 +41,7 @@ if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
   endif()
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
   # require at least clang 3.8.0
-  if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 3.9.0)
+  if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 3.8.0)
     message(WARNING, "Using boost::regex instead of std::regex due to old clang compiler")
     set(BOOST_REGEX regex)
   endif()


### PR DESCRIPTION
### Purpose

- change the check for clang compiler version for std::regex
- clang 3.8.0 seems fine