### PR TITLE
Flag to avoid using (wrong) InitialUnknowns

### DIFF
--- a/src/OMSimulatorLib/ComponentFMUME.cpp
+++ b/src/OMSimulatorLib/ComponentFMUME.cpp
@@ -31,6 +31,7 @@
 
 #include "ComponentFMUME.h"
 
+#include "Flags.h"
 #include "Logging.h"
 #include "Model.h"
 #include "ssd/Tags.h"
@@ -338,6 +339,18 @@ oms_status_enu_t oms3::ComponentFMUME::initializeDependencyGraph_initialUnknowns
   {
     logError(std::string(getCref()) + ": " + getPath() + " is already initialized");
     return oms_status_error;
+  }
+
+  if (Flags::IgnoreInitialUnknowns())
+  {
+    int N=initialUnknownsGraph.getNodes().size();
+    for (int i = 0; i < N; i++)
+    {
+      logDebug(std::string(getCref()) + ": " + getPath() + " initial unknown " + std::string(initialUnknownsGraph.getNodes()[i]) + " depends on all");
+      for (int j = 0; j < inputs.size(); j++)
+        initialUnknownsGraph.addEdge(inputs[j].makeConnector(), initialUnknownsGraph.getNodes()[i]);
+    }
+    return oms_status_ok;
   }
 
   size_t *startIndex=NULL, *dependency=NULL;

--- a/src/OMSimulatorLib/Flags.cpp
+++ b/src/OMSimulatorLib/Flags.cpp
@@ -187,6 +187,12 @@ oms_status_enu_t oms3::Flags::Help(const std::string& value)
   return oms_status_ok;
 }
 
+oms_status_enu_t oms3::Flags::IgnoreInitialUnknowns(const std::string& value)
+{
+  GetInstance().ignoreInitialUnknowns = (value == "true");
+  return oms_status_ok;
+}
+
 oms_status_enu_t oms3::Flags::Intervals(const std::string& value)
 {
   GetInstance().intervals = atoi(value.c_str());

--- a/src/OMSimulatorLib/Flags.h
+++ b/src/OMSimulatorLib/Flags.h
@@ -55,6 +55,7 @@ namespace oms3
     static oms_status_enu_t SetCommandLineOption(const std::string& cmd);
 
     static bool DefaultModeIsCS() {return GetInstance().defaultModeIsCS;}
+    static bool IgnoreInitialUnknowns() {return GetInstance().ignoreInitialUnknowns;}
     static bool InputDerivatives() {return GetInstance().inputDerivatives;}
     static bool ProgressBar() {return GetInstance().progressBar;}
     static bool SuppressPath() {return GetInstance().suppressPath;}
@@ -69,6 +70,7 @@ namespace oms3
     static void SuppressPath(bool value) {GetInstance().suppressPath = value;}
 
   private:
+    bool ignoreInitialUnknowns = false;
     bool suppressPath = false;
     bool progressBar = false;
     bool inputDerivatives = false;
@@ -106,6 +108,7 @@ namespace oms3
       {"", "", "FMU or SSP file", re_filename, Flags::Filename, false},
       {"--fetchAllVars", "", "", re_default, Flags::FetchAllVars, false},
       {"--help", "-h", "Displays the help text", re_void, Flags::Help, true},
+      {"--ignoreInitialUnknowns", "", "Ignore the initial unknowns from the modelDesction.xml", re_bool, Flags::IgnoreInitialUnknowns, false},
       {"--intervals", "-i", "Specifies the number of communication points (arg > 1)", re_number, Flags::Intervals, false},
       {"--logFile", "-l", "Specifies the logfile (stdout is used if no log file is specified)", re_default, Flags::LogFile, false},
       {"--logLevel", "", "0 default, 1 default+debug, 2 default+debug+trace", re_number, Flags::LogLevel, false},
@@ -128,6 +131,7 @@ namespace oms3
     static oms_status_enu_t FetchAllVars(const std::string& value);
     static oms_status_enu_t Filename(const std::string& value);
     static oms_status_enu_t Help(const std::string& value);
+    static oms_status_enu_t IgnoreInitialUnknowns(const std::string& value);
     static oms_status_enu_t Intervals(const std::string& value);
     static oms_status_enu_t LogFile(const std::string& value);
     static oms_status_enu_t LogLevel(const std::string& value);


### PR DESCRIPTION
### Purpose

The new flag `--ignoreInitialUnknowns=true` is introduced to ignore (wrong) initial unknowns from the modelDesction.xml.

### Type of Change

<!--- Please delete options that are not relevant. -->

- New feature (non-breaking change which adds functionality)

### Checklist

<!--- Please delete options that are not relevant. -->

- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas