### PR TITLE
Implement oms3_setTLMInitialValues

### DIFF
--- a/src/OMSimulatorLib/OMSimulator.cpp
+++ b/src/OMSimulatorLib/OMSimulator.cpp
@@ -781,6 +781,27 @@ oms_status_enu_t oms3_exportDependencyGraphs(const char* cref, const char* initi
   return system->exportDependencyGraphs(initialization, simulation);
 }
 
+oms_status_enu_t oms3_setTLMInitialValues(const char *cref, const char *ifc, const double values[], int nvalues)
+{
+  oms3::ComRef tail(cref);
+  oms3::ComRef front = tail.pop_front();
+
+  oms3::Model* model = oms3::Scope::GetInstance().getModel(front);
+  if (!model)
+    return logError_ModelNotInScope(front);
+
+  front = tail.pop_front();
+  oms3::System* system = model->getSystem(front);
+  if (!system)
+    return logError_SystemNotInModel(model->getCref(), front);
+
+  if (system->getType() != oms_system_tlm)
+    return logError_OnlyForTlmSystem;
+
+  oms3::SystemTLM* tlmsystem = reinterpret_cast<oms3::SystemTLM*>(system);
+  return tlmsystem->setInitialValues(tail, std::vector<double>(values, values+nvalues));
+}
+
 /* ************************************ */
 /* OMSimulator 2.0                      */
 /*                                      */

--- a/src/OMSimulatorLib/OMSimulator.h
+++ b/src/OMSimulatorLib/OMSimulator.h
@@ -96,6 +96,7 @@ oms_status_enu_t oms3_terminate(const char* cref);
 oms_status_enu_t oms3_setTLMSocketData(const char* cref, const char* address, int managerPort, int monitorPort);
 oms_status_enu_t oms3_setTLMPositionAndOrientation(const char *cref, double x1, double x2, double x3, double A11, double A12, double A13, double A21, double A22, double A23, double A31, double A32, double A33);
 oms_status_enu_t oms3_exportDependencyGraphs(const char* cref, const char* initialization, const char* simulation);
+oms_status_enu_t oms3_setTLMInitialValues(const char *cref, const char *ifc, const double values[], int nvalues);
 
 /* not implemented yet */
 oms_status_enu_t oms3_setSimulationInformation(const char* cref, ssd_simulation_information_t* info);

--- a/src/OMSimulatorLib/System.cpp
+++ b/src/OMSimulatorLib/System.cpp
@@ -662,6 +662,11 @@ oms3::TLMBusConnector* oms3::System::getTLMBusConnector(const oms3::ComRef& cref
   return NULL;
 }
 
+oms3::TLMBusConnector **oms3::System::getTLMBusConnectors()
+{
+  return &tlmbusconnectors[0];
+}
+
 oms3::Connection** oms3::System::getConnections(const oms3::ComRef& cref)
 {
   if (!cref.isEmpty())

--- a/src/OMSimulatorLib/System.cpp
+++ b/src/OMSimulatorLib/System.cpp
@@ -662,11 +662,6 @@ oms3::TLMBusConnector* oms3::System::getTLMBusConnector(const oms3::ComRef& cref
   return NULL;
 }
 
-oms3::TLMBusConnector **oms3::System::getTLMBusConnectors()
-{
-  return &tlmbusconnectors[0];
-}
-
 oms3::Connection** oms3::System::getConnections(const oms3::ComRef& cref)
 {
   if (!cref.isEmpty())

--- a/src/OMSimulatorLib/SystemTLM.cpp
+++ b/src/OMSimulatorLib/SystemTLM.cpp
@@ -241,7 +241,7 @@ oms_status_enu_t oms3::SystemTLM::setInitialValues(ComRef cref, std::vector<doub
   SystemWC* system = reinterpret_cast<SystemWC*>(getSystem(head));
 
   if(system == nullptr)
-    return logError_SubSystemNotInSystem(getName(),cref);
+    return logError_SubSystemNotInSystem(getCref(),cref);
 
   //Find interface log
   bool found = false;
@@ -285,7 +285,7 @@ oms_status_enu_t oms3::SystemTLM::updateInitialValues(const oms3::ComRef cref)
 {
   SystemWC* system = reinterpret_cast<SystemWC*>(getSystem(cref));
   if(system == nullptr)
-    return logError_SubSystemNotInSystem(getName(),cref);
+    return logError_SubSystemNotInSystem(getCref(),cref);
   if (std::find(connectedsubsystems.begin(), connectedsubsystems.end(), cref) == connectedsubsystems.end())
     return logError("System not connected to TLM sockets: "+std::string(cref));
   TLMPlugin* plugin = plugins.find(system)->second;

--- a/src/OMSimulatorLib/SystemTLM.cpp
+++ b/src/OMSimulatorLib/SystemTLM.cpp
@@ -38,6 +38,8 @@
 #include "ssd/Tags.h"
 #include "OMTLMSimulatorLib.h"
 
+#include <algorithm>
+
 oms3::SystemTLM::SystemTLM(const ComRef& cref, Model* parentModel, System* parentSystem)
   : oms3::System(cref, oms_system_tlm, parentModel, parentSystem)
 {
@@ -229,5 +231,157 @@ oms_status_enu_t oms3::SystemTLM::setPositionAndOrientation(const oms3::ComRef &
     ifcname = std::string(head)+"."+std::string(tail);  //Apply to interface
   }
   omtlm_setInitialPositionAndOrientation(model, ifcname.c_str(), x, A);
+  return oms_status_ok;
+}
+
+oms_status_enu_t oms3::SystemTLM::setInitialValues(ComRef cref, std::vector<double> values)
+{
+  oms3::ComRef tail(cref);
+  oms3::ComRef head = tail.pop_front();
+  SystemWC* system = reinterpret_cast<SystemWC*>(getSystem(head));
+
+  if(system == nullptr)
+    return logError_SubSystemNotInSystem(getName(),cref);
+
+  //Find interface log
+  bool found = false;
+  TLMBusConnector** tlmbuses = system->getTLMBusConnectors();
+  for (int i=0; tlmbuses[i]; ++i)
+  {
+    TLMBusConnector* bus = tlmbuses[i];
+    if(bus->getName() == tail) {
+      found = true;
+      if(bus->getDimensions() == 1 && bus->getCausality() != oms_causality_bidir) {
+        if(values.size() < 1) {
+          return logError("No initial TLM value specified.");
+        }
+        initialValues.insert(std::make_pair(cref, values));
+      }
+      else if(bus->getDimensions() == 1 && bus->getCausality() == oms_causality_bidir) {
+        if(values.size() < 2) {
+          return logError("Too few initial TLM values specified for 1D interface (should be 2, effort and flow).");
+        }
+        initialValues.insert(std::make_pair(cref, values));
+      }
+      else if(bus->getDimensions() == 3) {
+        if(values.size() < 12) {
+          return logError("Too few initial TLM values specified for 3D interface (should be 12, 3 forces, 3 torques, 3 velocities and 3 angular velocities).");
+        }
+        initialValues.insert(std::make_pair(cref, values));
+      }
+      break;
+    }
+  }
+
+  if(!found) {
+    return logError("TLMBusConnector \""+std::string(tail)+"\" not found in system \""+std::string(head)+"\"");
+  }
+
+  return oms_status_ok;
+}
+
+
+oms_status_enu_t oms3::SystemTLM::updateInitialValues(const oms3::ComRef cref)
+{
+  SystemWC* system = reinterpret_cast<SystemWC*>(getSystem(cref));
+  if(system == nullptr)
+    return logError_SubSystemNotInSystem(getName(),cref);
+  if (std::find(connectedsubsystems.begin(), connectedsubsystems.end(), cref) == connectedsubsystems.end())
+    return logError("System not connected to TLM sockets: "+std::string(cref));
+  TLMPlugin* plugin = plugins.find(system)->second;
+
+  //Apply initial values for signal and effort
+  TLMBusConnector** tlmbuses = system->getTLMBusConnectors();
+  for (int i=0; tlmbuses[i]; ++i)
+  {
+    TLMBusConnector* bus = tlmbuses[i];
+
+    if(bus->getDimensions() == 1 && bus->getCausality() == oms_causality_input) {
+      oms_tlm_sigrefs_signal_t tlmrefs;
+      double value;
+      if(initialValues.find(bus->getName()) != initialValues.end()) {
+        value = initialValues.find(bus->getName())->second[0];
+      }
+      else {
+        system->getReal(bus->getConnector(tlmrefs.y), value);
+      }
+      plugin->SetInitialValue(bus->getId(), value);
+    }
+    else if(bus->getDimensions() == 1 && bus->getCausality() == oms_causality_bidir &&
+            bus->getInterpolation() == oms_tlm_no_interpolation) {
+      oms_tlm_sigrefs_1d_t tlmrefs;
+      double effort,flow;
+      if(initialValues.find(bus->getName()) != initialValues.end()) {
+        effort = initialValues.find(bus->getName())->second[0];
+        flow = initialValues.find(bus->getName())->second[1];
+      }
+      else {
+        system->getReal(bus->getConnector(tlmrefs.f), effort);
+        system->getReal(bus->getConnector(tlmrefs.v), flow);
+      }
+      plugin->SetInitialForce1D(bus->getId(), effort);
+      plugin->SetInitialFlow1D(bus->getId(), flow);
+    }
+    else if(bus->getDimensions() == 1 && bus->getCausality() == oms_causality_bidir &&
+            bus->getInterpolation() != oms_tlm_no_interpolation) {
+      if(initialValues.find(bus->getName()) != initialValues.end()) {
+        double effort = initialValues.find(bus->getName())->second[0];
+        double flow = initialValues.find(bus->getName())->second[1];
+        plugin->SetInitialForce1D(bus->getId(), effort);
+        plugin->SetInitialFlow1D(bus->getId(), flow);
+      }
+    }
+    else if(bus->getDimensions() == 3 && bus->getCausality() == oms_causality_bidir &&
+            bus->getInterpolation() == oms_tlm_no_interpolation) {
+      oms_tlm_sigrefs_3d_t tlmrefs;
+      std::vector<double> effort(6,0);
+      std::vector<double> flow(6,0);
+      if(initialValues.find(bus->getName()) != initialValues.end()) {
+        effort[0] = initialValues.find(bus->getName())->second[0];
+        effort[1] = initialValues.find(bus->getName())->second[1];
+        effort[2] = initialValues.find(bus->getName())->second[2];
+        effort[3] = initialValues.find(bus->getName())->second[3];
+        effort[4] = initialValues.find(bus->getName())->second[4];
+        effort[5] = initialValues.find(bus->getName())->second[5];
+        flow[0] = initialValues.find(bus->getName())->second[6];
+        flow[1] = initialValues.find(bus->getName())->second[7];
+        flow[2] = initialValues.find(bus->getName())->second[8];
+        flow[3] = initialValues.find(bus->getName())->second[9];
+        flow[4] = initialValues.find(bus->getName())->second[10];
+        flow[5] = initialValues.find(bus->getName())->second[11];
+      }
+      else {
+        system->getReals(bus->getConnectors(tlmrefs.f), effort);
+        std::vector<int> flowrefs = tlmrefs.v;
+        flowrefs.insert(flowrefs.end(), tlmrefs.w.begin(), tlmrefs.w.end());
+        system->getReals(bus->getConnectors(flowrefs), flow);
+      }
+      plugin->SetInitialForce3D(bus->getId(), effort[0], effort[1], effort[2], effort[3], effort[4], effort[5]);
+      plugin->SetInitialFlow3D(bus->getId(), flow[0], flow[1], flow[2], flow[3], flow[4], flow[5]);
+    }
+    else if(bus->getDimensions() == 3 && bus->getCausality() == oms_causality_bidir &&
+            bus->getInterpolation() != oms_tlm_no_interpolation) {
+      oms_tlm_sigrefs_3d_t tlmrefs;
+      std::vector<double> effort(6,0);
+      std::vector<double> flow(6,0);
+      if(initialValues.find(bus->getName()) != initialValues.end()) {
+        effort[0] = initialValues.find(bus->getName())->second[0];
+        effort[1] = initialValues.find(bus->getName())->second[1];
+        effort[2] = initialValues.find(bus->getName())->second[2];
+        effort[3] = initialValues.find(bus->getName())->second[3];
+        effort[4] = initialValues.find(bus->getName())->second[4];
+        effort[5] = initialValues.find(bus->getName())->second[5];
+        flow[0] = initialValues.find(bus->getName())->second[6];
+        flow[1] = initialValues.find(bus->getName())->second[7];
+        flow[2] = initialValues.find(bus->getName())->second[8];
+        flow[3] = initialValues.find(bus->getName())->second[9];
+        flow[4] = initialValues.find(bus->getName())->second[10];
+        flow[5] = initialValues.find(bus->getName())->second[11];
+        plugin->SetInitialForce3D(bus->getId(), effort[0], effort[1], effort[2], effort[3], effort[4], effort[5]);
+        plugin->SetInitialFlow3D(bus->getId(), flow[0], flow[1], flow[2], flow[3], flow[4], flow[5]);
+      }
+    }
+  }
+
   return oms_status_ok;
 }

--- a/src/OMSimulatorLib/SystemTLM.h
+++ b/src/OMSimulatorLib/SystemTLM.h
@@ -59,6 +59,8 @@ namespace oms3
 
     oms_status_enu_t connectToSockets(const oms3::ComRef cref, std::string server);
     void disconnectFromSockets(const oms3::ComRef cref);
+    oms_status_enu_t setInitialValues(ComRef cref, std::vector<double> values);
+    oms_status_enu_t updateInitialValues(const oms3::ComRef cref);
 
   protected:
     SystemTLM(const ComRef& cref, Model* parentModel, System* parentSystem);
@@ -75,6 +77,8 @@ namespace oms3
 
     std::vector<ComRef> connectedsubsystems;
     std::map<System*, TLMPlugin*> plugins;
+    std::vector<ComRef> initializedsubsystems;
+    std::map<ComRef, std::vector<double> > initialValues;
 
     // simulation information
   };

--- a/src/OMSimulatorLib/SystemWC.cpp
+++ b/src/OMSimulatorLib/SystemWC.cpp
@@ -187,3 +187,14 @@ oms_status_enu_t oms3::SystemWC::getReal(const oms3::ComRef& cref, double& value
 {
   return logError_NotImplemented;
 }
+
+oms_status_enu_t oms3::SystemWC::setReals(const std::vector<oms3::ComRef> &crefs, std::vector<double> values)
+{
+  return logError_NotImplemented;
+}
+
+//Placeholder function
+oms_status_enu_t oms3::SystemWC::getReals(const std::vector<oms3::ComRef> &sr, std::vector<double> &values)
+{
+  return logError_NotImplemented;
+}

--- a/src/OMSimulatorLib/SystemWC.h
+++ b/src/OMSimulatorLib/SystemWC.h
@@ -63,6 +63,8 @@ namespace oms3
     oms_status_enu_t updateInputs(DirectedGraph& graph, bool discrete);
     oms_status_enu_t setReal(const ComRef& cref, double value);
     oms_status_enu_t getReal(const ComRef& cref, double& value);
+    oms_status_enu_t setReals(const std::vector<ComRef> &crefs, std::vector<double> values);
+    oms_status_enu_t getReals(const std::vector<ComRef> &crefs, std::vector<double> &values);
 
   protected:
     SystemWC(const ComRef& cref, Model* parentModel, System* parentSystem);

--- a/src/OMSimulatorLib/TLMBusConnector.cpp
+++ b/src/OMSimulatorLib/TLMBusConnector.cpp
@@ -123,6 +123,20 @@ void oms3::TLMBusConnector::setGeometry(const oms2::ssd::ConnectorGeometry *newG
     this->geometry = reinterpret_cast<ssd_connector_geometry_t*>(new oms2::ssd::ConnectorGeometry(*newGeometry));
 }
 
+oms3::ComRef oms3::TLMBusConnector::getConnector(int id) const
+{
+  return sortedConnectors[id];
+}
+
+std::vector<oms3::ComRef> oms3::TLMBusConnector::getConnectors(std::vector<int> ids) const
+{
+  std::vector<oms3::ComRef> retval;
+  for(int id : ids) {
+    retval.push_back(sortedConnectors[id]);
+  }
+  return retval;
+}
+
 oms_status_enu_t oms3::TLMBusConnector::addConnector(const oms3::ComRef &cref, std::string vartype)
 {
   if(std::find(variableTypes.begin(), variableTypes.end(), vartype) == variableTypes.end())

--- a/src/OMSimulatorLib/TLMBusConnector.h
+++ b/src/OMSimulatorLib/TLMBusConnector.h
@@ -113,6 +113,8 @@ typedef struct  {
     const oms_tlm_interpolation_t getInterpolation() const {return interpolation;}
     void setDelay(double delay) { this->delay = delay; }
     double getDelay() { return this->delay; }
+    oms3::ComRef getConnector(int id) const;
+    std::vector<oms3::ComRef> getConnectors(std::vector<int> ids) const;
     const oms2::ssd::ConnectorGeometry* getGeometry() const {return reinterpret_cast<oms2::ssd::ConnectorGeometry*>(geometry);}
 
     oms_status_enu_t addConnector(const oms3::ComRef& cref, std::string vartype);

--- a/src/OMSimulatorLua/OMSimulatorLua.c
+++ b/src/OMSimulatorLua/OMSimulatorLua.c
@@ -600,6 +600,67 @@ static int OMSimulatorLua_oms3_setTLMPositionAndOrientation(lua_State *L)
   return 1;
 }
 
+//oms_status_enu_t oms3_setTLMInitialValues(const char *cref, const char *ifc, double value1, double value2...));
+static int OMSimulatorLua_oms3_setTLMInitialValues(lua_State *L)
+{
+  //First parse initial arguments (3 or 8)
+  if(lua_gettop(L) != 3 && lua_gettop(L) != 4 && lua_gettop(L) != 14) {
+    return luaL_error(L, "expecting exactly 3, 4 or 14 arguments");
+  }
+
+  luaL_checktype(L, 1, LUA_TSTRING);
+  luaL_checktype(L, 2, LUA_TSTRING);
+  luaL_checktype(L, 3, LUA_TNUMBER);
+  if(lua_gettop(L) > 3) {
+    luaL_checktype(L, 4, LUA_TNUMBER);
+  }
+  if(lua_gettop(L) > 4) {
+    luaL_checktype(L, 5, LUA_TNUMBER);
+    luaL_checktype(L, 6, LUA_TNUMBER);
+    luaL_checktype(L, 7, LUA_TNUMBER);
+    luaL_checktype(L, 8, LUA_TNUMBER);
+    luaL_checktype(L, 9, LUA_TNUMBER);
+    luaL_checktype(L, 10, LUA_TNUMBER);
+    luaL_checktype(L, 11, LUA_TNUMBER);
+    luaL_checktype(L, 12, LUA_TNUMBER);
+    luaL_checktype(L, 13, LUA_TNUMBER);
+    luaL_checktype(L, 14, LUA_TNUMBER);
+  }
+
+  oms_status_enu_t status;
+  const char *cref =    lua_tostring(L, 1);
+  const char *subref =  lua_tostring(L, 2);
+  if(lua_gettop(L) == 3) {
+    double values[1];
+    values[0] = lua_tonumber(L,3);
+    status = oms3_setTLMInitialValues(cref, subref, values, 1);
+  }
+  else if(lua_gettop(L) == 4) {
+    double values[2];
+    values[0] = lua_tonumber(L,3);
+    values[1] = lua_tonumber(L,4);
+    status = oms3_setTLMInitialValues(cref, subref, values, 2);
+  }
+  else {
+    double values[12];
+    values[0] = lua_tonumber(L,3);
+    values[1] = lua_tonumber(L,4);
+    values[2] = lua_tonumber(L,5);
+    values[3] = lua_tonumber(L,6);
+    values[4] = lua_tonumber(L,7);
+    values[5] = lua_tonumber(L,8);
+    values[6] = lua_tonumber(L,9);
+    values[7] = lua_tonumber(L,10);
+    values[8] = lua_tonumber(L,11);
+    values[9] = lua_tonumber(L,12);
+    values[10] = lua_tonumber(L,13);
+    values[11] = lua_tonumber(L,14);
+    status = oms3_setTLMInitialValues(cref, subref, values, 12);
+  }
+  lua_pushinteger(L, status);
+  return 1;
+}
+
 /* ************************************ */
 /* OMSimulator 2.0                      */
 /*                                      */
@@ -2095,6 +2156,7 @@ DLLEXPORT int luaopen_OMSimulatorLua(lua_State *L)
   REGISTER_LUA_CALL(oms3_setTempDirectory);
   REGISTER_LUA_CALL(oms3_setTLMPositionAndOrientation);
   REGISTER_LUA_CALL(oms3_setTLMSocketData);
+  REGISTER_LUA_CALL(oms3_setTLMInitialValues);
   REGISTER_LUA_CALL(oms3_setWorkingDirectory);
   REGISTER_LUA_CALL(oms3_simulate);
   REGISTER_LUA_CALL(oms3_terminate);


### PR DESCRIPTION
### Purpose

Re-implement initial TLM values from oms2.

### Approach

- `oms3_setTLMInitialValues`
- `SystemTLM::setInitialValues`
- `SystemTLM::updateInitialValues`

### Type of Change

- New feature (non-breaking change which adds functionality)

### Checklist

- I have performed a self-review of my own code