### PR TITLE
Remove dangerous code

### DIFF
--- a/src/OMSimulatorLib/ComRef.cpp
+++ b/src/OMSimulatorLib/ComRef.cpp
@@ -83,18 +83,6 @@ bool oms3::ComRef::isEmpty() const
   return !(cref && cref[0] != '\0');
 }
 
-oms3::ComRef oms3::ComRef::pop_back()
-{
-  int dot=0;
-
-  for(int i=0; cref[i]; ++i)
-    if(cref[i] == '.')
-      dot = i;
-
-  cref[dot] = '\0';
-  return oms3::ComRef(cref+dot+1);
-}
-
 oms3::ComRef oms3::ComRef::front()
 {
   int dot=0;

--- a/src/OMSimulatorLib/ComRef.h
+++ b/src/OMSimulatorLib/ComRef.h
@@ -55,7 +55,6 @@ namespace oms3
     bool isValidIdent() const;
     bool isEmpty() const;
 
-    ComRef pop_back();
     ComRef front();
     ComRef pop_front();
 


### PR DESCRIPTION
### Purpose

I see actually no reason to use `oms3::ComRef::pop_back`. It might cause problems when beeing used, because FMI signal names can contain dots.

### Approach

Delete method `oms3::ComRef::pop_back`
