### PR TITLE
Implement SystemTLM::writeToSockets/readToSockets

### DIFF
--- a/src/OMSimulatorLib/System.cpp
+++ b/src/OMSimulatorLib/System.cpp
@@ -181,6 +181,15 @@ oms3::Component* oms3::System::getComponent(const oms3::ComRef& cref)
   return it->second;
 }
 
+oms3::System *oms3::System::getSubSystem(const oms3::ComRef &cref)
+{
+  auto it = subsystems.find(cref);
+  if (it == subsystems.end())
+    return NULL;
+
+  return it->second;
+}
+
 bool oms3::System::validCref(const oms3::ComRef& cref)
 {
   if (!cref.isValidIdent())
@@ -872,7 +881,7 @@ oms_status_enu_t oms3::System::addTLMBus(const oms3::ComRef& cref, const std::st
   if (!cref.isValidIdent())
     return logError("Not a valid ident: " + std::string(cref));
 
-  oms3::TLMBusConnector* bus = new oms3::TLMBusConnector(cref, domain, dimensions, interpolation);
+  oms3::TLMBusConnector* bus = new oms3::TLMBusConnector(cref, domain, dimensions, interpolation, this);
   tlmbusconnectors.back() = bus;
   tlmbusconnectors.push_back(NULL);
   element.setTLMBusConnectors(&tlmbusconnectors[0]);

--- a/src/OMSimulatorLib/System.h
+++ b/src/OMSimulatorLib/System.h
@@ -59,6 +59,7 @@ namespace oms3
     static System* NewSystem(const ComRef& cref, oms_system_enu_t type, Model* parentModel, System* parentSystem);
     System* getSystem(const ComRef& cref);
     Component* getComponent(const ComRef& cref);
+    System* getSubSystem(const ComRef& cref);
     const ComRef& getCref() const {return cref;}
     ComRef getFullCref() const;
     Element* getElement() {return &element;}

--- a/src/OMSimulatorLib/SystemTLM.cpp
+++ b/src/OMSimulatorLib/SystemTLM.cpp
@@ -385,3 +385,199 @@ oms_status_enu_t oms3::SystemTLM::updateInitialValues(const oms3::ComRef cref)
 
   return oms_status_ok;
 }
+
+void oms3::SystemTLM::writeToSockets(SystemWC *system, double time, Component* component)
+{
+  TLMPlugin *plugin = plugins.find(system)->second;
+  TLMBusConnector** tlmbuses = system->getTLMBusConnectors();
+  for(int i=0; tlmbuses[i]; ++i)
+  {
+    TLMBusConnector* bus = tlmbuses[i];
+
+    if(component && component != bus->getComponent()) {
+      continue; //Ignore FMUs not specified in vector
+    }
+
+    if(bus->getDimensions() == 1 && bus->getCausality() == oms_causality_output) {
+      oms_tlm_sigrefs_signal_t tlmrefs;
+      double value;
+      system->getReal(bus->getConnector(tlmrefs.y), value);
+      plugin->SetValueSignal(bus->getId(), time, value);
+    }
+    else if(bus->getDimensions() == 1 && bus->getCausality() == oms_causality_bidir) {
+      oms_tlm_sigrefs_1d_t tlmrefs;
+      double state, flow, force;
+      system->getReal(bus->getConnector(tlmrefs.x), state);
+      system->getReal(bus->getConnector(tlmrefs.v), flow);
+
+      //Important: OMTLMSimulator assumes that GetForce is called
+      //before SetMotion, in order to calculate the wave variable
+      plugin->GetForce1D(bus->getId(), time, flow, &force);
+
+      //Send the resulting motion back to master
+      plugin->SetMotion1D(bus->getId(), time, state, flow);
+    }
+    else if(bus->getDimensions() == 3 && bus->getCausality() == oms_causality_bidir) {
+
+      oms_tlm_sigrefs_3d_t tlmrefs;
+
+      std::vector<double> x(3,0);
+      std::vector<double> A(9,0);
+      std::vector<double> v(3,0);
+      std::vector<double> w(3,0);
+      std::vector<double> f(6,0);
+
+      system->getReals(bus->getConnectors(tlmrefs.x), x);
+      system->getReals(bus->getConnectors(tlmrefs.A), A);
+      system->getReals(bus->getConnectors(tlmrefs.v), v);
+      system->getReals(bus->getConnectors(tlmrefs.w), w);
+
+      //Important: OMTLMSimulator assumes that GetForce is called
+      //before SetMotion, in order to calculate the wave variable
+      plugin->GetForce3D(bus->getId(), time, &x[0], &A[0], &v[0], &w[0], &f[0]);
+
+      //Send the resulting motion back to master
+      plugin->SetMotion3D(bus->getId(), time, &x[0], &A[0], &v[0], &w[0]);
+    }
+  }
+}
+
+void oms3::SystemTLM::readFromSockets(SystemWC* system, double time, Component* component)
+{
+  TLMPlugin *plugin = plugins.find(system)->second;
+  TLMBusConnector** tlmbuses = system->getTLMBusConnectors();
+  for(int i=0; tlmbuses[i]; ++i)
+  {
+    TLMBusConnector* bus = tlmbuses[i];
+
+    if(component && component != bus->getComponent()) {
+      continue; //Ignore FMUs not specified in vector
+    }
+
+    if(bus->getDimensions() == 1 && bus->getCausality() == oms_causality_input) {
+      oms_tlm_sigrefs_signal_t tlmrefs;
+
+      double value;
+      plugin->GetValueSignal(bus->getId(), time, &value);
+      system->setReal(bus->getConnector(tlmrefs.y), value);
+    }
+    else if(bus->getDimensions() == 1 && bus->getCausality() == oms_causality_bidir &&
+            bus->getInterpolation() == oms_tlm_no_interpolation) {
+      oms_tlm_sigrefs_1d_t tlmrefs;
+
+      double flow,effort;
+
+      //Read position and speed from FMU
+      system->getReal(bus->getConnector(tlmrefs.v), flow);
+
+      //Get interpolated force
+      plugin->GetForce1D(bus->getId(), time, flow, &effort);
+
+      if(bus->getDomain() != "hydraulic") {
+          effort = -effort;
+      }
+
+      //Write force to FMU
+      system->setReal(bus->getConnector(tlmrefs.f), effort);
+    }
+    else if(bus->getDimensions() == 1 && bus->getCausality() == oms_causality_bidir &&
+            bus->getInterpolation() == oms_tlm_coarse_grained) {
+      oms_tlm_sigrefs_1d_cg_t tlmrefs;
+
+      double impedance, wave;
+      plugin->GetWaveImpedance1D(bus->getId(), time, &impedance, &wave);
+      system->setReal(bus->getConnector(tlmrefs.c), wave);
+      system->setReal(bus->getConnector(tlmrefs.Z), impedance);
+
+      double impedance2, wave2;
+      plugin->GetWaveImpedance1D(bus->getId(), time+system->getStepSize(), &impedance2, &wave2);
+
+      double dWave = (wave2-wave)/system->getStepSize();
+
+      system->setRealInputDerivatives(bus->getConnector(tlmrefs.c), 1, dWave);
+    }
+    else if(bus->getDimensions() == 1 && bus->getCausality() == oms_causality_bidir &&
+            bus->getInterpolation() == oms_tlm_fine_grained) {
+      oms_tlm_sigrefs_1d_fg_t tlmrefs;
+
+      double wave;
+      double impedance;
+
+      double t = time;
+      for(size_t i=0; i<10; ++i) {
+        plugin->GetWaveImpedance1D(bus->getId(), t, &impedance, &wave);
+        t += system->getStepSize()/9;
+
+        system->setReal(bus->getConnector(tlmrefs.c[i]), wave);
+        system->setReal(bus->getConnector(tlmrefs.t[i]), t);
+      }
+
+      system->setReal(bus->getConnector(tlmrefs.Z), impedance);
+    }
+    else if(bus->getDimensions() == 3 && bus->getCausality() == oms_causality_bidir &&
+            bus->getInterpolation() == oms_tlm_no_interpolation) {
+
+      oms_tlm_sigrefs_3d_t tlmrefs;
+
+      std::vector<double> x(3,0); //Dummy, GetForce3D needs it but does not use it
+      std::vector<double> A(9,0); //Dummy
+      std::vector<double> v(3,0);
+      std::vector<double> w(3,0);
+      std::vector<double> f(6,0);
+
+      //Read position and speed from FMU
+      system->getReals(bus->getConnectors(tlmrefs.v), v);
+      system->getReals(bus->getConnectors(tlmrefs.w), w);
+
+      //Get interpolated force
+      plugin->GetForce3D(bus->getId(), time,&x[0], &A[0], &v[0], &w[0], &f[0]);
+
+      for(size_t i=0; i<6; ++i) {
+        f[i] = -f[i];
+      }
+
+      //Write force to FMU
+      system->setReals(bus->getConnectors(tlmrefs.f), f);
+    }
+    else if(bus->getDimensions() == 3 && bus->getCausality() == oms_causality_bidir &&
+            bus->getInterpolation() == oms_tlm_coarse_grained) {
+      oms_tlm_sigrefs_3d_cg_t tlmrefs;
+      std::vector<double> waves(6,0);
+      double Zt, Zr;
+      plugin->GetWaveImpedance3D(bus->getId(), time, &Zt, &Zr, &waves[0]);
+      system->setReals(bus->getConnectors(tlmrefs.c), waves);
+      system->setReal(bus->getConnector(tlmrefs.Zt), Zt);
+      system->setReal(bus->getConnector(tlmrefs.Zr), Zr);
+
+      std::vector<double> waves2(6,0);
+      double Zt2, Zr2;
+      plugin->GetWaveImpedance3D(bus->getId(), time+system->getStepSize(), &Zt2, &Zr2, &waves2[0]);
+
+      std::vector<double> dWaves(6,0);
+      for(size_t i=0; i<6; ++i) {
+        double dWave = (waves2[i]-waves[i])/system->getStepSize();
+        system->setRealInputDerivatives(bus->getConnector(tlmrefs.c[i]), 1, dWave);
+      }
+    }
+    else if(bus->getDimensions() == 3 && bus->getCausality() == oms_causality_bidir &&
+            bus->getInterpolation() == oms_tlm_fine_grained) {
+      oms_tlm_sigrefs_3d_fg_t tlmrefs;
+
+      std::vector<double> waves(6,0);
+      double Zt,Zr;
+
+      double t = time;
+
+      for(size_t i=0; i<10; ++i) {
+        plugin->GetWaveImpedance3D(bus->getId(), t, &Zt, &Zr, &waves[0]);
+        t += system->getStepSize()/9;
+
+        system->setReals(bus->getConnectors(tlmrefs.c[i]), waves);
+        system->setReal(bus->getConnector(tlmrefs.t[i]), t);
+      }
+
+      system->setReal(bus->getConnector(tlmrefs.Zt), Zt);
+      system->setReal(bus->getConnector(tlmrefs.Zr), Zr);
+    }
+  }
+}

--- a/src/OMSimulatorLib/SystemTLM.h
+++ b/src/OMSimulatorLib/SystemTLM.h
@@ -40,6 +40,7 @@
 namespace oms3
 {
   class Model;
+  class SystemWC;
 
   class SystemTLM : public System
   {
@@ -61,6 +62,9 @@ namespace oms3
     void disconnectFromSockets(const oms3::ComRef cref);
     oms_status_enu_t setInitialValues(ComRef cref, std::vector<double> values);
     oms_status_enu_t updateInitialValues(const oms3::ComRef cref);
+
+    void writeToSockets(oms3::SystemWC *system, double time, Component *component);
+    void readFromSockets(SystemWC *system, double time, Component *component);
 
   protected:
     SystemTLM(const ComRef& cref, Model* parentModel, System* parentSystem);

--- a/src/OMSimulatorLib/SystemWC.cpp
+++ b/src/OMSimulatorLib/SystemWC.cpp
@@ -193,8 +193,12 @@ oms_status_enu_t oms3::SystemWC::setReals(const std::vector<oms3::ComRef> &crefs
   return logError_NotImplemented;
 }
 
-//Placeholder function
 oms_status_enu_t oms3::SystemWC::getReals(const std::vector<oms3::ComRef> &sr, std::vector<double> &values)
+{
+  return logError_NotImplemented;
+}
+
+oms_status_enu_t oms3::SystemWC::setRealInputDerivatives(const oms3::ComRef &cref, int order, double value)
 {
   return logError_NotImplemented;
 }

--- a/src/OMSimulatorLib/SystemWC.h
+++ b/src/OMSimulatorLib/SystemWC.h
@@ -65,6 +65,7 @@ namespace oms3
     oms_status_enu_t getReal(const ComRef& cref, double& value);
     oms_status_enu_t setReals(const std::vector<ComRef> &crefs, std::vector<double> values);
     oms_status_enu_t getReals(const std::vector<ComRef> &crefs, std::vector<double> &values);
+    oms_status_enu_t setRealInputDerivatives(const ComRef &cref, int order, double value);
 
   protected:
     SystemWC(const ComRef& cref, Model* parentModel, System* parentSystem);

--- a/src/OMSimulatorLib/TLMBusConnector.h
+++ b/src/OMSimulatorLib/TLMBusConnector.h
@@ -17,6 +17,9 @@
 
 namespace oms3
 {
+class Component;
+class System;
+
 typedef struct  {
     int y = 0;
 } oms_tlm_sigrefs_signal_t;
@@ -94,7 +97,7 @@ typedef struct  {
   class TLMBusConnector : protected oms3_tlmbusconnector_t
   {
   public:
-    TLMBusConnector(const oms3::ComRef& name, const std::string domain, const int dimensions, const oms_tlm_interpolation_t interpolation);
+    TLMBusConnector(const oms3::ComRef& name, const std::string domain, const int dimensions, const oms_tlm_interpolation_t interpolation, System* parentSystem=nullptr);
     ~TLMBusConnector();
 
     oms_status_enu_t exportToSSD(pugi::xml_node& root) const;
@@ -122,13 +125,18 @@ typedef struct  {
     oms_status_enu_t registerToSockets(TLMPlugin *plugin);
     int getId() const {return id;}
 
+    oms3::Component* getComponent();
+
   private:
     void updateVariableTypes();
+    oms3::Component *getComponent(const ComRef &conA, System *system) const;
 
     oms_causality_enu_t causality;
     std::map<std::string, oms3::ComRef> connectors;
     std::vector<oms3::ComRef> sortedConnectors;
     std::vector<std::string> variableTypes; //Used to keep track of TLM variable types
+    System* parentSystem;
+    Component* component;
 
     int id;
   };


### PR DESCRIPTION
### Purpose

It must be possible to read to/from TLM sockets in SystemTLM.

### Approach

Main functions:
- `SystemTLM::writeToSockets`
- `SystemTLM::readFromSockets`

Support functions:
- `System::getSubSystem`
- `TLMBusConnector::getComponent`

Not yet implemented support functions:
- `SystemWC::setRealInputDerivatives`

### Type of Change

- New feature (non-breaking change which adds functionality)

### Checklist

- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas