### PR TITLE
Improved error handling for TLM initialization

### DIFF
--- a/src/OMSimulatorLib/FMUWrapper.cpp
+++ b/src/OMSimulatorLib/FMUWrapper.cpp
@@ -593,7 +593,7 @@ void oms2::FMUWrapper::readFromTLMSockets(double time)
 {
 #if !defined(NO_TLM)
   FMICompositeModel *model = oms2::Scope::GetInstance().getFMICompositeModel(parent);
-  model->readFromSockets(time, element.getName().toString());
+  model->readFromTLMSockets(time, element.getName().toString());
 #else
   throw std::runtime_error("[oms2::FMUWrapper::readFromTLMSockets] Compiled without TLM support");
 #endif
@@ -603,7 +603,7 @@ void oms2::FMUWrapper::writeToTLMSockets(double time)
 {
 #if !defined(NO_TLM)
   FMICompositeModel *model = oms2::Scope::GetInstance().getFMICompositeModel(parent);
-  model->writeToSockets(time, element.getName().toString());
+  model->writeToTLMSockets(time, element.getName().toString());
 #else
   throw std::runtime_error("[oms2::FMUWrapper::writeToTLMSockets] Compiled without TLM support");
 #endif

--- a/src/OMSimulatorLib/TLM/TLMCompositeModel.h
+++ b/src/OMSimulatorLib/TLM/TLMCompositeModel.h
@@ -37,6 +37,7 @@
 
 #include <list>
 #include <map>
+#include <atomic>
 
 #include <pugixml.hpp>
 


### PR DESCRIPTION
### Related PRs

OpenModelica/OMTLMSimulator#98

### Purpose

1. All simulation threads must be aborted if any thread fails to connect to sockets
2. All simulation threads must be aborted if any submodel fails to initialize

### Approach

Split up simulation threads into three threads for each submodel: connect, initialize and simulate. Execute in fork-join pattern and check status on every synchronization point. Also make sure to call CheckModel() for all threads before ANY thread attempts to read/write to sockets, to prevent lock-up.

### Type of Change

<!--- Please delete options that are not relevant. -->

- New feature (non-breaking change which adds functionality)

### Checklist

<!--- Please delete options that are not relevant. -->

- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings