### PR TITLE
Check that FMUs for TLM interfaces exist

### DIFF
--- a/src/OMSimulatorLib/FMICompositeModel.h
+++ b/src/OMSimulatorLib/FMICompositeModel.h
@@ -103,6 +103,7 @@ namespace oms2
 
 #if !defined(NO_TLM)
     oms_status_enu_t addTLMInterface(TLMInterface *ifc);
+    std::vector<TLMInterface*> getTLMInterfaces() const { return tlmInterfaces; }
     oms_status_enu_t setTLMInitialValues(std::string ifc, std::vector<double> value);
 #endif
 

--- a/src/OMSimulatorLib/TLM/TLMCompositeModel.cpp
+++ b/src/OMSimulatorLib/TLM/TLMCompositeModel.cpp
@@ -444,6 +444,19 @@ oms_status_enu_t oms2::TLMCompositeModel::stepUntil(ResultWriter &resultWriter, 
   if(fmiModels.empty() && externalModels.empty())
     logWarning("oms2::TLMCompositeModel::stepUntil: Simulating empty model...");
 
+  //Check that required FMUs exist for all TLM interfaces
+  for(const auto &fmiModel : fmiModels) {
+    for(TLMInterface *ifc : fmiModel.second->getTLMInterfaces()) {
+      ComRef fmuRef;
+      fmuRef.append(this->getName());
+      fmuRef.append(ifc->getSubModelName());
+      fmuRef.append(ifc->getFMUName());
+      if(!oms2::Scope::GetInstance().exists(fmuRef)) {
+        return logError("[oms2::TLMCompositeModel::stepUntil] Cannot find FMU: "+fmuRef.toString());
+      }
+    }
+  }
+
   logInfo("Starting submodel threads.");
   std::string server = address + ":" + std::to_string(managerPort);
   std::vector<std::thread*> fmiModelThreads;


### PR DESCRIPTION
### Purpose

TLM simulations should be aborted if an FMU in a submodel fails to load.

### Approach

Loop through TLM interfaces and check that required FMUs exists in the FMI submodels.

### Type of Change

- New feature (non-breaking change which adds functionality)

### Checklist

- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings