### PR TITLE
Added TLMBusConnector connectors to C API

### DIFF
--- a/src/OMSimulatorLib/TLMBusConnector.h
+++ b/src/OMSimulatorLib/TLMBusConnector.h
@@ -121,6 +121,7 @@ typedef struct  {
     const oms2::ssd::ConnectorGeometry* getGeometry() const {return reinterpret_cast<oms2::ssd::ConnectorGeometry*>(geometry);}
 
     oms_status_enu_t addConnector(const oms3::ComRef& cref, std::string vartype);
+    void updateConnectors();
     void sortConnectors();
     oms_status_enu_t registerToSockets(TLMPlugin *plugin);
     int getId() const {return id;}

--- a/src/OMSimulatorLib/Types.h
+++ b/src/OMSimulatorLib/Types.h
@@ -392,6 +392,8 @@ typedef struct {
   int dimensions;
   double delay;
   oms_tlm_interpolation_t interpolation;
+  char** connectornames;
+  char** connectortypes;
 } oms3_tlmbusconnector_t;
 
 /**


### PR DESCRIPTION
### Purpose

Make sub-connectors to TLM bus connectors available in the C API.

### Approach

Added two arrays of char*, one for name and one for TLM variable type. They are synchronized with the C++ map whenever adding new connectors.

### Type of Change

- New feature (non-breaking change which adds functionality)

### Checklist

- I have performed a self-review of my own code