### PR TITLE
Replace boost::filesystem::unique_path

### DIFF
--- a/src/OMSimulatorLib/OMSBoost.cpp
+++ b/src/OMSimulatorLib/OMSBoost.cpp
@@ -73,18 +73,17 @@ boost::filesystem::path oms_canonical(boost::filesystem::path p)
 #endif
 }
 
-boost::filesystem::path oms_unique_path(std::string prefix)
+boost::filesystem::path oms_unique_path(const std::string& prefix)
 {
-#if (BOOST_VERSION >= 104500) // no temp_directory_path in boost < 1.45
-  return boost::filesystem::unique_path(prefix + "-%%%%");
-#else
-  int i;
+  const char lt[] = "0123456789abcdefghijklmnopqrstuvwxyz";
+  int size = strlen(lt);
+
   std::string s = prefix + "-";
-  for(i=0; i<4; i++)
-    s += std::string(1, ('A' + rand()%26));
+  for(int i=0; i<8; i++)
+    s += std::string(1, lt[rand() % size]);
+
   boost::filesystem::path p(s);
   return p;
-#endif
 }
 
 /*

--- a/src/OMSimulatorLib/OMSBoost.h
+++ b/src/OMSimulatorLib/OMSBoost.h
@@ -32,7 +32,7 @@
 #ifndef _OMS_BOOST_H_
 #define _OMS_BOOST_H_
 
- 
+
 #ifdef __cplusplus
 extern "C"
 {
@@ -42,12 +42,12 @@ extern "C"
 #if defined(_MSC_VER) || defined(__MINGW32__)
 #include <windows.h>
 #endif
-#endif 
+#endif
 
 #ifdef __cplusplus
 }
 #endif
- 
+
 #include <cstdlib>
 #include <string>
 #include <boost/version.hpp>
@@ -71,6 +71,6 @@ extern "C"
 
 boost::filesystem::path oms_temp_directory_path(void);
 boost::filesystem::path oms_canonical(boost::filesystem::path p);
-boost::filesystem::path oms_unique_path(std::string prefix);
+boost::filesystem::path oms_unique_path(const std::string& prefix);
 
 #endif


### PR DESCRIPTION
### Related Issues

Valgrind reports always issues with boost::filesystem::unique_path. 

### Purpose

Replace boost::filesystem::unique_path and make collisions less likely.
