### PR TITLE
Implement oms3_addConnector

### DIFF
--- a/src/OMSimulatorLib/Connector.cpp
+++ b/src/OMSimulatorLib/Connector.cpp
@@ -35,6 +35,152 @@
 
 #include <cstring>
 
+oms3::Connector::Connector(oms_causality_enu_t causality, oms_signal_type_enu_t type, const oms3::ComRef& name)
+{
+  this->causality = causality;
+  this->type = type;
+
+  std::string str(name);
+  this->name = new char[str.size()+1];
+  strcpy(this->name, str.c_str());
+
+  this->geometry = NULL;
+}
+
+oms3::Connector::Connector(oms_causality_enu_t causality, oms_signal_type_enu_t type, const oms3::ComRef &name, double height)
+{
+  this->causality = causality;
+  this->type = type;
+
+  std::string str(name);
+  this->name = new char[str.size()+1];
+  strcpy(this->name, str.c_str());
+
+  double x, y;
+  switch (causality)
+  {
+    case oms_causality_input:
+      // inputs are placed on the left of the component
+      x = 0.0;
+      y = height;
+      break;
+    case oms_causality_output:
+      // outputs are placed on the right of the component
+      x = 1.0;
+      y = height;
+      break;
+    default:
+      // parameters are placed on the top of the component
+      x = height;
+      y = 1.0;
+      break;
+  }
+  this->geometry = reinterpret_cast<ssd_connector_geometry_t*>(new oms2::ssd::ConnectorGeometry(x, y));
+}
+
+oms3::Connector::~Connector()
+{
+  if (this->name) delete[] this->name;
+  if (this->geometry) delete reinterpret_cast<oms2::ssd::ConnectorGeometry*>(this->geometry);
+}
+
+oms_status_enu_t oms3::Connector::exportToSSD(pugi::xml_node &root) const
+{
+  if (this->geometry)
+  {
+    pugi::xml_node node = root.append_child(oms2::ssd::ssd_connector);
+    node.append_attribute("name") = std::string(getName()).c_str();
+    switch (this->causality)
+    {
+    case oms_causality_input:
+      node.append_attribute("kind") = "input";
+      break;
+    case oms_causality_output:
+      node.append_attribute("kind") = "output";
+      break;
+    case oms_causality_parameter:
+      node.append_attribute("kind") = "parameter";
+      break;
+    }
+    switch (this->type)
+    {
+    case oms_signal_type_boolean:
+      node.append_attribute("type") = "Boolean";
+      break;
+    case oms_signal_type_enum:
+      node.append_attribute("type") = "Enumeration";
+      break;
+    case oms_signal_type_integer:
+      node.append_attribute("type") = "Integer";
+      break;
+    case oms_signal_type_real:
+      node.append_attribute("type") = "Real";
+      break;
+    case oms_signal_type_string:
+      node.append_attribute("type") = "String";
+      break;
+    }
+    return reinterpret_cast<oms2::ssd::ConnectorGeometry*>(this->geometry)->exportToSSD(node);
+  }
+  return oms_status_ok;
+}
+
+oms3::Connector::Connector(const oms3::Connector &rhs)
+{
+  this->causality = rhs.causality;
+  this->type = rhs.type;
+
+  this->name = new char[strlen(rhs.name)+1];
+  strcpy(this->name, rhs.name);
+
+  if (rhs.geometry)
+    this->geometry = reinterpret_cast<ssd_connector_geometry_t*>(new oms2::ssd::ConnectorGeometry(*reinterpret_cast<oms2::ssd::ConnectorGeometry*>(rhs.geometry)));
+  else
+    this->geometry = NULL;
+}
+
+oms3::Connector &oms3::Connector::operator=(const oms3::Connector &rhs)
+{
+  // check for self-assignment
+  if(&rhs == this)
+    return *this;
+
+  this->causality = rhs.causality;
+  this->type = rhs.type;
+
+  if (this->name)
+    delete[] this->name;
+  this->name = new char[strlen(rhs.name)+1];
+  strcpy(this->name, rhs.name);
+
+  this->setGeometry(reinterpret_cast<oms2::ssd::ConnectorGeometry*>(rhs.geometry));
+
+  return *this;
+}
+
+void oms3::Connector::setName(const oms3::ComRef &name)
+{
+  if (this->name)
+    delete[] this->name;
+
+  std::string str(name);
+  this->name = new char[str.size()+1];
+  strcpy(this->name, str.c_str());
+}
+
+void oms3::Connector::setGeometry(const oms2::ssd::ConnectorGeometry *newGeometry)
+{
+  if (this->geometry)
+  {
+    delete reinterpret_cast<oms2::ssd::ConnectorGeometry*>(this->geometry);
+    this->geometry = NULL;
+  }
+
+  if (newGeometry)
+    this->geometry = reinterpret_cast<ssd_connector_geometry_t*>(new oms2::ssd::ConnectorGeometry(*newGeometry));
+}
+
+
 oms2::Connector::Connector(oms_causality_enu_t causality, oms_signal_type_enu_t type, const oms2::SignalRef& name)
 {
   this->causality = causality;

--- a/src/OMSimulatorLib/Connector.h
+++ b/src/OMSimulatorLib/Connector.h
@@ -41,7 +41,7 @@
 
 #include <pugixml.hpp>
 
-namespace oms2
+namespace oms3
 {
   /**
    * \brief Connector
@@ -50,6 +50,41 @@ namespace oms2
   {
   public:
     /**
+     * This constructor creates a oms2::Connector without geometry information.
+     */
+    Connector(oms_causality_enu_t causality, oms_signal_type_enu_t type, const oms3::ComRef& name);
+    /**
+     * This constructor is used if the optional SSD element giving the geometry
+     * information of the connector is initialized as well.
+     */
+    Connector(oms_causality_enu_t causality, oms_signal_type_enu_t type, const oms3::ComRef& name, double height);
+    ~Connector();
+
+    oms_status_enu_t exportToSSD(pugi::xml_node& root) const;
+
+    // methods to copy the object
+    Connector(const Connector& rhs);
+    Connector& operator=(const Connector& rhs);
+
+    void setName(const oms3::ComRef& name);
+    void setGeometry(const oms2::ssd::ConnectorGeometry* newGeometry);
+
+    const oms_causality_enu_t getCausality() const {return causality;}
+    const oms_signal_type_enu_t getType() const {return type;}
+    const oms3::ComRef getName() const {return oms3::ComRef(std::string(name));}
+    const oms2::ssd::ConnectorGeometry* getGeometry() const {return reinterpret_cast<oms2::ssd::ConnectorGeometry*>(geometry);}
+  };
+}
+
+namespace oms2
+{
+/**
+   * \brief Connector
+   */
+class Connector : protected oms_connector_t
+{
+public:
+  /**
      * This constructor creates a oms2::Connector without geometry information.
      */
     Connector(oms_causality_enu_t causality, oms_signal_type_enu_t type, const oms2::SignalRef& name);

--- a/src/OMSimulatorLib/Element.cpp
+++ b/src/OMSimulatorLib/Element.cpp
@@ -88,23 +88,35 @@ void oms3::Element::setGeometry(const oms3::ssd::ElementGeometry* newGeometry)
   }
 }
 
-//void oms3::Element::setConnectors(const std::vector<oms2::Connector> newConnectors)
-//{
-//  logTrace();
-//
-//  if (this->connectors)
-//  {
-//    for (int i=0; this->connectors[i]; ++i)
-//      delete reinterpret_cast<oms2::Connector*>(this->connectors[i]);
-//    delete[] this->connectors;
-//  }
-//
-//  this->connectors = reinterpret_cast<oms_connector_t**>(new oms2::Connector*[newConnectors.size()+1]);
-//  this->connectors[newConnectors.size()] = NULL;
-//
-//  for (int i=0; i<newConnectors.size(); ++i)
-//    this->connectors[i] = reinterpret_cast<oms_connector_t*>(new oms2::Connector(newConnectors[i]));
-//}
+void oms3::Element::addConnector(oms3::Connector connector)
+{
+  std::vector<oms3::Connector> vConnectors;
+  for(int i=0; connectors && connectors[i]; ++i) {
+    oms3::Connector *tempCon = reinterpret_cast<oms3::Connector*>(connectors[i]);
+    vConnectors.push_back(*tempCon);
+  }
+  vConnectors.push_back(connector);
+
+  setConnectors(vConnectors);
+}
+
+void oms3::Element::setConnectors(const std::vector<oms3::Connector> newConnectors)
+{
+  logTrace();
+
+  if (this->connectors)
+  {
+    for (int i=0; this->connectors[i]; ++i)
+      delete reinterpret_cast<oms2::Connector*>(this->connectors[i]);
+    delete[] this->connectors;
+  }
+
+  this->connectors = reinterpret_cast<oms_connector_t**>(new oms3::Connector*[newConnectors.size()+1]);
+  this->connectors[newConnectors.size()] = NULL;
+
+  for (int i=0; i<newConnectors.size(); ++i)
+    this->connectors[i] = reinterpret_cast<oms_connector_t*>(new oms3::Connector(newConnectors[i]));
+}
 
 oms2::Element::Element(oms_element_type_enu_t type, const oms2::ComRef& name)
 {

--- a/src/OMSimulatorLib/Element.h
+++ b/src/OMSimulatorLib/Element.h
@@ -59,7 +59,8 @@ namespace oms3
 
     void setName(const ComRef& name);
     void setGeometry(const oms3::ssd::ElementGeometry* newGeometry);
-    //void setConnectors(const std::vector<oms3::Connector> newConnectors);
+    void setConnectors(const std::vector<oms3::Connector> newConnectors);
+    void addConnector(oms3::Connector connector);
 
   private:
     // methods to copy the object

--- a/src/OMSimulatorLib/OMSimulator.cpp
+++ b/src/OMSimulatorLib/OMSimulator.cpp
@@ -41,6 +41,7 @@
 #include "ResultReader.h"
 #include "Types.h"
 #include "Version.h"
+#include "System.h"
 
 #include <string>
 #include <boost/filesystem.hpp>
@@ -157,6 +158,27 @@ oms_status_enu_t oms3_getElement(const char* cref_, oms3_element_t** element)
 oms_status_enu_t oms3_getElements(const char* cref, oms3_element_t*** elements)
 {
   return oms3::Scope::GetInstance().getElements(oms3::ComRef(cref), reinterpret_cast<oms3::Element***>(elements));
+}
+
+oms_status_enu_t oms3_addConnector(const char *cref, oms_causality_enu_t causality, oms_signal_type_enu_t type)
+{
+  logTrace();
+
+  oms3::ComRef tail(cref);
+  oms3::ComRef modelCref = tail.pop_front();
+  oms3::ComRef systemCref = tail.pop_front();
+
+  oms3::Model* model = oms3::Scope::GetInstance().getModel(modelCref);
+  if(!model) {
+    return logError("Model \"" + std::string(modelCref) + "\" does not exist in the scope");
+  }
+
+  oms3::System* system = model->getSystem(systemCref);
+  if(!system) {
+    return logError("Model \"" + std::string(modelCref) + "\" does not contain system \"" + std::string(systemCref) + "\"");
+  }
+
+  return system->addConnector(tail, causality, type);
 }
 
 /* ************************************ */
@@ -748,3 +770,4 @@ int oms2_exists(const char* cref)
   logTrace();
   return oms2::Scope::GetInstance().exists(oms2::ComRef(cref)) ? 1 : 0;
 }
+

--- a/src/OMSimulatorLib/System.cpp
+++ b/src/OMSimulatorLib/System.cpp
@@ -206,3 +206,22 @@ oms_status_enu_t oms3::System::exportToSSD(pugi::xml_node& node) const
 
   return oms_status_ok;
 }
+
+oms_status_enu_t oms3::System::addConnector(const oms3::ComRef &cref, oms_causality_enu_t causality, oms_signal_type_enu_t type)
+{
+  oms3::ComRef tail(cref);
+  oms3::ComRef head = tail.pop_front();
+  auto subsystem = subsystems.find(head);
+  if(subsystem != subsystems.end()) {
+    return subsystem->second->addConnector(tail,causality,type);
+  }
+
+  if(!cref.isValidIdent()) {
+    return logError("Not a valid ident: "+std::string(cref));
+  }
+
+  oms3::Connector connector(causality, type, cref);
+  this->getElement()->addConnector(connector);
+
+  return oms_status_ok;
+}

--- a/src/OMSimulatorLib/System.h
+++ b/src/OMSimulatorLib/System.h
@@ -60,6 +60,7 @@ namespace oms3
     oms_status_enu_t addSubSystem(const oms3::ComRef& cref, oms_system_enu_t type);
     bool validCref(const oms3::ComRef& cref);
     oms_status_enu_t exportToSSD(pugi::xml_node& node) const;
+    oms_status_enu_t addConnector(const oms3::ComRef& cref, oms_causality_enu_t causality, oms_signal_type_enu_t type);
 
   protected:
     System(const ComRef& cref, oms_system_enu_t type, Model* parentModel, System* parentSystem);


### PR DESCRIPTION
### Purpose

Implementation of oms3_addConnector()

### Approach

New connector is appended to the connectors array in oms3::Element class. I also created a oms3::Connector class. Right now it is almost identical to oms2::Connector.

### Type of Change

- New feature (non-breaking change which adds functionality)

### Checklist

- I have performed a self-review of my own code
- My changes generate no new warnings