### PR TITLE
Remove element information from class Model

### DIFF
--- a/src/OMSimulatorLib/Element.cpp
+++ b/src/OMSimulatorLib/Element.cpp
@@ -37,7 +37,7 @@
 #include <cstring>
 #include <iostream>
 
-oms3::Element::Element(oms3_element_type_enu_t type, const oms3::ComRef& name)
+oms3::Element::Element(oms3_element_enu_t type, const oms3::ComRef& name)
 {
   this->type = type;
 
@@ -105,23 +105,6 @@ void oms3::Element::setGeometry(const oms3::ssd::ElementGeometry* newGeometry)
 //  for (int i=0; i<newConnectors.size(); ++i)
 //    this->connectors[i] = reinterpret_cast<oms_connector_t*>(new oms2::Connector(newConnectors[i]));
 //}
-
-void oms3::Element::describe()
-{
-  std::cout << "Element \"" + getName() + "\"" << std::endl;
-
-  switch(getType())
-  {
-    case oms_element_none:
-    case oms_element_model:      std::cout << "type: Model" << std::endl; break;
-    case oms_element_system:     std::cout << "type: System" << std::endl; break;
-    case oms_element_external:   std::cout << "type: External model" << std::endl; break;
-    case oms_element_fmu:        std::cout << "type: FMU" << std::endl; break;
-    case oms_element_table:      std::cout << "type: lookup table" << std::endl; break;
-    case oms_element_port:       std::cout << "type: port" << std::endl; break;
-    default:                     std::cout << "type: unknown" << std::endl; break;
-  }
-}
 
 oms2::Element::Element(oms_element_type_enu_t type, const oms2::ComRef& name)
 {

--- a/src/OMSimulatorLib/Element.h
+++ b/src/OMSimulatorLib/Element.h
@@ -49,10 +49,10 @@ namespace oms3
   class Element : protected oms3_element_t
   {
   public:
-    Element(oms3_element_type_enu_t type, const ComRef& name);
+    Element(oms3_element_enu_t type, const ComRef& name);
     ~Element();
 
-    const oms3_element_type_enu_t getType() const {return type;}
+    const oms3_element_enu_t getType() const {return type;}
     const oms3::ComRef getName() const {return oms3::ComRef(std::string(name));}
     //oms3::Connector** getConnectors() const {return reinterpret_cast<oms3::Connector**>(connectors);}
     const oms3::ssd::ElementGeometry* getGeometry() const {return reinterpret_cast<oms3::ssd::ElementGeometry*>(geometry);}
@@ -60,8 +60,6 @@ namespace oms3
     void setName(const ComRef& name);
     void setGeometry(const oms3::ssd::ElementGeometry* newGeometry);
     //void setConnectors(const std::vector<oms3::Connector> newConnectors);
-
-    void describe();
 
   private:
     // methods to copy the object

--- a/src/OMSimulatorLib/Model.cpp
+++ b/src/OMSimulatorLib/Model.cpp
@@ -44,7 +44,7 @@
 /* ************************************ */
 
 oms3::Model::Model(const oms3::ComRef& cref, const std::string& tempDir)
-  : element(oms_element_model, cref), cref(cref), tempDir(tempDir)
+  : cref(cref), tempDir(tempDir)
 {
   logInfo("New model \"" + std::string(cref) + "\" with corresponding temp directory \"" + tempDir + "\"");
 }

--- a/src/OMSimulatorLib/Model.h
+++ b/src/OMSimulatorLib/Model.h
@@ -54,7 +54,6 @@ namespace oms3
     static Model* NewModel(const ComRef& cref);
     const ComRef& getName() const {return cref;}
     System* getSystem(const ComRef& cref);
-    oms3::Element* getElement() {return &element;}
     oms_status_enu_t rename(const ComRef& cref);
     oms_status_enu_t list(const ComRef& cref, char** contents);
     oms_status_enu_t addSystem(const ComRef& cref, oms_system_enu_t type);
@@ -72,9 +71,6 @@ namespace oms3
     ComRef cref;
     System* system = NULL;
     std::string tempDir;
-
-  protected:
-    oms3::Element element;
   };
 }
 

--- a/src/OMSimulatorLib/Scope.cpp
+++ b/src/OMSimulatorLib/Scope.cpp
@@ -183,22 +183,17 @@ oms_status_enu_t oms3::Scope::getElement(const oms3::ComRef& cref, oms3::Element
   oms3::ComRef front = tail.pop_front();
   oms3::Model* model = getModel(front);
   if (!model)
-    return logError("oms3_getElement failed. Model \"" + std::string(front) + "\" does not exist in the scope");
+    return logError("Model \"" + std::string(front) + "\" does not exist in the scope");
 
   if (cref.isValidIdent())
-  {
-    *element = model->getElement();
-    return oms_status_ok;
-  }
-  else
-  {
-    oms3::System* system = model->getSystem(tail);
-    if (!system)
-      return logError("oms3_getElement failed. System \"" + std::string(tail) + "\" does not exist in the model \"" + std::string(front) + "\"");
+    return logError("A model has no element information");
 
-    *element = system->getElement();
-    return oms_status_ok;
-  }
+  oms3::System* system = model->getSystem(tail);
+  if (!system)
+    return logError("System \"" + std::string(tail) + "\" does not exist in the model \"" + std::string(front) + "\"");
+
+  *element = system->getElement();
+  return oms_status_ok;
 }
 
 oms3::Model* oms3::Scope::getModel(const oms3::ComRef& cref)

--- a/src/OMSimulatorLib/Types.h
+++ b/src/OMSimulatorLib/Types.h
@@ -83,14 +83,9 @@ typedef enum {
 } oms_solver_enu_t;
 
 typedef enum {
-  oms_element_none,
-  oms_element_model,      ///< composite model
-  oms_element_system,     ///< FMI or TLM system
-  oms_element_external, ///< External model
-  oms_element_fmu,      ///< FMU
-  oms_element_table,    ///< lookup table
-  oms_element_port      ///< port
-} oms3_element_type_enu_t;
+  oms_element_system,
+  oms_element_component
+} oms3_element_enu_t;
 
 typedef enum {
   oms_component_none,
@@ -107,6 +102,12 @@ typedef enum {
   oms_system_wc,       ///< Weakly Coupled System
   oms_system_sc        ///< Strongly Coupled System
 } oms_system_enu_t;
+
+typedef enum {
+  oms3_component_external, ///< External model
+  oms3_component_fmu,      ///< FMU
+  oms3_component_table     ///< lookup table
+} oms3_component_enu_t;
 
 typedef enum {
   oms_signal_type_real,
@@ -354,7 +355,7 @@ typedef struct {
  * \brief Element (aka ssd:Component)
  */
 typedef struct {
-  oms3_element_type_enu_t type;      ///< Element type, e.g. FMU
+  oms3_element_enu_t type;          ///< Element type, i.e. system or component
   char* name;                       ///< Name of the element
   oms_connector_t** connectors;     ///< List (null-terminated array) of all interface variables: inputs, outputs, and parameters.
   ssd_element_geometry_t* geometry; ///< Geometry information of the element
@@ -493,8 +494,6 @@ typedef struct {
    */
   bool canInterpolateInputs;
 } oms_fmu_info_t;
-
-
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
### Purpose

Clean up previous changes; See comments in #343.

### Approach

* Remove element information from class Model
* Restructure `oms3_element_enu_t`

