### PR TITLE
Copy the binaries to bin folder even for mingw

### DIFF
--- a/src/OMSimulatorLib/CMakeLists.txt
+++ b/src/OMSimulatorLib/CMakeLists.txt
@@ -139,8 +139,7 @@ ELSE()
 ENDIF()
 
 install(TARGETS OMSimulatorLib_shared DESTINATION lib/${HOST_SHORT})
-IF(WIN32 AND MSVC)
-  # MinGW can statically link
+IF(WIN32)
   install(TARGETS OMSimulatorLib_shared DESTINATION bin)
 ENDIF()
 


### PR DESCRIPTION
### Purpose

Allow dynamic linking from OMEdit built with mingw.

### Approach

Copy the binaries to the bin folder.

### Type of Change

- Bug fix (non-breaking change which fixes an issue)

### Checklist

- I have performed a self-review of my own code