### PR TITLE
Prefix the function name to the callback message

### DIFF
--- a/src/OMSimulatorLib/Logging.cpp
+++ b/src/OMSimulatorLib/Logging.cpp
@@ -172,10 +172,11 @@ oms_status_enu_t Log::Error(const std::string& msg, const std::string& function)
   log.numErrors++;
   log.numMessages++;
   std::ostream& stream = log.logFile.is_open() ? log.logFile : cerr;
-  log.printStringToStream(stream, "error", "[" + function + "] " + msg);
+  std::string fullMessage = "[" + function + "] " + msg;
+  log.printStringToStream(stream, "error", fullMessage);
 
   if (log.cb)
-    log.cb(oms_message_error, msg.c_str());
+    log.cb(oms_message_error, fullMessage.c_str());
 
   return oms_status_error;
 }

--- a/src/OMSimulatorLib/OMSimulator.cpp
+++ b/src/OMSimulatorLib/OMSimulator.cpp
@@ -89,7 +89,7 @@ oms_status_enu_t oms3_rename(const char* cref_, const char* newCref_)
   if (cref.isValidIdent())
     return oms3::Scope::GetInstance().renameModel(cref, newCref);
   else
-    return logError("oms3_rename failed. Only implemented for model identifiers");
+    return logError("Only implemented for model identifiers");
 }
 
 oms_status_enu_t oms3_delete(const char* cref_)
@@ -99,7 +99,7 @@ oms_status_enu_t oms3_delete(const char* cref_)
   if (cref.isValidIdent())
     return oms3::Scope::GetInstance().deleteModel(cref);
   else
-    return logError("oms3_delete failed. Only implemented for model identifiers");
+    return logError("Only implemented for model identifiers");
 }
 
 oms_status_enu_t oms3_export(const char* cref_, const char* filename)
@@ -118,19 +118,19 @@ oms_status_enu_t oms3_list(const char* cref_, char** contents)
   oms3::ComRef front = tail.pop_front();
   oms3::Model* model = oms3::Scope::GetInstance().getModel(front);
   if (!model)
-    return logError("oms3_list failed. Model \"" + std::string(front) + "\" does not exist in the scope");
+    return logError("Model \"" + std::string(front) + "\" does not exist in the scope");
 
   return model->list(tail, contents);
 }
 
 oms_status_enu_t oms3_parseModelName(const char* contents, char** cref)
 {
-  return logError("oms3_parseModelName not implemented");
+  return logError("Not implemented");
 }
 
 oms_status_enu_t oms3_importString(const char* contents, char** cref)
 {
-  return logError("oms3_importString not implemented");
+  return logError("Not implemented");
 }
 
 oms_status_enu_t oms3_addSystem(const char* cref_, oms_system_enu_t type)
@@ -139,14 +139,14 @@ oms_status_enu_t oms3_addSystem(const char* cref_, oms_system_enu_t type)
   oms3::ComRef modelCref = cref.pop_front();
   oms3::Model* model = oms3::Scope::GetInstance().getModel(modelCref);
   if (!model)
-    return logError("oms3_addSystem failed. Model \"" + std::string(modelCref) + "\" does not exist in the scope");
+    return logError("Model \"" + std::string(modelCref) + "\" does not exist in the scope");
 
   return model->addSystem(cref, type);
 }
 
 oms_status_enu_t oms3_copySystem(const char* source, const char* target)
 {
-  return logError("oms3_copySystem not implemented");
+  return logError("Not implemented");
 }
 
 oms_status_enu_t oms3_getElement(const char* cref_, oms3_element_t** element)

--- a/src/OMSimulatorLib/Scope.cpp
+++ b/src/OMSimulatorLib/Scope.cpp
@@ -64,7 +64,7 @@ oms_status_enu_t oms3::Scope::newModel(const oms3::ComRef& cref)
 {
   // check if cref is in scope
   if (getModel(cref))
-    return logError("oms3_newModel failed. A model \"" + std::string(cref) + "\" already exists in the scope");
+    return logError("A model \"" + std::string(cref) + "\" already exists in the scope");
 
   Model* model = oms3::Model::NewModel(cref);
   if (!model)
@@ -81,7 +81,7 @@ oms_status_enu_t oms3::Scope::deleteModel(const oms3::ComRef& cref)
 {
   auto it = models_map.find(cref);
   if (it == models_map.end())
-    return logError("oms3_delete failed. Model \"" + std::string(cref) + "\" does not exist in the scope");
+    return logError("Model \"" + std::string(cref) + "\" does not exist in the scope");
   delete models[it->second];
 
   models.pop_back();
@@ -100,7 +100,7 @@ oms_status_enu_t oms3::Scope::renameModel(const oms3::ComRef& cref, const oms3::
 {
   auto it = models_map.find(cref);
   if (it == models_map.end())
-    return logError("oms3_rename failed. Model \"" + std::string(cref) + "\" does not exist in the scope");
+    return logError("Model \"" + std::string(cref) + "\" does not exist in the scope");
 
   unsigned int index = it->second;
   oms_status_enu_t status = models[index]->rename(newCref);
@@ -117,14 +117,14 @@ oms_status_enu_t oms3::Scope::exportModel(const oms3::ComRef& cref, const std::s
 {
   oms3::Model* model = getModel(cref);
   if (!model)
-    return logError("oms3_export failed. Model \"" + std::string(cref) + "\" does not exist in the scope");
+    return logError("Model \"" + std::string(cref) + "\" does not exist in the scope");
 
   return model->exportToFile(filename);
 }
 
 oms_status_enu_t oms3::Scope::importModel(const std::string& filename, char** cref)
 {
-  return logError("oms3_import not implemented");
+  return logError("Not implemented");
 }
 
 oms_status_enu_t oms3::Scope::setTempDirectory(const std::string& newTempDir)


### PR DESCRIPTION
### Purpose

Prefix the function name to the error message.

### Approach

The function name was prefixed to the error message but not to the callback message.

### Type of Change

- Code refactoring (non-breaking change which improves maintainability)
- Bug fix (non-breaking change which fixes an issue)

### Checklist

- I have performed a self-review of my own code