### PR TITLE
Implement self referencing oms3_element_t type

### DIFF
--- a/src/OMSimulatorLib/Element.cpp
+++ b/src/OMSimulatorLib/Element.cpp
@@ -45,6 +45,7 @@ oms3::Element::Element(oms3_element_enu_t type, const oms3::ComRef& name)
   this->name = new char[str.size()+1];
   strcpy(this->name, str.c_str());
 
+  this->elements = NULL;
   this->connectors = NULL;
 
   this->geometry = reinterpret_cast<ssd_element_geometry_t*>(new oms3::ssd::ElementGeometry());
@@ -54,12 +55,16 @@ oms3::Element::~Element()
 {
   if (this->name)
     delete[] this->name;
+
+  // lochel: don't delete the sub-elements
+
   if (this->connectors)
   {
 //    for (int i=0; this->connectors[i]; ++i)
 //      delete reinterpret_cast<oms3::Connector*>(this->connectors[i]);
     delete[] this->connectors;
   }
+
   if (this->geometry)
     delete reinterpret_cast<oms3::ssd::ElementGeometry*>(this->geometry);
 }
@@ -91,6 +96,11 @@ void oms3::Element::setGeometry(const oms3::ssd::ElementGeometry* newGeometry)
 void oms3::Element::setConnectors(oms3::Connector** newConnectors)
 {
   this->connectors = reinterpret_cast<oms_connector_t**>(newConnectors);
+}
+
+void oms3::Element::setSubElements(oms3_element_t** subelements)
+{
+  this->elements = subelements;
 }
 
 /* ************************************ */

--- a/src/OMSimulatorLib/Element.cpp
+++ b/src/OMSimulatorLib/Element.cpp
@@ -58,13 +58,6 @@ oms3::Element::~Element()
 
   // lochel: don't delete the sub-elements
 
-  if (this->connectors)
-  {
-//    for (int i=0; this->connectors[i]; ++i)
-//      delete reinterpret_cast<oms3::Connector*>(this->connectors[i]);
-    delete[] this->connectors;
-  }
-
   if (this->geometry)
     delete reinterpret_cast<oms3::ssd::ElementGeometry*>(this->geometry);
 }

--- a/src/OMSimulatorLib/Element.h
+++ b/src/OMSimulatorLib/Element.h
@@ -60,6 +60,7 @@ namespace oms3
     void setName(const ComRef& name);
     void setGeometry(const oms3::ssd::ElementGeometry* newGeometry);
     void setConnectors(oms3::Connector** newConnectors);
+    void setSubElements(oms3_element_t** subelements);
 
   private:
     // methods to copy the object

--- a/src/OMSimulatorLib/Model.cpp
+++ b/src/OMSimulatorLib/Model.cpp
@@ -48,11 +48,13 @@ oms3::Model::Model(const oms3::ComRef& cref, const std::string& tempDir)
 {
   logInfo("New model \"" + std::string(cref) + "\" with corresponding temp directory \"" + tempDir + "\"");
   elements = NULL;
+
+  elements.push_back(NULL);
+  elements.push_back(NULL);
 }
 
 oms3::Model::~Model()
 {
-  deleteElements();
   if (system)
     delete system;
 }
@@ -156,7 +158,12 @@ oms_status_enu_t oms3::Model::addSystem(const oms3::ComRef& cref, oms_system_enu
   if (cref.isValidIdent() && !system)
   {
     system = System::NewSystem(cref, type, this, NULL);
-    return system ? oms_status_ok : oms_status_error;
+    if (system)
+    {
+      elements[0] = system->getElement();
+      return oms_status_ok;
+    }
+    return oms_status_error;
   }
 
   if (!system)
@@ -200,36 +207,6 @@ oms_status_enu_t oms3::Model::exportToFile(const std::string& filename) const
     return logError("xml export failed for \"" + filename + "\" (model \"" + std::string(this->getName()) + "\")");
 
   return oms_status_ok;
-}
-
-oms3::Element** oms3::Model::getElements()
-{
-  if (elements)
-    return elements;
-
-  updateElements();
-  return elements;
-}
-
-void oms3::Model::deleteElements()
-{
-  if (this->elements)
-  {
-    delete[] elements;
-    elements = NULL;
-  }
-}
-
-void oms3::Model::updateElements()
-{
-  deleteElements();
-
-  if (system)
-  {
-    elements = new oms3::Element*[2];
-    elements[0] = system->getElement();
-    elements[1] = NULL;
-  }
 }
 
 /* ************************************ */

--- a/src/OMSimulatorLib/Model.cpp
+++ b/src/OMSimulatorLib/Model.cpp
@@ -47,7 +47,6 @@ oms3::Model::Model(const oms3::ComRef& cref, const std::string& tempDir)
   : cref(cref), tempDir(tempDir)
 {
   logInfo("New model \"" + std::string(cref) + "\" with corresponding temp directory \"" + tempDir + "\"");
-  elements = NULL;
 
   elements.push_back(NULL);
   elements.push_back(NULL);

--- a/src/OMSimulatorLib/Model.h
+++ b/src/OMSimulatorLib/Model.h
@@ -60,7 +60,7 @@ namespace oms3
     oms_status_enu_t exportToSSD(pugi::xml_node& node) const;
     oms_status_enu_t exportToFile(const std::string& filename) const;
 
-    oms3::Element** getElements();
+    oms3::Element** getElements() {return &elements[0];}
 
   private:
     Model(const ComRef& cref, const std::string& tempDir);
@@ -74,11 +74,7 @@ namespace oms3
     System* system = NULL;
     std::string tempDir;
 
-    oms3::Element** elements;
-
-  protected:
-    void deleteElements();
-    void updateElements();
+    std::vector<oms3_element_t*> elements;
   };
 }
 

--- a/src/OMSimulatorLib/Model.h
+++ b/src/OMSimulatorLib/Model.h
@@ -74,7 +74,7 @@ namespace oms3
     System* system = NULL;
     std::string tempDir;
 
-    std::vector<oms3_element_t*> elements;
+    std::vector<oms3::Element*> elements;
   };
 }
 

--- a/src/OMSimulatorLib/OMSimulator.h
+++ b/src/OMSimulatorLib/OMSimulator.h
@@ -58,25 +58,25 @@ oms_status_enu_t oms3_import(const char* filename, char** cref);
 oms_status_enu_t oms3_list(const char* cref, char** contents);
 oms_status_enu_t oms3_parseModelName(const char* contents, char** cref);
 oms_status_enu_t oms3_importString(const char* contents, char** cref);
-
 oms_status_enu_t oms3_addSystem(const char* cref, oms_system_enu_t type);
 oms_status_enu_t oms3_copySystem(const char* source, const char* target);
+oms_status_enu_t oms3_getElement(const char* cref, oms3_element_t** element);
+oms_status_enu_t oms3_getElements(const char* cref, oms3_element_t*** elements);
+oms_status_enu_t oms3_addConnector(const char* cref, oms_causality_enu_t causality, oms_signal_type_enu_t type);
 
+/* not implemented yet */
 oms_status_enu_t oms3_getSystemType(const char* cref, oms_system_enu_t* type);
 oms_status_enu_t oms3_addSubModel(const char* cref, const char* fmuPath);
 oms_status_enu_t oms3_addExternalModel(const char* cref, const char* path, const char* startscript);
 oms_status_enu_t oms3_setSimulationInformation(const char* cref, ssd_simulation_information_t* info);
 oms_status_enu_t oms3_getSimulationInformation(const char* cref, ssd_simulation_information_t** info);
-oms_status_enu_t oms3_addConnector(const char* cref, oms_causality_enu_t causality, oms_signal_type_enu_t type);
 oms_status_enu_t oms3_addConnection(const char* crefA, const char* crefB);
 oms_status_enu_t oms3_addTLMConnection(const char* crefA, const char* crefB, double delay, double alpha, double Zf, double Zfr);
 oms_status_enu_t oms3_addBus(const char* cref);
 oms_status_enu_t oms3_addTLMBus(const char* cref, const char* domain, const char* dimension, const char* interpolation);
 oms_status_enu_t oms3_addConnectorToBus(const char* busCref, const char* connectorCref);
 oms_status_enu_t oms3_addConnectorToTLMBus(const char* busCref, const char* connectorCref, oms_tlm_connector_type_enu_t type);
-oms_status_enu_t oms3_getElement(const char* cref, oms3_element_t** element);
 oms_status_enu_t oms3_setElementGeometry(const char* cref, const ssd_element_geometry_t* geometry);
-oms_status_enu_t oms3_getElements(const char* cref, oms3_element_t*** elements);
 oms_status_enu_t oms3_getSubModelPath(const char* cref, char** path);
 oms_status_enu_t oms3_getFMUInfo(const char* cref, const oms_fmu_info_t** fmuInfo);
 oms_status_enu_t oms3_setConnectorGeometry(const char* connector, const ssd_connector_geometry_t* geometry);

--- a/src/OMSimulatorLib/System.cpp
+++ b/src/OMSimulatorLib/System.cpp
@@ -223,7 +223,8 @@ oms_status_enu_t oms3::System::exportToSSD(pugi::xml_node& node) const
 
   pugi::xml_node connectors_node = node.append_child(oms2::ssd::ssd_connectors);
   for(const auto& connector : connectors)
-    connector->exportToSSD(connectors_node);
+    if (connector)
+      connector->exportToSSD(connectors_node);
 
   return oms_status_ok;
 }
@@ -244,6 +245,7 @@ oms_status_enu_t oms3::System::addConnector(const oms3::ComRef &cref, oms_causal
   oms3::Connector* connector = new oms3::Connector(causality, type, cref);
   connectors.back() = connector;
   connectors.push_back(NULL);
+  element.setConnectors(&connectors[0]);
 
   return oms_status_ok;
 }

--- a/src/OMSimulatorLib/System.cpp
+++ b/src/OMSimulatorLib/System.cpp
@@ -44,6 +44,9 @@ oms3::System::System(const oms3::ComRef& cref, oms_system_enu_t type, oms3::Mode
 {
   connectors.push_back(NULL);
   element.setConnectors(&connectors[0]);
+
+  subelements.push_back(NULL);
+  element.setSubElements(&subelements[0]);
 }
 
 oms3::System::~System()
@@ -173,8 +176,14 @@ oms_status_enu_t oms3::System::addSubSystem(const oms3::ComRef& cref, oms_system
   {
     System* system = System::NewSystem(cref, type, NULL, this);
     if (system)
+    {
       subsystems[cref] = system;
-    return system ? oms_status_ok : oms_status_error;
+      subelements.back() = reinterpret_cast<oms3_element_t*>(system->getElement());
+      subelements.push_back(NULL);
+      element.setSubElements(&subelements[0]);
+      return oms_status_ok;
+    }
+    return oms_status_error;
   }
 
   ComRef tail(cref);

--- a/src/OMSimulatorLib/System.h
+++ b/src/OMSimulatorLib/System.h
@@ -69,9 +69,6 @@ namespace oms3
     System(System const& copy);            ///< not implemented
     System& operator=(System const& copy); ///< not implemented
 
-    oms3::Element element;
-    std::vector<oms3::Connector*> connectors;
-
   private:
     ComRef cref;
     oms_system_enu_t type;
@@ -79,6 +76,10 @@ namespace oms3
     System* parentSystem;
     std::map<ComRef, System*> subsystems;
     std::map<ComRef, Component*> components;
+
+    oms3::Element element;
+    std::vector<oms3::Connector*> connectors;
+    std::vector<oms3_element_t*> subelements;
   };
 }
 

--- a/src/OMSimulatorLib/Types.h
+++ b/src/OMSimulatorLib/Types.h
@@ -355,11 +355,12 @@ typedef struct {
 /**
  * \brief Element (aka ssd:Component)
  */
-typedef struct {
-  oms3_element_enu_t type;          ///< Element type, i.e. system or component
-  char* name;                       ///< Name of the element
-  oms_connector_t** connectors;     ///< List (null-terminated array) of all interface variables: inputs, outputs, and parameters.
-  ssd_element_geometry_t* geometry; ///< Geometry information of the element
+typedef struct _oms3_element_t{
+  oms3_element_enu_t type;           ///< Element type, i.e. system or component
+  char* name;                        ///< Name of the element
+  struct _oms3_element_t** elements; ///< List (null-terminated array) of all sub-elements
+  oms_connector_t** connectors;      ///< List (null-terminated array) of all interface variables: inputs, outputs, and parameters.
+  ssd_element_geometry_t* geometry;  ///< Geometry information of the element
 } oms3_element_t;
 
 typedef struct {


### PR DESCRIPTION
### Purpose

Extend the element information by its sub-elements.

### Approach

Implement `oms3_element_t` as self referencing struct.

### Type of Change

<!--- Please delete options that are not relevant. -->

- Code refactoring (non-breaking change which improves maintainability)
- New feature (non-breaking change which adds functionality)
- This change requires a documentation update
