### PR TITLE
Delete busconnectors in system destructor

### DIFF
--- a/src/OMSimulatorLib/System.cpp
+++ b/src/OMSimulatorLib/System.cpp
@@ -66,6 +66,9 @@ oms3::System::~System()
 
   for (const auto& subsystem : subsystems)
     delete subsystem.second;
+
+  for (const auto& busconnector : busconnectors)
+    delete busconnector;
 }
 
 oms3::System* oms3::System::NewSystem(const oms3::ComRef& cref, oms_system_enu_t type, oms3::Model* parentModel, oms3::System* parentSystem)


### PR DESCRIPTION
### Purpose

- Delete busconnectors when system is destroyed, to avoid memory leak

### Type of Change

- Bug fix (non-breaking change which fixes an issue)

### Checklist

- I have performed a self-review of my own code