### PR TITLE
Fix oms3_getElement for components

### DIFF
--- a/src/OMSimulatorLib/Model.cpp
+++ b/src/OMSimulatorLib/Model.cpp
@@ -117,17 +117,29 @@ oms3::System* oms3::Model::getSystem(const oms3::ComRef& cref)
   oms3::ComRef tail(cref);
   oms3::ComRef front = tail.pop_front();
 
-  oms3::System* system = NULL;
-
   if (this->system->getName() == front)
   {
-    system = this->system;
-
-    if (!tail.isEmpty())
-      system = system->getSystem(tail);
+    if (tail.isEmpty())
+      return system;
+    else
+      return system->getSystem(tail);
   }
 
-  return system;
+  return NULL;
+}
+
+oms3::Component* oms3::Model::getComponent(const oms3::ComRef& cref)
+{
+  if (!system)
+    return NULL;
+
+  oms3::ComRef tail(cref);
+  oms3::ComRef front = tail.pop_front();
+
+  if (this->system->getName() == front)
+    return system->getComponent(tail);
+
+  return NULL;
 }
 
 oms_status_enu_t oms3::Model::list(const oms3::ComRef& cref, char** contents)

--- a/src/OMSimulatorLib/Model.h
+++ b/src/OMSimulatorLib/Model.h
@@ -40,6 +40,7 @@
 
 namespace oms3
 {
+  class Component;
   class System;
 
   class Model
@@ -54,6 +55,7 @@ namespace oms3
     static Model* NewModel(const ComRef& cref);
     const ComRef& getName() const {return cref;}
     System* getSystem(const ComRef& cref);
+    Component* getComponent(const ComRef& cref);
     std::string getTempDirectory() const {return tempDir;}
     oms_status_enu_t rename(const ComRef& cref);
     oms_status_enu_t list(const ComRef& cref, char** contents);

--- a/src/OMSimulatorLib/Scope.cpp
+++ b/src/OMSimulatorLib/Scope.cpp
@@ -282,10 +282,7 @@ std::string oms3::Scope::getWorkingDirectory()
 oms_status_enu_t oms3::Scope::getElement(const oms3::ComRef& cref, oms3::Element** element)
 {
   if (!element)
-  {
-    logWarning("[oms3::Scope::getElement] NULL pointer");
-    return oms_status_warning;
-  }
+    return logWarning("[oms3::Scope::getElement] NULL pointer");
 
   oms3::ComRef tail(cref);
   oms3::ComRef front = tail.pop_front();
@@ -297,20 +294,22 @@ oms_status_enu_t oms3::Scope::getElement(const oms3::ComRef& cref, oms3::Element
     return logError("A model has no element information");
 
   oms3::System* system = model->getSystem(tail);
-  if (!system)
-    return logError("Model \"" + std::string(front) + "\" does not contain system \"" + std::string(tail) + "\"");
+  oms3::Component* component = model->getComponent(tail);
+  if (!system && !component)
+    return logError("Model \"" + std::string(front) + "\" does not contain system or component \"" + std::string(tail) + "\"");
 
-  *element = system->getElement();
+  if (system)
+    *element = system->getElement();
+  else
+    *element = component->getElement();
+
   return oms_status_ok;
 }
 
 oms_status_enu_t oms3::Scope::getElements(const oms3::ComRef& cref, oms3::Element*** elements)
 {
   if (!elements)
-  {
-    logWarning("[oms3::Scope::getElements] NULL pointer");
-    return oms_status_warning;
-  }
+    return logWarning("[oms3::Scope::getElements] NULL pointer");
 
   oms3::ComRef tail(cref);
   oms3::ComRef front = tail.pop_front();


### PR DESCRIPTION
### Purpose

Fix oms3_getElement for components; it was only implemented for systems.

### Type of Change

<!--- Please delete options that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)

### Checklist

<!--- Please delete options that are not relevant. -->

- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
-