### PR TITLE
Fix initialization of composite models

### DIFF
--- a/src/OMSimulatorLib/ComponentTable.cpp
+++ b/src/OMSimulatorLib/ComponentTable.cpp
@@ -169,7 +169,13 @@ oms_status_enu_t oms3::ComponentTable::exportToSSD(pugi::xml_node& node) const
   return oms_status_ok;
 }
 
-oms_status_enu_t oms3::ComponentTable::initialize()
+oms_status_enu_t oms3::ComponentTable::instantiate()
+{
+  time = getModel()->getStartTime();
+  return oms_status_ok;
+}
+
+oms_status_enu_t oms3::ComponentTable::reset()
 {
   time = getModel()->getStartTime();
   return oms_status_ok;
@@ -198,7 +204,7 @@ oms_status_enu_t oms3::ComponentTable::getReal(const oms3::ComRef& cref, double&
     }
   }
 
-  logError("out of range");
+  logError("out of range (cref=" + std::string(cref) + ", time=" + std::to_string(time) + ")");
   value = 0.0;
   return oms_status_error;
 }

--- a/src/OMSimulatorLib/ComponentTable.h
+++ b/src/OMSimulatorLib/ComponentTable.h
@@ -54,10 +54,10 @@ namespace oms3
     static Component* NewComponent(const pugi::xml_node& node, System* parentSystem);
 
     oms_status_enu_t exportToSSD(pugi::xml_node& node) const;
-    oms_status_enu_t instantiate() {return oms_status_ok;}
-    oms_status_enu_t initialize();
+    oms_status_enu_t instantiate();
+    oms_status_enu_t initialize() {return oms_status_ok;}
     oms_status_enu_t terminate() {return oms_status_ok;}
-    oms_status_enu_t reset() {return oms_status_ok;}
+    oms_status_enu_t reset();
 
     oms_status_enu_t stepUntil(double stopTime) {time = stopTime; return oms_status_ok;}
 

--- a/src/OMSimulatorLib/SystemWC.cpp
+++ b/src/OMSimulatorLib/SystemWC.cpp
@@ -88,6 +88,8 @@ oms_status_enu_t oms3::SystemWC::importFromSSD_SimulationInformation(const pugi:
 
 oms_status_enu_t oms3::SystemWC::instantiate()
 {
+  time = getModel()->getStartTime();
+
   for (const auto& subsystem : getSubSystems())
     if (oms_status_ok != subsystem.second->instantiate())
       return oms_status_error;
@@ -118,7 +120,11 @@ oms_status_enu_t oms3::SystemWC::initialize()
   clock.reset();
   CallClock callClock(clock);
 
-  time = getModel()->getStartTime();
+  if (oms_status_ok != updateDependencyGraphs())
+    return oms_status_error;
+
+  if (oms_status_ok != updateInputs(initialUnknownsGraph))
+    return oms_status_error;
 
   for (const auto& subsystem : getSubSystems())
     if (oms_status_ok != subsystem.second->initialize())
@@ -133,12 +139,6 @@ oms_status_enu_t oms3::SystemWC::initialize()
   derBuffer = NULL;
   if (Flags::InputDerivatives())
     derBuffer = new double[getMaxOutputDerivativeOrder()];
-
-  if (oms_status_ok != updateDependencyGraphs())
-    return oms_status_error;
-
-  if (oms_status_ok != updateInputs(initialUnknownsGraph))
-    return oms_status_error;
 
   return oms_status_ok;
 }


### PR DESCRIPTION
### Related Issues

OpenModelica/OpenModelica-testsuite#1101

### Purpose

Fix initialization of composite models.

### Approach

Propagate start values and values depending on them before initializing local components.

### Type of Change

<!--- Please delete options that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)

### Checklist

<!--- Please delete options that are not relevant. -->

- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas