### PR TITLE
C requires that a struct or union has at least one member

### DIFF
--- a/src/OMSimulatorLib/Types.h
+++ b/src/OMSimulatorLib/Types.h
@@ -327,6 +327,7 @@ typedef struct {
  * does not presume or require the existence of this functionality.
  */
 typedef struct {
+  int dummy; ///< just to make msvc happy
 } ssd_simulation_information_t;
 
 /**


### PR DESCRIPTION
### Purpose

C requires that a struct or union has at least one member

### Approach

Add a dummy member.
