### PR TITLE
Logging: do not call vsnprintf for disabled debug messages

### DIFF
--- a/src/OMSimulatorLib/Component.cpp
+++ b/src/OMSimulatorLib/Component.cpp
@@ -59,6 +59,12 @@ void oms3::fmiLogger(jm_callbacks* c, jm_string module, jm_log_level_enu_t log_l
 
 void oms3::fmi2logger(fmi2_component_environment_t env, fmi2_string_t instanceName, fmi2_status_t status, fmi2_string_t category, fmi2_string_t message, ...)
 {
+  if ((status == fmi2_status_ok || status == fmi2_status_pending) && !logDebugEnabled())
+  {
+    // When frequently called for debug logging during simulation, avoid costly formatting.
+    return;
+  }
+
   int len;
   char msg[1000];
   va_list argp;

--- a/src/OMSimulatorLib/Logging.cpp
+++ b/src/OMSimulatorLib/Logging.cpp
@@ -184,6 +184,12 @@ oms_status_enu_t Log::Error(const std::string& msg, const std::string& function)
   return oms_status_error;
 }
 
+bool Log::DebugEnabled()
+{
+  Log& log = getInstance();
+  return log.logLevel >= 1;
+}
+
 void Log::Debug(const std::string& msg)
 {
   Log& log = getInstance();
@@ -198,6 +204,12 @@ void Log::Debug(const std::string& msg)
 
   if (log.cb)
     log.cb(oms_message_debug, msg.c_str());
+}
+
+bool Log::TraceEnabled()
+{
+  Log& log = getInstance();
+  return log.logLevel >= 2;
 }
 
 void Log::Trace(const std::string& function, const std::string& file, const long line)

--- a/src/OMSimulatorLib/Logging.h
+++ b/src/OMSimulatorLib/Logging.h
@@ -67,6 +67,9 @@ public:
   static oms_status_enu_t setLoggingLevel(int logLevel);
   static const int getLoggingLevel();
 
+  static bool DebugEnabled();
+  static bool TraceEnabled();
+
 private:
   Log();
   ~Log();
@@ -101,9 +104,16 @@ private:
 #define logError(msg)   Log::Error(msg, __func__)
 
 #ifdef OMS_DEBUG_LOGGING
+  // In case some preparation is required
+  #define logDebugEnabled() Log::DebugEnabled()
+  #define logTraceEnabled() Log::TraceEnabled()
+
   #define logDebug(msg) Log::Debug(msg)
   #define logTrace()    Log::Trace(__FUNCTION_NAME__, __FILE__, __LINE__)
 #else
+  #define logDebugEnabled() (0)
+  #define logTraceEnabled() (0)
+
   #define logDebug(msg) ((void)0)
   #define logTrace()    ((void)0)
 #endif


### PR DESCRIPTION
... otherwise huge amount of time is spent inside the `fmi2GetReal -> oms3::fmi2logger` with some FMUs.

### Related Issues

This [testsuite failure](https://libraries.openmodelica.org/branches/master-fmi/Buildings_3.0.0/files/Buildings_3.0.0_Buildings.BoundaryConditions.SolarGeometry.BaseClasses.Examples.AltitudeAngle.sim), fox example.

### Purpose

Significantly speedup FMU execution by eliminating unused computations in `oms3::fmi2logger`.

### Approach

Some FMUs frequently log their debug messages during simulation. While it would be good to inhibit such logging at all when not required, it seems to be generally useful to not format a log message with `vsnprintf` when it would be dropped anyway if it ultimately occurred.

### Type of Change

- Bug fix (non-breaking change which fixes an issue)

### Checklist

- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
