### PR TITLE
TLMBusConnectors in Component class

### DIFF
--- a/src/OMSimulatorLib/Component.h
+++ b/src/OMSimulatorLib/Component.h
@@ -69,6 +69,12 @@ namespace oms3
     Model* getModel() const;
     void setGeometry(const ssd::ElementGeometry& geometry) {element.setGeometry(&geometry);}
 
+    oms_status_enu_t addTLMBus(const oms3::ComRef& cref, const std::string domain, const int dimensions, const oms_tlm_interpolation_t interpolation);
+    oms3::TLMBusConnector *getTLMBusConnector(const oms3::ComRef &cref);
+    TLMBusConnector **getTLMBusConnectors() {return &tlmbusconnectors[0];}
+    oms_status_enu_t addConnectorToTLMBus(const ComRef& busCref, const ComRef& connectorCref, const std::string type);
+    oms_status_enu_t deleteConnectorFromTLMBus(const ComRef& busCref, const ComRef& connectorCref);
+
     virtual oms_status_enu_t exportToSSD(pugi::xml_node& node) const = 0;
     virtual oms_status_enu_t instantiate() = 0;
     virtual oms_status_enu_t initialize() = 0;
@@ -98,6 +104,7 @@ namespace oms3
     DirectedGraph outputsGraph;
     Element element;
     std::vector<Connector*> connectors;
+    std::vector<TLMBusConnector*> tlmbusconnectors;
 
   private:
     System* parentSystem;

--- a/src/OMSimulatorLib/ComponentFMUCS.cpp
+++ b/src/OMSimulatorLib/ComponentFMUCS.cpp
@@ -292,6 +292,16 @@ oms3::Component* oms3::ComponentFMUCS::NewComponent(const pugi::xml_node& node, 
 
 oms_status_enu_t oms3::ComponentFMUCS::exportToSSD(pugi::xml_node& node) const
 {
+  if (tlmbusconnectors[0])
+  {
+    pugi::xml_node annotations_node = node.append_child(oms2::ssd::ssd_annotations);
+    pugi::xml_node annotation_node = annotations_node.append_child(oms2::ssd::ssd_annotation);
+    annotation_node.append_attribute("type") = oms::annotation_type;
+    for (const auto& tlmbusconnector : tlmbusconnectors)
+      if (tlmbusconnector)
+        tlmbusconnector->exportToSSD(annotation_node);
+  }
+
   node.append_attribute("name") = this->getCref().c_str();
   node.append_attribute("type") = "application/x-fmu-sharedlibrary";
   node.append_attribute("source") = getPath().c_str();

--- a/src/OMSimulatorLib/ComponentFMUME.cpp
+++ b/src/OMSimulatorLib/ComponentFMUME.cpp
@@ -294,6 +294,16 @@ oms3::Component* oms3::ComponentFMUME::NewComponent(const pugi::xml_node& node, 
 
 oms_status_enu_t oms3::ComponentFMUME::exportToSSD(pugi::xml_node& node) const
 {
+  if (tlmbusconnectors[0])
+  {
+    pugi::xml_node annotations_node = node.append_child(oms2::ssd::ssd_annotations);
+    pugi::xml_node annotation_node = annotations_node.append_child(oms2::ssd::ssd_annotation);
+    annotation_node.append_attribute("type") = oms::annotation_type;
+    for (const auto& tlmbusconnector : tlmbusconnectors)
+      if (tlmbusconnector)
+        tlmbusconnector->exportToSSD(annotation_node);
+  }
+
   node.append_attribute("name") = this->getCref().c_str();
   node.append_attribute("type") = "application/x-fmu-sharedlibrary";
   node.append_attribute("source") = getPath().c_str();

--- a/src/OMSimulatorLib/ExternalModel.cpp
+++ b/src/OMSimulatorLib/ExternalModel.cpp
@@ -42,15 +42,10 @@
 oms3::ExternalModel::ExternalModel(const oms3::ComRef& cref, System* parentSystem, const std::string& path, const std::string& startscript)
   : oms3::Component(cref, oms_component_external, parentSystem, path), startscript(startscript)
 {
-  tlmbusconnectors.push_back(NULL);
-  element.setTLMBusConnectors(&tlmbusconnectors[0]);
 }
 
 oms3::ExternalModel::~ExternalModel()
 {
-  for (const auto tlmbusconnector : tlmbusconnectors)
-    if(tlmbusconnector)
-      delete tlmbusconnector;
 }
 
 oms3::ExternalModel* oms3::ExternalModel::NewComponent(const oms3::ComRef& cref, System* parentSystem, const std::string& path, const std::string& startscript)
@@ -63,27 +58,6 @@ oms3::ExternalModel* oms3::ExternalModel::NewComponent(const oms3::ComRef& cref,
 
   oms3::ExternalModel* model = new oms3::ExternalModel(cref, parentSystem, path, startscript);
   return model;
-}
-
-oms_status_enu_t oms3::ExternalModel::addTLMBus(const oms3::ComRef &cref, const std::string domain, const int dimensions, const oms_tlm_interpolation_t interpolation)
-{
-  if(!cref.isValidIdent()) {
-    return logError("Not a valid ident: "+std::string(cref));
-  }
-  oms3::TLMBusConnector* bus = new oms3::TLMBusConnector(cref, domain, dimensions, interpolation);
-  tlmbusconnectors.back() = bus;
-  tlmbusconnectors.push_back(NULL);
-  element.setTLMBusConnectors(&tlmbusconnectors[0]);
-  return oms_status_ok;
-}
-
-oms3::TLMBusConnector *oms3::ExternalModel::getTLMBusConnector(const oms3::ComRef &cref)
-{
-  for(auto &tlmbusconnector : tlmbusconnectors) {
-    if(tlmbusconnector && tlmbusconnector->getName() == cref)
-      return tlmbusconnector;
-  }
-  return NULL;
 }
 
 oms_status_enu_t oms3::ExternalModel::setRealParameter(const std::string &var, double value)

--- a/src/OMSimulatorLib/ExternalModel.h
+++ b/src/OMSimulatorLib/ExternalModel.h
@@ -50,8 +50,6 @@ namespace oms3
     ~ExternalModel();
     static ExternalModel* NewComponent(const oms3::ComRef& cref, System* parentSystem, const std::string& path, const std::string& startscript);
 
-    oms_status_enu_t addTLMBus(const oms3::ComRef& cref, const std::string domain, const int dimensions, const oms_tlm_interpolation_t interpolation);
-    oms3::TLMBusConnector *getTLMBusConnector(const oms3::ComRef &cref);
     oms_status_enu_t setRealParameter(const std::string& var, double value);
     oms_status_enu_t getRealParameter(const std::string& var, double& value);
     const std::string& getStartScript() const {return startscript;}
@@ -77,7 +75,6 @@ namespace oms3
   private:
     std::string startscript;
     std::map<std::string, oms3::Option<double>> realParameters;
-    std::vector<oms3::TLMBusConnector*> tlmbusconnectors;
   };
 }
 

--- a/src/OMSimulatorLib/Logging.h
+++ b/src/OMSimulatorLib/Logging.h
@@ -125,4 +125,11 @@ private:
 #define logError_SystemNotInModel(model, system)             logError("Model \"" + std::string(model) + "\" does not contain system \"" + std::string(system) + "\"")
 #define logError_Termination(system)                         logError("Termination of system \"" + std::string(system) + "\" failed")
 #define logError_WrongSchema(name)                           logError("Wrong xml schema detected. Unexpected tag \"" + name + "\"")
+#define logError_InvalidIdent(cref)                          logError("\"" + std::string(cref) + "\" is not a valid ident")
+#define logError_AlreadyInScope(cref)                        logError("\"" + std::string(cref) + "\" already exists in the scope")
+#define logError_BusAndConnectorNotSameModel                 logError("Bus and connector must belong to same model")
+#define logError_BusAndConnectorNotSameSystem                logError("Bus and connector must belong to same system")
+#define logError_NotForExternalModels                        logError("Not available for external models")
+#define logError_ConnectorNotInComponent(cref, component)    logError("Connector \"" + std::string(cref) + "\" not found in component \"" + std::string(component->getFullCref()) + "\"")
+#define logError_NoConnectorsInTLMBus(cref)                  logError("No connectors in TLM bus: \"" + std::string(cref) + "\"")
 #endif

--- a/src/OMSimulatorLib/TLMBusConnector.h
+++ b/src/OMSimulatorLib/TLMBusConnector.h
@@ -97,7 +97,7 @@ typedef struct  {
   class TLMBusConnector : protected oms3_tlmbusconnector_t
   {
   public:
-    TLMBusConnector(const oms3::ComRef& name, const std::string domain, const int dimensions, const oms_tlm_interpolation_t interpolation, System* parentSystem=nullptr);
+    TLMBusConnector(const oms3::ComRef& name, const std::string domain, const int dimensions, const oms_tlm_interpolation_t interpolation, System* parentSystem=nullptr, Component* component=nullptr);
     ~TLMBusConnector();
 
     oms_status_enu_t exportToSSD(pugi::xml_node& root) const;
@@ -108,6 +108,12 @@ typedef struct  {
 
     void setName(const oms3::ComRef& name);
     void setGeometry(const oms2::ssd::ConnectorGeometry* newGeometry);
+
+    void setReal(int i, double value);
+    void getReal(int i, double &value);
+    void setReals(std::vector<int> i, std::vector<double> values);
+    void getReals(std::vector<int> i, std::vector<double>& values);
+    void setRealInputDerivatives(int i, int order, double value);
 
     const oms3::ComRef getName() const {return oms3::ComRef(name);}
     const std::string getDomain() const {return domain;}
@@ -128,10 +134,12 @@ typedef struct  {
     int getId() const {return id;}
 
     oms3::Component* getComponent();
+    oms3::TLMBusConnector* getActualBus();
 
   private:
     void updateVariableTypes();
-    oms3::Component *getComponent(const ComRef &conA, System *system) const;
+    oms3::Component* getComponent(const ComRef &conA, System *system) const;
+    oms3::TLMBusConnector* getActualBus(ComRef cref, System *system);
 
     oms_causality_enu_t causality;
     std::map<std::string, oms3::ComRef> connectors;
@@ -139,6 +147,7 @@ typedef struct  {
     std::vector<std::string> variableTypes; //Used to keep track of TLM variable types
     System* parentSystem;
     Component* component = nullptr;
+    TLMBusConnector *actualBus = nullptr;
 
     int id;
   };


### PR DESCRIPTION
### Purpose

Add TLM bus connectors directly on components (FMUs or external models), to reduce number of connections and connectors.

### Approach

- Add support to TLMBusConnectors in Component class
- Read/write directly to/from component-level bus 
- Expose system-level bus to TLM manager

### Type of Change

- New feature (non-breaking change which adds functionality)

### Checklist

- I have performed a self-review of my own code