### PR TITLE
Type check in (some) system methods

### DIFF
--- a/src/OMSimulatorLib/Logging.h
+++ b/src/OMSimulatorLib/Logging.h
@@ -106,5 +106,8 @@ private:
 #define logError_ModelNotInScope(cref)             logError("Model \"" + std::string(cref) + "\" does not exist in the scope")
 #define logError_NotImplemented                    logError("Not implemented")
 #define logError_SystemNotInModel(model, system)   logError("Model \"" + std::string(model) + "\" does not contain system \"" + std::string(system) + "\"")
+#define logError_NotForTlmSystem                   logError("Not available for TLM systems");
+#define logError_OnlyForTlmSystem                  logError("Only available for TLM systems");
+#define logError_NotForScSystem                    logError("Not available for strongly coupled systems");
 
 #endif

--- a/src/OMSimulatorLib/System.cpp
+++ b/src/OMSimulatorLib/System.cpp
@@ -199,6 +199,9 @@ oms_status_enu_t oms3::System::addSubSystem(const oms3::ComRef& cref, oms_system
 {
   if (cref.isValidIdent())
   {
+    if(this->type == oms_system_sc)
+      return logError_NotForScSystem;
+
     System* system = System::NewSystem(cref, type, NULL, this);
     if (system)
     {
@@ -617,6 +620,8 @@ oms_status_enu_t oms3::System::addConnector(const oms3::ComRef &cref, oms_causal
     return subsystem->second->addConnector(tail,causality,type);
   }
 
+  if(this->type == oms_system_tlm)
+    return logError_NotForTlmSystem;
   if(!cref.isValidIdent()) {
     return logError("Not a valid ident: "+std::string(cref));
   }
@@ -815,6 +820,9 @@ oms_status_enu_t oms3::System::updateConnection(const oms3::ComRef &crefA, const
 
 oms_status_enu_t oms3::System::addTLMConnection(const oms3::ComRef &crefA, const oms3::ComRef &crefB, double delay, double alpha, double linearimpedance, double angularimpedance)
 {
+  if(type != oms_system_tlm)
+    return logError_OnlyForTlmSystem;
+
   oms3::ComRef tailA(crefA);
   oms3::ComRef headA = tailA.pop_front();
 
@@ -855,6 +863,9 @@ oms_status_enu_t oms3::System::addBus(const oms3::ComRef &cref)
   if(subsystem != subsystems.end()) {
     return subsystem->second->addBus(tail);
   }
+
+  if(type == oms_system_tlm)
+    return logError_NotForTlmSystem;
   if(!cref.isValidIdent()) {
     return logError("Not a valid ident: "+std::string(cref));
   }
@@ -877,6 +888,9 @@ oms_status_enu_t oms3::System::addTLMBus(const oms3::ComRef &cref, const std::st
   if(externalmodel != externalmodels.end()) {
     return externalmodel->second->addTLMBus(tail, domain, dimensions, interpolation);
   }
+
+  if(type == oms_system_tlm)
+    return logError_NotForTlmSystem;
   if(!cref.isValidIdent()) {
     return logError("Not a valid ident: "+std::string(cref));
   }
@@ -903,6 +917,8 @@ oms_status_enu_t oms3::System::addConnectorToBus(const oms3::ComRef &busCref, co
 
   if(!busTail.isEmpty() && !connectorTail.isEmpty() && busHead != connectorHead)
     return logError("Connector and bus must belong to the same system");
+  if(type == oms_system_tlm)
+    return logError_NotForTlmSystem;
 
   for(auto& bus : busconnectors) {
     if(bus && bus->getName() == busCref) {
@@ -926,6 +942,9 @@ oms_status_enu_t oms3::System::addConnectorToTLMBus(const oms3::ComRef &busCref,
     }
   }
 
+  if(this->type == oms_system_tlm)
+    return logError_NotForTlmSystem;
+
   //Check that connector exists in system
   bool found = false;
   for(auto& connector : connectors)
@@ -946,9 +965,8 @@ oms_status_enu_t oms3::System::addConnectorToTLMBus(const oms3::ComRef &busCref,
 
 oms_status_enu_t oms3::System::addExternalModel(const oms3::ComRef &cref, std::string path, std::string startscript)
 {
-  if(type != oms_system_tlm) {
-    return logError("Only implemented for TLM systems");
-  }
+  if(type != oms_system_tlm)
+    return logError_OnlyForTlmSystem;
 
   if (cref.isValidIdent())
   {


### PR DESCRIPTION
### Purpose

Some system class methods should only be available to certain system types.

### Approach

Add a type check at the beginning of each function and return error message if type is wrong.

### Alternative solution

- Only implement methods for the correct class; this would require a lot of castings
- Make methods virtual and overload them in correct class, with error message in base class
- Perform type check externally before calling each function

### Type of Change

- New feature (non-breaking change which adds functionality)

### Checklist

- I have performed a self-review of my own code
- My changes generate no new warnings