### PR TITLE
Check if it is not allowed to set a start value

### DIFF
--- a/src/OMSimulatorLib/ComponentFMUCS.cpp
+++ b/src/OMSimulatorLib/ComponentFMUCS.cpp
@@ -749,6 +749,10 @@ oms_status_enu_t oms3::ComponentFMUCS::setReal(const ComRef& cref, double value)
   if (!fmu || j < 0)
     return oms_status_error;
 
+  if (oms_modelState_initialization == getModel()->getModelState())
+    if (allVariables[j].isCalculated() || allVariables[j].isIndependent())
+      return logWarning("It is not allowed to provide a start value if initial=\"calculated\" or causality=\"independent\".");
+
   fmi2_value_reference_t vr = allVariables[j].getValueReference();
   if (fmi2_status_ok != fmi2_import_set_real(fmu, &vr, 1, &value))
     return oms_status_error;

--- a/src/OMSimulatorLib/ComponentFMUME.cpp
+++ b/src/OMSimulatorLib/ComponentFMUME.cpp
@@ -685,6 +685,10 @@ oms_status_enu_t oms3::ComponentFMUME::setReal(const ComRef& cref, double value)
   if (!fmu || j < 0)
     return oms_status_error;
 
+  if (oms_modelState_initialization == getModel()->getModelState())
+    if (allVariables[j].isCalculated() || allVariables[j].isIndependent())
+      return logWarning("It is not allowed to provide a start value if initial=\"calculated\" or causality=\"independent\".");
+
   fmi2_value_reference_t vr = allVariables[j].getValueReference();
   if (fmi2_status_ok != fmi2_import_set_real(fmu, &vr, 1, &value))
     return oms_status_error;


### PR DESCRIPTION
### Purpose

It is not allowed to provide a start value if initial="calculated" or causality="independent".

### Type of Change

<!--- Please delete options that are not relevant. -->

- New feature (non-breaking change which adds functionality)

### Checklist

<!--- Please delete options that are not relevant. -->

- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas