### PR TITLE
Make OMSimulator support integer connections

### DIFF
--- a/src/OMSimulatorLib/FMICompositeModel.cpp
+++ b/src/OMSimulatorLib/FMICompositeModel.cpp
@@ -1591,6 +1591,26 @@ void oms2::FMICompositeModel::finalizeTLMSockets()
 }
 #endif //!defined(NO_TLM)
 
+oms_status_enu_t oms2::FMICompositeModel::setInteger(const oms2::SignalRef& sr, int value)
+{
+  oms2::FMISubModel* model = getSubModel(sr.getCref());
+  if (!model)
+    return oms_status_error;
+
+  return model->setInteger(sr, value);
+}
+
+oms_status_enu_t oms2::FMICompositeModel::getInteger(const oms2::SignalRef& sr, int& value)
+{
+  oms2::FMISubModel* model = getSubModel(sr.getCref());
+  if (!model)
+    return oms_status_error;
+
+  oms_status_enu_t status = model->getInteger(sr, value);
+  return status;
+}
+
+
 oms_status_enu_t oms2::FMICompositeModel::setReal(const oms2::SignalRef& sr, double value)
 {
   oms2::FMISubModel* model = getSubModel(sr.getCref());
@@ -1705,10 +1725,18 @@ oms_status_enu_t oms2::FMICompositeModel::updateInputs(oms2::DirectedGraph& grap
       int output = sortedConnections[i][0].first;
       int input = sortedConnections[i][0].second;
 
-      double value = 0.0;
-      getReal(graph.nodes[output].getSignalRef(), value);
-      setReal(graph.nodes[input].getSignalRef(), value);
-      //std::cout << "[time " << time << "] " << graph.nodes[output].getSignalRef().toString() << " -> " << graph.nodes[input].getSignalRef().toString() << " (value: " << value << ")" << std::endl;
+      if (graph.nodes[output].isTypeReal()) {
+         double value = 0.0;
+         getReal(graph.nodes[output].getSignalRef(), value);
+         setReal(graph.nodes[input].getSignalRef(), value);
+        //std::cout << "[time " << time << "] " << graph.nodes[output].getSignalRef().toString() << " -> " << graph.nodes[input].getSignalRef().toString() << " (value: " << value << ")" << std::endl;
+      } else //if (graph.nodes[output].isTypeInteger()) 
+      {
+        int value=0;
+        getInteger(graph.nodes[output].getSignalRef(), value);
+        setInteger(graph.nodes[input].getSignalRef(), value);
+      }
+
     }
     else
     {

--- a/src/OMSimulatorLib/FMICompositeModel.h
+++ b/src/OMSimulatorLib/FMICompositeModel.h
@@ -97,6 +97,9 @@ namespace oms2
 #endif
     void simulate_asynchronous(ResultWriter& resultWriter, double stopTime, double communicationInterval, double loggingInterval, void (*cb)(const char* ident, double time, oms_status_enu_t status));
 
+    oms_status_enu_t setInteger(const oms2::SignalRef& sr, int value);
+    oms_status_enu_t getInteger(const oms2::SignalRef& sr, int& value);
+
     oms_status_enu_t setReal(const oms2::SignalRef& sr, double value);
     oms_status_enu_t setReals(const std::vector<oms2::SignalRef> &sr, std::vector<double> values);
     oms_status_enu_t getReal(const oms2::SignalRef& sr, double& value);


### PR DESCRIPTION
### Related Issues

#415 (partial fix)

### Purpose

Support integer signal connections between FMUs.

### Approach

Before updating signal values, the type is checked and the appropriate get/set functions are called.

### Type of Change

<!--- Please delete options that are not relevant. -->

- New feature (non-breaking change which adds functionality)

### Checklist

<!--- Please delete options that are not relevant. -->

- I have performed a self-review of my own code
