### PR TITLE
boost::filesystem::unique path doesn't exist in boost < 1.45

### DIFF
--- a/src/OMSimulatorLib/Model.cpp
+++ b/src/OMSimulatorLib/Model.cpp
@@ -70,7 +70,7 @@ oms3::Model* oms3::Model::NewModel(const oms3::ComRef& cref)
     return NULL;
   }
 
-  std::string tempDir = (boost::filesystem::path(Scope::GetInstance().getTempDirectory().c_str()) / boost::filesystem::unique_path(std::string(cref) + "-%%%%")).string();
+  std::string tempDir = (boost::filesystem::path(Scope::GetInstance().getTempDirectory().c_str()) / oms_unique_path(std::string(cref))).string();
   if (boost::filesystem::is_directory(tempDir))
   {
     logError("Unique temp directory does already exist. Clean up the temp directory \"" + Scope::GetInstance().getTempDirectory() + "\" and try again.");

--- a/src/OMSimulatorLib/OMSBoost.cpp
+++ b/src/OMSimulatorLib/OMSBoost.cpp
@@ -31,7 +31,7 @@
 
 #include <OMSBoost.h>
 
-boost::filesystem::path oms2_temp_directory_path(void)
+boost::filesystem::path oms_temp_directory_path(void)
 {
 #if (BOOST_VERSION >= 104600) // no temp_directory_path in boost < 1.46
   return boost::filesystem::temp_directory_path();
@@ -64,7 +64,7 @@ boost::filesystem::path oms2_temp_directory_path(void)
 }
 
 
-boost::filesystem::path oms2_canonical(boost::filesystem::path p)
+boost::filesystem::path oms_canonical(boost::filesystem::path p)
 {
 #if (BOOST_VERSION >= 104600) // no temp_directory_path in boost < 1.46
   return boost::filesystem::canonical(p);
@@ -73,6 +73,19 @@ boost::filesystem::path oms2_canonical(boost::filesystem::path p)
 #endif
 }
 
+boost::filesystem::path oms_unique_path(std::string prefix)
+{
+#if (BOOST_VERSION >= 104500) // no temp_directory_path in boost < 1.45
+  return boost::filesystem::unique_path(prefix + "-%%%%");
+#else
+  int i;
+  std::string s = prefix;
+  for(i=0; i<4; i++)
+    s += std::string(1, ('A' + rand()%26));
+  boost::filesystem::path p(s);
+  return p;
+#endif
+}
 
 /*
 

--- a/src/OMSimulatorLib/OMSBoost.h
+++ b/src/OMSimulatorLib/OMSBoost.h
@@ -49,6 +49,7 @@ extern "C"
 #endif
  
 #include <cstdlib>
+#include <string>
 #include <boost/version.hpp>
 #include <boost/filesystem.hpp>
 
@@ -60,7 +61,8 @@ extern "C"
 #endif
 
 
-boost::filesystem::path oms2_temp_directory_path(void);
-boost::filesystem::path oms2_canonical(boost::filesystem::path p);
+boost::filesystem::path oms_temp_directory_path(void);
+boost::filesystem::path oms_canonical(boost::filesystem::path p);
+boost::filesystem::path oms_unique_path(std::string prefix);
 
 #endif

--- a/src/OMSimulatorLib/Scope.cpp
+++ b/src/OMSimulatorLib/Scope.cpp
@@ -41,7 +41,7 @@ oms3::Scope::Scope()
 {
   this->models.push_back(NULL);
 
-  boost::filesystem::path tempDir = oms2_temp_directory_path() / "omsimulator";
+  boost::filesystem::path tempDir = oms_temp_directory_path() / "omsimulator";
   setTempDirectory(tempDir.string());
 
   setWorkingDirectory(".");
@@ -142,7 +142,7 @@ oms_status_enu_t oms3::Scope::setTempDirectory(const std::string& newTempDir)
   boost::filesystem::path path(newTempDir.c_str());
   try
   {
-    path = oms2_canonical(path);
+    path = oms_canonical(path);
   }
   catch(std::exception e)
   {
@@ -169,7 +169,7 @@ oms_status_enu_t oms3::Scope::setWorkingDirectory(const std::string& newWorkingD
   boost::filesystem::current_path(path);
   try
   {
-    path = oms2_canonical(path);
+    path = oms_canonical(path);
   }
   catch(std::exception e)
   {
@@ -266,7 +266,7 @@ oms3::Model* oms3::Scope::getModel(const oms3::ComRef& cref)
 oms2::Scope::Scope()
 {
   logTrace();
-  boost::filesystem::path tempPath = oms2_temp_directory_path();
+  boost::filesystem::path tempPath = oms_temp_directory_path();
   tempDir = tempPath.string();
 }
 
@@ -571,7 +571,7 @@ oms_status_enu_t oms2::Scope::setTempDirectory(const std::string& newTempDir)
   boost::filesystem::path path(newTempDir.c_str());
   try
   {
-    path = oms2_canonical(path);
+    path = oms_canonical(path);
   }
   catch(std::exception e)
   {


### PR DESCRIPTION
### Purpose

- attempt to fix Linux nightly builds
- provide alternative implementation in oms_unique_path
- rename oms2_* from OMBoost.* to oms_

