### PR TITLE
Implement TLMBusConnector::sortConnectors

### DIFF
--- a/src/OMSimulatorLib/TLMBusConnector.cpp
+++ b/src/OMSimulatorLib/TLMBusConnector.cpp
@@ -50,8 +50,8 @@ oms_status_enu_t oms3::TLMBusConnector::exportToSSD(pugi::xml_node &root) const
   pugi::xml_node signals_node = bus_node.append_child(oms::signals);
   for(auto& connector : connectors) {
     pugi::xml_node signal_node = signals_node.append_child(oms::signal);
-    signal_node.append_attribute("name") = connector.first.c_str();
-    signal_node.append_attribute("type") = connector.second.c_str();
+    signal_node.append_attribute("name") = connector.second.c_str();
+    signal_node.append_attribute("type") = connector.first.c_str();
   }
 
   if (this->geometry)
@@ -128,9 +128,24 @@ oms_status_enu_t oms3::TLMBusConnector::addConnector(const oms3::ComRef &cref, s
   if(std::find(variableTypes.begin(), variableTypes.end(), vartype) == variableTypes.end())
     return logError("Unknown TLM variable type: "+vartype);
 
-  connectors[cref] = vartype;
+  oms3::ComRef tempRef = cref;
+  connectors.insert(std::make_pair(vartype, tempRef));
+
+  sortConnectors();
+
   return oms_status_ok;
 }
+
+void oms3::TLMBusConnector::sortConnectors()
+{
+  if(variableTypes.size() == connectors.size()) {
+    for(const std::string& type : variableTypes) {
+      oms3::ComRef name = connectors.find(type)->second;
+      sortedConnectors.push_back(std::string(name));
+    }
+  }
+}
+
 
 void oms3::TLMBusConnector::updateVariableTypes()
 {

--- a/src/OMSimulatorLib/TLMBusConnector.cpp
+++ b/src/OMSimulatorLib/TLMBusConnector.cpp
@@ -179,19 +179,15 @@ void oms3::TLMBusConnector::updateVariableTypes()
   }
   else if(dimensions == 3 && interpolation == oms_tlm_fine_grained) {
     variableTypes = { "state1", "state2", "state3",
-                     "A11","A12","A13","A21","A22","A23","A31","A32","A33",
-                     "flow1", "flow2", "flow3", "flow4", "flow5", "flow6",
-                     "wave1_1",  "wave1_2",  "wave1_3",  "wave1_4",  "wave1_5",  "wave1_6",
-                     "wave2_1",  "wave2_2",  "wave2_3",  "wave2_4",  "wave2_5",  "wave2_6",
-                     "wave3_1",  "wave3_2",  "wave3_3",  "wave3_4",  "wave3_5",  "wave3_6",
-                     "wave4_1",  "wave4_2",  "wave4_3",  "wave4_4",  "wave4_5",  "wave4_6",
-                     "wave5_1",  "wave5_2",  "wave5_3",  "wave5_4",  "wave5_5",  "wave5_6",
-                     "wave6_1",  "wave6_2",  "wave6_3",  "wave6_4",  "wave6_5",  "wave6_6",
-                     "wave7_1",  "wave7_2",  "wave7_3",  "wave7_4",  "wave7_5",  "wave7_6",
-                     "wave8_1",  "wave8_2",  "wave8_3",  "wave8_4",  "wave8_5",  "wave8_6",
-                     "wave9_1",  "wave9_2",  "wave9_3",  "wave9_4",  "wave9_5",  "wave9_6",
-                     "wave10_1", "wave10_2", "wave10_3", "wave10_4", "wave10_5", "wave10_6",
+                      "A11","A12","A13","A21","A22","A23","A31","A32","A33",
+                      "flow1", "flow2", "flow3", "flow4", "flow5", "flow6",
+                      "wave1_1", "wave2_1", "wave3_1", "wave4_1", "wave5_1", "wave6_1", "wave7_1", "wave8_1", "wave9_1", "wave 10_1",
+                      "wave1_2", "wave2_2", "wave3_2", "wave4_2", "wave5_2", "wave6_2", "wave7_2", "wave8_2", "wave9_2", "wave 10_2",
+                      "wave1_3", "wave2_3", "wave3_3", "wave4_3", "wave5_3", "wave6_3", "wave7_3", "wave8_3", "wave9_3", "wave 10_3",
+                      "wave1_4", "wave2_4", "wave3_4", "wave4_4", "wave5_4", "wave6_4", "wave7_4", "wave8_4", "wave9_4", "wave 10_4",
+                      "wave1_5", "wave2_5", "wave3_5", "wave4_5", "wave5_5", "wave6_5", "wave7_5", "wave8_5", "wave9_5", "wave 10_5",
+                      "wave1_6", "wave2_6", "wave3_6", "wave4_6", "wave5_6", "wave6_6", "wave7_6", "wave8_6", "wave9_6", "wave 10_6",
                       "time1", "time2", "time3", "time4", "time5", "time6", "time7", "time8", "time9", "time10",
-                     "linearimpedance", "angularimpedance"};
+                      "linearimpedance", "angularimpedance"};
   }
 }

--- a/src/OMSimulatorLib/TLMBusConnector.h
+++ b/src/OMSimulatorLib/TLMBusConnector.h
@@ -16,6 +16,77 @@
 
 namespace oms3
 {
+typedef struct  {
+    int y = 0;
+} oms_tlm_sigrefs_signal_t;
+
+typedef struct  {
+    int x = 0;
+    int v = 1;
+    int f = 2;
+} oms_tlm_sigrefs_1d_t;
+
+typedef struct  {
+    int x = 0;
+    int v = 1;
+    int c = 2;
+    int Z = 3;
+} oms_tlm_sigrefs_1d_cg_t;
+
+typedef struct  {
+    int x = 0;
+    int v = 1;
+    std::vector<int> c = {2,3,4,5,6,7,8,9,10,11};
+    std::vector<int> t = {12,13,14,15,16,17,18,19,20,21};
+    int Z = 22;
+} oms_tlm_sigrefs_1d_fg_t;
+
+typedef struct  {
+    std::vector<int> x   = {0,1};
+    std::vector<int> phi = {2};
+    std::vector<int> v   = {3,4};
+    std::vector<int> w   = {5};
+    std::vector<int> f   = {6,7,8};
+} oms_tlm_sigrefs_2d_t;
+
+typedef struct  {
+    std::vector<int> x = {0,1,2};
+    std::vector<int> A = {3,4,5,6,7,8,9,10,11};
+    std::vector<int> v = {12,13,14};
+    std::vector<int> w = {15,16,17};
+    std::vector<int> f = {18,19,20,21,22,23};
+} oms_tlm_sigrefs_3d_t;
+
+typedef struct  {
+    std::vector<int> x = {0,1,2};
+    std::vector<int> A = {3,4,5,6,7,8,9,10,11};
+    std::vector<int> v = {12,13,14};
+    std::vector<int> w = {15,16,17};
+    std::vector<int> c = {18,19,20,21,22,23};
+    int Zt = 24;
+    int Zr = 25;
+} oms_tlm_sigrefs_3d_cg_t;
+
+typedef struct  {
+    std::vector<int> x =  {0,1,2};
+    std::vector<int> A =  {3,4,5,6,7,8,9,10,11};
+    std::vector<int> v =  {12,13,14};
+    std::vector<int> w =  {15,16,17};
+    std::vector< std::vector<int> > c = { {18,28,38,48,58,68},
+                                          {19,29,39,49,59,69},
+                                          {20,30,40,50,60,70},
+                                          {21,31,41,51,61,71},
+                                          {22,32,42,52,62,72},
+                                          {23,33,43,53,63,73},
+                                          {24,34,44,54,64,74},
+                                          {25,35,45,55,65,75},
+                                          {26,36,46,56,66,76},
+                                          {27,37,47,57,67,77} };
+    std::vector<int> t = { 78,79,80,81,82,83,84,85,86,87};
+    int Zt = 88;
+    int Zr = 89;
+} oms_tlm_sigrefs_3d_fg_t;
+
   /**
    * \brief TLMBusConnector
    */
@@ -42,14 +113,18 @@ namespace oms3
     const oms2::ssd::ConnectorGeometry* getGeometry() const {return reinterpret_cast<oms2::ssd::ConnectorGeometry*>(geometry);}
 
     oms_status_enu_t addConnector(const oms3::ComRef& cref, std::string vartype);
+    void sortConnectors();
+    int getId() const {return id;}
 
   private:
     void updateVariableTypes();
 
     oms_causality_enu_t causality;
-
-    std::map<oms3::ComRef, std::string> connectors;
+    std::map<std::string, oms3::ComRef> connectors;
+    std::vector<oms3::ComRef> sortedConnectors;
     std::vector<std::string> variableTypes; //Used to keep track of TLM variable types
+
+    int id;
   };
 }
 


### PR DESCRIPTION
### Related PRs

OpenModelica/OMSimulator-testsuite#99

### Purpose

TLMBus subconnectors must be sorted prior to simulation, for index-based access during simulation.

### Approach

Sort them and store in a vector of pointers.

### Type of Change

- New feature (non-breaking change which adds functionality)

### Checklist

- I have performed a self-review of my own code