### PR TITLE
Support TLM socket data in SystemTLM

### DIFF
--- a/src/OMSimulatorLib/OMSimulator.cpp
+++ b/src/OMSimulatorLib/OMSimulator.cpp
@@ -42,6 +42,7 @@
 #include "ResultReader.h"
 #include "Scope.h"
 #include "System.h"
+#include "SystemTLM.h"
 #include "Types.h"
 #include "Version.h"
 
@@ -689,6 +690,27 @@ oms_status_enu_t oms3_terminate(const char* cref_)
     return logError_ModelNotInScope(cref);
 
   return model->terminate();
+}
+
+oms_status_enu_t oms3_setTLMSocketData(const char *cref, const char *address, int managerPort, int monitorPort)
+{
+  oms3::ComRef tail(cref);
+  oms3::ComRef front = tail.pop_front();
+
+  oms3::Model* model = oms3::Scope::GetInstance().getModel(front);
+  if(!model)
+    return logError_ModelNotInScope(front);
+
+  front = tail.pop_front();
+  oms3::System* system = model->getSystem(front);
+  if(!system)
+    return logError_SystemNotInModel(model->getName(), front);
+
+  if(system->getType() != oms_system_tlm)
+    return logError_OnlyForTlmSystem;
+
+  oms3::SystemTLM* tlmsystem = reinterpret_cast<oms3::SystemTLM*>(system);
+  return tlmsystem->setSocketData(address, managerPort, monitorPort);
 }
 
 /* ************************************ */

--- a/src/OMSimulatorLib/OMSimulator.h
+++ b/src/OMSimulatorLib/OMSimulator.h
@@ -92,6 +92,7 @@ oms_status_enu_t oms3_instantiate(const char* cref);
 oms_status_enu_t oms3_initialize(const char* cref);
 oms_status_enu_t oms3_simulate(const char* cref);
 oms_status_enu_t oms3_terminate(const char* cref);
+oms_status_enu_t oms3_setTLMSocketData(const char* cref, const char* address, int managerPort, int monitorPort);
 
 /* not implemented yet */
 oms_status_enu_t oms3_setSimulationInformation(const char* cref, ssd_simulation_information_t* info);

--- a/src/OMSimulatorLib/SystemTLM.cpp
+++ b/src/OMSimulatorLib/SystemTLM.cpp
@@ -88,6 +88,24 @@ oms_status_enu_t oms3::SystemTLM::exportToSSD_SimulationInformation(pugi::xml_no
 
 oms_status_enu_t oms3::SystemTLM::importFromSSD_SimulationInformation(const pugi::xml_node& node)
 {
+  pugi::xml_node annotationsNode = node.child(oms2::ssd::ssd_annotations);
+  if(annotationsNode) {
+    pugi::xml_node annotationNode = annotationsNode.child(oms2::ssd::ssd_annotation);
+    if(annotationNode && std::string(annotationNode.attribute("type").as_string()) == "org.openmodelica") {
+      pugi::xml_node tlmmasterNode = annotationNode.child("oms:TlmMaster");
+      for (auto it = tlmmasterNode.attributes_begin(); it != tlmmasterNode.attributes_end(); ++it)
+      {
+        std::string name = it->name();
+        if (name == "ip")
+          this->address = it->value();
+        else if(name == "managerport")
+          this->managerPort = tlmmasterNode.attribute("managerport").as_int();
+        else if(name == "monitorport")
+          this->monitorPort = tlmmasterNode.attribute("monitorport").as_int();
+      }
+    }
+  }
+
   return oms_status_ok;
 }
 

--- a/src/OMSimulatorLib/SystemTLM.h
+++ b/src/OMSimulatorLib/SystemTLM.h
@@ -48,6 +48,7 @@ namespace oms3
     static System* NewSystem(const oms3::ComRef& cref, Model* parentModel, System* parentSystem);
     oms_status_enu_t exportToSSD_SimulationInformation(pugi::xml_node& node) const;
     oms_status_enu_t importFromSSD_SimulationInformation(const pugi::xml_node& node);
+    oms_status_enu_t setSocketData(const std::string& address, int managerPort, int monitorPort);
 
     oms_status_enu_t instantiate();
     oms_status_enu_t initialize();
@@ -61,10 +62,12 @@ namespace oms3
     SystemTLM& operator=(SystemTLM const& copy); ///< not implemented
 
   private:
+    void* model;
+    std::string address = "";
+    int managerPort=0;
+    int monitorPort=0;
+
     // simulation information
-    // ip
-    // managerport
-    // monitorport
   };
 }
 

--- a/src/OMSimulatorLua/OMSimulatorLua.c
+++ b/src/OMSimulatorLua/OMSimulatorLua.c
@@ -512,6 +512,26 @@ static int OMSimulatorLua_oms3_terminate(lua_State *L)
   return 1;
 }
 
+//oms_status_enu_t oms3_setTLMSocketData(const char* cref, const char* address, int managerPort, int monitorPort)
+static int OMSimulatorLua_oms3_setTLMSocketData(lua_State *L)
+{
+  if (lua_gettop(L) != 4)
+    return luaL_error(L, "expecting exactly 4 arguments");
+  luaL_checktype(L, 1, LUA_TSTRING);
+  luaL_checktype(L, 2, LUA_TSTRING);
+  luaL_checktype(L, 3, LUA_TNUMBER);
+  luaL_checktype(L, 4, LUA_TNUMBER);
+
+  const char *cref =    lua_tostring(L, 1);
+  const char *address = lua_tostring(L, 2);
+  int managerPort =     lua_tonumber(L, 3);
+  int monitorPort =     lua_tonumber(L, 4);
+
+  oms_status_enu_t status = oms3_setTLMSocketData(cref, address, managerPort, monitorPort);
+  lua_pushinteger(L, status);
+  return 1;
+}
+
 /* ************************************ */
 /* OMSimulator 2.0                      */
 /*                                      */
@@ -2006,6 +2026,7 @@ DLLEXPORT int luaopen_OMSimulatorLua(lua_State *L)
   REGISTER_LUA_CALL(oms3_setTempDirectory);
   REGISTER_LUA_CALL(oms3_setWorkingDirectory);
   REGISTER_LUA_CALL(oms3_terminate);
+  REGISTER_LUA_CALL(oms3_setTLMSocketData);
   /* ************************************ */
   /* OMSimulator 2.0                      */
   /*                                      */


### PR DESCRIPTION
### Related PRs

OpenModelica/OMSimulator-testsuite#98

### Purpose

Support socket data in TLM systems:
- address (ip)
- manager port
- monitor port

### Approach

- `setSocketData` function in SystemTLM
-  `oms3_setTLMSocketData` API function
- `oms3_setTLMSocketData` Lua function
- Load TLM socket data from SSD
- Save TLM socket data to SSD

### Type of Change

- New feature (non-breaking change which adds functionality)

### Checklist

- I have performed a self-review of my own code