### PR TITLE
Bus geometry

### DIFF
--- a/src/OMSimulatorLib/BusConnector.cpp
+++ b/src/OMSimulatorLib/BusConnector.cpp
@@ -35,6 +35,11 @@ oms_status_enu_t oms3::BusConnector::exportToSSD(pugi::xml_node &root) const
     signal_node.append_attribute("name") = connector.c_str();
   }
 
+  if (this->geometry)
+  {
+    return reinterpret_cast<oms2::ssd::ConnectorGeometry*>(this->geometry)->exportToSSD(bus_node);
+  }
+
   return oms_status_ok;
 }
 

--- a/src/OMSimulatorLib/OMSimulator.cpp
+++ b/src/OMSimulatorLib/OMSimulator.cpp
@@ -393,6 +393,25 @@ oms_status_enu_t oms3_getBus(const char* cref, oms3_busconnector_t** busConnecto
   return oms_status_ok;
 }
 
+oms_status_enu_t oms3_setBusGeometry(const char* cref, const ssd_connector_geometry_t* geometry)
+{
+  oms3::ComRef tail(cref);
+  oms3::ComRef modelCref = tail.pop_front();
+  oms3::ComRef systemCref = tail.pop_front();
+
+  oms3::Model* model = oms3::Scope::GetInstance().getModel(modelCref);
+  if (!model) {
+    return logError_ModelNotInScope(modelCref);
+  }
+
+  oms3::System* system = model->getSystem(systemCref);
+  if (!system) {
+    return logError_SystemNotInModel(modelCref, systemCref);
+  }
+
+  return system->setBusGeometry(tail, reinterpret_cast<const oms2::ssd::ConnectorGeometry*>(geometry));
+}
+
 oms_status_enu_t oms3_addTLMBus(const char *cref, const char *domain, const int dimensions, const oms_tlm_interpolation_t interpolation)
 {
   logTrace();

--- a/src/OMSimulatorLib/OMSimulator.h
+++ b/src/OMSimulatorLib/OMSimulator.h
@@ -67,13 +67,14 @@ oms_status_enu_t oms3_addConnector(const char* cref, oms_causality_enu_t causali
 oms_status_enu_t oms3_getConnector(const char* cref, oms_connector_t** connector);
 oms_status_enu_t oms3_setCommandLineOption(const char* cmd);
 oms_status_enu_t oms3_getSystemType(const char* cref, oms_system_enu_t* type);
-oms_status_enu_t oms3_setConnectorGeometry(const char* connector, const ssd_connector_geometry_t* geometry);
+oms_status_enu_t oms3_setConnectorGeometry(const char* cref, const ssd_connector_geometry_t* geometry);
 oms_status_enu_t oms3_setConnectionGeometry(const char* crefA, const char* crefB, const ssd_connection_geometry_t* geometry);
 oms_status_enu_t oms3_getConnections(const char* cref, oms3_connection_t*** connections);
 oms_status_enu_t oms3_addConnection(const char* crefA, const char* crefB);
 oms_status_enu_t oms3_addBus(const char* cref);
 oms_status_enu_t oms3_getBus(const char* cref, oms3_busconnector_t** busConnector);
 oms_status_enu_t oms3_addConnectorToBus(const char* busCref, const char* connectorCref);
+oms_status_enu_t oms3_setBusGeometry(const char* bus, const ssd_connector_geometry_t* geometry);
 oms_status_enu_t oms3_addTLMBus(const char* cref, const char* domain, const int dimensions, const oms_tlm_interpolation_t interpolation);
 oms_status_enu_t oms3_addConnectorToTLMBus(const char* busCref, const char* connectorCref, const char *type);
 oms_status_enu_t oms3_addTLMConnection(const char* crefA, const char* crefB, double delay, double alpha, double impedance, double impedancerot);

--- a/src/OMSimulatorLib/System.cpp
+++ b/src/OMSimulatorLib/System.cpp
@@ -806,3 +806,19 @@ oms_status_enu_t oms3::System::setConnectionGeometry(const oms3::ComRef &crefA, 
 
   return logError("Connector(s) not found in system");
 }
+
+oms_status_enu_t oms3::System::setBusGeometry(const oms3::ComRef &cref, const oms2::ssd::ConnectorGeometry *geometry)
+{
+  oms3::ComRef tail(cref);
+  oms3::ComRef head = tail.pop_front();
+  auto subsystem = subsystems.find(head);
+  if (subsystem != subsystems.end())
+    return subsystem->second->setBusGeometry(tail,geometry);
+
+  oms3::BusConnector* busConnector = this->getBusConnector(cref);
+  if (busConnector) {
+    busConnector->setGeometry(geometry);
+    return oms_status_ok;
+  }
+  return logError("Bus "+std::string(cref)+" not found in system "+std::string(getName()));
+}

--- a/src/OMSimulatorLib/System.h
+++ b/src/OMSimulatorLib/System.h
@@ -81,6 +81,7 @@ namespace oms3
     oms_status_enu_t addTLMBus(const oms3::ComRef& cref, const std::string domain, const int dimensions, const oms_tlm_interpolation_t interpolation);
     oms_status_enu_t addConnectorToBus(const oms3::ComRef& busCref, const oms3::ComRef& connectorCref);
     oms_status_enu_t addConnectorToTLMBus(const oms3::ComRef& busCref, const oms3::ComRef& connectorCref, const std::string type);
+    oms_status_enu_t setBusGeometry(const oms3::ComRef& cref, const oms2::ssd::ConnectorGeometry* geometry);
 
   protected:
     System(const ComRef& cref, oms_system_enu_t type, Model* parentModel, System* parentSystem);


### PR DESCRIPTION
### Purpose

Save the bus geometry information in SSD.

### Approach

Implemented oms3_setBusGeometry.
Export the bus geometry SSD.

### Type of Change

- Code refactoring (non-breaking change which improves maintainability)
- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

### Checklist

- I have performed a self-review of my own code