### PR TITLE
Save TLM composite models to SSD

### DIFF
--- a/src/OMSimulatorLib/FMICompositeModel.cpp
+++ b/src/OMSimulatorLib/FMICompositeModel.cpp
@@ -171,6 +171,16 @@ oms_status_enu_t oms2::FMICompositeModel::save(pugi::xml_node& node)
       return status;
   }
 
+  pugi::xml_node nodeAnnotations = node.append_child(oms2::ssd::ssd_annotations);
+  pugi::xml_node nodeAnnotation = nodeAnnotations.append_child(oms2::ssd::ssd_annotation);
+  nodeAnnotation.append_attribute("type") = "org.openmodelica";
+  for (const TLMInterface *ifc : tlmInterfaces)
+  {
+    status = ifc->exportToSSD(nodeAnnotation);
+    if(oms_status_ok != status)
+      return status;
+  }
+
   return oms_status_ok;
 }
 
@@ -1290,11 +1300,12 @@ oms_status_enu_t oms2::FMICompositeModel::updateInitialTLMValues()
 {
   //Apply initial values for signal and effort
   for(TLMInterface *ifc : tlmInterfaces) {
+    std::string name = ifc->getName().toString();
     if(ifc->getDimensions() == 1 && ifc->getCausality() == oms_causality_input) {
       oms_tlm_sigrefs_signal_t tlmrefs;
       double value;
-      if(tlmInitialValues.find(ifc->getName()) != tlmInitialValues.end()) {
-        value = tlmInitialValues.find(ifc->getName())->second[0];
+      if(tlmInitialValues.find(name) != tlmInitialValues.end()) {
+        value = tlmInitialValues.find(name)->second[0];
       }
       else {
         this->getReal(ifc->getSubSignal(tlmrefs.y), value);
@@ -1305,9 +1316,9 @@ oms_status_enu_t oms2::FMICompositeModel::updateInitialTLMValues()
             ifc->getInterpolationMethod() == oms_tlm_no_interpolation) {
       oms_tlm_sigrefs_1d_t tlmrefs;
       double effort,flow;
-      if(tlmInitialValues.find(ifc->getName()) != tlmInitialValues.end()) {
-        effort = tlmInitialValues.find(ifc->getName())->second[0];
-        flow = tlmInitialValues.find(ifc->getName())->second[1];
+      if(tlmInitialValues.find(name) != tlmInitialValues.end()) {
+        effort = tlmInitialValues.find(name)->second[0];
+        flow = tlmInitialValues.find(name)->second[1];
       }
       else {
         this->getReal(ifc->getSubSignal(tlmrefs.f), effort);
@@ -1318,9 +1329,9 @@ oms_status_enu_t oms2::FMICompositeModel::updateInitialTLMValues()
     }
     else if(ifc->getDimensions() == 1 && ifc->getCausality() == oms_causality_bidir &&
             ifc->getInterpolationMethod() != oms_tlm_no_interpolation) {
-      if(tlmInitialValues.find(ifc->getName()) != tlmInitialValues.end()) {
-        double effort = tlmInitialValues.find(ifc->getName())->second[0];
-        double flow = tlmInitialValues.find(ifc->getName())->second[1];
+      if(tlmInitialValues.find(name) != tlmInitialValues.end()) {
+        double effort = tlmInitialValues.find(name)->second[0];
+        double flow = tlmInitialValues.find(name)->second[1];
         plugin->SetInitialForce1D(ifc->getId(), effort);
         plugin->SetInitialFlow1D(ifc->getId(), flow);
       }
@@ -1330,19 +1341,19 @@ oms_status_enu_t oms2::FMICompositeModel::updateInitialTLMValues()
       oms_tlm_sigrefs_3d_t tlmrefs;
       std::vector<double> effort(6,0);
       std::vector<double> flow(6,0);
-      if(tlmInitialValues.find(ifc->getName()) != tlmInitialValues.end()) {
-        effort[0] = tlmInitialValues.find(ifc->getName())->second[0];
-        effort[1] = tlmInitialValues.find(ifc->getName())->second[1];
-        effort[2] = tlmInitialValues.find(ifc->getName())->second[2];
-        effort[3] = tlmInitialValues.find(ifc->getName())->second[3];
-        effort[4] = tlmInitialValues.find(ifc->getName())->second[4];
-        effort[5] = tlmInitialValues.find(ifc->getName())->second[5];
-        flow[0] = tlmInitialValues.find(ifc->getName())->second[6];
-        flow[1] = tlmInitialValues.find(ifc->getName())->second[7];
-        flow[2] = tlmInitialValues.find(ifc->getName())->second[8];
-        flow[3] = tlmInitialValues.find(ifc->getName())->second[9];
-        flow[4] = tlmInitialValues.find(ifc->getName())->second[10];
-        flow[5] = tlmInitialValues.find(ifc->getName())->second[11];
+      if(tlmInitialValues.find(name) != tlmInitialValues.end()) {
+        effort[0] = tlmInitialValues.find(name)->second[0];
+        effort[1] = tlmInitialValues.find(name)->second[1];
+        effort[2] = tlmInitialValues.find(name)->second[2];
+        effort[3] = tlmInitialValues.find(name)->second[3];
+        effort[4] = tlmInitialValues.find(name)->second[4];
+        effort[5] = tlmInitialValues.find(name)->second[5];
+        flow[0] = tlmInitialValues.find(name)->second[6];
+        flow[1] = tlmInitialValues.find(name)->second[7];
+        flow[2] = tlmInitialValues.find(name)->second[8];
+        flow[3] = tlmInitialValues.find(name)->second[9];
+        flow[4] = tlmInitialValues.find(name)->second[10];
+        flow[5] = tlmInitialValues.find(name)->second[11];
       }
       else {
         this->getReals(ifc->getSubSignalSet(tlmrefs.f), effort);
@@ -1358,19 +1369,19 @@ oms_status_enu_t oms2::FMICompositeModel::updateInitialTLMValues()
       oms_tlm_sigrefs_3d_t tlmrefs;
       std::vector<double> effort(6,0);
       std::vector<double> flow(6,0);
-      if(tlmInitialValues.find(ifc->getName()) != tlmInitialValues.end()) {
-        effort[0] = tlmInitialValues.find(ifc->getName())->second[0];
-        effort[1] = tlmInitialValues.find(ifc->getName())->second[1];
-        effort[2] = tlmInitialValues.find(ifc->getName())->second[2];
-        effort[3] = tlmInitialValues.find(ifc->getName())->second[3];
-        effort[4] = tlmInitialValues.find(ifc->getName())->second[4];
-        effort[5] = tlmInitialValues.find(ifc->getName())->second[5];
-        flow[0] = tlmInitialValues.find(ifc->getName())->second[6];
-        flow[1] = tlmInitialValues.find(ifc->getName())->second[7];
-        flow[2] = tlmInitialValues.find(ifc->getName())->second[8];
-        flow[3] = tlmInitialValues.find(ifc->getName())->second[9];
-        flow[4] = tlmInitialValues.find(ifc->getName())->second[10];
-        flow[5] = tlmInitialValues.find(ifc->getName())->second[11];
+      if(tlmInitialValues.find(name) != tlmInitialValues.end()) {
+        effort[0] = tlmInitialValues.find(name)->second[0];
+        effort[1] = tlmInitialValues.find(name)->second[1];
+        effort[2] = tlmInitialValues.find(name)->second[2];
+        effort[3] = tlmInitialValues.find(name)->second[3];
+        effort[4] = tlmInitialValues.find(name)->second[4];
+        effort[5] = tlmInitialValues.find(name)->second[5];
+        flow[0] = tlmInitialValues.find(name)->second[6];
+        flow[1] = tlmInitialValues.find(name)->second[7];
+        flow[2] = tlmInitialValues.find(name)->second[8];
+        flow[3] = tlmInitialValues.find(name)->second[9];
+        flow[4] = tlmInitialValues.find(name)->second[10];
+        flow[5] = tlmInitialValues.find(name)->second[11];
         plugin->SetInitialForce3D(ifc->getId(), effort[0], effort[1], effort[2], effort[3], effort[4], effort[5]);
         plugin->SetInitialFlow3D(ifc->getId(), flow[0], flow[1], flow[2], flow[3], flow[4], flow[5]);
       }
@@ -1644,7 +1655,7 @@ oms_status_enu_t oms2::FMICompositeModel::setTLMInitialValues(std::string ifcnam
   //Find interface log
   bool found = false;
   for(TLMInterface* ifc: tlmInterfaces) {
-    if(ifc->getName() == ifcname) {
+    if(ifc->getName().toString() == ifcname) {
       found = true;
       if(ifc->getDimensions() == 1 && ifc->getCausality() != oms_causality_bidir) {
         if(values.size() < 1) {

--- a/src/OMSimulatorLib/FMICompositeModel.h
+++ b/src/OMSimulatorLib/FMICompositeModel.h
@@ -105,7 +105,7 @@ namespace oms2
 
 #if !defined(NO_TLM)
     oms_status_enu_t addTLMInterface(TLMInterface *ifc);
-    std::vector<TLMInterface*> getTLMInterfaces() const { return tlmInterfaces; }
+    std::vector<TLMInterface*> getTLMInterfaces() { return tlmInterfaces; }
     oms_status_enu_t setTLMInitialValues(std::string ifc, std::vector<double> value);
 #endif
 
@@ -142,6 +142,9 @@ namespace oms2
 #if !defined(NO_TLM)
     oms_status_enu_t updateInitialTLMValues();
     void finalizeTLMSockets();
+    std::string tlmDomainToString(std::string domain, int dimensions, oms_causality_enu_t causality);
+    std::string tlmInterpolationToString(oms_tlm_interpolation_t method);
+
   public:
     oms_status_enu_t setupTLMSockets(double startTime, std::string server);
     void readFromTLMSockets(double time, std::string fmu = "");

--- a/src/OMSimulatorLib/Model.cpp
+++ b/src/OMSimulatorLib/Model.cpp
@@ -272,8 +272,7 @@ oms_status_enu_t oms2::Model::saveOrList(const std::string& filename, char** con
       break;
 
     case oms_component_tlm:
-      logError("xml export isn't implemented yet for TLM composite models");
-      status = oms_status_error;
+      status = getTLMCompositeModel()->save(ssd_System);
       break;
   }
 

--- a/src/OMSimulatorLib/Scope.cpp
+++ b/src/OMSimulatorLib/Scope.cpp
@@ -1389,7 +1389,7 @@ oms_status_enu_t oms2::Scope::addTLMInterface(const oms2::ComRef &cref, const om
     return oms_status_error;
   }
 
-  return model->getTLMCompositeModel()->addInterface(name.toString(), dimensions, causality, domain, interpolation, subref, sigrefs);
+  return model->getTLMCompositeModel()->addInterface(name, dimensions, causality, domain, interpolation, subref, sigrefs);
 }
 
 oms_status_enu_t oms2::Scope::setTLMPositionAndOrientation(const oms2::ComRef &cref, const SignalRef &ifc, std::vector<double> x, std::vector<double> A)

--- a/src/OMSimulatorLib/TLM/TLMCompositeModel.h
+++ b/src/OMSimulatorLib/TLM/TLMCompositeModel.h
@@ -57,12 +57,13 @@ namespace oms2
   public:
     static TLMCompositeModel* NewModel(const ComRef& name);
     static TLMCompositeModel* LoadModel(const pugi::xml_node& node);
+    oms_status_enu_t save(pugi::xml_node& node);
 
     oms_element_type_enu_t getType() {return oms_component_tlm;}
     oms_status_enu_t addFMIModel(FMICompositeModel *model);
 
     oms_status_enu_t addInterface(oms2::TLMInterface* ifc);
-    oms_status_enu_t addInterface(std::string name, int dimensions, oms_causality_enu_t causality, std::string domain, oms_tlm_interpolation_t interpolation, const ComRef &cref, std::vector<SignalRef> &sigrefs);
+    oms_status_enu_t addInterface(ComRef name, int dimensions, oms_causality_enu_t causality, std::string domain, oms_tlm_interpolation_t interpolation, const ComRef &cref, std::vector<SignalRef> &sigrefs);
 
     oms_status_enu_t setPositionAndOrientation(const SignalRef& ifc, std::vector<double> x, std::vector<double> A);
 
@@ -104,6 +105,9 @@ namespace oms2
     TLMCompositeModel(TLMCompositeModel const& copy);            ///< not implemented
     TLMCompositeModel& operator=(TLMCompositeModel const& copy); ///< not implemented
 
+    std::string causalityToString(oms_causality_enu_t causality);
+    std::string interpolationMethodToString(oms_tlm_interpolation_t method);
+
   private:
     ComRef name;
     void* model;
@@ -114,6 +118,7 @@ namespace oms2
     std::list<TLMInterface*> interfaces;
     std::string address;
     int managerPort;
+    int monitorPort;
   };
 }
 

--- a/src/OMSimulatorLib/TLM/TLMInterface.cpp
+++ b/src/OMSimulatorLib/TLM/TLMInterface.cpp
@@ -33,11 +33,11 @@
 #include "Logging.h"
 
 oms2::TLMInterface::TLMInterface(const oms2::ComRef &cref,
-                                 const std::string name,
+                                 const ComRef name,
                                  oms_causality_enu_t causality,
                                  const std::string domain,
                                  const int dimensions, oms_tlm_interpolation_t interpolation, const std::vector<SignalRef> &sigrefs)
-  : sig(cref, name)
+  : sig(cref, name.toString())
 {
   this->cref = cref;
   this->name = name;
@@ -48,7 +48,142 @@ oms2::TLMInterface::TLMInterface(const oms2::ComRef &cref,
   this->interpolationMethod = interpolation;
 }
 
-oms2::ComRef oms2::TLMInterface::getFMUName()
+oms_status_enu_t oms2::TLMInterface::exportToSSD(pugi::xml_node &root) const
+{
+  pugi::xml_node nodeBus = root.append_child("OMSimulator:Bus");
+  nodeBus.append_attribute("name") = name.toString().c_str();
+  nodeBus.append_attribute("type") = "tlm";
+  nodeBus.append_attribute("domain") = tlmDomainToString(domain,dimensions,causality).c_str();
+  nodeBus.append_attribute("interpolation") = tlmInterpolationToString(interpolationMethod).c_str();
+  pugi::xml_node nodeSignals = nodeBus.append_child("Signals");
+
+  if(dimensions == 1 && causality != oms_causality_bidir) {
+    oms_tlm_sigrefs_signal_t tlmrefs;
+    pugi::xml_node ssd_Signal = nodeSignals.append_child("Signal");
+    ssd_Signal.append_attribute("name") = sigrefs[tlmrefs.y].getVar().c_str();
+    ssd_Signal.append_attribute("type") = "value";
+  }
+  else if(causality == oms_causality_bidir) {
+    std::vector<std::string> names, tlmvars;
+    if(dimensions == 1 && interpolationMethod == oms_tlm_no_interpolation) {
+      for(const SignalRef &sigref : sigrefs) {
+        names.push_back(sigref.getVar());
+      }
+      tlmvars = { "state", "flow", "effort" };
+    }
+    else if(dimensions == 1 && interpolationMethod == oms_tlm_coarse_grained) {
+      for(const SignalRef &sigref : sigrefs) {
+        names.push_back(sigref.getVar());
+      }
+      tlmvars = { "state", "flow", "wave", "impedance" };
+    }
+    else if(dimensions == 1 && interpolationMethod == oms_tlm_fine_grained) {
+      for(const SignalRef &sigref : sigrefs) {
+        names.push_back(sigref.getVar());
+      }
+      tlmvars = { "state", "flow",
+                  "wave1", "wave2", "wave3", "wave4", "wave5",
+                  "wave6", "wave7", "wave8", "wave9", "wave10",
+                  "time1", "time2", "time3", "time4", "time5",
+                  "time6", "time7", "time8", "time9", "time10",
+                  "impedance" };
+    }
+    else if(dimensions == 3 && interpolationMethod == oms_tlm_no_interpolation) {
+      for(const SignalRef &sigref : sigrefs) {
+        names.push_back(sigref.getVar());
+      }
+      tlmvars = { "state1", "state2", "state3"
+                  "A11",    "A12",    "A13",
+                  "A21",    "A22",    "A23",
+                  "A31",    "A32",    "A33",
+                  "flow1",  "flow2",  "flow3",
+                  "flow4",  "flow5",  "flow6",
+                  "effort1","effort2","effort3",
+                  "effort4","effort3","effort4"
+                };
+    }
+    else if(dimensions == 3 && interpolationMethod == oms_tlm_coarse_grained) {
+      for(const SignalRef &sigref : sigrefs) {
+        names.push_back(sigref.getVar());
+      }
+      tlmvars = { "state1", "state2", "state3"
+                  "A1_1",   "A1_2",   "A1_3",
+                  "A2_1",   "A2_2",   "A2_3",
+                  "A3_1",   "A3_2",   "A3_3",
+                  "flow1",  "flow2",  "flow3",
+                  "flow4",  "flow5",  "flow6",
+                  "wave1",  "wave2",  "wave3",
+                  "wave4",  "wave3",  "wave4",
+                  "impedance_t","impedance_r"
+                };
+    }
+    else if(dimensions == 3 && interpolationMethod == oms_tlm_fine_grained) {
+      for(const SignalRef &sigref : sigrefs) {
+        names.push_back(sigref.getVar());
+      }
+      tlmvars = { "state1",   "state2",   "state3"
+                  "A1_1",     "A1_2",     "A1_3",
+                  "A2_1",     "A2_2",     "A2_3",
+                  "A3_1",     "A3_2",     "A3_3",
+                  "flow1",    "flow2",    "flow3",
+                  "flow4",    "flow5",    "flow6",
+                  "wave1_1",  "wave2_1",  "wave3_1",  "wave4_1",  "wave5_1",  "wave6_1",
+                  "wave1_2",  "wave2_2",  "wave3_2",  "wave4_2",  "wave5_2",  "wave6_2",
+                  "wave1_3",  "wave2_3",  "wave3_3",  "wave4_3",  "wave5_3",  "wave6_3",
+                  "wave1_4",  "wave2_4",  "wave3_4",  "wave4_4",  "wave5_4",  "wave6_4",
+                  "wave1_5",  "wave2_5",  "wave3_5",  "wave4_5",  "wave5_5",  "wave6_5",
+                  "wave1_6",  "wave2_6",  "wave3_6",  "wave4_6",  "wave5_6",  "wave6_6",
+                  "wave1_7",  "wave2_7",  "wave3_7",  "wave4_7",  "wave5_7",  "wave6_7",
+                  "wave1_8",  "wave2_8",  "wave3_8",  "wave4_8",  "wave5_8",  "wave6_8",
+                  "wave1_9",  "wave2_9",  "wave3_9",  "wave4_9",  "wave5_9",  "wave6_9",
+                  "wave1_10", "wave2_10", "wave3_10", "wave4_10", "wave5_10", "wave6_10",
+                  "time1",    "time2",    "time3",    "time4",    "time5",
+                  "time6",    "time7",    "time8",    "time9",    "time10",
+                  "impedance_t","impedance_r"
+                };
+    }
+
+    for(size_t i=0; i<names.size(); ++i) {
+      //Sub-connector
+      pugi::xml_node ssd_SubConnector = nodeSignals.append_child("Signal");
+      ssd_SubConnector.append_attribute("name") = names[i].c_str();
+      ssd_SubConnector.append_attribute("type") = tlmvars[i].c_str();
+    }
+  }
+
+  return oms_status_ok;
+}
+
+
+std::string oms2::TLMInterface::tlmDomainToString(std::string domain, int dimensions, oms_causality_enu_t causality) const
+{
+  if(domain == "Signal" && causality == oms_causality_input) {
+    return "Signal_in";
+  }
+  else if(domain == "Signal" && causality == oms_causality_output) {
+    return "Signal_out";
+  }
+  else if(domain != "Signal") {
+    return domain+"_"+std::to_string(dimensions)+"D";
+  }
+  else {
+    return "Undefined";
+  }
+}
+
+std::string oms2::TLMInterface::tlmInterpolationToString(oms_tlm_interpolation_t method) const {
+  switch(method) {
+  case oms_tlm_no_interpolation:
+    return "none";
+  case oms_tlm_coarse_grained:
+    return "coarsegrained";
+  case oms_tlm_fine_grained:
+    return "finegrained";
+  }
+  return "undefined";
+}
+
+oms2::ComRef oms2::TLMInterface::getFMUName() const
 {
   return sigrefs[0].getCref();
 }
@@ -77,9 +212,9 @@ oms_status_enu_t oms2::TLMInterface::doRegister(TLMPlugin *plugin)
   if(causality == oms_causality_output) omtlm_causality = "Output";
   else if(causality == oms_causality_input)  omtlm_causality = "Input";
 
-  this->id = plugin->RegisteTLMInterface(name,omtlm_dimensions,omtlm_causality,domain);
+  this->id = plugin->RegisteTLMInterface(name.toString(),omtlm_dimensions,omtlm_causality,domain);
   if(this->id < 0) {
-    logError("Failed to register TLM interface: "+name);
+    logError("Failed to register TLM interface: "+name.toString());
     return oms_status_error;
   }
 

--- a/src/OMSimulatorLib/TLM/TLMInterface.h
+++ b/src/OMSimulatorLib/TLM/TLMInterface.h
@@ -37,6 +37,8 @@
 #include "Types.h"
 #include "../../OMTLMSimulator/common/Plugin/PluginImplementer.h"
 
+#include <pugixml.hpp>
+
 namespace oms2
 {
   typedef struct  {
@@ -114,7 +116,7 @@ typedef struct  {
   {
   public:
     TLMInterface(const oms2::ComRef& cref,
-                 const std::string name,
+                 const ComRef name,
                  oms_causality_enu_t causality,
                  const std::string domain,
                  const int dimensions,
@@ -122,19 +124,21 @@ typedef struct  {
                  const std::vector<SignalRef> &sigrefs);
     ~TLMInterface() {}
 
-    oms2::SignalRef getSignal() { return sig; }
-    oms2::ComRef getSubModelName() { return cref; }
-    oms2::ComRef getFMUName();
-    std::string getName() { return name; }
-    oms_causality_enu_t getCausality() { return causality; }
-    std::string getDomain() { return domain; }
-    int getDimensions() { return dimensions; }
-    oms_tlm_interpolation_t getInterpolationMethod() { return interpolationMethod; }
+    oms_status_enu_t exportToSSD(pugi::xml_node& root) const;
+
+    oms2::SignalRef getSignal() const { return sig; }
+    oms2::ComRef getSubModelName() const { return cref; }
+    oms2::ComRef getFMUName() const;
+    oms2::ComRef getName() const { return name; }
+    oms_causality_enu_t getCausality() const { return causality; }
+    std::string getDomain() const { return domain; }
+    int getDimensions() const { return dimensions; }
+    oms_tlm_interpolation_t getInterpolationMethod() const { return interpolationMethod; }
     void setDelay(double delay) { this->delay = delay; }
-    double getDelay() { return this->delay; }
-    std::vector<SignalRef> getSubSignals() { return sigrefs; }
+    double getDelay() const { return this->delay; }
+    std::vector<SignalRef> getSubSignals() const { return sigrefs; }
     std::vector<SignalRef> getSubSignalSet(std::vector<int> ids);
-    SignalRef getSubSignal(int i) { return sigrefs[i]; }
+    SignalRef getSubSignal(int i) const { return sigrefs[i]; }
     oms_status_enu_t doRegister(TLMPlugin *plugin);
     int getId() { return this->id; }
 
@@ -144,7 +148,7 @@ typedef struct  {
   private:
     SignalRef sig;
     oms2::ComRef cref;
-    std::string name;
+    ComRef name;
     oms_causality_enu_t causality;
     std::string domain;
     int dimensions;
@@ -152,6 +156,8 @@ typedef struct  {
     oms_tlm_interpolation_t interpolationMethod;
     double delay;
     int id;
+    std::string tlmDomainToString(std::string domain, int dimensions, oms_causality_enu_t causality) const;
+    std::string tlmInterpolationToString(oms_tlm_interpolation_t method) const;
   };
 
   inline bool operator==(const TLMInterface& lhs, const TLMInterface& rhs) {return (lhs.cref.c_str() == rhs.cref.c_str() && lhs.name == rhs.name);}

--- a/src/OMSimulatorLib/ssd/Tags.cpp
+++ b/src/OMSimulatorLib/ssd/Tags.cpp
@@ -32,6 +32,7 @@
 #include "Tags.h"
 
 const char* oms2::ssd::ssd_annotations                  = "ssd:Annotations";
+const char* oms2::ssd::ssd_annotation                   = "ssd:Annotation";
 const char* oms2::ssd::ssd_component                    = "ssd:Component";
 const char* oms2::ssd::ssd_connection                   = "ssd:Connection";
 const char* oms2::ssd::ssd_connection_geometry          = "ssd:ConnectionGeometry";
@@ -45,3 +46,5 @@ const char* oms2::ssd::ssd_enumerations                 = "ssd:Enumerations";
 const char* oms2::ssd::ssd_system                       = "ssd:System";
 const char* oms2::ssd::ssd_system_structure_description = "ssd:SystemStructureDescription";
 const char* oms2::ssd::ssd_units                        = "ssd:Units";
+const char* oms2::ssd::ssd_simulation_information       = "ssd:SimulationInformation";
+const char* oms2::ssd::ssd_elements                     = "ssd:Elements";

--- a/src/OMSimulatorLib/ssd/Tags.h
+++ b/src/OMSimulatorLib/ssd/Tags.h
@@ -37,6 +37,7 @@ namespace oms2
   namespace ssd
   {
     extern const char* ssd_annotations;
+    extern const char* ssd_annotation;
     extern const char* ssd_component;
     extern const char* ssd_connection;
     extern const char* ssd_connection_geometry;
@@ -50,6 +51,8 @@ namespace oms2
     extern const char* ssd_system;
     extern const char* ssd_system_structure_description;
     extern const char* ssd_units;
+    extern const char* ssd_simulation_information;
+    extern const char* ssd_elements;
   }
 }
 


### PR DESCRIPTION
### Related Issues

#312 

### Purpose

Exporting TLM models to SSD format.

### Approach

Add save() method to TLMCompositeModel class.

### Type of Change

- New feature (non-breaking change which adds functionality)

### Checklist

- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings

### Open Questions and Pre-Merge TODOs

- [X] Save TLM submodels to SSD
- [X] Save external TLM models to SSD
- [X] Save signal interfaces to SSD
- [X] Save 1D bidirectional interfaces to SSD
- [x] Save 3D bidirectional interfaces to SSD
- [x] Save interfaces for external models
- [x] Save TLM connections

### Test Scripts

[testscripts.zip](https://github.com/OpenModelica/OMSimulator/files/2339485/testscripts.zip)