### PR TITLE
Implement TLMBusConnector::getCausality

### DIFF
--- a/src/OMSimulatorLib/TLMBusConnector.cpp
+++ b/src/OMSimulatorLib/TLMBusConnector.cpp
@@ -16,6 +16,13 @@ oms3::TLMBusConnector::TLMBusConnector(const oms3::ComRef &name, const std::stri
   this->dimensions = dimensions;
   this->interpolation = interpolation;
 
+  if(domain == "input")
+    causality = oms_causality_input;
+  else if(domain == "output")
+    causality = oms_causality_output;
+  else
+    causality = oms_causality_bidir;
+
   updateVariableTypes();
 }
 

--- a/src/OMSimulatorLib/TLMBusConnector.h
+++ b/src/OMSimulatorLib/TLMBusConnector.h
@@ -37,6 +37,7 @@ namespace oms3
     const oms3::ComRef getName() const {return oms3::ComRef(std::string(name));}
     const std::string getDomain() const {return domain;}
     const int getDimensions() const {return dimensions;}
+    const oms_causality_enu_t getCausality() const {return causality;}
     const oms_tlm_interpolation_t getInterpolation() const {return interpolation;}
     const oms2::ssd::ConnectorGeometry* getGeometry() const {return reinterpret_cast<oms2::ssd::ConnectorGeometry*>(geometry);}
 
@@ -44,6 +45,8 @@ namespace oms3
 
   private:
     void updateVariableTypes();
+
+    oms_causality_enu_t causality;
 
     std::map<oms3::ComRef, std::string> connectors;
     std::vector<std::string> variableTypes; //Used to keep track of TLM variable types


### PR DESCRIPTION
### Purpose

TLM read/write fucntions need to query TLMBusConnector for causality on every communication step. Comparing an enum is much more efficient than comparing a string.

### Approach

Define causality based on domain when creating the bus connector. Obtain causality with get function.

### Type of Change

- New feature (non-breaking change which adds functionality)

### Checklist

- I have performed a self-review of my own code