### PR TITLE
Remove oms3_setTLMInitialValues

### DIFF
--- a/src/OMSimulatorLib/OMSimulator.cpp
+++ b/src/OMSimulatorLib/OMSimulator.cpp
@@ -870,27 +870,6 @@ oms_status_enu_t oms3_exportDependencyGraphs(const char* cref, const char* initi
   return system->exportDependencyGraphs(initialization, simulation);
 }
 
-oms_status_enu_t oms3_setTLMInitialValues(const char *cref, const char *ifc, const double values[], int nvalues)
-{
-  oms3::ComRef tail(cref);
-  oms3::ComRef front = tail.pop_front();
-
-  oms3::Model* model = oms3::Scope::GetInstance().getModel(front);
-  if (!model)
-    return logError_ModelNotInScope(front);
-
-  front = tail.pop_front();
-  oms3::System* system = model->getSystem(front);
-  if (!system)
-    return logError_SystemNotInModel(model->getCref(), front);
-
-  if (system->getType() != oms_system_tlm)
-    return logError_OnlyForTlmSystem;
-
-  oms3::SystemTLM* tlmsystem = reinterpret_cast<oms3::SystemTLM*>(system);
-  return tlmsystem->setInitialValues(tail, std::vector<double>(values, values+nvalues));
-}
-
 oms_status_enu_t oms3_getReal(const char* cref, double* value)
 {
   oms3::ComRef tail(cref);

--- a/src/OMSimulatorLib/OMSimulator.h
+++ b/src/OMSimulatorLib/OMSimulator.h
@@ -108,7 +108,6 @@ oms_status_enu_t oms3_setStopTime(const char* cref, double stopTime);
 oms_status_enu_t oms3_setTempDirectory(const char* newTempDir);
 oms_status_enu_t oms3_setTLMBusGeometry(const char* bus, const ssd_connector_geometry_t* geometry);
 oms_status_enu_t oms3_setTLMConnectionParameters(const char* crefA, const char* crefB, const oms3_tlm_connection_parameters_t* parameters);
-oms_status_enu_t oms3_setTLMInitialValues(const char *cref, const char *ifc, const double values[], int nvalues);
 oms_status_enu_t oms3_setTLMPositionAndOrientation(const char *cref, double x1, double x2, double x3, double A11, double A12, double A13, double A21, double A22, double A23, double A31, double A32, double A33);
 oms_status_enu_t oms3_setTLMSocketData(const char* cref, const char* address, int managerPort, int monitorPort);
 oms_status_enu_t oms3_setWorkingDirectory(const char* newWorkingDir);

--- a/src/OMSimulatorLib/SystemTLM.h
+++ b/src/OMSimulatorLib/SystemTLM.h
@@ -60,7 +60,6 @@ namespace oms3
 
     oms_status_enu_t connectToSockets(const oms3::ComRef cref, std::string server);
     void disconnectFromSockets(const oms3::ComRef cref);
-    oms_status_enu_t setInitialValues(ComRef cref, std::vector<double> values);
     oms_status_enu_t updateInitialValues(const oms3::ComRef cref);
 
     oms_status_enu_t initializeSubSystem(ComRef cref);
@@ -86,7 +85,6 @@ namespace oms3
     std::vector<ComRef> connectedsubsystems;
     std::map<System*, TLMPlugin*> plugins;
     std::vector<ComRef> initializedsubsystems;
-    std::map<ComRef, std::vector<double> > initialValues;
     std::mutex pluginsMutex;
     std::mutex setConnectedMutex;
     std::mutex setInitializedMutex;

--- a/src/OMSimulatorLua/OMSimulatorLua.c
+++ b/src/OMSimulatorLua/OMSimulatorLua.c
@@ -782,67 +782,6 @@ static int OMSimulatorLua_oms3_setTLMPositionAndOrientation(lua_State *L)
   return 1;
 }
 
-//oms_status_enu_t oms3_setTLMInitialValues(const char *cref, const char *ifc, double value1, double value2...));
-static int OMSimulatorLua_oms3_setTLMInitialValues(lua_State *L)
-{
-  //First parse initial arguments (3 or 8)
-  if(lua_gettop(L) != 3 && lua_gettop(L) != 4 && lua_gettop(L) != 14) {
-    return luaL_error(L, "expecting exactly 3, 4 or 14 arguments");
-  }
-
-  luaL_checktype(L, 1, LUA_TSTRING);
-  luaL_checktype(L, 2, LUA_TSTRING);
-  luaL_checktype(L, 3, LUA_TNUMBER);
-  if(lua_gettop(L) > 3) {
-    luaL_checktype(L, 4, LUA_TNUMBER);
-  }
-  if(lua_gettop(L) > 4) {
-    luaL_checktype(L, 5, LUA_TNUMBER);
-    luaL_checktype(L, 6, LUA_TNUMBER);
-    luaL_checktype(L, 7, LUA_TNUMBER);
-    luaL_checktype(L, 8, LUA_TNUMBER);
-    luaL_checktype(L, 9, LUA_TNUMBER);
-    luaL_checktype(L, 10, LUA_TNUMBER);
-    luaL_checktype(L, 11, LUA_TNUMBER);
-    luaL_checktype(L, 12, LUA_TNUMBER);
-    luaL_checktype(L, 13, LUA_TNUMBER);
-    luaL_checktype(L, 14, LUA_TNUMBER);
-  }
-
-  oms_status_enu_t status;
-  const char *cref =    lua_tostring(L, 1);
-  const char *subref =  lua_tostring(L, 2);
-  if(lua_gettop(L) == 3) {
-    double values[1];
-    values[0] = lua_tonumber(L,3);
-    status = oms3_setTLMInitialValues(cref, subref, values, 1);
-  }
-  else if(lua_gettop(L) == 4) {
-    double values[2];
-    values[0] = lua_tonumber(L,3);
-    values[1] = lua_tonumber(L,4);
-    status = oms3_setTLMInitialValues(cref, subref, values, 2);
-  }
-  else {
-    double values[12];
-    values[0] = lua_tonumber(L,3);
-    values[1] = lua_tonumber(L,4);
-    values[2] = lua_tonumber(L,5);
-    values[3] = lua_tonumber(L,6);
-    values[4] = lua_tonumber(L,7);
-    values[5] = lua_tonumber(L,8);
-    values[6] = lua_tonumber(L,9);
-    values[7] = lua_tonumber(L,10);
-    values[8] = lua_tonumber(L,11);
-    values[9] = lua_tonumber(L,12);
-    values[10] = lua_tonumber(L,13);
-    values[11] = lua_tonumber(L,14);
-    status = oms3_setTLMInitialValues(cref, subref, values, 12);
-  }
-  lua_pushinteger(L, status);
-  return 1;
-}
-
 //oms_status_enu_t oms3_setResultFile(const char* cref, const char* filename, unsigned int bufferSize);
 static int OMSimulatorLua_oms3_setResultFile(lua_State *L)
 {
@@ -2479,7 +2418,6 @@ DLLEXPORT int luaopen_OMSimulatorLua(lua_State *L)
   REGISTER_LUA_CALL(oms3_setStartTime);
   REGISTER_LUA_CALL(oms3_setStopTime);
   REGISTER_LUA_CALL(oms3_setTempDirectory);
-  REGISTER_LUA_CALL(oms3_setTLMInitialValues);
   REGISTER_LUA_CALL(oms3_setTLMPositionAndOrientation);
   REGISTER_LUA_CALL(oms3_setTLMSocketData);
   REGISTER_LUA_CALL(oms3_setWorkingDirectory);

--- a/src/OMSimulatorPython/OMSimulator.py
+++ b/src/OMSimulatorPython/OMSimulator.py
@@ -290,9 +290,6 @@ class OMSimulator:
     self.obj.oms3_exportDependencyGraphs.argtypes = [ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p]
     self.obj.oms3_exportDependencyGraphs.restype = ctypes.c_int
 
-    self.obj.oms3_setTLMInitialValues.argtypes = [ctypes.c_char_p, ctypes.c_char_p, ctypes.Array, ctypes.c_int]
-    self.obj.oms3_setTLMInitialValues.restype = ctypes.c_int
-
     self.obj.oms3_getReal.argtypes = [ctypes.c_char_p]
     self.obj.oms3_getReal.restype = ctypes.c_int
 
@@ -432,8 +429,6 @@ class OMSimulator:
     return self.obj.oms3_setTLMPositionAndOrientation(self.checkstring(cref), x1, x2, x3, A11, A12, A13, A21, A22, A23, A31, A32, A33)
   def oms3_exportDependencyGraphs(self, cref, initialization, simulation):
     return self.obj.oms3_exportDependencyGraphs(self.checkstring(cref), self.checkstring(initialization), self.checkstring(simulation))
-  def oms3_setTLMInitialValues(self, cref, ifc, values, nvalues):
-    return self.obj.oms3_setTLMInitialValues(self.checkstring(cref), self.checkstring(ifc), values, nvalues)
   def oms3_getReal(self, cref):
     value = ctypes.c_double()
     status = self.obj.oms3_getReal(self.checkstring(cref), ctypes.byref(value))


### PR DESCRIPTION
### Purpose

TLM initialization should be handled by oms3_setReal. At least I hope this is possible in all cases.

### Approach

- Remove `oms3_setTLMInitialValues`
- Use wave variables for TLM buses where effort variable is not available

- Code refactoring (non-breaking change which improves maintainability)
- New feature (non-breaking change which adds functionality)

### Checklist

- I have performed a self-review of my own code