### PR TITLE
Add oms3_setSignalFiler

### DIFF
--- a/src/OMSimulatorLib/OMSimulator.cpp
+++ b/src/OMSimulatorLib/OMSimulator.cpp
@@ -1078,6 +1078,19 @@ oms_status_enu_t oms3_setResultFile(const char* cref_, const char* filename, int
     return logError_OnlyForModel;
 }
 
+oms_status_enu_t oms3_setSignalFilter(const char* cref, const char* regex)
+{
+  oms_status_enu_t status;
+
+  status = oms3_removeSignalsFromResults(cref, ".*");
+  if (oms_status_ok != status) return status;
+
+  status = oms3_addSignalsToResults(cref, regex);
+  if (oms_status_ok != status) return status;
+
+  return oms_status_ok;
+}
+
 oms_status_enu_t oms3_addSignalsToResults(const char* cref, const char* regex)
 {
   oms3::ComRef tail(cref);
@@ -1782,13 +1795,13 @@ oms_status_enu_t oms2_setMasterAlgorithm(const char* ident, const char* masterAl
   return oms2::Scope::GetInstance().setMasterAlgorithm(oms2::ComRef(ident), std::string(masterAlgorithm));
 }
 
-oms_status_enu_t oms2_addEventIndicator(const char* signal) 
+oms_status_enu_t oms2_addEventIndicator(const char* signal)
 {
   logTrace();
   return oms2::Scope::GetInstance().addEventIndicator(oms2::SignalRef(signal));
 }
 
-oms_status_enu_t oms2_addTimeIndicator(const char* signal) 
+oms_status_enu_t oms2_addTimeIndicator(const char* signal)
 {
   logTrace();
   return oms2::Scope::GetInstance().addTimeIndicator(oms2::SignalRef(signal));
@@ -1806,7 +1819,7 @@ oms_status_enu_t oms2_addDynamicValueIndicator(const char* signal, const char* l
   return oms2::Scope::GetInstance().addDynamicValueIndicator(oms2::SignalRef(signal), oms2::SignalRef(lower), oms2::SignalRef(upper), stepSize);
 }
 
-oms_status_enu_t oms2_setMinimalStepSize(const char* ident, double min) 
+oms_status_enu_t oms2_setMinimalStepSize(const char* ident, double min)
 {
   logTrace();
   return oms2::Scope::GetInstance().setMinimalStepSize(oms2::ComRef(ident),min);

--- a/src/OMSimulatorLib/OMSimulator.h
+++ b/src/OMSimulatorLib/OMSimulator.h
@@ -101,13 +101,14 @@ oms_status_enu_t oms3_setConnectorGeometry(const char* cref, const ssd_connector
 oms_status_enu_t oms3_setElementGeometry(const char* cref, const ssd_element_geometry_t* geometry);
 oms_status_enu_t oms3_setFixedStepSize(const char* cref, double stepSize);
 oms_status_enu_t oms3_setInteger(const char* cref, int value);
-void oms3_setLoggingCallback(void (*cb)(oms_message_type_enu_t type, const char* message));
 oms_status_enu_t oms3_setLogFile(const char* filename);
+void oms3_setLoggingCallback(void (*cb)(oms_message_type_enu_t type, const char* message));
 oms_status_enu_t oms3_setLoggingInterval(const char* cref, double loggingInterval);
 oms_status_enu_t oms3_setLoggingLevel(int logLevel);
 void oms3_setMaxLogFileSize(const unsigned long size);
 oms_status_enu_t oms3_setReal(const char* cref, double value);
 oms_status_enu_t oms3_setResultFile(const char* cref, const char* filename, int bufferSize);
+oms_status_enu_t oms3_setSignalFilter(const char* cref, const char* regex);
 oms_status_enu_t oms3_setSolver(const char* cref, const char* solver);
 oms_status_enu_t oms3_setStartTime(const char* cref, double startTime);
 oms_status_enu_t oms3_setStopTime(const char* cref, double stopTime);
@@ -754,9 +755,9 @@ oms_status_enu_t oms2_setMasterAlgorithm(const char* ident, const char* masterAl
 
 /**
  * \brief Add signal to the set of event indicators for step size control
- * 
+ *
  * A change in the value of the signal indicates a discrete event.
- * 
+ *
  * \param signal    [in] Name of event indicator signal
  * \return          Error status
  */
@@ -764,9 +765,9 @@ oms_status_enu_t oms2_addEventIndicator(const char* signal);
 
 /**
  * \brief Add signal to the set of time indicators for step size control
- * 
- * The signal must be real-valued. The value indicated the time of the next expected discrete event. 
- * 
+ *
+ * The signal must be real-valued. The value indicated the time of the next expected discrete event.
+ *
  * \param signal    [in] Name of time indicator signal
  * \return          Error status
  */
@@ -774,10 +775,10 @@ oms_status_enu_t oms2_addTimeIndicator(const char* signal);
 
 /**
  * \brief Add an interval to the static value indicator for step size control
- * 
- * The signal must be real valued. 
+ *
+ * The signal must be real valued.
  * When the signal's value is in the specified interval, the step size is at most the specified value.
- * 
+ *
  * \param signal    [in] Name of value indicator signal
  * \param lower     [in] Lower bound of interval
  * \param upper     [in] Upper bound of interval
@@ -788,22 +789,22 @@ oms_status_enu_t oms2_addStaticValueIndicator(const char* signal, double lower, 
 
 /**
  * \brief Add an interval to the dynamic value indicator for step size control
- * 
- * The signals must be real valued. 
+ *
+ * The signals must be real valued.
  * The current bounds of the interval are specified by the value of lower and upper.
  * When the signals value is in the specified interval, the step size is at most the specified value.
- * 
+ *
  * \param signal    [in] Name of value indicator signal
  * \param lower     [in] Name of signal specifying lower bound of interval
  * \param upper     [in] Name of signal specifying upper bound of interval
  * \param stepSize  [in] Step size to set when the signal's value is within the bounds of the interval
  * \return          Error status
  */
-oms_status_enu_t oms2_addDynamicValueIndicator(const char* signal, const char* lower, const char* upper, double stepSize);   
+oms_status_enu_t oms2_addDynamicValueIndicator(const char* signal, const char* lower, const char* upper, double stepSize);
 
 /**
  * \brief Set minimal step size of simulation with variable step sizes
- * 
+ *
  * \param ident     [in] Name of the model instance
  * \param min       [in] Minimal step size
  * \return          Error status
@@ -812,7 +813,7 @@ oms_status_enu_t oms2_setMinimalStepSize(const char* ident, double min);
 
 /**
  * \brief Set maximal step size of simulation with variable step sizes
- * 
+ *
  * \param ident     [in] Name of the model instance
  * \param max       [in] Maximal step size
  * \return          Error status

--- a/src/OMSimulatorLua/OMSimulatorLua.c
+++ b/src/OMSimulatorLua/OMSimulatorLua.c
@@ -860,6 +860,20 @@ static int OMSimulatorLua_oms3_setResultFile(lua_State *L)
   return 1;
 }
 
+//oms_status_enu_t oms3_setSignalFilter(const char* cref, const char* regex)
+static int OMSimulatorLua_oms3_setSignalFilter(lua_State *L)
+{
+  if (lua_gettop(L) != 2)
+    return luaL_error(L, "expecting exactly 2 argument");
+  luaL_checktype(L, 1, LUA_TSTRING);
+
+  const char* cref = lua_tostring(L, 1);
+  const char* regex = lua_tostring(L, 2);
+  oms_status_enu_t status = oms3_setSignalFilter(cref, regex);
+  lua_pushinteger(L, status);
+  return 1;
+}
+
 //oms_status_enu_t oms3_addSignalsToResults(const char* cref, const char* regex);
 static int OMSimulatorLua_oms3_addSignalsToResults(lua_State *L)
 {
@@ -1509,7 +1523,7 @@ static int OMSimulatorLua_oms2_addEventIndicator(lua_State *L)
   oms_status_enu_t status=oms2_addEventIndicator(ident);
 
   lua_pushinteger(L,status);
-  return 1;  
+  return 1;
 }
 
 //oms_status_enu_t oms2_addTimeIndicator(const char* signal);
@@ -1523,7 +1537,7 @@ static int OMSimulatorLua_oms2_addTimeIndicator(lua_State *L)
   oms_status_enu_t status=oms2_addTimeIndicator(ident);
 
   lua_pushinteger(L,status);
-  return 1;  
+  return 1;
 }
 
 //oms_status_enu_t oms2_addStaticValueIndicator(const char* signal, double lower, double upper, double stepSize);
@@ -1564,9 +1578,9 @@ static int OMSimulatorLua_oms2_addDynamicValueIndicator(lua_State *L)
 
   lua_pushinteger(L,status);
   return 1;
-}   
+}
 
-//oms_status_enu_t oms2_setMinimalStepSize(const char* ident, double min); 
+//oms_status_enu_t oms2_setMinimalStepSize(const char* ident, double min);
 static int OMSimulatorLua_oms2_setMinimalStepSize(lua_State *L)
 {
   if (lua_gettop(L) != 2)
@@ -2570,6 +2584,7 @@ DLLEXPORT int luaopen_OMSimulatorLua(lua_State *L)
   REGISTER_LUA_CALL(oms3_setMaxLogFileSize);
   REGISTER_LUA_CALL(oms3_setReal);
   REGISTER_LUA_CALL(oms3_setResultFile);
+  REGISTER_LUA_CALL(oms3_setSignalFilter);
   REGISTER_LUA_CALL(oms3_setStartTime);
   REGISTER_LUA_CALL(oms3_setStopTime);
   REGISTER_LUA_CALL(oms3_setTempDirectory);

--- a/src/OMSimulatorPython/OMSimulator.py
+++ b/src/OMSimulatorPython/OMSimulator.py
@@ -309,6 +309,9 @@ class OMSimulator:
     self.obj.oms3_setResultFile.argtypes = [ctypes.c_char_p, ctypes.c_char_p, ctypes.c_int]
     self.obj.oms3_setResultFile.restype = ctypes.c_int
 
+    self.obj.oms3_setSignalFilter.argtypes = [ctypes.c_char_p, ctypes.c_char_p]
+    self.obj.oms3_setSignalFilter.restype = ctypes.c_int
+
     self.obj.oms3_addSignalsToResults.argtypes = [ctypes.c_char_p, ctypes.c_char_p]
     self.obj.oms3_addSignalsToResults.restype = ctypes.c_int
 
@@ -460,6 +463,8 @@ class OMSimulator:
     return self.obj.oms3_setReal(self.checkstring(signal), value)
   def oms3_setResultFile(self, cref, filename, bufferSize):
     return self.obj.oms3_setResultFile(self.checkstring(cref), self.checkstring(filename), bufferSize)
+  def oms3_setSignalFilter(self, cref, regex):
+    return self.obj.oms3_setSignalFilter(self.checkstring(cref), self.checkstring(regex))
   def oms3_addSignalsToResults(self, cref, regex):
     return self.obj.oms3_addSignalsToResults(self.checkstring(cref), self.checkstring(regex))
   def oms3_removeSignalsFromResults(self, cref, regex):


### PR DESCRIPTION
### Related Issues

#347

### Purpose

Make filtering of the signals that should be written to the results more convenient.

### Approach

Calling `oms3_removeSignalsFromResults("model", ".*")` and `oms3_addSignalsToResults("model", regex)`

### Type of Change

<!--- Please delete options that are not relevant. -->

- New feature (non-breaking change which adds functionality)
