### PR TITLE
Implement TLMBusConnector::registerToSockets

### DIFF
--- a/src/OMSimulatorLib/TLMBusConnector.cpp
+++ b/src/OMSimulatorLib/TLMBusConnector.cpp
@@ -146,6 +146,34 @@ void oms3::TLMBusConnector::sortConnectors()
   }
 }
 
+oms_status_enu_t oms3::TLMBusConnector::registerToSockets(TLMPlugin *plugin)
+{
+  if(sortedConnectors.empty())
+    return logError("All required connectors not added to TLM bus");
+
+  //OMTLMSimulator uses degrees of freedom as "dimensions",
+  //so convert to this:
+  int omtlm_dimensions = dimensions;
+  if(dimensions == 2) omtlm_dimensions = 3;
+  if(dimensions == 3) omtlm_dimensions = 6;
+
+  //Convert causality to string
+  std::string omtlm_causality = "Bidirectional";
+  if(std::string(domain) == "input")
+    omtlm_causality = "Input";
+  else if(std::string(domain) == "output")
+    omtlm_causality = "Output";
+
+  this->id = plugin->RegisteTLMInterface(name,omtlm_dimensions,omtlm_causality,domain);
+
+  if(this->id < 0) {
+    logError("Failed to register TLM interface: "+std::string(name));
+    return oms_status_error;
+  }
+
+  return oms_status_ok;
+}
+
 
 void oms3::TLMBusConnector::updateVariableTypes()
 {

--- a/src/OMSimulatorLib/TLMBusConnector.h
+++ b/src/OMSimulatorLib/TLMBusConnector.h
@@ -7,6 +7,7 @@
 #include "Types.h"
 #include "Connector.h"
 #include "ssd/ConnectorGeometry.h"
+#include "../../OMTLMSimulator/common/Plugin/PluginImplementer.h"
 
 #include <string>
 #include <vector>
@@ -114,6 +115,7 @@ typedef struct  {
 
     oms_status_enu_t addConnector(const oms3::ComRef& cref, std::string vartype);
     void sortConnectors();
+    oms_status_enu_t registerToSockets(TLMPlugin *plugin);
     int getId() const {return id;}
 
   private:


### PR DESCRIPTION
### Purpose

TLM interfaces (a.k.a. TLMBusConnectors) must register themselves to TLM manager.

### Approach

- `TLMBusConnector::registerToSockets()`

### Type of Change

- New feature (non-breaking change which adds functionality)

### Checklist

- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas