### PR TITLE
Implement --fetchAllVars for CS-FMUs

### DIFF
--- a/src/OMSimulatorLib/Component.h
+++ b/src/OMSimulatorLib/Component.h
@@ -66,6 +66,7 @@ namespace oms3
     const std::string& getPath() const {return path;}
     oms_component_enu_t getType() const {return type;}
     virtual const FMUInfo* getFMUInfo() const {return NULL;}
+    void fetchAllVars() {fetchAllVars_ = true;}
     System* getParentSystem() const {return parentSystem;}
     Model* getModel() const;
     void setGeometry(const ssd::ElementGeometry& geometry) {element.setGeometry(&geometry);}
@@ -118,6 +119,7 @@ namespace oms3
 
     Clock clock;
     unsigned int clock_id;
+    bool fetchAllVars_ = false;
 
   private:
     System* parentSystem;

--- a/src/OMSimulatorLib/ComponentFMUCS.cpp
+++ b/src/OMSimulatorLib/ComponentFMUCS.cpp
@@ -504,6 +504,20 @@ oms_status_enu_t oms3::ComponentFMUCS::stepUntil(double stopTime)
       reinterpret_cast<SystemTLM*>(topLevelSystem)->readFromSockets(reinterpret_cast<SystemWC*>(getParentSystem()), time, this);
 #endif
 
+    // HACK for certain FMUs
+    if (fetchAllVars_)
+    {
+      for (auto &v : allVariables)
+      {
+        if (v.isTypeReal())
+        {
+          double realValue;
+          if (oms_status_ok != getReal(v.getCref(), realValue))
+            logError("failed to fetch variable " + std::string(v));
+        }
+      }
+    }
+
     fmistatus = fmi2_import_do_step(fmu, time, hdef, fmi2_true);
     time += hdef;
 

--- a/src/OMSimulatorLib/Flags.h
+++ b/src/OMSimulatorLib/Flags.h
@@ -32,6 +32,9 @@
 #ifndef _OMS3_FLAGS_H_
 #define _OMS3_FLAGS_H_
 
+#include "Types.h"
+#include <string>
+
 namespace oms3
 {
   class Flags
@@ -49,6 +52,7 @@ namespace oms3
   public:
     static bool SuppressPath() {return GetInstance().suppressPath;}
     static void SuppressPath(bool value) {GetInstance().suppressPath = value;}
+    static oms_status_enu_t SetCommandLineOption(const std::string& cmd);
 
   private:
     bool suppressPath;

--- a/src/OMSimulatorLib/OMSimulator.cpp
+++ b/src/OMSimulatorLib/OMSimulator.cpp
@@ -286,14 +286,7 @@ oms_status_enu_t oms3_getConnector(const char* cref, oms_connector_t** connector
 
 oms_status_enu_t oms3_setCommandLineOption(const char* cmd)
 {
-  if (std::string(cmd) == "--suppressPath=true")
-    oms3::Flags::SuppressPath(true);
-  else if (std::string(cmd) == "--suppressPath=false")
-    oms3::Flags::SuppressPath(false);
-  else
-    return logError("Unknown flag or option: \"" + std::string(cmd) + "\"");
-
-  return oms_status_ok;
+  return oms3::Flags::SetCommandLineOption(std::string(cmd));
 }
 
 oms_status_enu_t oms3_getSystemType(const char* cref, oms_system_enu_t* type)


### PR DESCRIPTION
### Related Issues

requested by @meek1 

### Purpose

Workaround for certain FMUs...

Usage (lua):
```
oms3_addSubModel("test.co_sim.A", "../FMUs/source.fmu")
oms3_setCommandLineOption("--fetchAllVars=test.co_sim.A")
```

### Type of Change

<!--- Please delete options that are not relevant. -->

- Code refactoring (non-breaking change which improves maintainability)
- New feature (non-breaking change which adds functionality)
