### PR TITLE
Implement a progress bar for stepUntil

### DIFF
--- a/src/OMSimulatorLib/Flags.cpp
+++ b/src/OMSimulatorLib/Flags.cpp
@@ -40,7 +40,6 @@
 #include <RegEx.h>
 
 oms3::Flags::Flags()
-  : suppressPath(false)
 {
 }
 
@@ -79,6 +78,8 @@ oms_status_enu_t oms3::Flags::SetCommandLineOption(const std::string& cmd)
 
   if (isOptionAndValue(cmd, "--suppressPath", value, re_bool))
     oms3::Flags::SuppressPath(value == "true");
+  else if (isOptionAndValue(cmd, "--progressBar", value, re_bool))
+    GetInstance().progressBar = (value == "true");
   else if (isOptionAndValue(cmd, "--fetchAllVars", value, re_default))
   {
     oms3::ComRef tail(value);

--- a/src/OMSimulatorLib/Flags.h
+++ b/src/OMSimulatorLib/Flags.h
@@ -50,12 +50,15 @@ namespace oms3
     static Flags& GetInstance();
 
   public:
-    static bool SuppressPath() {return GetInstance().suppressPath;}
-    static void SuppressPath(bool value) {GetInstance().suppressPath = value;}
     static oms_status_enu_t SetCommandLineOption(const std::string& cmd);
 
+    static bool SuppressPath() {return GetInstance().suppressPath;}
+    static void SuppressPath(bool value) {GetInstance().suppressPath = value;}
+    static bool ProgressBar() {return GetInstance().progressBar;}
+
   private:
-    bool suppressPath;
+    bool suppressPath = false;
+    bool progressBar = false;
   };
 }
 

--- a/src/OMSimulatorLib/Logging.cpp
+++ b/src/OMSimulatorLib/Logging.cpp
@@ -33,10 +33,11 @@
 #include "Version.h"
 #include "Types.h"
 
-#include <iostream>
-#include <fstream>
-#include <stdlib.h>
+#include <cstring>
 #include <ctime>
+#include <fstream>
+#include <iostream>
+#include <stdlib.h>
 
 using namespace std;
 
@@ -75,6 +76,8 @@ Log& Log::getInstance()
 
 void Log::printStringToStream(std::ostream& stream, const std::string& type, const std::string& msg)
 {
+  TerminateBar();
+
   std::string timeStamp, padding;
   if (logFile.is_open())
   {
@@ -268,4 +271,46 @@ oms_status_enu_t Log::setLoggingLevel(int logLevel)
 #endif
 
 return oms_status_ok;
+}
+
+void Log::ProgressBar(double start, double stop, double value)
+{
+  Log& log = getInstance();
+
+  if (log.progress)
+    printf("\r");
+  else
+    log.percent = -1;
+
+  const char* label = "info:    ";
+
+  int width = 72 - strlen(label);
+  int pos = ((value - start) * width) / (stop - start) ;
+  int percent = ((value - start) * 100) / (stop - start);
+
+  if (log.percent == percent)
+    return;
+  log.percent = percent;
+
+  printf("%s[", label);
+
+  //fill progress bar with =
+  for (int i = 0; i<pos; i++)
+    printf("%c", '=');
+
+  //fill progress bar with spaces
+  printf("% *s", width - pos + 1, "]");
+  printf(" %3d%%", percent);
+  log.progress = true;
+}
+
+void Log::TerminateBar()
+{
+  Log& log = getInstance();
+
+  if (log.progress)
+  {
+    printf("\n");
+    log.progress = false;
+  }
 }

--- a/src/OMSimulatorLib/Logging.h
+++ b/src/OMSimulatorLib/Logging.h
@@ -57,6 +57,9 @@ public:
   static void Debug(const std::string& msg);
   static void Trace(const std::string& function, const std::string& file, const long line);
 
+  static void ProgressBar(double start, double stop, double value);
+  static void TerminateBar();
+
   static oms_status_enu_t setLogFile(const std::string& filename);
   static void setMaxLogFileSize(const unsigned long size) {getInstance().limit=1024*1024*size;}
 
@@ -85,6 +88,9 @@ private:
 
   unsigned long limit = 1024*1024*50;
   unsigned long size = 0;
+
+  bool progress = false;
+  int percent;
 
   void (*cb)(oms_message_type_enu_t type, const char* message);
 };

--- a/src/OMSimulatorLib/SystemSC.cpp
+++ b/src/OMSimulatorLib/SystemSC.cpp
@@ -33,6 +33,7 @@
 
 #include "Component.h"
 #include "ComponentFMUME.h"
+#include "Flags.h"
 #include "Model.h"
 #include "Types.h"
 #include "ssd/Tags.h"
@@ -439,6 +440,10 @@ oms_status_enu_t oms3::SystemSC::stepUntil(double stopTime, void (*cb)(const cha
   double hdef = maximumStepSize;
 
   fmi2_boolean_enu_t terminate_sim = fmi2_false;
+  double startTime=time;
+
+  if (Flags::ProgressBar())
+    logInfo("stepUntil [" + std::to_string(startTime) + "; " + std::to_string(stopTime) + "]");
 
   // main simulation loop
   while (time < stopTime && !terminate_sim)
@@ -582,6 +587,9 @@ oms_status_enu_t oms3::SystemSC::stepUntil(double stopTime, void (*cb)(const cha
     if (cb)
       cb(modelName.c_str(), time, oms_status_ok);
 
+    if (Flags::ProgressBar())
+      Log::ProgressBar(startTime, stopTime, time);
+
     if (isTopLevelSystem() && getModel()->cancelSimulation())
     {
       cb(modelName.c_str(), time, oms_status_discard);
@@ -590,6 +598,11 @@ oms_status_enu_t oms3::SystemSC::stepUntil(double stopTime, void (*cb)(const cha
   }
 
   time = stopTime;
+  if (Flags::ProgressBar())
+  {
+    Log::ProgressBar(startTime, stopTime, time);
+    Log::TerminateBar();
+  }
   return oms_status_ok;
 }
 


### PR DESCRIPTION
### Purpose

Adding a progress bar to the stepUntil function (wc & sc systems).

The progress bar needs to be enabled using the following command:
```lua
oms3_setCommandLineOption("--progressBar=true")
```

The progress information looks like this:

![tty](https://user-images.githubusercontent.com/8457302/49878375-b940a000-fe27-11e8-86e6-fb92018b09fb.gif)

### Type of Change

<!--- Please delete options that are not relevant. -->

- New feature (non-breaking change which adds functionality)

### Checklist

<!--- Please delete options that are not relevant. -->

- I have performed a self-review of my own code
- My changes generate no new warnings

