### PR TITLE
Walltime support for TLM submodels

### DIFF
--- a/src/OMSimulatorLib/FMICompositeModel.cpp
+++ b/src/OMSimulatorLib/FMICompositeModel.cpp
@@ -1220,7 +1220,7 @@ oms_status_enu_t oms2::FMICompositeModel::simulateTLM(double stopTime, double lo
   while (time < stopTime)
   {
     logDebug("doStep: " + std::to_string(time) + " -> " + std::to_string(time+communicationInterval));
-
+    clock.tic();
     time += communicationInterval;
     if (time > stopTime)
       time = stopTime;
@@ -1243,6 +1243,7 @@ oms_status_enu_t oms2::FMICompositeModel::simulateTLM(double stopTime, double lo
     }
     else
       updateInputs(outputsGraph);
+    clock.toc();
   }
 
   finalizeTLMSockets();


### PR DESCRIPTION
### Purpose

Print walltime for FMI composite models also when they are submodels to a TLM composite model.

### Type of Change

- Bug fix (non-breaking change which fixes an issue)

### Checklist

- I have performed a self-review of my own code
