### PR TITLE
Improved thread-safedy for TLM simulations

### DIFF
--- a/src/OMSimulatorLib/SystemTLM.cpp
+++ b/src/OMSimulatorLib/SystemTLM.cpp
@@ -258,7 +258,9 @@ oms_status_enu_t oms3::SystemTLM::connectToSockets(const oms3::ComRef cref, std:
   logInfo("Creating TLM plugin instance for "+std::string(cref));
 
   TLMPlugin* plugin = TLMPlugin::CreateInstance();
+  pluginsMutex.lock();
   plugins[system] = plugin;
+  pluginsMutex.unlock();
 
   logInfo("Initializing plugin for "+std::string(cref));
 
@@ -297,7 +299,9 @@ void oms3::SystemTLM::disconnectFromSockets(const oms3::ComRef cref)
     //destroyed before master has read all data
     TLMPlugin *plugin = plugins.find(system)->second;
     delete plugin;
+    pluginsMutex.lock();
     plugins[system] = nullptr;
+    pluginsMutex.unlock();
   }
 }
 

--- a/src/OMSimulatorLib/SystemTLM.h
+++ b/src/OMSimulatorLib/SystemTLM.h
@@ -87,6 +87,7 @@ namespace oms3
     std::map<System*, TLMPlugin*> plugins;
     std::vector<ComRef> initializedsubsystems;
     std::map<ComRef, std::vector<double> > initialValues;
+    std::mutex pluginsMutex;
     std::mutex setConnectedMutex;
     std::mutex setInitializedMutex;
     std::map<System*, std::mutex> socketMutexes;


### PR DESCRIPTION
### Purpose

Prevent concurrent insertions into std::map from different threads. Hopefully this will resolve instabilities with oms3 TLM test models. 

### Type of Change

- Bug fix (non-breaking change which fixes an issue)

### Checklist

- I have performed a self-review of my own code