### PR TITLE
Implemented oms3_getBus

### DIFF
--- a/src/OMSimulatorLib/OMSimulator.cpp
+++ b/src/OMSimulatorLib/OMSimulator.cpp
@@ -174,12 +174,12 @@ oms_status_enu_t oms3_setElementGeometry(const char* cref, const ssd_element_geo
 
   oms3::Model* model = oms3::Scope::GetInstance().getModel(modelCref);
   if (!model) {
-    return logError("Model \"" + std::string(modelCref) + "\" does not exist in the scope");
+    return logError_ModelNotInScope(modelCref);
   }
 
   oms3::System* system = model->getSystem(tail);
   if (!system) {
-    return logError("Model \"" + std::string(modelCref) + "\" does not contain system \"" + std::string(tail) + "\"");
+    return logError_SystemNotInModel(modelCref, tail);
   }
 
   system->setGeometry(*reinterpret_cast<const oms3::ssd::ElementGeometry*>(geometry));
@@ -214,13 +214,13 @@ oms_status_enu_t oms3_getConnector(const char* cref, oms_connector_t** connector
   oms3::ComRef systemCref = tail.pop_front();
 
   oms3::Model* model = oms3::Scope::GetInstance().getModel(modelCref);
-  if(!model) {
-    return logError("Model \"" + std::string(modelCref) + "\" does not exist in the scope");
+  if (!model) {
+    return logError_ModelNotInScope(modelCref);
   }
 
   oms3::System* system = model->getSystem(systemCref);
-  if(!system) {
-    return logError("Model \"" + std::string(modelCref) + "\" does not contain system \"" + std::string(systemCref) + "\"");
+  if (!system) {
+    return logError_SystemNotInModel(modelCref, tail);
   }
 
   oms3::Connector** connector_ = reinterpret_cast<oms3::Connector**>(connector);
@@ -274,13 +274,13 @@ oms_status_enu_t oms3_addConnection(const char *crefA, const char *crefB)
   tailB.pop_front();
 
   oms3::Model* model = oms3::Scope::GetInstance().getModel(modelCref);
-  if(!model) {
-    return logError("Model: "+std::string(modelCref)+" not found in scope");
+  if (!model) {
+    return logError_ModelNotInScope(modelCref);
   }
 
   oms3::System* system = model->getSystem(systemCref);
-  if(!system) {
-    return logError("System: "+std::string(systemCref)+" not found in scope");
+  if (!system) {
+    return logError_SystemNotInModel(modelCref, systemCref);
   }
 
   return system->addConnection(tailA,tailB);
@@ -295,13 +295,13 @@ oms_status_enu_t oms3_setConnectorGeometry(const char *cref, const ssd_connector
   oms3::ComRef systemCref = tail.pop_front();
 
   oms3::Model* model = oms3::Scope::GetInstance().getModel(modelCref);
-  if(!model) {
-    return logError("Model \"" + std::string(modelCref) + "\" does not exist in the scope");
+  if (!model) {
+    return logError_ModelNotInScope(modelCref);
   }
 
   oms3::System* system = model->getSystem(systemCref);
-  if(!system) {
-    return logError("Model \"" + std::string(modelCref) + "\" does not contain system \"" + std::string(systemCref) + "\"");
+  if (!system) {
+    return logError_SystemNotInModel(modelCref, systemCref);
   }
 
   return system->setConnectorGeometry(tail, reinterpret_cast<const oms2::ssd::ConnectorGeometry*>(geometry));
@@ -320,13 +320,13 @@ oms_status_enu_t oms3_setConnectionGeometry(const char *crefA, const char *crefB
   tailB.pop_front();
 
   oms3::Model* model = oms3::Scope::GetInstance().getModel(modelCref);
-  if(!model) {
-    return logError("Model: "+std::string(modelCref)+" not found in scope");
+  if (!model) {
+    return logError_ModelNotInScope(modelCref);
   }
 
   oms3::System* system = model->getSystem(systemCref);
-  if(!system) {
-    return logError("System: "+std::string(systemCref)+" not found in scope");
+  if (!system) {
+    return logError_SystemNotInModel(modelCref, systemCref);
   }
 
   return system->setConnectionGeometry(tailA,tailB, reinterpret_cast<const oms2::ssd::ConnectionGeometry*>(geometry));
@@ -341,13 +341,13 @@ oms_status_enu_t oms3_getConnections(const char *cref, oms3_connection_t ***conn
   oms3::ComRef systemCref = tail.pop_front();
 
   oms3::Model* model = oms3::Scope::GetInstance().getModel(modelCref);
-  if(!model) {
-    return logError("Model \"" + std::string(modelCref) + "\" does not exist in the scope");
+  if (!model) {
+    return logError_ModelNotInScope(modelCref);
   }
 
   oms3::System* system = model->getSystem(systemCref);
-  if(!system) {
-    return logError("Model \"" + std::string(modelCref) + "\" does not contain system \"" + std::string(systemCref) + "\"");
+  if (!system) {
+    return logError_SystemNotInModel(modelCref, systemCref);
   }
 
   (*connections) = reinterpret_cast<oms3_connection_t**>(system->getConnections(tail));
@@ -362,12 +362,12 @@ oms_status_enu_t oms3_addBus(const char *cref)
   oms3::ComRef modelCref = tail.pop_front();
   oms3::ComRef systemCref = tail.pop_front();
   oms3::Model* model = oms3::Scope::GetInstance().getModel(modelCref);
-  if(!model) {
-    return logError("Model \"" + std::string(modelCref) + "\" does not exist in the scope");
+  if (!model) {
+    return logError_ModelNotInScope(modelCref);
   }
   oms3::System* system = model->getSystem(systemCref);
-  if(!system) {
-    return logError("Model \"" + std::string(modelCref) + "\" does not contain system \"" + std::string(systemCref) + "\"");
+  if (!system) {
+    return logError_SystemNotInModel(modelCref, systemCref);
   }
   return system->addBus(tail);
 }
@@ -380,12 +380,12 @@ oms_status_enu_t oms3_getBus(const char* cref, oms3_busconnector_t** busConnecto
 
   oms3::Model* model = oms3::Scope::GetInstance().getModel(modelCref);
   if (!model) {
-    return logError("Model \"" + std::string(modelCref) + "\" does not exist in the scope");
+    return logError_ModelNotInScope(modelCref);
   }
 
   oms3::System* system = model->getSystem(systemCref);
   if (!system) {
-    return logError("Model \"" + std::string(modelCref) + "\" does not contain system \"" + std::string(systemCref) + "\"");
+    return logError_SystemNotInModel(modelCref, systemCref);
   }
 
   oms3::BusConnector** busConnector_ = reinterpret_cast<oms3::BusConnector**>(busConnector);
@@ -417,17 +417,17 @@ oms_status_enu_t oms3_addConnectorToBus(const char *busCref, const char *connect
   oms3::ComRef modelCref = busTail.pop_front();
   oms3::ComRef systemCref = busTail.pop_front();
   oms3::ComRef connectorTail(connectorCref);
-  if(modelCref != connectorTail.pop_front())
+  if (modelCref != connectorTail.pop_front())
     return logError("Bus and connector must belong to same model");
-  if(systemCref != connectorTail.pop_front())
+  if (systemCref != connectorTail.pop_front())
     return logError("Bus and connector must belong to same system");
   oms3::Model* model = oms3::Scope::GetInstance().getModel(modelCref);
-  if(!model) {
-    return logError("Model \"" + std::string(modelCref) + "\" does not exist in the scope");
+  if (!model) {
+    return logError_ModelNotInScope(modelCref);
   }
   oms3::System* system = model->getSystem(systemCref);
-  if(!system) {
-    return logError("Model \"" + std::string(modelCref) + "\" does not contain system \"" + std::string(systemCref) + "\"");
+  if (!system) {
+    return logError_SystemNotInModel(modelCref, systemCref);
   }
   return system->addConnectorToBus(busTail, connectorTail);
 }
@@ -439,17 +439,17 @@ oms_status_enu_t oms3_addConnectorToTLMBus(const char *busCref, const char *conn
   oms3::ComRef modelCref = busTail.pop_front();
   oms3::ComRef systemCref = busTail.pop_front();
   oms3::ComRef connectorTail(connectorCref);
-  if(modelCref != connectorTail.pop_front())
+  if (modelCref != connectorTail.pop_front())
     return logError("Bus and connector must belong to same model");
-  if(systemCref != connectorTail.pop_front())
+  if (systemCref != connectorTail.pop_front())
     return logError("Bus and connector must belong to same system");
   oms3::Model* model = oms3::Scope::GetInstance().getModel(modelCref);
-  if(!model) {
-    return logError("Model \"" + std::string(modelCref) + "\" does not exist in the scope");
+  if (!model) {
+    return logError_ModelNotInScope(modelCref);
   }
   oms3::System* system = model->getSystem(systemCref);
-  if(!system) {
-    return logError("Model \"" + std::string(modelCref) + "\" does not contain system \"" + std::string(systemCref) + "\"");
+  if (!system) {
+    return logError_SystemNotInModel(modelCref, systemCref);
   }
   return system->addConnectorToTLMBus(busTail, connectorTail, type);
 }

--- a/src/OMSimulatorLib/OMSimulator.cpp
+++ b/src/OMSimulatorLib/OMSimulator.cpp
@@ -372,6 +372,27 @@ oms_status_enu_t oms3_addBus(const char *cref)
   return system->addBus(tail);
 }
 
+oms_status_enu_t oms3_getBus(const char* cref, oms3_busconnector_t** busConnector)
+{
+  oms3::ComRef tail(cref);
+  oms3::ComRef modelCref = tail.pop_front();
+  oms3::ComRef systemCref = tail.pop_front();
+
+  oms3::Model* model = oms3::Scope::GetInstance().getModel(modelCref);
+  if (!model) {
+    return logError("Model \"" + std::string(modelCref) + "\" does not exist in the scope");
+  }
+
+  oms3::System* system = model->getSystem(systemCref);
+  if (!system) {
+    return logError("Model \"" + std::string(modelCref) + "\" does not contain system \"" + std::string(systemCref) + "\"");
+  }
+
+  oms3::BusConnector** busConnector_ = reinterpret_cast<oms3::BusConnector**>(busConnector);
+  *busConnector_ = system->getBusConnector(tail);
+  return oms_status_ok;
+}
+
 oms_status_enu_t oms3_addTLMBus(const char *cref, const char *domain, const int dimensions, const oms_tlm_interpolation_t interpolation)
 {
   logTrace();

--- a/src/OMSimulatorLib/OMSimulator.h
+++ b/src/OMSimulatorLib/OMSimulator.h
@@ -72,6 +72,7 @@ oms_status_enu_t oms3_setConnectionGeometry(const char* crefA, const char* crefB
 oms_status_enu_t oms3_getConnections(const char* cref, oms3_connection_t*** connections);
 oms_status_enu_t oms3_addConnection(const char* crefA, const char* crefB);
 oms_status_enu_t oms3_addBus(const char* cref);
+oms_status_enu_t oms3_getBus(const char* cref, oms3_busconnector_t** busConnector);
 oms_status_enu_t oms3_addConnectorToBus(const char* busCref, const char* connectorCref);
 oms_status_enu_t oms3_addTLMBus(const char* cref, const char* domain, const int dimensions, const oms_tlm_interpolation_t interpolation);
 oms_status_enu_t oms3_addConnectorToTLMBus(const char* busCref, const char* connectorCref, const char *type);

--- a/src/OMSimulatorLib/System.cpp
+++ b/src/OMSimulatorLib/System.cpp
@@ -414,6 +414,17 @@ oms3::Connector *oms3::System::getConnector(const oms3::ComRef &cref)
 
 oms3::BusConnector *oms3::System::getBusConnector(const oms3::ComRef &cref)
 {
+  oms3::ComRef tail(cref);
+  oms3::ComRef head = tail.pop_front();
+  auto subsystem = subsystems.find(head);
+  if (subsystem != subsystems.end()) {
+    return subsystem->second->getBusConnector(tail);
+  }
+  if (!cref.isValidIdent()) {
+    logError("Not a valid ident: "+std::string(cref));
+    return NULL;
+  }
+
   for(auto &busconnector : busconnectors) {
     if(busconnector && busconnector->getName() == cref)
       return busconnector;


### PR DESCRIPTION
### Purpose

API to get the `oms3_busconnector_t` struct.
Use the `logError_ModelNotInScope` and `logError_SystemNotInModel` defines.

### Type of Change

- Code refactoring (non-breaking change which improves maintainability)
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

### Checklist

- I have performed a self-review of my own code