### PR TITLE
Prevent add variable of existing type to TLM bus

### DIFF
--- a/src/OMSimulatorLib/Logging.h
+++ b/src/OMSimulatorLib/Logging.h
@@ -135,4 +135,6 @@ private:
 #define logError_TlmBusNotInSystem(cref, system)             logError("TLM bus connector \"" + std::string(cref) + "\" not found in system \"" + std::string(system->getFullCref()) + "\"")
 #define logError_BusNotInComponent(cref, component)          logError("Bus connector \"" + std::string(cref) + "\" not found in component \"" + std::string(component->getFullCref()) + "\"")
 #define logError_TlmBusNotInComponent(cref, component)       logError("TLM bus connector \"" + std::string(cref) + "\" not found in component \"" + std::string(component->getFullCref()) + "\"")
+#define logError_UnknownTLMVariableType(vartype)             logError("Unknown TLM variable type: \""+vartype+"\"")
+#define logError_VariableTypeAlreadyInTLMBus(cref,vartype)   logError("TLM bus connector \"" + std::string(cref) + "\" already contains a variable with type \"" + vartype + "\"")
 #endif

--- a/src/OMSimulatorLib/TLM/TLMBusConnector.cpp
+++ b/src/OMSimulatorLib/TLM/TLMBusConnector.cpp
@@ -211,7 +211,11 @@ std::vector<oms3::ComRef> oms3::TLMBusConnector::getConnectors(std::vector<int> 
 oms_status_enu_t oms3::TLMBusConnector::addConnector(const oms3::ComRef &cref, std::string vartype)
 {
   if(std::find(variableTypes.begin(), variableTypes.end(), vartype) == variableTypes.end())
-    return logError("Unknown TLM variable type: "+vartype);
+    return logError_UnknownTLMVariableType(vartype);
+
+  if(connectors.find(vartype) != connectors.end()) {
+    return logError_VariableTypeAlreadyInTLMBus(this->getName(), vartype);
+  }
 
   oms3::ComRef tempRef = cref;
   connectors.insert(std::make_pair(vartype, tempRef));


### PR DESCRIPTION
### Purpose

Only one connector of each type is allowed in a  TLM bus.

### Approach

Check if variable type already exists. If so, return error.

### Type of Change

- Bug fix (non-breaking change which fixes an issue)

### Checklist

- I have performed a self-review of my own code
- I have added tests that prove my fix is effective or that my feature works