### PR TITLE
Swap arguments of oms2_saveModel

### DIFF
--- a/doc/UsersGuide/source/api/saveModel.rst
+++ b/doc/UsersGuide/source/api/saveModel.rst
@@ -8,21 +8,21 @@ Dumps SSD representation of a given FMI composite model to a file.
 #LUA#
 .. code-block:: lua
 
-  status = oms2_saveModel(filename, ident)
+  status = oms2_saveModel(ident, filename)
 
 #END#
 
 #PYTHON#
 .. code-block:: python
 
-  status = session.saveModel(filename, ident)
+  status = session.saveModel(ident, filename)
 
 #END#
 
 #CAPI#
 .. code-block:: c
 
-  oms_status_enu_t oms2_saveModel(const char* filename, const char* ident);
+  oms_status_enu_t oms2_saveModel(const char* ident, const char* filename);
 
 #END#
 

--- a/src/OMSimulatorLib/OMSimulator.cpp
+++ b/src/OMSimulatorLib/OMSimulator.cpp
@@ -164,10 +164,10 @@ oms_status_enu_t oms2_loadModelFromString(const char* contents, char** ident)
   return oms_status_ok;
 }
 
-oms_status_enu_t oms2_saveModel(const char* filename, const char* ident)
+oms_status_enu_t oms2_saveModel(const char* ident, const char* filename)
 {
   logTrace();
-  return oms2::Scope::GetInstance().saveModel(filename, oms2::ComRef(ident));
+  return oms2::Scope::GetInstance().saveModel(oms2::ComRef(ident), filename);
 }
 
 oms_status_enu_t oms2_listModel(const char* ident, char** contents)

--- a/src/OMSimulatorLib/OMSimulator.h
+++ b/src/OMSimulatorLib/OMSimulator.h
@@ -142,11 +142,11 @@ oms_status_enu_t oms2_loadModelFromString(const char* contents, char** ident);
 /**
  * \brief Loads a FMI composite model from xml representation.
  *
- * \param filename   [in] Path to the xml file; An existing file will be overwritten
  * \param ident      [in] Name of the model to export
+ * \param filename   [in] Path to the xml file; An existing file will be overwritten
  * \return           Error status
  */
-oms_status_enu_t oms2_saveModel(const char* filename, const char* ident);
+oms_status_enu_t oms2_saveModel(const char* ident, const char* filename);
 
 /**
  * \brief Lists the contents of a composite model.

--- a/src/OMSimulatorLib/Scope.cpp
+++ b/src/OMSimulatorLib/Scope.cpp
@@ -231,7 +231,7 @@ oms2::Model* oms2::Scope::loadModel(const std::string& filename)
   return model;
 }
 
-oms_status_enu_t oms2::Scope::saveModel(const std::string& filename, const oms2::ComRef& name)
+oms_status_enu_t oms2::Scope::saveModel(const oms2::ComRef& name, const std::string& filename)
 {
   logTrace();
 

--- a/src/OMSimulatorLib/Scope.h
+++ b/src/OMSimulatorLib/Scope.h
@@ -75,7 +75,7 @@ namespace oms2
     bool exists(const ComRef& cref);
     oms_status_enu_t rename(const ComRef& identOld, const ComRef& identNew);
     Model* loadModel(const std::string& filename);
-    oms_status_enu_t saveModel(const std::string& filename, const ComRef& name);
+    oms_status_enu_t saveModel(const ComRef& name, const std::string& filename);
     oms_status_enu_t listModel(const ComRef& name, char** contents);
     oms_status_enu_t getElement(const ComRef& cref, oms2::Element** element);
     oms_status_enu_t setElementGeometry(const ComRef& cref, const oms2::ssd::ElementGeometry* geometry);

--- a/src/OMSimulatorLua/OMSimulatorLua.c
+++ b/src/OMSimulatorLua/OMSimulatorLua.c
@@ -237,7 +237,7 @@ static int OMSimulatorLua_oms2_loadModelFromString(lua_State *L)
   return 2;
 }
 
-//oms_status_enu_t oms2_saveModel(const char* filename, const char* ident);
+//oms_status_enu_t oms2_saveModel(const char* ident, const char* filename);
 static int OMSimulatorLua_oms2_saveModel(lua_State *L)
 {
   if (lua_gettop(L) != 2)
@@ -245,9 +245,9 @@ static int OMSimulatorLua_oms2_saveModel(lua_State *L)
   luaL_checktype(L, 1, LUA_TSTRING);
   luaL_checktype(L, 2, LUA_TSTRING);
 
-  const char* filename = lua_tostring(L, 1);
-  const char* ident = lua_tostring(L, 2);
-  oms_status_enu_t status = oms2_saveModel(filename, ident);
+  const char* ident = lua_tostring(L, 1);
+  const char* filename = lua_tostring(L, 2);
+  oms_status_enu_t status = oms2_saveModel(ident, filename);
 
   lua_pushinteger(L, status);
   return 1;

--- a/src/OMSimulatorPython/OMSimulator.py
+++ b/src/OMSimulatorPython/OMSimulator.py
@@ -245,8 +245,8 @@ class OMSimulator:
     return self.obj.oms2_removeSignalsFromResults(str.encode(cref), str.encode(regex))
   def reset(self, ident):
     return self.obj.oms2_reset(str.encode(ident))
-  def saveModel(self, filename, ident):
-    return self.obj.oms2_saveModel(str.encode(filename), str.encode(ident))
+  def saveModel(self, ident, filename):
+    return self.obj.oms2_saveModel(str.encode(ident), str.encode(filename))
   def listModel(self, ident):
     contents = ctypes.c_char_p()
     status = self.obj.oms2_listModel(str.encode(ident), ctypes.byref(contents))


### PR DESCRIPTION
### Purpose

Swap arguments of oms2_saveModel, since most other functions use also the cref as first argument.

### Type of Change

<!--- Please delete options that are not relevant. -->

- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

### Checklist

<!--- Please delete options that are not relevant. -->

- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- I have added tests that prove my fix is effective or that my feature works