### PR TITLE
Implement oms3::ExternalModel

### DIFF
--- a/src/OMSimulatorLib/ExternalModel.cpp
+++ b/src/OMSimulatorLib/ExternalModel.cpp
@@ -33,10 +33,113 @@
 #include "Logging.h"
 #include "Element.h"
 #include "Types.h"
+#include "ssd/Tags.h"
 
 #include <cstring>
 #include <map>
 #include <iostream>
+
+oms3::ExternalModel *oms3::ExternalModel::NewModel(const oms3::ComRef &cref, const std::string &path, const std::string &startscript)
+{
+  if (!cref.isValidIdent())
+  {
+    logError("\"" + std::string(cref) + "\" is not a valid ident");
+    return NULL;
+  }
+
+  oms3::ExternalModel *model = new oms3::ExternalModel(cref, path, startscript);
+  return model;
+}
+
+oms_status_enu_t oms3::ExternalModel::addTLMBus(const oms3::ComRef &cref, const std::string domain, const int dimensions, const oms_tlm_interpolation_t interpolation)
+{
+  if(!cref.isValidIdent()) {
+    return logError("Not a valid ident: "+std::string(cref));
+  }
+  oms3::TLMBusConnector* bus = new oms3::TLMBusConnector(cref, domain, dimensions, interpolation);
+  tlmbusconnectors.back() = bus;
+  tlmbusconnectors.push_back(NULL);
+  element.setTLMBusConnectors(&tlmbusconnectors[0]);
+  return oms_status_ok;
+}
+
+oms3::TLMBusConnector *oms3::ExternalModel::getTLMBusConnector(const oms3::ComRef &cref)
+{
+  for(auto &tlmbusconnector : tlmbusconnectors) {
+    if(tlmbusconnector && tlmbusconnector->getName() == cref)
+      return tlmbusconnector;
+  }
+  return NULL;
+}
+
+oms_status_enu_t oms3::ExternalModel::setRealParameter(const std::string &var, double value)
+{
+  std::map<std::string, oms2::Option<double>>::iterator it;
+  it = realParameters.find(var);
+
+  if(it != realParameters.end()) {
+    it->second.setValue(value);
+    return oms_status_ok;
+  }
+
+  return oms_status_error;
+}
+
+oms_status_enu_t oms3::ExternalModel::getRealParameter(const std::string &var, double &value)
+{
+  std::map<std::string, oms2::Option<double>>::iterator it;
+  it = realParameters.find(var);
+
+  if(it != realParameters.end()) {
+    value = it->second.getValue();
+    return oms_status_ok;
+  }
+
+  return oms_status_error;
+}
+
+oms3::ExternalModel::ExternalModel(const oms3::ComRef &cref, const std::string &path, const std::string &startscript)
+  : element(oms_element_externalmodel, cref), cref(cref), startscript(startscript), path(path)
+{
+  logTrace();
+
+  this->path = path;
+  this->startscript = startscript;
+  this->cref = cref;
+
+  tlmbusconnectors.push_back(NULL);
+  element.setTLMBusConnectors(&tlmbusconnectors[0]);
+}
+
+oms3::ExternalModel::~ExternalModel()
+{
+  for (const auto tlmbusconnector : tlmbusconnectors)
+    if(tlmbusconnector)
+      delete tlmbusconnector;
+}
+
+oms_status_enu_t oms3::ExternalModel::exportToSSD(pugi::xml_node& node) const
+{
+  if(tlmbusconnectors[0]) {
+    pugi::xml_node annotations_node = node.append_child(oms2::ssd::ssd_annotations);
+    pugi::xml_node annotation_node = annotations_node.append_child(oms2::ssd::ssd_annotation);
+    annotation_node.append_attribute("type") = "org.openmodelica";
+    for (const auto& tlmbusconnector : tlmbusconnectors)
+      if(tlmbusconnector)
+        tlmbusconnector->exportToSSD(annotation_node);
+  }
+
+  node.append_attribute("name") = this->getName().c_str();
+  node.append_attribute("source") = this->path.c_str();
+  pugi::xml_node siminfo_node = node.append_child(oms2::ssd::ssd_simulation_information);
+  pugi::xml_node annotations_node = siminfo_node.append_child(oms2::ssd::ssd_annotations);
+  pugi::xml_node annotation_node = annotations_node.append_child(oms2::ssd::ssd_annotation);
+  annotation_node.append_attribute("type") = "org.openmodelica";
+  pugi::xml_node externalmodel_node = annotation_node.append_child("OMSimulator:ExternalModel");
+  externalmodel_node.append_attribute("startscript") = this->startscript.c_str();
+
+  return oms_status_ok;
+}
 
 
 oms_status_enu_t oms2::ExternalModel::setRealParameter(const std::string &var, double value)

--- a/src/OMSimulatorLib/ExternalModel.h
+++ b/src/OMSimulatorLib/ExternalModel.h
@@ -40,6 +40,47 @@
 #include <vector>
 #include <map>
 
+namespace oms3
+{
+  class ExternalModel
+  {
+  public:
+    static ExternalModel* NewModel(const oms3::ComRef& cref, const std::string& path, const std::string& startscript);
+
+    void setName(const ComRef& name) {element.setName(name);}
+    void setGeometry(const oms3::ssd::ElementGeometry& geometry) {element.setGeometry(&geometry);}
+
+    const ComRef getName() const {return oms3::ComRef(element.getName());}
+    const oms3::ssd::ElementGeometry* getGeometry() {return element.getGeometry();}
+    oms3::Element* getElement() {return &element;}
+
+    oms_status_enu_t addTLMBus(const oms3::ComRef& cref, const std::string domain, const int dimensions, const oms_tlm_interpolation_t interpolation);
+    oms3::TLMBusConnector *getTLMBusConnector(const oms3::ComRef &cref);
+    oms_status_enu_t setRealParameter(const std::string& var, double value);
+    oms_status_enu_t getRealParameter(const std::string& var, double& value);
+    const std::string& getModelPath() const {return path;}
+    const std::string& getStartScript() const {return startscript;}
+    const std::map<std::string, oms2::Option<double>>& getRealParameters() const {return realParameters;}
+
+    oms_status_enu_t exportToSSD(pugi::xml_node& node) const;
+
+  protected:
+    ComRef cref;
+    oms3::Element element;
+
+  private:
+    ExternalModel(const oms3::ComRef& cref, const std::string& path, const std::string& startscript);
+    ~ExternalModel();
+
+
+    std::string path;
+    std::string startscript;
+
+    std::map<std::string, oms2::Option<double>> realParameters;
+    std::vector<oms3::TLMBusConnector*> tlmbusconnectors;
+  };
+}
+
 namespace oms2
 {
   class ExternalModel

--- a/src/OMSimulatorLib/OMSimulator.cpp
+++ b/src/OMSimulatorLib/OMSimulator.cpp
@@ -538,6 +538,27 @@ oms_status_enu_t oms3_addTLMConnection(const char *crefA, const char *crefB, dou
   return system->addTLMConnection(tailA,tailB,delay,alpha,impedance,impedancerot);
 }
 
+oms_status_enu_t oms3_addExternalModel(const char *cref, const char *path, const char *startscript)
+{
+  logTrace();
+
+  oms3::ComRef tail(cref);
+  oms3::ComRef modelCref = tail.pop_front();
+  oms3::ComRef systemCref = tail.pop_front();
+
+  oms3::Model* model = oms3::Scope::GetInstance().getModel(modelCref);
+  if(!model) {
+    return logError_ModelNotInScope(modelCref);
+  }
+
+  oms3::System* system = model->getSystem(systemCref);
+  if(!system) {
+    return logError_SystemNotInModel(modelCref, systemCref);
+  }
+
+  return system->addExternalModel(tail, path, startscript);
+}
+
 /* ************************************ */
 /* OMSimulator 2.0                      */
 /*                                      */

--- a/src/OMSimulatorLib/OMSimulator.h
+++ b/src/OMSimulatorLib/OMSimulator.h
@@ -80,10 +80,10 @@ oms_status_enu_t oms3_getTLMBus(const char* cref, oms3_tlmbusconnector_t** tlmBu
 oms_status_enu_t oms3_addConnectorToTLMBus(const char* busCref, const char* connectorCref, const char *type);
 oms_status_enu_t oms3_setTLMBusGeometry(const char* bus, const ssd_connector_geometry_t* geometry);
 oms_status_enu_t oms3_addTLMConnection(const char* crefA, const char* crefB, double delay, double alpha, double impedance, double impedancerot);
+oms_status_enu_t oms3_addExternalModel(const char* cref, const char* path, const char* startscript);
 
 /* not implemented yet */
 oms_status_enu_t oms3_addSubModel(const char* cref, const char* fmuPath);
-oms_status_enu_t oms3_addExternalModel(const char* cref, const char* path, const char* startscript);
 oms_status_enu_t oms3_setSimulationInformation(const char* cref, ssd_simulation_information_t* info);
 oms_status_enu_t oms3_getSimulationInformation(const char* cref, ssd_simulation_information_t** info);
 oms_status_enu_t oms3_getSubModelPath(const char* cref, char** path);

--- a/src/OMSimulatorLib/System.h
+++ b/src/OMSimulatorLib/System.h
@@ -39,6 +39,7 @@
 #include "ssd/ConnectorGeometry.h"
 #include "BusConnector.h"
 #include "TLMBusConnector.h"
+#include "ExternalModel.h"
 
 #include <pugixml.hpp>
 #include <map>
@@ -83,6 +84,7 @@ namespace oms3
     oms_status_enu_t addConnectorToTLMBus(const oms3::ComRef& busCref, const oms3::ComRef& connectorCref, const std::string type);
     oms_status_enu_t setBusGeometry(const oms3::ComRef& cref, const oms2::ssd::ConnectorGeometry* geometry);
     oms_status_enu_t setTLMBusGeometry(const oms3::ComRef& cref, const oms2::ssd::ConnectorGeometry* geometry);
+    oms_status_enu_t addExternalModel(const ComRef &cref, std::string path, std::string startscript);
 
   protected:
     System(const ComRef& cref, oms_system_enu_t type, Model* parentModel, System* parentSystem);
@@ -98,6 +100,7 @@ namespace oms3
     System* parentSystem;
     std::map<ComRef, System*> subsystems;
     std::map<ComRef, Component*> components;
+    std::map<ComRef, ExternalModel*> externalmodels;
 
     oms3::Element element;
     std::vector<oms3::Connector*> connectors;   ///< last element is always NULL

--- a/src/OMSimulatorLib/Types.h
+++ b/src/OMSimulatorLib/Types.h
@@ -79,7 +79,8 @@ typedef enum {
 typedef enum {
   oms_element_none,
   oms_element_system,
-  oms_element_component
+  oms_element_component,
+  oms_element_externalmodel
 } oms3_element_enu_t;
 
 typedef enum {

--- a/src/OMSimulatorLua/OMSimulatorLua.c
+++ b/src/OMSimulatorLua/OMSimulatorLua.c
@@ -436,6 +436,26 @@ static int OMSimulatorLua_oms3_addTLMConnection(lua_State *L)
 
   return 1;
 }
+
+//oms_status_enu_t oms3_addExternalModel(const char *cref, const char *path, const char *startscript)
+static int OMSimulatorLua_oms3_addExternalModel(lua_State *L)
+{
+  if (lua_gettop(L) != 3)
+    return luaL_error(L, "expecting exactly 3 arguments");
+  luaL_checktype(L, 1, LUA_TSTRING);
+  luaL_checktype(L, 2, LUA_TSTRING);
+  luaL_checktype(L, 3, LUA_TSTRING);
+
+  const char* cref = lua_tostring(L, 1);
+  const char* path = lua_tostring(L, 2);
+  const char* startscript = lua_tostring(L, 3);
+  oms_status_enu_t status = oms3_addExternalModel(cref, path, startscript);
+
+  lua_pushinteger(L, status);
+
+  return 1;
+}
+
 /* ************************************ */
 /* OMSimulator 2.0                      */
 /*                                      */
@@ -1925,6 +1945,7 @@ DLLEXPORT int luaopen_OMSimulatorLua(lua_State *L)
   REGISTER_LUA_CALL(oms3_addConnectorToBus);
   REGISTER_LUA_CALL(oms3_addConnectorToTLMBus);
   REGISTER_LUA_CALL(oms3_addTLMConnection);
+  REGISTER_LUA_CALL(oms3_addExternalModel);
   /* ************************************ */
   /* OMSimulator 2.0                      */
   /*                                      */


### PR DESCRIPTION
### Related PRs
OpenModelica/OMSimulator-testsuite#87

### Purpose

- Implement oms3::ExternalModel
- Implement oms3_addExternalModel
- Support external models in oms3_addTLMBus
- Save external models to SSD

### Type of Change

<!--- Please delete options that are not relevant. -->

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

### Checklist

- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have added tests that prove my fix is effective or that my feature works
