### PR TITLE
Implement oms3_setTLMPositionAndOrientation

### DIFF
--- a/src/OMSimulatorLib/OMSimulator.cpp
+++ b/src/OMSimulatorLib/OMSimulator.cpp
@@ -713,6 +713,29 @@ oms_status_enu_t oms3_setTLMSocketData(const char *cref, const char *address, in
   return tlmsystem->setSocketData(address, managerPort, monitorPort);
 }
 
+oms_status_enu_t oms3_setTLMPositionAndOrientation(const char *cref, double x1, double x2, double x3, double A11, double A12, double A13, double A21, double A22, double A23, double A31, double A32, double A33)
+{
+  oms3::ComRef tail(cref);
+  oms3::ComRef front = tail.pop_front();
+
+  oms3::Model* model = oms3::Scope::GetInstance().getModel(front);
+  if(!model)
+    return logError_ModelNotInScope(front);
+
+  front = tail.pop_front();
+  oms3::System* system = model->getSystem(front);
+  if(!system)
+    return logError_SystemNotInModel(model->getName(), front);
+
+  if(system->getType() != oms_system_tlm)
+    return logError_OnlyForTlmSystem;
+
+  oms3::SystemTLM* tlmsystem = reinterpret_cast<oms3::SystemTLM*>(system);
+  std::vector<double> x = {x1,x2,x3};
+  std::vector<double> A = {A11,A12,A13,A21,A22,A23,A31,A32,A33};
+  return tlmsystem->setPositionAndOrientation(tail, x, A);
+}
+
 /* ************************************ */
 /* OMSimulator 2.0                      */
 /*                                      */

--- a/src/OMSimulatorLib/OMSimulator.h
+++ b/src/OMSimulatorLib/OMSimulator.h
@@ -93,6 +93,7 @@ oms_status_enu_t oms3_initialize(const char* cref);
 oms_status_enu_t oms3_simulate(const char* cref);
 oms_status_enu_t oms3_terminate(const char* cref);
 oms_status_enu_t oms3_setTLMSocketData(const char* cref, const char* address, int managerPort, int monitorPort);
+oms_status_enu_t oms3_setTLMPositionAndOrientation(const char *cref, double x1, double x2, double x3, double A11, double A12, double A13, double A21, double A22, double A23, double A31, double A32, double A33);
 
 /* not implemented yet */
 oms_status_enu_t oms3_setSimulationInformation(const char* cref, ssd_simulation_information_t* info);

--- a/src/OMSimulatorLib/SystemTLM.cpp
+++ b/src/OMSimulatorLib/SystemTLM.cpp
@@ -140,3 +140,23 @@ oms_status_enu_t oms3::SystemTLM::setSocketData(const std::string &address, int 
   this->monitorPort = monitorPort;
   return oms_status_ok;
 }
+
+oms_status_enu_t oms3::SystemTLM::setPositionAndOrientation(const oms3::ComRef &cref, std::vector<double> x, std::vector<double> A)
+{
+  ComRef tail = cref;
+  ComRef head = tail.pop_front();
+
+  if(getSubSystems().find(head) == getSubSystems().end() &&
+     getComponents().find(head) == getComponents().end()) {
+    return logError("Sub-model \""+std::string(head)+"\" not found.");
+  }
+  std::string ifcname;
+  if(tail.isEmpty()) {
+    ifcname = std::string(head);   //Apply to component
+  }
+  else {
+    ifcname = std::string(head)+"."+std::string(tail);  //Apply to interface
+  }
+  omtlm_setInitialPositionAndOrientation(model, ifcname.c_str(), x, A);
+  return oms_status_ok;
+}

--- a/src/OMSimulatorLib/SystemTLM.h
+++ b/src/OMSimulatorLib/SystemTLM.h
@@ -49,6 +49,7 @@ namespace oms3
     oms_status_enu_t exportToSSD_SimulationInformation(pugi::xml_node& node) const;
     oms_status_enu_t importFromSSD_SimulationInformation(const pugi::xml_node& node);
     oms_status_enu_t setSocketData(const std::string& address, int managerPort, int monitorPort);
+    oms_status_enu_t setPositionAndOrientation(const ComRef &cref, std::vector<double> x, std::vector<double> A);
 
     oms_status_enu_t instantiate();
     oms_status_enu_t initialize();

--- a/src/OMSimulatorLua/OMSimulatorLua.c
+++ b/src/OMSimulatorLua/OMSimulatorLua.c
@@ -532,6 +532,42 @@ static int OMSimulatorLua_oms3_setTLMSocketData(lua_State *L)
   return 1;
 }
 
+//oms_status_enu_t oms2_setTLMPositionAndOrientation(const char *cref, double x1, double x2, double x3, double A11, double A12, double A13, double A21, double A22, double A23, double A31, double A32, double A33)
+static int OMSimulatorLua_oms3_setTLMPositionAndOrientation(lua_State *L)
+{
+  if (lua_gettop(L) != 13)
+    return luaL_error(L, "expecting exactly 13 arguments");
+
+  luaL_checktype(L, 1, LUA_TSTRING);
+  luaL_checktype(L, 2, LUA_TSTRING);
+  const char *cref =  lua_tostring(L, 1);
+  const char *ifc = lua_tostring(L, 2);
+  int i;
+
+  //Position
+  double x[3];
+  for(i=0; i<3; ++i) {
+    luaL_checktype(L, i+3, LUA_TNUMBER);
+    x[i] = lua_tonumber(L, i+3);
+  }
+
+  //Orientation (3x3 matrix, stored as 1x9 vector)
+  double A[9];
+  for(i=0; i<9; ++i) {
+    luaL_checktype(L, i+6, LUA_TNUMBER);
+    A[i] = lua_tonumber(L, i+6);
+  }
+
+  oms_status_enu_t status = oms3_setTLMPositionAndOrientation(cref,
+                                                              x[0], x[1], x[2],
+                                                              A[0], A[1], A[2],
+                                                              A[3], A[4], A[5],
+                                                              A[6], A[7], A[8]);
+
+  lua_pushinteger(L, status);
+  return 1;
+}
+
 /* ************************************ */
 /* OMSimulator 2.0                      */
 /*                                      */
@@ -2027,6 +2063,7 @@ DLLEXPORT int luaopen_OMSimulatorLua(lua_State *L)
   REGISTER_LUA_CALL(oms3_setWorkingDirectory);
   REGISTER_LUA_CALL(oms3_terminate);
   REGISTER_LUA_CALL(oms3_setTLMSocketData);
+  REGISTER_LUA_CALL(oms3_setTLMPositionAndOrientation);
   /* ************************************ */
   /* OMSimulator 2.0                      */
   /*                                      */


### PR DESCRIPTION
### Purpose

Reimplement functionality from `oms2_setTLMPositionAndOrientation`.

### Approach

Implement `setPositionAndOrientation` function in SystemTLM.

### Type of Change

- New feature (non-breaking change which adds functionality)

### Checklist

- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas