### PR TITLE
Fix segfault in oms3::System::exportToSSD()

### DIFF
--- a/src/OMSimulatorLib/System.cpp
+++ b/src/OMSimulatorLib/System.cpp
@@ -213,8 +213,10 @@ oms_status_enu_t oms3::System::exportToSSD(pugi::xml_node& node) const
   }
 
   pugi::xml_node connectors_node = node.append_child(oms2::ssd::ssd_connectors);
-  for(const auto& connector : connectors)
-    connector->exportToSSD(connectors_node);
+  for(const auto& connector : connectors) {
+    if(connector) //Must check since vector is null-terminated
+      connector->exportToSSD(connectors_node);
+  }
 
   return oms_status_ok;
 }


### PR DESCRIPTION
### Purpose

The connectors vector in oms3::System is null-terminated. Iterating over the elements causes a segmentation fault on last element.

### Approach

Check if each element exists before using it.

### Type of Change

<!--- Please delete options that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)

### Checklist

- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- My changes generate no new warnings
