### PR TITLE
Misc warning fixes

### DIFF
--- a/src/OMSimulatorLib/Model.cpp
+++ b/src/OMSimulatorLib/Model.cpp
@@ -255,13 +255,13 @@ oms_status_enu_t oms3::Model::importFromSSD(const pugi::xml_node& node)
 
       // lochel: I guess that can somehow be improved
       oms_system_enu_t systemType = oms_system_tlm;
-      if (it->child(oms2::ssd::ssd_simulation_information).child("VariableStepSolver").attribute("description").as_string() != "")
+      if (std::string(it->child(oms2::ssd::ssd_simulation_information).child("VariableStepSolver").attribute("description").as_string()) != "")
         systemType = oms_system_sc;
-      if (it->child(oms2::ssd::ssd_simulation_information).child("FixedStepSolver").attribute("description").as_string() != "")
+      if (std::string(it->child(oms2::ssd::ssd_simulation_information).child("FixedStepSolver").attribute("description").as_string()) != "")
         systemType = oms_system_sc;
-      if (it->child(oms2::ssd::ssd_simulation_information).child("VariableStepMaster").attribute("description").as_string() != "")
+      if (std::string(it->child(oms2::ssd::ssd_simulation_information).child("VariableStepMaster").attribute("description").as_string()) != "")
         systemType = oms_system_wc;
-      if (it->child(oms2::ssd::ssd_simulation_information).child("FixedStepMaster").attribute("description").as_string() != "")
+      if (std::string(it->child(oms2::ssd::ssd_simulation_information).child("FixedStepMaster").attribute("description").as_string()) != "")
         systemType = oms_system_wc;
 
       if (oms_status_ok != addSystem(systemCref, systemType))

--- a/src/OMSimulatorLib/OMSimulator.cpp
+++ b/src/OMSimulatorLib/OMSimulator.cpp
@@ -1357,8 +1357,8 @@ oms_status_enu_t oms3_extractFMIKind(const char* filename, oms_fmi_kind_enu_t* k
     return logError("loading \"" + xml_file + "\" failed (" + std::string(result.description()) + ")");
   const pugi::xml_node node = doc.document_element(); // ssd:SystemStructureDescription
 
-  bool cs = (node.child("CoSimulation").attribute("modelIdentifier").as_string() != "");
-  bool me = (node.child("ModelExchange").attribute("modelIdentifier").as_string() != "");
+  bool cs = (std::string(node.child("CoSimulation").attribute("modelIdentifier").as_string()) != "");
+  bool me = (std::string(node.child("ModelExchange").attribute("modelIdentifier").as_string()) != "");
 
   if (me && cs)
     *kind = oms_fmi_kind_me_and_cs;

--- a/src/OMSimulatorLib/PMRChannel.h
+++ b/src/OMSimulatorLib/PMRChannel.h
@@ -72,7 +72,7 @@ namespace oms2
     void write(T v)
     {
       logTrace();
-      while (is_produced_.load()) std::this_thread::yield;
+      while (is_produced_.load()) std::this_thread::yield();
       switch (rt_) {
         case RateTransition::FASTTOSLOW:
           v_ = v;
@@ -99,7 +99,7 @@ namespace oms2
     {
       logTrace();
       T v;
-      while (!is_produced_.load()) std::this_thread::yield;
+      while (!is_produced_.load()) std::this_thread::yield();
       switch (rt_) {
         case RateTransition::FASTTOSLOW:
           v = v_;

--- a/src/OMSimulatorLib/System.cpp
+++ b/src/OMSimulatorLib/System.cpp
@@ -513,13 +513,13 @@ oms_status_enu_t oms3::System::importFromSSD(const pugi::xml_node& node)
 
           // lochel: I guess that can somehow be improved
           oms_system_enu_t systemType = oms_system_tlm;
-          if (itElements->child(oms2::ssd::ssd_simulation_information).child("VariableStepSolver").attribute("description").as_string() != "")
+          if (std::string(itElements->child(oms2::ssd::ssd_simulation_information).child("VariableStepSolver").attribute("description").as_string()) != "")
             systemType = oms_system_sc;
-          if (itElements->child(oms2::ssd::ssd_simulation_information).child("FixedStepSolver").attribute("description").as_string() != "")
+          if (std::string(itElements->child(oms2::ssd::ssd_simulation_information).child("FixedStepSolver").attribute("description").as_string()) != "")
             systemType = oms_system_sc;
-          if (itElements->child(oms2::ssd::ssd_simulation_information).child("VariableStepMaster").attribute("description").as_string() != "")
+          if (std::string(itElements->child(oms2::ssd::ssd_simulation_information).child("VariableStepMaster").attribute("description").as_string()) != "")
             systemType = oms_system_wc;
-          if (itElements->child(oms2::ssd::ssd_simulation_information).child("FixedStepMaster").attribute("description").as_string() != "")
+          if (std::string(itElements->child(oms2::ssd::ssd_simulation_information).child("FixedStepMaster").attribute("description").as_string()) != "")
             systemType = oms_system_wc;
 
           if (oms_status_ok != addSubSystem(systemCref, systemType))


### PR DESCRIPTION
### Related Issues

Misc compiler warnings, most of them seem to be real issues, but review is required.

### Purpose

* To make easier to find one's own warnings introduced :)
* To fix some errors that seems to be "sleeping" bugs

### Approach

Make code behave as intended as far as I understand it. I touched only seemingly obvious places. 

When comparing strings with `""` I used slow-but-explicit approach with converting them to `std::string` as in other places in the code base. These particular cases can be optimized as `(str)[0] != 0` but this will probably make it harder to read.

### Type of Change

- Code refactoring (non-breaking change which improves maintainability)
- Bug fix (non-breaking change which fixes an issue)

### Checklist

- I have performed a self-review of my own code

### Open Questions and Pre-Merge TODOs

Review is required to assert that these code snippets were really intended by their authors.
