### PR TITLE
Added exists() function to TLMCompositeModel

### DIFF
--- a/src/OMSimulatorLib/Scope.cpp
+++ b/src/OMSimulatorLib/Scope.cpp
@@ -1974,6 +1974,9 @@ bool oms2::Scope::exists(const ComRef& cref)
 #if !defined(NO_TLM)
       // case 2b: sub-model (TLM composite model)
       TLMCompositeModel* tlmModel = model->getTLMCompositeModel();
+      ComRef tempRef = cref;
+      tempRef.popFirst();
+      return tlmModel->exists(tempRef);
 #endif
       logError("[oms2::Scope::exists] not implemented for TLM composite models");
       return 0;

--- a/src/OMSimulatorLib/TLM/TLMCompositeModel.h
+++ b/src/OMSimulatorLib/TLM/TLMCompositeModel.h
@@ -71,6 +71,10 @@ namespace oms2
     oms_status_enu_t addConnection(const oms2::TLMConnection& connection);
     oms_status_enu_t addConnection(const SignalRef& signalA, const SignalRef& signalB, double delay, double alpha, double Zf, double Zfr);
 
+    bool exists(const ComRef& subref);
+    FMICompositeModel* getFMIModel(const oms2::ComRef& cref);
+
+
     oms_status_enu_t setSocketData(const std::string &address,
                                    int managerPort,
                                    int monitorPort);


### PR DESCRIPTION
### Related Issues

#305

### Purpose

Support Scope::exists() for TLM submodels.
Prevent adding FMI submodel and external models with same name.

### Approach

Added exists() and getFMIModel() functions in TLMCompositeModel.

### Type of Change

- New feature (non-breaking change which adds functionality)

### Checklist

- I have performed a self-review of my own code
- My changes generate no new warnings