### PR TITLE
Fix oms3_terminate

### DIFF
--- a/src/OMSimulatorLib/ComponentFMUCS.cpp
+++ b/src/OMSimulatorLib/ComponentFMUCS.cpp
@@ -429,11 +429,14 @@ oms_status_enu_t oms3::ComponentFMUCS::terminate()
   fmi2_status_t fmistatus = fmi2_import_terminate(fmu);
   if (fmi2_status_ok != fmistatus)
     return logError_Termination(getCref());
+
+  fmi2_import_free_instance(fmu);
+  fmi2_import_destroy_dllfmu(fmu);
   return oms_status_ok;
 }
 
 oms_status_enu_t oms3::ComponentFMUCS::stepUntil(double stopTime)
-{  
+{
   System *topLevelSystem = getModel()->getTopLevelSystem();
 
   fmi2_status_t fmistatus;


### PR DESCRIPTION
### Related Issues

Reported by @adeas31 

### Purpose

Fix warnings of the kind `warning: module FMILIB: FMU binary is already loaded` after calling `oms3_terminate` and then again `oms3_instantiate`.

### Approach

Unload FMU binary properly when calling `oms3_terminate`.

### Type of Change

<!--- Please delete options that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)