### PR TITLE
Fix addConnection for bus connections

### DIFF
--- a/src/OMSimulatorLib/Logging.h
+++ b/src/OMSimulatorLib/Logging.h
@@ -104,6 +104,7 @@ private:
 // Common error messages
 #define logError_ComponentNotInSystem(system, component)     logError("System \"" + std::string(system->getFullCref()) + "\" does not contain component \"" + std::string(component) + "\"")
 #define logError_ConnectionNotInSystem(crefA, crefB, system) logError("Connection <\"" + std::string(crefA) + "\", \"" + std::string(crefB) + "\"> not found in system \"" + std::string(system->getFullCref()) + "\"")
+#define logError_ConnectionExistsAlready(crefA, crefB, system) logError("Connection <\"" + std::string(crefA) + "\", \"" + std::string(crefB) + "\"> exists already in system \"" + std::string(system->getFullCref()) + "\"")
 #define logError_ConnectorNotInSystem(cref, system)          logError("Connector \"" + std::string(cref) + "\" not found in system \"" + std::string(system->getFullCref()) + "\"")
 #define logError_Initialization(system)                      logError("Initialization of system \"" + std::string(system) + "\" failed")
 #define logError_ModelInWrongState(cref)                     logError("Model \"" + std::string(cref) + "\" is in wrong model state")


### PR DESCRIPTION
### Purpose

* Remove unneccessary restrictions to bus connections
* Test if connection exists already, before adding a new connection
* Fix getConnection by making it commutative.

### Type of Change

<!--- Please delete options that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)

### Checklist

<!--- Please delete options that are not relevant. -->

- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas