### PR TITLE
fix linking issues for boost < 1.57 on Linux

### DIFF
--- a/src/OMSimulatorLib/OMSBoost.h
+++ b/src/OMSimulatorLib/OMSBoost.h
@@ -51,7 +51,15 @@ extern "C"
 #include <cstdlib>
 #include <string>
 #include <boost/version.hpp>
+// boost version < 1.57 has issues linking boost::filesystem::copy_file
+// https://svn.boost.org/trac10/ticket/6124
+#if (BOOST_VERSION < 105700)
+#define BOOST_NO_CXX11_SCOPED_ENUMS
+#endif // #if (BOOST_VERSION < 105700)
 #include <boost/filesystem.hpp>
+#if (BOOST_VERSION < 105700)
+#undef BOOST_NO_CXX11_SCOPED_ENUMS
+#endif // #if (BOOST_VERSION < 105700)
 
 #if (BOOST_VERSION >= 105300)
 #include <boost/lockfree/queue.hpp>


### PR DESCRIPTION
### Purpose

Fix linking with boost < 1.57

### Approach

define/undefine BOOST_NO_CXX11_SCOPED_ENUMS before/after including filesystem.hpp
for boost < 1.57

### Type of Change

- Build fix (non-breaking change which fixes an issue)

### Checklist

- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
