### PR TITLE
Some fixes for 3D TLM with oms3

### DIFF
--- a/src/OMSimulatorLib/System.cpp
+++ b/src/OMSimulatorLib/System.cpp
@@ -1632,14 +1632,26 @@ oms_status_enu_t oms3::System::setReal(const ComRef& cref, double value)
   return oms_status_error;
 }
 
-oms_status_enu_t oms3::System::getReals(const std::vector<oms3::ComRef> &sr, std::vector<double> &values) const
+oms_status_enu_t oms3::System::getReals(const std::vector<oms3::ComRef> &sr, std::vector<double> &values)
 {
-  return logError_NotImplemented;
+  oms_status_enu_t status;
+  for(int i=0; i<sr.size(); ++i) {
+    status = getReal(sr[i],values[i]);
+    if(status != oms_status_ok)
+      break;
+  }
+  return status;
 }
 
 oms_status_enu_t oms3::System::setReals(const std::vector<oms3::ComRef> &crefs, std::vector<double> values)
 {
-  return logError_NotImplemented;
+  oms_status_enu_t status;
+  for(int i=0; i<crefs.size(); ++i) {
+    status = setReal(crefs[i],values[i]);
+    if(status != oms_status_ok)
+      break;
+  }
+  return status;
 }
 
 oms_status_enu_t oms3::System::setRealInputDerivatives(const oms3::ComRef &cref, int order, double value)

--- a/src/OMSimulatorLib/System.h
+++ b/src/OMSimulatorLib/System.h
@@ -123,7 +123,7 @@ namespace oms3
     oms_status_enu_t setInteger(const ComRef& cref, int value);
     oms_status_enu_t setReal(const ComRef& cref, double value);
 
-    oms_status_enu_t getReals(const std::vector<ComRef> &crefs, std::vector<double> &values) const;
+    oms_status_enu_t getReals(const std::vector<ComRef> &crefs, std::vector<double> &values);
     oms_status_enu_t setReals(const std::vector<ComRef> &crefs, std::vector<double> values);
     oms_status_enu_t setRealInputDerivatives(const ComRef &cref, int order, double value);
 

--- a/src/OMSimulatorLib/SystemTLM.cpp
+++ b/src/OMSimulatorLib/SystemTLM.cpp
@@ -146,7 +146,13 @@ oms_status_enu_t oms3::SystemTLM::initialize()
       else if(tlmbus->getCausality() == oms_causality_bidir)
         causality = "bidirectional";
 
-      omtlm_addInterface(model, subsystem.second->getCref().c_str(), tlmbus->getName().c_str(),tlmbus->getDimensions(), causality.c_str(), tlmbus->getDomain().c_str());
+      //OMTLMSimulator uses degrees of freedom as "dimensions",
+      //so convert to this:
+      int dimensions = tlmbus->getDimensions();
+      if(dimensions == 2) dimensions = 3;
+      if(dimensions == 3) dimensions = 6;
+
+      omtlm_addInterface(model, subsystem.second->getCref().c_str(), tlmbus->getName().c_str(),dimensions, causality.c_str(), tlmbus->getDomain().c_str());
     }
   }
 


### PR DESCRIPTION
### Purpose

Make 3D TLM simulations work with oms3.

### Approach

- Implement `SystemTLM::setReals`
- Implement `SystemTLM::getReals`
- Convert number of dimensions for OMTLMSimulator

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

### Checklist

- I have performed a self-review of my own code