### PR TITLE
Added `oms3_deleteConnectorFromTLMBus`

### DIFF
--- a/src/OMSimulatorLib/Logging.h
+++ b/src/OMSimulatorLib/Logging.h
@@ -120,4 +120,6 @@ private:
 #define logError_Termination(system)                         logError("Termination of system \"" + std::string(system) + "\" failed")
 #define logError_WrongSchema(name)                           logError("Wrong xml schema detected. Unexpected tag \"" + name + "\"")
 #define logError_InvalidIdent(cref)                          logError("\"" + std::string(cref) + "\" is not a valid ident")
+#define logError_BusAndConnectorNotSameModel                 logError("Bus and connector must belong to same model")
+#define logError_BusAndConnectorNotSameSystem                logError("Bus and connector must belong to same system")
 #endif

--- a/src/OMSimulatorLib/OMSimulator.cpp
+++ b/src/OMSimulatorLib/OMSimulator.cpp
@@ -493,9 +493,9 @@ oms_status_enu_t oms3_addConnectorToBus(const char *busCref, const char *connect
   oms3::ComRef systemCref = busTail.pop_front();
   oms3::ComRef connectorTail(connectorCref);
   if (modelCref != connectorTail.pop_front())
-    return logError("Bus and connector must belong to same model");
+    return logError_BusAndConnectorNotSameModel;
   if (systemCref != connectorTail.pop_front())
-    return logError("Bus and connector must belong to same system");
+    return logError_BusAndConnectorNotSameSystem;
   oms3::Model* model = oms3::Scope::GetInstance().getModel(modelCref);
   if (!model) {
     return logError_ModelNotInScope(modelCref);
@@ -515,9 +515,9 @@ oms_status_enu_t oms3_deleteConnectorFromBus(const char *busCref, const char *co
   oms3::ComRef systemCref = busTail.pop_front();
   oms3::ComRef connectorTail(connectorCref);
   if (modelCref != connectorTail.pop_front())
-    return logError("Bus and connector must belong to same model");
+    return logError_BusAndConnectorNotSameModel;
   if (systemCref != connectorTail.pop_front())
-    return logError("Bus and connector must belong to same system");
+    return logError_BusAndConnectorNotSameSystem;
   oms3::Model* model = oms3::Scope::GetInstance().getModel(modelCref);
   if (!model) {
     return logError_ModelNotInScope(modelCref);
@@ -536,9 +536,9 @@ oms_status_enu_t oms3_addConnectorToTLMBus(const char *busCref, const char *conn
   oms3::ComRef systemCref = busTail.pop_front();
   oms3::ComRef connectorTail(connectorCref);
   if (modelCref != connectorTail.pop_front())
-    return logError("Bus and connector must belong to same model");
+    return logError_BusAndConnectorNotSameModel;
   if (systemCref != connectorTail.pop_front())
-    return logError("Bus and connector must belong to same system");
+    return logError_BusAndConnectorNotSameSystem;
   oms3::Model* model = oms3::Scope::GetInstance().getModel(modelCref);
   if (!model) {
     return logError_ModelNotInScope(modelCref);
@@ -548,6 +548,28 @@ oms_status_enu_t oms3_addConnectorToTLMBus(const char *busCref, const char *conn
     return logError_SystemNotInModel(modelCref, systemCref);
   }
   return system->addConnectorToTLMBus(busTail, connectorTail, type);
+}
+
+oms_status_enu_t oms3_deleteConnectorFromTLMBus(const char *busCref, const char *connectorCref)
+{
+  logTrace();
+  oms3::ComRef busTail(busCref);
+  oms3::ComRef modelCref = busTail.pop_front();
+  oms3::ComRef systemCref = busTail.pop_front();
+  oms3::ComRef connectorTail(connectorCref);
+  if (modelCref != connectorTail.pop_front())
+    return logError_BusAndConnectorNotSameModel;
+  if (systemCref != connectorTail.pop_front())
+    return logError_BusAndConnectorNotSameSystem;
+  oms3::Model* model = oms3::Scope::GetInstance().getModel(modelCref);
+  if (!model) {
+    return logError_ModelNotInScope(modelCref);
+  }
+  oms3::System* system = model->getSystem(systemCref);
+  if (!system) {
+    return logError_SystemNotInModel(modelCref, systemCref);
+  }
+  return system->deleteConnectorFromTLMBus(busTail, connectorTail);
 }
 
 oms_status_enu_t oms3_setTLMBusGeometry(const char* cref, const ssd_connector_geometry_t* geometry)

--- a/src/OMSimulatorLib/OMSimulator.h
+++ b/src/OMSimulatorLib/OMSimulator.h
@@ -83,6 +83,7 @@ oms_status_enu_t oms3_setBusGeometry(const char* bus, const ssd_connector_geomet
 oms_status_enu_t oms3_addTLMBus(const char* cref, const char* domain, const int dimensions, const oms_tlm_interpolation_t interpolation);
 oms_status_enu_t oms3_getTLMBus(const char* cref, oms3_tlmbusconnector_t** tlmBusConnector);
 oms_status_enu_t oms3_addConnectorToTLMBus(const char* busCref, const char* connectorCref, const char *type);
+oms_status_enu_t oms3_deleteConnectorFromTLMBus(const char* busCref, const char* connectorCref);
 oms_status_enu_t oms3_setTLMBusGeometry(const char* bus, const ssd_connector_geometry_t* geometry);
 oms_status_enu_t oms3_addTLMConnection(const char* crefA, const char* crefB, double delay, double alpha, double linearimpedance, double angularimpedance);
 oms_status_enu_t oms3_addExternalModel(const char* cref, const char* path, const char* startscript);

--- a/src/OMSimulatorLib/System.cpp
+++ b/src/OMSimulatorLib/System.cpp
@@ -929,7 +929,7 @@ oms_status_enu_t oms3::System::addConnectorToBus(const oms3::ComRef& busCref, co
   }
 
   if (!busTail.isEmpty() && !connectorTail.isEmpty() && busHead != connectorHead)
-    return logError("Connector and bus must belong to the same system");
+    return logError_BusAndConnectorNotSameSystem;
   if (type == oms_system_tlm)
     return logError_NotForTlmSystem;
 
@@ -955,14 +955,14 @@ oms_status_enu_t oms3::System::deleteConnectorFromBus(const oms3::ComRef& busCre
   }
 
   if(!busTail.isEmpty() && !connectorTail.isEmpty() && busHead != connectorHead)
-    return logError("Connector and bus must belong to the same system");
+    return logError_BusAndConnectorNotSameSystem;
   if(type == oms_system_tlm)
     return logError_NotForTlmSystem;
 
   for(auto& bus : busconnectors)
     if(bus && bus->getName() == busCref)
       if (oms_status_ok != bus->deleteConnector(connectorCref))
-        return logError("Connector not found: "+std::string(connectorCref));
+        return logError_ConnectorNotInSystem(connectorCref, this);
 
   return oms_status_ok;
 }
@@ -990,7 +990,7 @@ oms_status_enu_t oms3::System::addConnectorToTLMBus(const oms3::ComRef& busCref,
     if (connector && connector->getName() == connectorCref)
       found = true;
   if (!found)
-    return logError("Connector not found in system: " + std::string(connectorCref));
+    return logError_ConnectorNotInSystem(connectorCref, this);
 
   for(auto& bus : tlmbusconnectors)
   {
@@ -1001,6 +1001,33 @@ oms_status_enu_t oms3::System::addConnectorToTLMBus(const oms3::ComRef& busCref,
         return status;
     }
   }
+  return oms_status_ok;
+}
+
+oms_status_enu_t oms3::System::deleteConnectorFromTLMBus(const oms3::ComRef& busCref, const oms3::ComRef& connectorCref)
+{
+  oms3::ComRef busTail(busCref);
+  oms3::ComRef busHead = busTail.pop_front();
+  oms3::ComRef connectorTail(connectorCref);
+  oms3::ComRef connectorHead = connectorTail.pop_front();
+  //If both bus and connector references the same subsystem, recurse into that subsystem
+  if(busHead == connectorHead)
+  {
+    auto subsystem = subsystems.find(busHead);
+    if(subsystem != subsystems.end())
+      return subsystem->second->deleteConnectorFromTLMBus(busTail,connectorTail);
+  }
+
+  if(!busTail.isEmpty() && !connectorTail.isEmpty() && busHead != connectorHead)
+    return logError_BusAndConnectorNotSameSystem;
+  if(type == oms_system_tlm)
+    return logError_NotForTlmSystem;
+
+  for(auto& bus : tlmbusconnectors)
+    if(bus && bus->getName() == busCref)
+      if (oms_status_ok != bus->deleteConnector(connectorCref))
+        return logError_ConnectorNotInSystem(connectorCref, this);
+
   return oms_status_ok;
 }
 

--- a/src/OMSimulatorLib/System.h
+++ b/src/OMSimulatorLib/System.h
@@ -92,6 +92,7 @@ namespace oms3
     oms_status_enu_t addConnectorToBus(const ComRef& busCref, const ComRef& connectorCref);
     oms_status_enu_t deleteConnectorFromBus(const ComRef& busCref, const ComRef& connectorCref);
     oms_status_enu_t addConnectorToTLMBus(const ComRef& busCref, const ComRef& connectorCref, const std::string type);
+    oms_status_enu_t deleteConnectorFromTLMBus(const ComRef& busCref, const ComRef& connectorCref);
     oms_status_enu_t setBusGeometry(const ComRef& cref, const oms2::ssd::ConnectorGeometry* geometry);
     oms_status_enu_t setTLMBusGeometry(const ComRef& cref, const oms2::ssd::ConnectorGeometry* geometry);
     oms_status_enu_t addExternalModel(const ComRef &cref, std::string path, std::string startscript);

--- a/src/OMSimulatorLib/TLMBusConnector.cpp
+++ b/src/OMSimulatorLib/TLMBusConnector.cpp
@@ -165,6 +165,19 @@ oms_status_enu_t oms3::TLMBusConnector::addConnector(const oms3::ComRef &cref, s
   return oms_status_ok;
 }
 
+oms_status_enu_t oms3::TLMBusConnector::deleteConnector(const oms3::ComRef &cref)
+{
+  for (auto it = connectors.begin(); it != connectors.end(); ++it) {
+    if ((*it).second == cref) {
+      connectors.erase(it);
+      updateConnectors();
+      sortConnectors();
+      return oms_status_ok;
+    }
+  }
+  return oms_status_error;
+}
+
 void oms3::TLMBusConnector::sortConnectors()
 {
   if(variableTypes.size() == connectors.size()) {

--- a/src/OMSimulatorLib/TLMBusConnector.h
+++ b/src/OMSimulatorLib/TLMBusConnector.h
@@ -121,6 +121,7 @@ typedef struct  {
     const oms2::ssd::ConnectorGeometry* getGeometry() const {return reinterpret_cast<oms2::ssd::ConnectorGeometry*>(geometry);}
 
     oms_status_enu_t addConnector(const oms3::ComRef& cref, std::string vartype);
+    oms_status_enu_t deleteConnector(const oms3::ComRef& cref);
     void updateConnectors();
     void sortConnectors();
     oms_status_enu_t registerToSockets(TLMPlugin *plugin);

--- a/src/OMSimulatorLua/OMSimulatorLua.c
+++ b/src/OMSimulatorLua/OMSimulatorLua.c
@@ -460,6 +460,23 @@ static int OMSimulatorLua_oms3_addConnectorToBus(lua_State *L)
   return 1;
 }
 
+//oms_status_enu_t oms3_deleteConnectorFromBus(const char *busCref, const char *connectorCref)
+static int OMSimulatorLua_oms3_deleteConnectorFromBus(lua_State *L)
+{
+  if (lua_gettop(L) != 2)
+    return luaL_error(L, "expecting exactly 2 arguments");
+  luaL_checktype(L, 1, LUA_TSTRING);
+  luaL_checktype(L, 2, LUA_TSTRING);
+
+  const char* busCref = lua_tostring(L, 1);
+  const char* connectorCref = lua_tostring(L, 2);
+  oms_status_enu_t status = oms3_deleteConnectorFromBus(busCref,connectorCref);
+
+  lua_pushinteger(L, status);
+
+  return 1;
+}
+
 //oms_status_enu_t oms3_addConnectorToTLMBus(const char* busCref, const char* connectorCref, const char* type);
 static int OMSimulatorLua_oms3_addConnectorToTLMBus(lua_State *L)
 {
@@ -473,6 +490,23 @@ static int OMSimulatorLua_oms3_addConnectorToTLMBus(lua_State *L)
   const char* connectorCref = lua_tostring(L, 2);
   const char* type = lua_tostring(L, 3);
   oms_status_enu_t status = oms3_addConnectorToTLMBus(busCref,connectorCref,type);
+
+  lua_pushinteger(L, status);
+
+  return 1;
+}
+
+//oms_status_enu_t oms3_deleteConnectorFromTLMBus(const char *busCref, const char *connectorCref)
+static int OMSimulatorLua_oms3_deleteConnectorFromTLMBus(lua_State *L)
+{
+  if (lua_gettop(L) != 2)
+    return luaL_error(L, "expecting exactly 2 arguments");
+  luaL_checktype(L, 1, LUA_TSTRING);
+  luaL_checktype(L, 2, LUA_TSTRING);
+
+  const char* busCref = lua_tostring(L, 1);
+  const char* connectorCref = lua_tostring(L, 2);
+  oms_status_enu_t status = oms3_deleteConnectorFromTLMBus(busCref,connectorCref);
 
   lua_pushinteger(L, status);
 
@@ -2303,7 +2337,9 @@ DLLEXPORT int luaopen_OMSimulatorLua(lua_State *L)
   REGISTER_LUA_CALL(oms3_addConnection);
   REGISTER_LUA_CALL(oms3_addConnector);
   REGISTER_LUA_CALL(oms3_addConnectorToBus);
+  REGISTER_LUA_CALL(oms3_deleteConnectorFromBus);
   REGISTER_LUA_CALL(oms3_addConnectorToTLMBus);
+  REGISTER_LUA_CALL(oms3_deleteConnectorFromTLMBus);
   REGISTER_LUA_CALL(oms3_addExternalModel);
   REGISTER_LUA_CALL(oms3_addSignalsToResults);
   REGISTER_LUA_CALL(oms3_addSubModel);


### PR DESCRIPTION
### Purpose

API to delete a connector from TLM bus
Lua bindings for `oms3_deleteConnectorFromBus` and `oms3_deleteConnectorFromTLMBus`
Improved some error messages

### Type of Change

- Code refactoring (non-breaking change which improves maintainability)
- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

### Checklist

- I have performed a self-review of my own code
- I have added tests that prove my fix is effective or that my feature works