### PR TITLE
Implement oms3_reset

### DIFF
--- a/src/OMSimulatorLib/Component.h
+++ b/src/OMSimulatorLib/Component.h
@@ -79,6 +79,7 @@ namespace oms3
     virtual oms_status_enu_t instantiate() = 0;
     virtual oms_status_enu_t initialize() = 0;
     virtual oms_status_enu_t terminate() = 0;
+    virtual oms_status_enu_t reset() = 0;
 
     const DirectedGraph& getInitialUnknownsGraph() {return initialUnknownsGraph;}
     const DirectedGraph& getOutputsGraph() {return outputsGraph;}

--- a/src/OMSimulatorLib/ComponentFMUCS.cpp
+++ b/src/OMSimulatorLib/ComponentFMUCS.cpp
@@ -454,6 +454,15 @@ oms_status_enu_t oms3::ComponentFMUCS::terminate()
   return oms_status_ok;
 }
 
+oms_status_enu_t oms3::ComponentFMUCS::reset()
+{
+  fmi2_status_t fmistatus = fmi2_import_reset(fmu);
+  if (fmi2_status_ok != fmistatus)
+    return logError_ResetFailed(getCref());
+
+  return oms_status_ok;
+}
+
 oms_status_enu_t oms3::ComponentFMUCS::stepUntil(double stopTime)
 {
   System *topLevelSystem = getModel()->getTopLevelSystem();

--- a/src/OMSimulatorLib/ComponentFMUCS.h
+++ b/src/OMSimulatorLib/ComponentFMUCS.h
@@ -61,6 +61,7 @@ namespace oms3
     oms_status_enu_t instantiate();
     oms_status_enu_t initialize();
     oms_status_enu_t terminate();
+    oms_status_enu_t reset();
 
     oms_status_enu_t stepUntil(double stopTime);
 

--- a/src/OMSimulatorLib/ComponentFMUME.cpp
+++ b/src/OMSimulatorLib/ComponentFMUME.cpp
@@ -483,6 +483,15 @@ oms_status_enu_t oms3::ComponentFMUME::terminate()
   return oms_status_ok;
 }
 
+oms_status_enu_t oms3::ComponentFMUME::reset()
+{
+  fmi2_status_t fmistatus = fmi2_import_reset(fmu);
+  if (fmi2_status_ok != fmistatus)
+    return logError_ResetFailed(getCref());
+
+  return oms_status_ok;
+}
+
 oms_status_enu_t oms3::ComponentFMUME::getBoolean(const ComRef& cref, bool& value)
 {
   int j=-1;

--- a/src/OMSimulatorLib/ComponentFMUME.h
+++ b/src/OMSimulatorLib/ComponentFMUME.h
@@ -59,6 +59,7 @@ namespace oms3
     oms_status_enu_t instantiate();
     oms_status_enu_t initialize();
     oms_status_enu_t terminate();
+    oms_status_enu_t reset();
 
     oms_status_enu_t initializeDependencyGraph_initialUnknowns();
     oms_status_enu_t initializeDependencyGraph_outputs();

--- a/src/OMSimulatorLib/ComponentTable.cpp
+++ b/src/OMSimulatorLib/ComponentTable.cpp
@@ -167,19 +167,9 @@ oms_status_enu_t oms3::ComponentTable::exportToSSD(pugi::xml_node& node) const
   return oms_status_ok;
 }
 
-oms_status_enu_t oms3::ComponentTable::instantiate()
-{
-  return oms_status_ok;
-}
-
 oms_status_enu_t oms3::ComponentTable::initialize()
 {
   time = getModel()->getStartTime();
-  return oms_status_ok;
-}
-
-oms_status_enu_t oms3::ComponentTable::terminate()
-{
   return oms_status_ok;
 }
 

--- a/src/OMSimulatorLib/ComponentTable.h
+++ b/src/OMSimulatorLib/ComponentTable.h
@@ -54,9 +54,10 @@ namespace oms3
     static Component* NewComponent(const pugi::xml_node& node, System* parentSystem);
 
     oms_status_enu_t exportToSSD(pugi::xml_node& node) const;
-    oms_status_enu_t instantiate();
+    oms_status_enu_t instantiate() {return oms_status_ok;}
     oms_status_enu_t initialize();
-    oms_status_enu_t terminate();
+    oms_status_enu_t terminate() {return oms_status_ok;}
+    oms_status_enu_t reset() {return oms_status_ok;}
 
     oms_status_enu_t getReal(const ComRef& cref, double& value);
 

--- a/src/OMSimulatorLib/ExternalModel.cpp
+++ b/src/OMSimulatorLib/ExternalModel.cpp
@@ -125,6 +125,11 @@ oms_status_enu_t oms3::ExternalModel::terminate()
   return logError_NotImplemented;
 }
 
+oms_status_enu_t oms3::ExternalModel::reset()
+{
+  return logError_NotImplemented;
+}
+
 oms_status_enu_t oms3::ExternalModel::registerSignalsForResultFile(ResultWriter& resultFile)
 {
   return logError_NotImplemented;

--- a/src/OMSimulatorLib/ExternalModel.h
+++ b/src/OMSimulatorLib/ExternalModel.h
@@ -59,6 +59,7 @@ namespace oms3
     oms_status_enu_t instantiate();
     oms_status_enu_t initialize();
     oms_status_enu_t terminate();
+    oms_status_enu_t reset();
 
     oms_status_enu_t updateDependencyGraphs() {return oms_status_error;}
 

--- a/src/OMSimulatorLib/Logging.h
+++ b/src/OMSimulatorLib/Logging.h
@@ -124,6 +124,7 @@ private:
 #define logError_SubSystemNotInSystem(system, subsystem)     logError("System \"" + std::string(system) + "\" does not contain subsystem \"" + std::string(subsystem) + "\"")
 #define logError_SystemNotInModel(model, system)             logError("Model \"" + std::string(model) + "\" does not contain system \"" + std::string(system) + "\"")
 #define logError_Termination(system)                         logError("Termination of system \"" + std::string(system) + "\" failed")
+#define logError_ResetFailed(system)                         logError("failed to reset system \"" + std::string(system) + "\" to instantiation mode")
 #define logError_WrongSchema(name)                           logError("Wrong xml schema detected. Unexpected tag \"" + name + "\"")
 #define logError_InvalidIdent(cref)                          logError("\"" + std::string(cref) + "\" is not a valid ident")
 #define logError_AlreadyInScope(cref)                        logError("\"" + std::string(cref) + "\" already exists in the scope")

--- a/src/OMSimulatorLib/Model.cpp
+++ b/src/OMSimulatorLib/Model.cpp
@@ -542,6 +542,27 @@ oms_status_enu_t oms3::Model::terminate()
   return oms_status_ok;
 }
 
+oms_status_enu_t oms3::Model::reset()
+{
+  if (oms_modelState_simulation != modelState)
+    return logError_ModelInWrongState(this);
+
+  if (!system)
+    return logError("Model doesn't contain a system");
+
+  if (oms_status_ok != system->reset())
+    return logError_ResetFailed(system->getFullCref());
+
+  if (resultFile)
+  {
+    delete resultFile;
+    resultFile = NULL;
+  }
+
+  modelState = oms_modelState_instantiated;
+  return oms_status_ok;
+}
+
 oms_status_enu_t oms3::Model::registerSignalsForResultFile()
 {
   if (!resultFile)

--- a/src/OMSimulatorLib/Model.h
+++ b/src/OMSimulatorLib/Model.h
@@ -78,6 +78,7 @@ namespace oms3
     oms_status_enu_t simulate();
     oms_status_enu_t stepUntil(double stopTime);
     oms_status_enu_t terminate();
+    oms_status_enu_t reset();
 
     oms_modelState_enu_t getModelState() const {return modelState;}
 

--- a/src/OMSimulatorLib/OMSimulator.cpp
+++ b/src/OMSimulatorLib/OMSimulator.cpp
@@ -814,6 +814,17 @@ oms_status_enu_t oms3_stepUntil(const char* cref_, double stopTime)
   return model->stepUntil(stopTime);
 }
 
+oms_status_enu_t oms3_reset(const char* cref_)
+{
+  oms3::ComRef cref(cref_);
+
+  oms3::Model* model = oms3::Scope::GetInstance().getModel(cref);
+  if (!model)
+    return logError_ModelNotInScope(cref);
+
+  return model->reset();
+}
+
 oms_status_enu_t oms3_terminate(const char* cref_)
 {
   oms3::ComRef cref(cref_);

--- a/src/OMSimulatorLib/OMSimulator.h
+++ b/src/OMSimulatorLib/OMSimulator.h
@@ -93,6 +93,7 @@ oms_status_enu_t oms3_newModel(const char* cref);
 oms_status_enu_t oms3_parseModelName(const char* contents, char** cref);
 oms_status_enu_t oms3_removeSignalsFromResults(const char* cref, const char* regex);
 oms_status_enu_t oms3_rename(const char* cref, const char* newCref);
+oms_status_enu_t oms3_reset(const char* cref);
 oms_status_enu_t oms3_setBoolean(const char* cref, bool value);
 oms_status_enu_t oms3_setBusGeometry(const char* bus, const ssd_connector_geometry_t* geometry);
 oms_status_enu_t oms3_setCommandLineOption(const char* cmd);

--- a/src/OMSimulatorLib/System.h
+++ b/src/OMSimulatorLib/System.h
@@ -114,6 +114,7 @@ namespace oms3
     virtual oms_status_enu_t instantiate() = 0;
     virtual oms_status_enu_t initialize() = 0;
     virtual oms_status_enu_t terminate() = 0;
+    virtual oms_status_enu_t reset() = 0;
     virtual oms_status_enu_t stepUntil(double stopTime, void (*cb)(const char* ident, double time, oms_status_enu_t status)) = 0;
 
     oms_status_enu_t getBoolean(const ComRef& cref, bool& value);

--- a/src/OMSimulatorLib/SystemSC.h
+++ b/src/OMSimulatorLib/SystemSC.h
@@ -57,6 +57,7 @@ namespace oms3
     oms_status_enu_t instantiate();
     oms_status_enu_t initialize();
     oms_status_enu_t terminate();
+    oms_status_enu_t reset();
     oms_status_enu_t stepUntil(double stopTime, void (*cb)(const char* ident, double time, oms_status_enu_t status));
 
     double getTolerance() const {return relativeTolerance;}

--- a/src/OMSimulatorLib/SystemTLM.cpp
+++ b/src/OMSimulatorLib/SystemTLM.cpp
@@ -173,6 +173,14 @@ oms_status_enu_t oms3::SystemTLM::terminate()
   return oms_status_ok;
 }
 
+oms_status_enu_t oms3::SystemTLM::reset()
+{
+  for (const auto& subsystem : getSubSystems())
+    if (oms_status_ok != subsystem.second->reset())
+      return oms_status_error;
+  return oms_status_ok;
+}
+
 oms_status_enu_t oms3::SystemTLM::stepUntil(double stopTime, void (*cb)(const char* ident, double time, oms_status_enu_t status))
 {
   omtlm_setStartTime(model, getModel()->getStartTime());

--- a/src/OMSimulatorLib/SystemTLM.h
+++ b/src/OMSimulatorLib/SystemTLM.h
@@ -56,6 +56,7 @@ namespace oms3
     oms_status_enu_t instantiate();
     oms_status_enu_t initialize();
     oms_status_enu_t terminate();
+    oms_status_enu_t reset();
     oms_status_enu_t stepUntil(double stopTime, void (*cb)(const char* ident, double time, oms_status_enu_t status));
 
     oms_status_enu_t connectToSockets(const oms3::ComRef cref, std::string server);

--- a/src/OMSimulatorLib/SystemWC.cpp
+++ b/src/OMSimulatorLib/SystemWC.cpp
@@ -130,6 +130,19 @@ oms_status_enu_t oms3::SystemWC::terminate()
   return oms_status_ok;
 }
 
+oms_status_enu_t oms3::SystemWC::reset()
+{
+  for (const auto& subsystem : getSubSystems())
+    if (oms_status_ok != subsystem.second->reset())
+      return oms_status_error;
+
+  for (const auto& component : getComponents())
+    if (oms_status_ok != component.second->reset())
+      return oms_status_error;
+
+  return oms_status_ok;
+}
+
 oms_status_enu_t oms3::SystemWC::stepUntil(double stopTime, void (*cb)(const char* ident, double time, oms_status_enu_t status))
 {
   ComRef modelName = this->getModel()->getCref();

--- a/src/OMSimulatorLib/SystemWC.h
+++ b/src/OMSimulatorLib/SystemWC.h
@@ -53,6 +53,7 @@ namespace oms3
     oms_status_enu_t instantiate();
     oms_status_enu_t initialize();
     oms_status_enu_t terminate();
+    oms_status_enu_t reset();
     oms_status_enu_t stepUntil(double stopTime, void (*cb)(const char* ident, double time, oms_status_enu_t status));
 
     double getTolerance() const {return tolerance;}

--- a/src/OMSimulatorLua/OMSimulatorLua.c
+++ b/src/OMSimulatorLua/OMSimulatorLua.c
@@ -696,6 +696,19 @@ static int OMSimulatorLua_oms3_terminate(lua_State *L)
   return 1;
 }
 
+//oms_status_enu_t oms3_reset(const char* ident);
+static int OMSimulatorLua_oms3_reset(lua_State *L)
+{
+  if (lua_gettop(L) != 1)
+    return luaL_error(L, "expecting exactly 1 argument");
+  luaL_checktype(L, 1, LUA_TSTRING);
+
+  const char* ident = lua_tostring(L, 1);
+  oms_status_enu_t status = oms3_reset(ident);
+  lua_pushinteger(L, status);
+  return 1;
+}
+
 //oms_status_enu_t oms3_simulate(const char* cref);
 static int OMSimulatorLua_oms3_simulate(lua_State *L)
 {
@@ -2420,6 +2433,7 @@ DLLEXPORT int luaopen_OMSimulatorLua(lua_State *L)
   REGISTER_LUA_CALL(oms3_parseModelName);
   REGISTER_LUA_CALL(oms3_removeSignalsFromResults);
   REGISTER_LUA_CALL(oms3_rename);
+  REGISTER_LUA_CALL(oms3_reset);
   REGISTER_LUA_CALL(oms3_setBoolean);
   REGISTER_LUA_CALL(oms3_setCommandLineOption);
   REGISTER_LUA_CALL(oms3_setFixedStepSize);

--- a/src/OMSimulatorPython/OMSimulator.py
+++ b/src/OMSimulatorPython/OMSimulator.py
@@ -284,6 +284,9 @@ class OMSimulator:
     self.obj.oms3_terminate.argtypes = [ctypes.c_char_p]
     self.obj.oms3_terminate.restype = ctypes.c_int
 
+    self.obj.oms3_reset.argtypes = [ctypes.c_char_p]
+    self.obj.oms3_reset.restype = ctypes.c_int
+
     self.obj.oms3_setTLMSocketData.argtypes = [ctypes.c_char_p, ctypes.c_char_p, ctypes.c_int, ctypes.c_int]
     self.obj.oms3_setTLMSocketData.restype = ctypes.c_int
 
@@ -428,6 +431,8 @@ class OMSimulator:
     return self.obj.oms3_stepUntil(self.checkstring(cref), stopTime)
   def oms3_terminate(self, cref):
     return self.obj.oms3_terminate(self.checkstring(cref))
+  def oms3_reset(self, cref):
+    return self.obj.oms3_reset(self.checkstring(cref))
   def oms3_setTLMSocketData(self, cref, address, managerPort, monitorPort):
     return self.obj.oms3_setTLMSocketData(self.checkstring(cref), self.checkstring(address), managerPort, monitorPort)
   def oms3_setTLMPositionAndOrientation(self, cref, x1, x2, x3, A11, A12, A13, A21, A22, A23, A31, A32, A33):


### PR DESCRIPTION
### Purpose

`oms3_reset` returns the model into the instantiated mode. That way the same model with different initialization can be run faster, because the fmus doesn’t need to be extracted and loaded.