### PR TITLE
Save connectors to SSD

### DIFF
--- a/src/OMSimulatorLib/Connector.cpp
+++ b/src/OMSimulatorLib/Connector.cpp
@@ -86,40 +86,40 @@ oms3::Connector::~Connector()
 
 oms_status_enu_t oms3::Connector::exportToSSD(pugi::xml_node &root) const
 {
+  pugi::xml_node node = root.append_child(oms2::ssd::ssd_connector);
+  node.append_attribute("name") = std::string(getName()).c_str();
+  switch (this->causality)
+  {
+  case oms_causality_input:
+    node.append_attribute("kind") = "input";
+    break;
+  case oms_causality_output:
+    node.append_attribute("kind") = "output";
+    break;
+  case oms_causality_parameter:
+    node.append_attribute("kind") = "parameter";
+    break;
+  }
+  switch (this->type)
+  {
+  case oms_signal_type_boolean:
+    node.append_attribute("type") = "Boolean";
+    break;
+  case oms_signal_type_enum:
+    node.append_attribute("type") = "Enumeration";
+    break;
+  case oms_signal_type_integer:
+    node.append_attribute("type") = "Integer";
+    break;
+  case oms_signal_type_real:
+    node.append_attribute("type") = "Real";
+    break;
+  case oms_signal_type_string:
+    node.append_attribute("type") = "String";
+    break;
+  }
   if (this->geometry)
   {
-    pugi::xml_node node = root.append_child(oms2::ssd::ssd_connector);
-    node.append_attribute("name") = std::string(getName()).c_str();
-    switch (this->causality)
-    {
-    case oms_causality_input:
-      node.append_attribute("kind") = "input";
-      break;
-    case oms_causality_output:
-      node.append_attribute("kind") = "output";
-      break;
-    case oms_causality_parameter:
-      node.append_attribute("kind") = "parameter";
-      break;
-    }
-    switch (this->type)
-    {
-    case oms_signal_type_boolean:
-      node.append_attribute("type") = "Boolean";
-      break;
-    case oms_signal_type_enum:
-      node.append_attribute("type") = "Enumeration";
-      break;
-    case oms_signal_type_integer:
-      node.append_attribute("type") = "Integer";
-      break;
-    case oms_signal_type_real:
-      node.append_attribute("type") = "Real";
-      break;
-    case oms_signal_type_string:
-      node.append_attribute("type") = "String";
-      break;
-    }
     return reinterpret_cast<oms2::ssd::ConnectorGeometry*>(this->geometry)->exportToSSD(node);
   }
   return oms_status_ok;

--- a/src/OMSimulatorLib/Element.cpp
+++ b/src/OMSimulatorLib/Element.cpp
@@ -88,39 +88,16 @@ void oms3::Element::setGeometry(const oms3::ssd::ElementGeometry* newGeometry)
   }
 }
 
-void oms3::Element::addConnector(oms3::Connector connector)
+void oms3::Element::setConnectors(oms3::Connector** newConnectors)
 {
-  std::vector<oms3::Connector> tempConnectors;
-  getConnectors(tempConnectors);
-  tempConnectors.push_back(connector);
-  setConnectors(tempConnectors);
+  this->connectors = reinterpret_cast<oms_connector_t**>(newConnectors);
 }
 
-void oms3::Element::getConnectors(std::vector<Connector> &connectors) const
-{
-  for(int i=0; this->connectors && this->connectors[i]; ++i) {
-    oms3::Connector *tempCon = reinterpret_cast<oms3::Connector*>(this->connectors[i]);
-    connectors.push_back(*tempCon);
-  }
-}
-
-void oms3::Element::setConnectors(const std::vector<oms3::Connector> newConnectors)
-{
-  logTrace();
-
-  if (this->connectors)
-  {
-    for (int i=0; this->connectors[i]; ++i)
-      delete reinterpret_cast<oms2::Connector*>(this->connectors[i]);
-    delete[] this->connectors;
-  }
-
-  this->connectors = reinterpret_cast<oms_connector_t**>(new oms3::Connector*[newConnectors.size()+1]);
-  this->connectors[newConnectors.size()] = NULL;
-
-  for (int i=0; i<newConnectors.size(); ++i)
-    this->connectors[i] = reinterpret_cast<oms_connector_t*>(new oms3::Connector(newConnectors[i]));
-}
+/* ************************************ */
+/* oms2                                 */
+/*                                      */
+/*                                      */
+/* ************************************ */
 
 oms2::Element::Element(oms_element_type_enu_t type, const oms2::ComRef& name)
 {

--- a/src/OMSimulatorLib/Element.cpp
+++ b/src/OMSimulatorLib/Element.cpp
@@ -90,14 +90,18 @@ void oms3::Element::setGeometry(const oms3::ssd::ElementGeometry* newGeometry)
 
 void oms3::Element::addConnector(oms3::Connector connector)
 {
-  std::vector<oms3::Connector> vConnectors;
-  for(int i=0; connectors && connectors[i]; ++i) {
-    oms3::Connector *tempCon = reinterpret_cast<oms3::Connector*>(connectors[i]);
-    vConnectors.push_back(*tempCon);
-  }
-  vConnectors.push_back(connector);
+  std::vector<oms3::Connector> tempConnectors;
+  getConnectors(tempConnectors);
+  tempConnectors.push_back(connector);
+  setConnectors(tempConnectors);
+}
 
-  setConnectors(vConnectors);
+void oms3::Element::getConnectors(std::vector<Connector> &connectors) const
+{
+  for(int i=0; this->connectors && this->connectors[i]; ++i) {
+    oms3::Connector *tempCon = reinterpret_cast<oms3::Connector*>(this->connectors[i]);
+    connectors.push_back(*tempCon);
+  }
 }
 
 void oms3::Element::setConnectors(const std::vector<oms3::Connector> newConnectors)

--- a/src/OMSimulatorLib/Element.h
+++ b/src/OMSimulatorLib/Element.h
@@ -61,6 +61,7 @@ namespace oms3
     void setGeometry(const oms3::ssd::ElementGeometry* newGeometry);
     void setConnectors(const std::vector<oms3::Connector> newConnectors);
     void addConnector(oms3::Connector connector);
+    void getConnectors(std::vector<oms3::Connector> &connectors) const;
 
   private:
     // methods to copy the object

--- a/src/OMSimulatorLib/Element.h
+++ b/src/OMSimulatorLib/Element.h
@@ -54,14 +54,12 @@ namespace oms3
 
     const oms3_element_enu_t getType() const {return type;}
     const oms3::ComRef getName() const {return oms3::ComRef(std::string(name));}
-    //oms3::Connector** getConnectors() const {return reinterpret_cast<oms3::Connector**>(connectors);}
+    oms3::Connector** getConnectors() const {return reinterpret_cast<oms3::Connector**>(connectors);}
     const oms3::ssd::ElementGeometry* getGeometry() const {return reinterpret_cast<oms3::ssd::ElementGeometry*>(geometry);}
 
     void setName(const ComRef& name);
     void setGeometry(const oms3::ssd::ElementGeometry* newGeometry);
-    void setConnectors(const std::vector<oms3::Connector> newConnectors);
-    void addConnector(oms3::Connector connector);
-    void getConnectors(std::vector<oms3::Connector> &connectors) const;
+    void setConnectors(oms3::Connector** newConnectors);
 
   private:
     // methods to copy the object

--- a/src/OMSimulatorLib/System.cpp
+++ b/src/OMSimulatorLib/System.cpp
@@ -190,18 +190,27 @@ oms_status_enu_t oms3::System::exportToSSD(pugi::xml_node& node) const
 {
   node.append_attribute("name") = this->getName().c_str();
 
+  pugi::xml_node elements_node = node.append_child(oms2::ssd::ssd_elements);
+
   for (const auto& subsystem : subsystems)
   {
-    pugi::xml_node system_node = node.append_child(oms2::ssd::ssd_system);
+    pugi::xml_node system_node = elements_node.append_child(oms2::ssd::ssd_system);
     if (oms_status_ok != subsystem.second->exportToSSD(system_node))
       return logError("export of system failed");
   }
 
   for (const auto& component : components)
   {
-    pugi::xml_node component_node = node.append_child(oms2::ssd::ssd_component);
+    pugi::xml_node component_node = elements_node.append_child(oms2::ssd::ssd_component);
     if (oms_status_ok != component.second->exportToSSD(component_node))
       return logError("export of component failed");
+  }
+
+  pugi::xml_node connectors_node = node.append_child(oms2::ssd::ssd_connectors);
+  std::vector<oms3::Connector> connectors;
+  this->element.getConnectors(connectors);
+  for(auto &connector : connectors) {
+    connector.exportToSSD(connectors_node);
   }
 
   return oms_status_ok;

--- a/src/OMSimulatorLib/System.h
+++ b/src/OMSimulatorLib/System.h
@@ -70,6 +70,7 @@ namespace oms3
     System& operator=(System const& copy); ///< not implemented
 
     oms3::Element element;
+    std::vector<oms3::Connector*> connectors;
 
   private:
     ComRef cref;

--- a/src/OMSimulatorLib/ssd/Tags.cpp
+++ b/src/OMSimulatorLib/ssd/Tags.cpp
@@ -45,3 +45,4 @@ const char* oms2::ssd::ssd_enumerations                 = "ssd:Enumerations";
 const char* oms2::ssd::ssd_system                       = "ssd:System";
 const char* oms2::ssd::ssd_system_structure_description = "ssd:SystemStructureDescription";
 const char* oms2::ssd::ssd_units                        = "ssd:Units";
+const char* oms2::ssd::ssd_elements                        = "ssd:Elements";

--- a/src/OMSimulatorLib/ssd/Tags.h
+++ b/src/OMSimulatorLib/ssd/Tags.h
@@ -50,6 +50,7 @@ namespace oms2
     extern const char* ssd_system;
     extern const char* ssd_system_structure_description;
     extern const char* ssd_units;
+    extern const char* ssd_elements;
   }
 }
 


### PR DESCRIPTION
### Purpose

Save oms3::Connector to SSD

### Approach

- Call oms3::Connector::exportToSSD from oms3::System::exportToSSD
- Added oms3::Element::getConnectors function
- Added missing Elements tag when saving subsystems and components

### Type of Change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

### Checklist

- I have performed a self-review of my own code
- My changes generate no new warnings
