### PR TITLE
Enable oms3_setLoggingLevel for TLM simulations

### DIFF
--- a/src/OMSimulatorLib/Logging.cpp
+++ b/src/OMSimulatorLib/Logging.cpp
@@ -270,7 +270,13 @@ oms_status_enu_t Log::setLoggingLevel(int logLevel)
     Warning("debug logging is not available");
 #endif
 
-return oms_status_ok;
+  return oms_status_ok;
+}
+
+const int Log::getLoggingLevel()
+{
+  Log& log = getInstance();
+  return log.logLevel;
 }
 
 void Log::ProgressBar(double start, double stop, double value)

--- a/src/OMSimulatorLib/Logging.h
+++ b/src/OMSimulatorLib/Logging.h
@@ -65,6 +65,7 @@ public:
 
   static void setLoggingCallback(void (*cb)(oms_message_type_enu_t type, const char* message)) {getInstance().cb = cb;}
   static oms_status_enu_t setLoggingLevel(int logLevel);
+  static const int getLoggingLevel();
 
 private:
   Log();

--- a/src/OMSimulatorLib/TLM/SystemTLM.cpp
+++ b/src/OMSimulatorLib/TLM/SystemTLM.cpp
@@ -46,7 +46,12 @@ oms3::SystemTLM::SystemTLM(const ComRef& cref, Model* parentModel, System* paren
 {
   logTrace();
   model = omtlm_newModel(cref.c_str());
-  omtlm_setLogLevel(model, 1);
+
+  omtlm_setLogLevel(model, TLMLogLevel::Fatal);
+  if(Log::getLoggingLevel() == 1)
+    omtlm_setLogLevel(model, TLMLogLevel::Info);
+  else if(Log::getLoggingLevel() == 2)
+    omtlm_setLogLevel(model, TLMLogLevel::Debug);
 }
 
 oms3::SystemTLM::~SystemTLM()


### PR DESCRIPTION
### Purpose

Propagate logging level setting to TLM logger.

### Approach

Translate OMSimulator logging level to TLM logging level and then use OMTLMSimulator API:
0 default -> TLMErrorLog::FatalError
1 default+debug -> TLMErrorLog::Info
2 default+debug+trace -> TLMErrorLog::Debug
(i.e. TLMErrorLog::Warning level is never used)

### Type of Change

- New feature (non-breaking change which adds functionality)

### Checklist

- I have performed a self-review of my own code