### PR TITLE
Re-implement TLM capabilities for oms3 (wip)

### DIFF
--- a/src/OMSimulatorLib/Logging.h
+++ b/src/OMSimulatorLib/Logging.h
@@ -113,6 +113,7 @@ private:
 #define logError_OnlyForModel                              logError("Only implemented for model identifiers")
 #define logError_OnlyForTlmSystem                          logError("Only available for TLM systems");
 #define logError_SystemNotInModel(model, system)           logError("Model \"" + std::string(model) + "\" does not contain system \"" + std::string(system) + "\"")
+#define logError_SubSystemNotInSystem(system, subsystem)   logError("System \"" + std::string(system) + "\" does not contain subsystem \"" + std::string(subsystem) + "\"")
 #define logError_Termination(system)                       logError("Termination of system \"" + std::string(system) + "\" failed")
 #define logError_WrongSchema(name)                         logError("Wrong xml schema detected. Unexpected tag \"" + name + "\"")
 

--- a/src/OMSimulatorLib/System.cpp
+++ b/src/OMSimulatorLib/System.cpp
@@ -647,6 +647,11 @@ oms3::TLMBusConnector *oms3::System::getTLMBusConnector(const oms3::ComRef& cref
   return NULL;
 }
 
+oms3::TLMBusConnector **oms3::System::getTLMBusConnectors()
+{
+  return &tlmbusconnectors[0];
+}
+
 oms3::Connection **oms3::System::getConnections(const oms3::ComRef& cref) {
   if (!cref.isEmpty()) {
     oms3::ComRef tail(cref);

--- a/src/OMSimulatorLib/System.h
+++ b/src/OMSimulatorLib/System.h
@@ -112,8 +112,6 @@ namespace oms3
     oms_system_enu_t type;
     Model* parentModel;
     System* parentSystem;
-    std::map<ComRef, System*> subsystems;
-    std::map<ComRef, Component*> components;
 
     Element element;
     std::vector<Connector*> connectors;   ///< last element is always NULL
@@ -123,6 +121,10 @@ namespace oms3
     std::vector<Connection*> connections; ///< last element is always NULL
 
     Connection* getConnection(const ComRef& crefA, const ComRef& crefB);
+  protected:
+    std::map<ComRef, System*> subsystems;
+    std::map<ComRef, Component*> components;
+    std::vector<oms3::TLMBusConnector*> tlmbusconnectors;
   };
 }
 

--- a/src/OMSimulatorLib/System.h
+++ b/src/OMSimulatorLib/System.h
@@ -74,6 +74,7 @@ namespace oms3
     Connector* getConnector(const ComRef& cref);
     BusConnector* getBusConnector(const ComRef& cref);
     TLMBusConnector *getTLMBusConnector(const ComRef& cref);
+    TLMBusConnector **getTLMBusConnectors();
     Connection** getConnections(const ComRef &cref);
     oms_status_enu_t addConnection(const ComRef& crefA, const ComRef& crefB);
     oms_status_enu_t updateConnection(const ComRef& crefA, const ComRef& crefB, const oms3_connection_t* connection);

--- a/src/OMSimulatorLib/SystemTLM.h
+++ b/src/OMSimulatorLib/SystemTLM.h
@@ -40,6 +40,7 @@
 namespace oms3
 {
   class Model;
+  class SystemWC;
 
   class SystemTLM : public System
   {
@@ -60,6 +61,10 @@ namespace oms3
     void disconnectFromSockets(const oms3::ComRef cref);
     oms_status_enu_t setInitialValues(ComRef cref, std::vector<double> values);
     oms_status_enu_t updateInitialValues(const oms3::ComRef cref);
+
+    oms_status_enu_t initialize(ComRef cref, double startTime, double tolerance);         ///< not implemented
+    oms_status_enu_t simulate(ComRef cref, double stopTime, double loggingInterval);      ///< not implemented
+    void writeToSockets(oms3::SystemWC *system, double time, std::string fmu);
 
   protected:
     SystemTLM(const ComRef& cref, Model* parentModel, System* parentSystem);

--- a/src/OMSimulatorLib/SystemTLM.h
+++ b/src/OMSimulatorLib/SystemTLM.h
@@ -65,6 +65,7 @@ namespace oms3
     oms_status_enu_t initialize(ComRef cref, double startTime, double tolerance);         ///< not implemented
     oms_status_enu_t simulate(ComRef cref, double stopTime, double loggingInterval);      ///< not implemented
     void writeToSockets(oms3::SystemWC *system, double time, std::string fmu);
+    void readFromSockets(SystemWC *system, double time, std::string fmu);
 
   protected:
     SystemTLM(const ComRef& cref, Model* parentModel, System* parentSystem);

--- a/src/OMSimulatorLib/SystemTLM.h
+++ b/src/OMSimulatorLib/SystemTLM.h
@@ -35,6 +35,7 @@
 #include "ComRef.h"
 #include "System.h"
 #include "Types.h"
+#include "../../OMTLMSimulator/common/Plugin/PluginImplementer.h"
 
 namespace oms3
 {
@@ -55,6 +56,9 @@ namespace oms3
     oms_status_enu_t initialize();
     oms_status_enu_t terminate();
 
+    oms_status_enu_t connectToSockets(const oms3::ComRef cref, std::string server);
+    void disconnectFromSockets(const oms3::ComRef cref);
+
   protected:
     SystemTLM(const ComRef& cref, Model* parentModel, System* parentSystem);
 
@@ -67,6 +71,9 @@ namespace oms3
     std::string address = "";
     int managerPort=0;
     int monitorPort=0;
+
+    std::vector<ComRef> connectedsubsystems;
+    std::map<System*, TLMPlugin*> plugins;
 
     // simulation information
   };

--- a/src/OMSimulatorLib/SystemTLM.h
+++ b/src/OMSimulatorLib/SystemTLM.h
@@ -58,6 +58,8 @@ namespace oms3
 
     oms_status_enu_t connectToSockets(const oms3::ComRef cref, std::string server);
     void disconnectFromSockets(const oms3::ComRef cref);
+    oms_status_enu_t setInitialValues(ComRef cref, std::vector<double> values);
+    oms_status_enu_t updateInitialValues(const oms3::ComRef cref);
 
   protected:
     SystemTLM(const ComRef& cref, Model* parentModel, System* parentSystem);
@@ -74,6 +76,8 @@ namespace oms3
 
     std::vector<ComRef> connectedsubsystems;
     std::map<System*, TLMPlugin*> plugins;
+    std::vector<ComRef> initializedsubsystems;
+    std::map<ComRef, std::vector<double> > initialValues;
 
     // simulation information
   };

--- a/src/OMSimulatorLib/SystemTLM.h
+++ b/src/OMSimulatorLib/SystemTLM.h
@@ -52,6 +52,7 @@ namespace oms3
     oms_status_enu_t importFromSSD_SimulationInformation(const pugi::xml_node& node);
     oms_status_enu_t setSocketData(const std::string& address, int managerPort, int monitorPort);
     oms_status_enu_t setPositionAndOrientation(const ComRef &cref, std::vector<double> x, std::vector<double> A);
+    oms_status_enu_t simulate();
 
     oms_status_enu_t instantiate();
     oms_status_enu_t initialize();
@@ -61,9 +62,10 @@ namespace oms3
     void disconnectFromSockets(const oms3::ComRef cref);
     oms_status_enu_t setInitialValues(ComRef cref, std::vector<double> values);
     oms_status_enu_t updateInitialValues(const oms3::ComRef cref);
-
-    oms_status_enu_t initialize(ComRef cref, double startTime, double tolerance);         ///< not implemented
-    oms_status_enu_t simulate(ComRef cref, double stopTime, double loggingInterval);      ///< not implemented
+    oms_status_enu_t initialize(ComRef cref, double startTime, double tolerance);
+    oms_status_enu_t simulate(ComRef cref, double stopTime, double loggingInterval);
+    oms_status_enu_t initializeSubSystem(ComRef cref);
+    oms_status_enu_t simulateSubSystem(ComRef cref);
     void writeToSockets(oms3::SystemWC *system, double time, std::string fmu);
     void readFromSockets(SystemWC *system, double time, std::string fmu);
 

--- a/src/OMSimulatorLib/SystemWC.cpp
+++ b/src/OMSimulatorLib/SystemWC.cpp
@@ -119,3 +119,27 @@ oms_status_enu_t oms3::SystemWC::terminate()
 
   return oms_status_ok;
 }
+
+//Placeholder function
+oms_status_enu_t oms3::SystemWC::setReal(const oms3::ComRef &cref, double value)
+{
+  return oms_status_fatal;
+}
+
+//Placeholder function
+oms_status_enu_t oms3::SystemWC::setReals(const std::vector<oms3::ComRef> &crefs, std::vector<double> values)
+{
+  return oms_status_fatal;
+}
+
+//Placeholder function
+oms_status_enu_t oms3::SystemWC::getReal(const oms3::ComRef &sr, double &value)
+{
+  return oms_status_fatal;
+}
+
+//Placeholder function
+oms_status_enu_t oms3::SystemWC::getReals(const std::vector<oms3::ComRef> &sr, std::vector<double> &values)
+{
+  return oms_status_fatal;
+}

--- a/src/OMSimulatorLib/SystemWC.cpp
+++ b/src/OMSimulatorLib/SystemWC.cpp
@@ -133,6 +133,12 @@ oms_status_enu_t oms3::SystemWC::setReals(const std::vector<oms3::ComRef> &crefs
 }
 
 //Placeholder function
+oms_status_enu_t oms3::SystemWC::setRealInputDerivatives(const oms3::ComRef &cref, int order, double value)
+{
+  return oms_status_fatal;
+}
+
+//Placeholder function
 oms_status_enu_t oms3::SystemWC::getReal(const oms3::ComRef &sr, double &value)
 {
   return oms_status_fatal;

--- a/src/OMSimulatorLib/SystemWC.h
+++ b/src/OMSimulatorLib/SystemWC.h
@@ -56,6 +56,7 @@ namespace oms3
 
     oms_status_enu_t setReal(const oms3::ComRef& cref, double value);
     oms_status_enu_t setReals(const std::vector<oms3::ComRef> &crefs, std::vector<double> values);
+    oms_status_enu_t setRealInputDerivatives(const oms3::ComRef &cref, int order, double value);
     oms_status_enu_t getReal(const oms3::ComRef& sr, double& value);
     oms_status_enu_t getReals(const std::vector<oms3::ComRef> &sr, std::vector<double> &values);
 

--- a/src/OMSimulatorLib/SystemWC.h
+++ b/src/OMSimulatorLib/SystemWC.h
@@ -54,6 +54,11 @@ namespace oms3
     oms_status_enu_t initialize();
     oms_status_enu_t terminate();
 
+    oms_status_enu_t setReal(const oms3::ComRef& cref, double value);
+    oms_status_enu_t setReals(const std::vector<oms3::ComRef> &crefs, std::vector<double> values);
+    oms_status_enu_t getReal(const oms3::ComRef& sr, double& value);
+    oms_status_enu_t getReals(const std::vector<oms3::ComRef> &sr, std::vector<double> &values);
+
   protected:
     SystemWC(const ComRef& cref, Model* parentModel, System* parentSystem);
 

--- a/src/OMSimulatorLib/TLMBusConnector.cpp
+++ b/src/OMSimulatorLib/TLMBusConnector.cpp
@@ -123,6 +123,20 @@ void oms3::TLMBusConnector::setGeometry(const oms2::ssd::ConnectorGeometry *newG
     this->geometry = reinterpret_cast<ssd_connector_geometry_t*>(new oms2::ssd::ConnectorGeometry(*newGeometry));
 }
 
+oms3::ComRef oms3::TLMBusConnector::getConnector(int id) const
+{
+  return sortedConnectors[id];
+}
+
+std::vector<oms3::ComRef> oms3::TLMBusConnector::getConnectors(std::vector<int> ids) const
+{
+  std::vector<oms3::ComRef> retval;
+  for(int id : ids) {
+    retval.push_back(sortedConnectors[id]);
+  }
+  return retval;
+}
+
 oms_status_enu_t oms3::TLMBusConnector::addConnector(const oms3::ComRef &cref, std::string vartype)
 {
   if(std::find(variableTypes.begin(), variableTypes.end(), vartype) == variableTypes.end())

--- a/src/OMSimulatorLib/TLMBusConnector.h
+++ b/src/OMSimulatorLib/TLMBusConnector.h
@@ -111,6 +111,8 @@ typedef struct  {
     const int getDimensions() const {return dimensions;}
     const oms_causality_enu_t getCausality() const {return causality;}
     const oms_tlm_interpolation_t getInterpolation() const {return interpolation;}
+    void setDelay(double delay) { this->delay = delay; }
+    double getDelay() { return this->delay; }
     const oms2::ssd::ConnectorGeometry* getGeometry() const {return reinterpret_cast<oms2::ssd::ConnectorGeometry*>(geometry);}
 
     oms_status_enu_t addConnector(const oms3::ComRef& cref, std::string vartype);

--- a/src/OMSimulatorLib/TLMBusConnector.h
+++ b/src/OMSimulatorLib/TLMBusConnector.h
@@ -113,6 +113,8 @@ typedef struct  {
     const oms_tlm_interpolation_t getInterpolation() const {return interpolation;}
     void setDelay(double delay) { this->delay = delay; }
     double getDelay() { return this->delay; }
+    oms3::ComRef getConnector(int id) const;
+    std::vector<oms3::ComRef> getConnectors(std::vector<int> ids) const;
     const oms2::ssd::ConnectorGeometry* getGeometry() const {return reinterpret_cast<oms2::ssd::ConnectorGeometry*>(geometry);}
 
     oms_status_enu_t addConnector(const oms3::ComRef& cref, std::string vartype);

--- a/src/OMSimulatorLib/Types.h
+++ b/src/OMSimulatorLib/Types.h
@@ -398,6 +398,7 @@ typedef struct {
   ssd_connector_geometry_t* geometry;
   char* domain;
   int dimensions;
+  double delay;
   oms_tlm_interpolation_t interpolation;
 } oms3_tlmbusconnector_t;
 


### PR DESCRIPTION
### Purpose

Re-implement TLM simulation capabilities for oms3

### Approach

Copy methods from TLMInterface, TLMCompositeModel and FMICompositeModel classes to new oms3 classes. Modify them wherever needed.

### Type of Change

- New feature (non-breaking change which adds functionality)

### Checklist

- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas

### Open Questions and Pre-Merge TODOs

- [ ] Implement initialization
- [ ] Implement simulation
- [ ] How obtain start time and communication step?
- [ ] Implement read/write when setReal/getReal are implemented
