### PR TITLE
Log all variables with TLM simulations

### DIFF
--- a/src/OMSimulatorLib/Component.h
+++ b/src/OMSimulatorLib/Component.h
@@ -60,6 +60,7 @@ namespace oms3
     ComRef getFullCref() const;
     Element* getElement() {return &element;}
     Connector* getConnector(const ComRef& cref);
+    Connector** getConnectors() {return &connectors[0];}
     oms_status_enu_t deleteConnector(const ComRef& cref);
     oms_status_enu_t deleteResources();
     oms_status_enu_t getAllResources(std::vector<std::string>& resources) const {resources.push_back(path); return oms_status_ok;}

--- a/src/OMSimulatorLib/Model.h
+++ b/src/OMSimulatorLib/Model.h
@@ -90,6 +90,7 @@ namespace oms3
     double getStopTime() const {return stopTime;}
 
     oms_status_enu_t setLoggingInterval(double loggingInterval);
+    double getLoggingInterval() const {return loggingInterval;}
     oms_status_enu_t setResultFile(const std::string& filename, int bufferSize);
     oms_status_enu_t emit(double time, bool force=false);
     oms_status_enu_t addSignalsToResults(const char* regex);

--- a/src/OMSimulatorLib/System.h
+++ b/src/OMSimulatorLib/System.h
@@ -80,6 +80,7 @@ namespace oms3
     void setGeometry(const ssd::ElementGeometry& geometry) {element.setGeometry(&geometry);}
     oms_status_enu_t addConnector(const ComRef& cref, oms_causality_enu_t causality, oms_signal_type_enu_t type);
     Connector* getConnector(const ComRef& cref);
+    Connector** getConnectors() {return &connectors[0];}
     BusConnector* getBusConnector(const ComRef& cref);
     oms_status_enu_t addTLMConnection(const ComRef& crefA, const ComRef& crefB, double delay, double alpha, double linearimpedance, double angularimpedance);
     oms_status_enu_t setTLMConnectionParameters(const ComRef &crefA, const ComRef &crefB, const oms3_tlm_connection_parameters_t* parameters);
@@ -135,8 +136,8 @@ namespace oms3
 
     bool isTopLevelSystem() const {return (parentSystem == NULL);}
 
-    oms_status_enu_t registerSignalsForResultFile(ResultWriter& resultFile);
-    oms_status_enu_t updateSignals(ResultWriter& resultFile);
+    virtual oms_status_enu_t registerSignalsForResultFile(ResultWriter& resultFile);
+    virtual oms_status_enu_t updateSignals(ResultWriter& resultFile);
     oms_status_enu_t addSignalsToResults(const char* regex);
     oms_status_enu_t removeSignalsFromResults(const char* regex);
 

--- a/src/OMSimulatorLib/TLM/SystemTLM.cpp
+++ b/src/OMSimulatorLib/TLM/SystemTLM.cpp
@@ -35,9 +35,8 @@
 #include "Model.h"
 #include "SystemWC.h"
 #include "Types.h"
-#include "OMTLMSimulatorLib.h"
+#include "OMTLMSimulatorLib/OMTLMSimulatorLib.h"
 #include "ssd/Tags.h"
-#include "OMTLMSimulatorLib.h"
 
 #include <thread>
 #include <algorithm>
@@ -48,7 +47,6 @@ oms3::SystemTLM::SystemTLM(const ComRef& cref, Model* parentModel, System* paren
   logTrace();
   model = omtlm_newModel(cref.c_str());
   omtlm_setLogLevel(model, 1);
-  omtlm_setNumLogStep(model, 1000);
 }
 
 oms3::SystemTLM::~SystemTLM()
@@ -124,6 +122,8 @@ oms_status_enu_t oms3::SystemTLM::instantiate()
 
 oms_status_enu_t oms3::SystemTLM::initialize()
 {
+  omtlm_setLogStepSize(model, getModel()->getLoggingInterval());
+
   actualManagerPort = desiredManagerPort;
   actualMonitorPort = desiredMonitorPort;
 #ifndef _WIN32
@@ -223,7 +223,7 @@ oms_status_enu_t oms3::SystemTLM::initialize()
     omtlm_addConnection(model,connections[i]->getSignalA().c_str(),connections[i]->getSignalB().c_str(),tlmpars->delay,tlmpars->linearimpedance,tlmpars->angularimpedance,tlmpars->alpha);
   }
 
-  logStep = getModel()->getLoggingInterval();
+  logStep = (getModel()->getLoggingInterval() > 0) ? getModel()->getLoggingInterval() : 1e-3;
   nextLogTime = getModel()->getStartTime()+logStep;
 
   return oms_status_ok;

--- a/src/OMSimulatorLib/TLM/SystemTLM.h
+++ b/src/OMSimulatorLib/TLM/SystemTLM.h
@@ -67,6 +67,12 @@ namespace oms3
     oms_status_enu_t simulateSubSystem(ComRef cref, double stopTime);
     void writeToSockets(oms3::SystemWC *system, double time, Component *component);
     void readFromSockets(SystemWC *system, double time, Component *component);
+    void sendValueToLogger(int varId, double time, double value);
+    int registerLogVariable();
+    void registerLogVariables(System* system, ResultWriter& resultFile);
+    void sendValuesToLogger(System* system, double time);
+    oms_status_enu_t registerSignalsForResultFile(ResultWriter& resultFile);
+    oms_status_enu_t updateSignals(ResultWriter& resultFile);
 
   protected:
     SystemTLM(const ComRef& cref, Model* parentModel, System* parentSystem);
@@ -76,6 +82,13 @@ namespace oms3
     SystemTLM& operator=(SystemTLM const& copy); ///< not implemented
 
   private:
+    double interpolate(double t1, double t2, double x1, double x2, double t)
+    {
+      if(t2 == t1)
+        return x2;
+      return x1 + (x2-x1)/(t2-t1)*(t-t1);
+    }
+
     void* model;
     std::string address = "";
     int desiredManagerPort=0;
@@ -90,6 +103,15 @@ namespace oms3
     std::mutex setConnectedMutex;
     std::mutex setInitializedMutex;
     std::map<System*, std::mutex> socketMutexes;
+    std::mutex logMutex;
+
+    int numLogVars = 0;
+    std::map<int, std::vector<std::pair<double,double> > > logBuffer;
+    double nextLogTime;
+    double logTime;
+    double logStep = 1e-2;
+    std::map<TLMBusConnector*, int> busLogIds;
+    std::map<Connector*, int> connectorLogIds;
 
     // simulation information
   };


### PR DESCRIPTION
### Purpose

Log all variables with TLM simulations.

### Approach

Buffer values in SystemTLM class whenever writeToSockets is called. Update result file on regular logging interval. Wait until all variables are available for the log time, and interpolate backwards if necessary.

### Type of Change

- New feature (non-breaking change which adds functionality)

### Checklist

- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have added tests that prove my fix is effective or that my feature works