### PR TITLE
Prevent adding invalid subsystem kinds

### DIFF
--- a/src/OMSimulatorLib/Model.cpp
+++ b/src/OMSimulatorLib/Model.cpp
@@ -164,7 +164,7 @@ oms_status_enu_t oms3::Model::addSystem(const oms3::ComRef& cref, oms_system_enu
   oms3::ComRef front = tail.pop_front();
 
   if (system->getName() == front)
-    return system->addSystem(tail, type, this, NULL);
+    return system->addSubSystem(tail, type);
 
   return logError("wrong input \"" + std::string(front) + "\" != \"" + std::string(system->getName()) + "\"");
 }

--- a/src/OMSimulatorLib/System.h
+++ b/src/OMSimulatorLib/System.h
@@ -57,7 +57,7 @@ namespace oms3
     oms3::Element* getElement() {return &element;}
     oms_status_enu_t list(const ComRef& cref, char** contents);
     oms_system_enu_t getType() const {return type;}
-    oms_status_enu_t addSystem(const oms3::ComRef& cref, oms_system_enu_t type, Model* parentModel, System* parentSystem);
+    oms_status_enu_t addSubSystem(const oms3::ComRef& cref, oms_system_enu_t type);
     bool validCref(const oms3::ComRef& cref);
     oms_status_enu_t exportToSSD(pugi::xml_node& node) const;
 


### PR DESCRIPTION
### Purpose

Better error messages

### Approach

Fetch errors as early as possible.
