### PR TITLE
Allow setting start values before an FMU is instantiated

### DIFF
--- a/src/OMSimulatorLib/ComponentFMUCS.h
+++ b/src/OMSimulatorLib/ComponentFMUCS.h
@@ -108,9 +108,9 @@ namespace oms
     std::vector<Variable> parameters;
     std::vector<bool> exportVariables;
 
-    std::map<std::string, Option<double>> realParameters;
-    std::map<std::string, Option<int>> integerParameters;
-    std::map<std::string, Option<bool>> booleanParameters;
+    std::map<ComRef, double> realStartValues;  ///< parameters and start values defined before instantiating the FMU
+    std::map<ComRef, int> integerStartValues;  ///< parameters and start values defined before instantiating the FMU
+    std::map<ComRef, bool> booleanStartValues; ///< parameters and start values defined before instantiating the FMU
 
     std::unordered_map<unsigned int /*result file var ID*/, unsigned int /*allVariables ID*/> resultFileMapping;
 

--- a/src/OMSimulatorLib/ComponentFMUME.cpp
+++ b/src/OMSimulatorLib/ComponentFMUME.cpp
@@ -207,13 +207,6 @@ oms::Component* oms::ComponentFMUME::NewComponent(const oms::ComRef& cref, oms::
   // create some special variable maps
   for (auto const& v : component->allVariables)
   {
-    if (v.isParameter() && v.isTypeReal())
-      component->realParameters[std::string(v)] = oms::Option<double>();
-    else if (v.isParameter() && v.isTypeInteger())
-      component->integerParameters[std::string(v)] = oms::Option<int>();
-    else if (v.isParameter() && v.isTypeBoolean())
-      component->booleanParameters[std::string(v)] = oms::Option<bool>();
-
     if (v.isInput())
       component->inputs.push_back(v);
     else if (v.isOutput())
@@ -448,6 +441,26 @@ oms_status_enu_t oms::ComponentFMUME::instantiate()
   if (jm_status_error == jmstatus)
     return logError_FMUCall("fmi2_import_instantiate", this);
 
+  // set start values
+  for (const auto& v : booleanStartValues)
+  {
+    if (oms_status_ok != setBoolean(v.first, v.second))
+      return logError("Failed to set start value for " + std::string(v.first));
+  }
+  booleanStartValues.clear();
+  for (const auto& v : integerStartValues)
+  {
+    if (oms_status_ok != setInteger(v.first, v.second))
+      return logError("Failed to set start value for " + std::string(v.first));
+  }
+  integerStartValues.clear();
+  for (const auto& v : realStartValues)
+  {
+    if (oms_status_ok != setReal(v.first, v.second))
+      return logError("Failed to set start value for " + std::string(v.first));
+  }
+  realStartValues.clear();
+
   // enterInitialization
   const double& startTime = getParentSystem()->getModel()->getStartTime();
   double relativeTolerance = 0.0;
@@ -653,10 +666,15 @@ oms_status_enu_t oms::ComponentFMUME::setBoolean(const ComRef& cref, bool value)
   if (!fmu || j < 0)
     return oms_status_error;
 
-  fmi2_value_reference_t vr = allVariables[j].getValueReference();
-  int value_ = value ? 1 : 0;
-  if (fmi2_status_ok != fmi2_import_set_boolean(fmu, &vr, 1, &value_))
-    return oms_status_error;
+  if (oms_modelState_virgin == getModel()->getModelState())
+    booleanStartValues[allVariables[j].getCref()] = value;
+  else
+  {
+    fmi2_value_reference_t vr = allVariables[j].getValueReference();
+    int value_ = value ? 1 : 0;
+    if (fmi2_status_ok != fmi2_import_set_boolean(fmu, &vr, 1, &value_))
+      return oms_status_error;
+  }
 
   return oms_status_ok;
 }
@@ -677,9 +695,14 @@ oms_status_enu_t oms::ComponentFMUME::setInteger(const ComRef& cref, int value)
   if (!fmu || j < 0)
     return oms_status_error;
 
-  fmi2_value_reference_t vr = allVariables[j].getValueReference();
-  if (fmi2_status_ok != fmi2_import_set_integer(fmu, &vr, 1, &value))
-    return oms_status_error;
+  if (oms_modelState_virgin == getModel()->getModelState())
+    integerStartValues[allVariables[j].getCref()] = value;
+  else
+  {
+    fmi2_value_reference_t vr = allVariables[j].getValueReference();
+    if (fmi2_status_ok != fmi2_import_set_integer(fmu, &vr, 1, &value))
+      return oms_status_error;
+  }
 
   return oms_status_ok;
 }
@@ -700,13 +723,18 @@ oms_status_enu_t oms::ComponentFMUME::setReal(const ComRef& cref, double value)
   if (!fmu || j < 0)
     return oms_status_error;
 
-  if (getModel()->validState(oms_modelState_initialization))
+  if (getModel()->validState(oms_modelState_virgin|oms_modelState_enterInstantiation|oms_modelState_instantiated))
     if (allVariables[j].isCalculated() || allVariables[j].isIndependent())
       return logWarning("It is not allowed to provide a start value if initial=\"calculated\" or causality=\"independent\".");
 
-  fmi2_value_reference_t vr = allVariables[j].getValueReference();
-  if (fmi2_status_ok != fmi2_import_set_real(fmu, &vr, 1, &value))
-    return oms_status_error;
+  if (oms_modelState_virgin == getModel()->getModelState())
+    realStartValues[allVariables[j].getCref()] = value;
+  else
+  {
+    fmi2_value_reference_t vr = allVariables[j].getValueReference();
+    if (fmi2_status_ok != fmi2_import_set_real(fmu, &vr, 1, &value))
+      return oms_status_error;
+  }
 
   return oms_status_ok;
 }

--- a/src/OMSimulatorLib/ComponentFMUME.h
+++ b/src/OMSimulatorLib/ComponentFMUME.h
@@ -118,9 +118,9 @@ namespace oms
     std::vector<Variable> parameters;
     std::vector<bool> exportVariables;
 
-    std::map<std::string, Option<double>> realParameters;
-    std::map<std::string, Option<int>> integerParameters;
-    std::map<std::string, Option<bool>> booleanParameters;
+    std::map<ComRef, double> realStartValues;  ///< parameters and start values defined before instantiating the FMU
+    std::map<ComRef, int> integerStartValues;  ///< parameters and start values defined before instantiating the FMU
+    std::map<ComRef, bool> booleanStartValues; ///< parameters and start values defined before instantiating the FMU
 
     std::unordered_map<unsigned int /*result file var ID*/, unsigned int /*allVariables ID*/> resultFileMapping;
   };

--- a/src/OMSimulatorLib/Model.cpp
+++ b/src/OMSimulatorLib/Model.cpp
@@ -353,7 +353,7 @@ oms_status_enu_t oms::Model::getAllResources(std::vector<std::string>& resources
 
 oms_status_enu_t oms::Model::setStartTime(double value)
 {
-  if (!validState(oms_modelState_virgin|oms_modelState_instantiated))
+  if (!validState(oms_modelState_virgin|oms_modelState_enterInstantiation|oms_modelState_instantiated))
     return logError_ModelInWrongState(this);
 
   startTime = value;
@@ -362,7 +362,7 @@ oms_status_enu_t oms::Model::setStartTime(double value)
 
 oms_status_enu_t oms::Model::setStopTime(double value)
 {
-  if (!validState(oms_modelState_virgin|oms_modelState_instantiated))
+  if (!validState(oms_modelState_virgin|oms_modelState_enterInstantiation|oms_modelState_instantiated))
     return logError_ModelInWrongState(this);
 
   stopTime = value;
@@ -371,20 +371,20 @@ oms_status_enu_t oms::Model::setStopTime(double value)
 
 oms_status_enu_t oms::Model::instantiate()
 {
-  if (!validState(oms_modelState_virgin))
+  if (!validState(oms_modelState_virgin|oms_modelState_enterInstantiation))
     return logError_ModelInWrongState(this);
 
   if (!system)
     return logError("Model doesn't contain a system");
 
-  modelState = oms_modelState_virgin;
+  modelState = oms_modelState_enterInstantiation;
   if (oms_status_ok != system->instantiate())
   {
     terminate();
     return oms_status_error;
   }
-
   modelState = oms_modelState_instantiated;
+
   return oms_status_ok;
 }
 

--- a/src/OMSimulatorLib/System.cpp
+++ b/src/OMSimulatorLib/System.cpp
@@ -1595,7 +1595,7 @@ oms_status_enu_t oms::System::getReal(const ComRef& cref, double& value)
 
 oms_status_enu_t oms::System::setBoolean(const ComRef& cref, bool value)
 {
-  if (!getModel()->validState(oms_modelState_instantiated|oms_modelState_initialization|oms_modelState_simulation))
+  if (!getModel()->validState(oms_modelState_virgin|oms_modelState_enterInstantiation|oms_modelState_instantiated|oms_modelState_initialization|oms_modelState_simulation))
     return logError_ModelInWrongState(getModel());
 
   oms::ComRef tail(cref);
@@ -1621,7 +1621,7 @@ oms_status_enu_t oms::System::setBoolean(const ComRef& cref, bool value)
 
 oms_status_enu_t oms::System::setInteger(const ComRef& cref, int value)
 {
-  if (!getModel()->validState(oms_modelState_instantiated|oms_modelState_initialization|oms_modelState_simulation))
+  if (!getModel()->validState(oms_modelState_virgin|oms_modelState_enterInstantiation|oms_modelState_instantiated|oms_modelState_initialization|oms_modelState_simulation))
     return logError_ModelInWrongState(getModel());
 
   oms::ComRef tail(cref);
@@ -1647,7 +1647,7 @@ oms_status_enu_t oms::System::setInteger(const ComRef& cref, int value)
 
 oms_status_enu_t oms::System::setReal(const ComRef& cref, double value)
 {
-  if (!getModel()->validState(oms_modelState_instantiated|oms_modelState_initialization|oms_modelState_simulation))
+  if (!getModel()->validState(oms_modelState_virgin|oms_modelState_enterInstantiation|oms_modelState_instantiated|oms_modelState_initialization|oms_modelState_simulation))
     return logError_ModelInWrongState(getModel());
 
   oms::ComRef tail(cref);

--- a/src/OMSimulatorLib/Types.h
+++ b/src/OMSimulatorLib/Types.h
@@ -50,11 +50,12 @@ typedef enum {
 } oms_status_enu_t;
 
 typedef enum {
-  oms_modelState_virgin         = 1<<0,
-  oms_modelState_instantiated   = 1<<1,
-  oms_modelState_initialization = 1<<2,
-  oms_modelState_simulation     = 1<<3,
-  oms_modelState_error          = 1<<4
+  oms_modelState_virgin             = 1<<0,
+  oms_modelState_enterInstantiation = 1<<1,
+  oms_modelState_instantiated       = 1<<2,
+  oms_modelState_initialization     = 1<<3,
+  oms_modelState_simulation         = 1<<4,
+  oms_modelState_error              = 1<<5
 } oms_modelState_enu_t;
 
 typedef enum {


### PR DESCRIPTION
### Related Issues

#529 

### Purpose

Allow setting start values even before an FMU is instantiated

### Type of Change

<!--- Please delete options that are not relevant. -->

- New feature (non-breaking change which adds functionality)

### Checklist

<!--- Please delete options that are not relevant. -->

- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas