### PR TITLE
Call `oms2_freeMemory` in the python binding of `oms2_parseString`

### DIFF
--- a/doc/UsersGuide/source/api/freeMemory.rst
+++ b/doc/UsersGuide/source/api/freeMemory.rst
@@ -1,0 +1,31 @@
+#CAPTION#
+freeMemory
+----------
+
+Free the memory allocated by some other API. Pass the object for which memory is allocated.
+You can directly call free on the object or can use this function.
+#END#
+
+#LUA#
+.. code-block:: lua
+
+  oms2_freeMemory(obj)
+
+#END#
+
+#PYTHON#
+.. code-block:: python
+
+  session.freeMemory(cref)
+
+#END#
+
+#CAPI#
+.. code-block:: c
+
+  oms_status_enu_t oms2_freeMemory(void* obj);
+
+#END#
+
+#DESCRIPTION#
+#END#

--- a/src/OMSimulatorPython/OMSimulator.py
+++ b/src/OMSimulatorPython/OMSimulator.py
@@ -239,6 +239,7 @@ class OMSimulator:
   def parseString(self, contents):
     ident = ctypes.c_char_p()
     status = self.obj.oms2_parseString(str.encode(contents), ctypes.byref(ident))
+    self.obj.oms2_freeMemory(ident)
     return [status, ident.value]
   def loadString(self, contents):
     ident = ctypes.c_char_p()


### PR DESCRIPTION
### Purpose

`oms2_freeMemory` is not called for `oms2_parseString` python binding
Added documentation for `oms2_freeMemory`

### Approach

Call `oms2_freeMemory` in the python binding of `oms2_parseString` to fix the memory leak in python binding.

### Type of Change

- Code refactoring (non-breaking change which improves maintainability)
- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update

### Checklist

- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation