### PR TITLE
Export and Import geometry information

### DIFF
--- a/src/OMSimulatorLib/OMSimulator.cpp
+++ b/src/OMSimulatorLib/OMSimulator.cpp
@@ -494,6 +494,25 @@ oms_status_enu_t oms3_addConnectorToTLMBus(const char *busCref, const char *conn
   return system->addConnectorToTLMBus(busTail, connectorTail, type);
 }
 
+oms_status_enu_t oms3_setTLMBusGeometry(const char* cref, const ssd_connector_geometry_t* geometry)
+{
+  oms3::ComRef tail(cref);
+  oms3::ComRef modelCref = tail.pop_front();
+  oms3::ComRef systemCref = tail.pop_front();
+
+  oms3::Model* model = oms3::Scope::GetInstance().getModel(modelCref);
+  if (!model) {
+    return logError_ModelNotInScope(modelCref);
+  }
+
+  oms3::System* system = model->getSystem(systemCref);
+  if (!system) {
+    return logError_SystemNotInModel(modelCref, systemCref);
+  }
+
+  return system->setTLMBusGeometry(tail, reinterpret_cast<const oms2::ssd::ConnectorGeometry*>(geometry));
+}
+
 oms_status_enu_t oms3_addTLMConnection(const char *crefA, const char *crefB, double delay, double alpha, double impedance, double impedancerot)
 {
   logTrace();

--- a/src/OMSimulatorLib/OMSimulator.h
+++ b/src/OMSimulatorLib/OMSimulator.h
@@ -78,6 +78,7 @@ oms_status_enu_t oms3_setBusGeometry(const char* bus, const ssd_connector_geomet
 oms_status_enu_t oms3_addTLMBus(const char* cref, const char* domain, const int dimensions, const oms_tlm_interpolation_t interpolation);
 oms_status_enu_t oms3_getTLMBus(const char* cref, oms3_tlmbusconnector_t** tlmBusConnector);
 oms_status_enu_t oms3_addConnectorToTLMBus(const char* busCref, const char* connectorCref, const char *type);
+oms_status_enu_t oms3_setTLMBusGeometry(const char* bus, const ssd_connector_geometry_t* geometry);
 oms_status_enu_t oms3_addTLMConnection(const char* crefA, const char* crefB, double delay, double alpha, double impedance, double impedancerot);
 
 /* not implemented yet */

--- a/src/OMSimulatorLib/System.h
+++ b/src/OMSimulatorLib/System.h
@@ -82,6 +82,7 @@ namespace oms3
     oms_status_enu_t addConnectorToBus(const oms3::ComRef& busCref, const oms3::ComRef& connectorCref);
     oms_status_enu_t addConnectorToTLMBus(const oms3::ComRef& busCref, const oms3::ComRef& connectorCref, const std::string type);
     oms_status_enu_t setBusGeometry(const oms3::ComRef& cref, const oms2::ssd::ConnectorGeometry* geometry);
+    oms_status_enu_t setTLMBusGeometry(const oms3::ComRef& cref, const oms2::ssd::ConnectorGeometry* geometry);
 
   protected:
     System(const ComRef& cref, oms_system_enu_t type, Model* parentModel, System* parentSystem);

--- a/src/OMSimulatorLib/TLMBusConnector.cpp
+++ b/src/OMSimulatorLib/TLMBusConnector.cpp
@@ -46,6 +46,11 @@ oms_status_enu_t oms3::TLMBusConnector::exportToSSD(pugi::xml_node &root) const
     signal_node.append_attribute("type") = connector.second.c_str();
   }
 
+  if (this->geometry)
+  {
+    return reinterpret_cast<oms2::ssd::ConnectorGeometry*>(this->geometry)->exportToSSD(bus_node);
+  }
+
   return oms_status_ok;
 }
 


### PR DESCRIPTION
### Purpose

- [x] Implemented oms3_setTLMBusGeometry
- [x] Export tlm bus geometry
- [x] Import system element geometry
- [x] Import connector geometry
- [x] Import bus geometry
- [x] Import tlm bus geometry

### Type of Change

- Code refactoring (non-breaking change which improves maintainability)
- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

### Checklist

- I have performed a self-review of my own code