### PR TITLE
Remove oms prefix for python bindings

### DIFF
--- a/doc/UsersGuide/source/OMSimulatorPython.rst
+++ b/doc/UsersGuide/source/OMSimulatorPython.rst
@@ -13,27 +13,27 @@ Examples
 .. code-block:: python
 
   from OMSimulator import OMSimulator
-  session = OMSimulator()
+  oms = OMSimulator()
 
-  session.newFMIModel("model")
+  oms.newFMIModel("model")
 
   # instantiate FMUs
-  session.addFMU("model", "FMUs/submodelA.fmu", "A")
-  session.addFMU("model", "FMUs/submodelB.fmu", "B")
+  oms.addFMU("model", "FMUs/submodelA.fmu", "A")
+  oms.addFMU("model", "FMUs/submodelB.fmu", "B")
 
   # add connections
-  session.addConnection("model", "A:in1", "B:out1")
-  session.addConnection("model", "A:in2", "B:out2")
-  session.addConnection("model", "A:out1", "B:in1")
-  session.addConnection("model", "A:out2", "B:in2")
+  oms.addConnection("model", "A:in1", "B:out1")
+  oms.addConnection("model", "A:in2", "B:out2")
+  oms.addConnection("model", "A:out1", "B:in1")
+  oms.addConnection("model", "A:out2", "B:in2")
 
-  session.setStopTime("model", 2.0)
-  session.setCommunicationInterval("model", 1e-5)
-  session.setResultFile("model", "AB_res.mat")
+  oms.setStopTime("model", 2.0)
+  oms.setCommunicationInterval("model", 1e-5)
+  oms.setResultFile("model", "AB_res.mat")
 
-  session.initialize("model")
-  session.simulate("model")
-  session.unloadModel("model")
+  oms.initialize("model")
+  oms.simulate("model")
+  oms.unloadModel("model")
 
 .. index:: OMSimulatorPython; Scripting Commands
 

--- a/doc/UsersGuide/source/api/addBus.rst
+++ b/doc/UsersGuide/source/api/addBus.rst
@@ -15,7 +15,7 @@ Adds a bus to a given component.
 #PYTHON#
 .. code-block:: python
 
-  status = session.oms_addBus(cref)
+  status = oms.addBus(cref)
 
 #END#
 

--- a/doc/UsersGuide/source/api/addConnection.rst
+++ b/doc/UsersGuide/source/api/addConnection.rst
@@ -16,7 +16,7 @@ specified as fully qualified component references, e.g., `"model.system.componen
 #PYTHON#
 .. code-block:: python
 
-  status = session.oms_addConnection(crefA, crefB)
+  status = oms.addConnection(crefA, crefB)
 
 #END#
 

--- a/doc/UsersGuide/source/api/addConnector.rst
+++ b/doc/UsersGuide/source/api/addConnector.rst
@@ -15,7 +15,7 @@ Adds a connector to a given component.
 #PYTHON#
 .. code-block:: python
 
-  status = session.oms_addConnector(cref, causality, type)
+  status = oms.addConnector(cref, causality, type)
 
 #END#
 

--- a/doc/UsersGuide/source/api/addConnectorToBus.rst
+++ b/doc/UsersGuide/source/api/addConnectorToBus.rst
@@ -15,7 +15,7 @@ Adds a connector to a bus.
 #PYTHON#
 .. code-block:: python
 
-  status = session.oms_addConnectorToBus(busCref, connectorCref)
+  status = oms.addConnectorToBus(busCref, connectorCref)
 
 #END#
 

--- a/doc/UsersGuide/source/api/addConnectorToTLMBus.rst
+++ b/doc/UsersGuide/source/api/addConnectorToTLMBus.rst
@@ -15,7 +15,7 @@ Adds a connector to a TLM bus.
 #PYTHON#
 .. code-block:: python
 
-  status = session.oms_addConnectorToTLMBus(busCref, connectorCref, type)
+  status = oms.addConnectorToTLMBus(busCref, connectorCref, type)
 
 #END#
 

--- a/doc/UsersGuide/source/api/addExternalModel.rst
+++ b/doc/UsersGuide/source/api/addExternalModel.rst
@@ -15,7 +15,7 @@ Adds an external model to a TLM system.
 #PYTHON#
 .. code-block:: python
 
-  status = session.oms_addExternalModel(cref, path, startscript)
+  status = oms.addExternalModel(cref, path, startscript)
 
 #END#
 

--- a/doc/UsersGuide/source/api/addSignalsToResults.rst
+++ b/doc/UsersGuide/source/api/addSignalsToResults.rst
@@ -15,7 +15,7 @@ Add all variables that match the given regex to the result file.
 #PYTHON#
 .. code-block:: python
 
-  status = session.oms_addSignalsToResults(cref, regex)
+  status = oms.addSignalsToResults(cref, regex)
 
 #END#
 

--- a/doc/UsersGuide/source/api/addSubModel.rst
+++ b/doc/UsersGuide/source/api/addSubModel.rst
@@ -15,7 +15,7 @@ Adds a component to a system.
 #PYTHON#
 .. code-block:: python
 
-  status = session.oms_addSubModel(cref, fmuPath)
+  status = oms.addSubModel(cref, fmuPath)
 
 #END#
 

--- a/doc/UsersGuide/source/api/addSystem.rst
+++ b/doc/UsersGuide/source/api/addSystem.rst
@@ -15,7 +15,7 @@ Adds a (sub-)system to a model or system.
 #PYTHON#
 .. code-block:: python
 
-  status = session.oms_addSystem(cref, type)
+  status = oms.addSystem(cref, type)
 
 #END#
 

--- a/doc/UsersGuide/source/api/addTLMBus.rst
+++ b/doc/UsersGuide/source/api/addTLMBus.rst
@@ -15,7 +15,7 @@ Adds a TLM bus.
 #PYTHON#
 .. code-block:: python
 
-  status = session.oms_addTLMBus(cref, domain, dimensions, interpolation)
+  status = oms.addTLMBus(cref, domain, dimensions, interpolation)
 
 #END#
 

--- a/doc/UsersGuide/source/api/addTLMConnection.rst
+++ b/doc/UsersGuide/source/api/addTLMConnection.rst
@@ -15,7 +15,7 @@ Connects two TLM connectors.
 #PYTHON#
 .. code-block:: python
 
-  status = session.oms_addTLMConnection(crefA, crefB, delay, alpha, linearimpedance, angularimpedance)
+  status = oms.addTLMConnection(crefA, crefB, delay, alpha, linearimpedance, angularimpedance)
 
 #END#
 

--- a/doc/UsersGuide/source/api/compareSimulationResults.rst
+++ b/doc/UsersGuide/source/api/compareSimulationResults.rst
@@ -36,7 +36,7 @@ The following table describes the return values:
 #PYTHON#
 .. code-block:: python
 
-  session.oms_compareSimulationResults(filenameA, filenameB, var, relTol, absTol)
+  oms.compareSimulationResults(filenameA, filenameB, var, relTol, absTol)
 
 #END#
 

--- a/doc/UsersGuide/source/api/copySystem.rst
+++ b/doc/UsersGuide/source/api/copySystem.rst
@@ -15,7 +15,7 @@ Copies a system.
 #PYTHON#
 .. code-block:: python
 
-  status = session.oms_copySystem(source, target)
+  status = oms.copySystem(source, target)
 
 #END#
 

--- a/doc/UsersGuide/source/api/delete.rst
+++ b/doc/UsersGuide/source/api/delete.rst
@@ -15,7 +15,7 @@ Deletes a connector, component, system, or model object.
 #PYTHON#
 .. code-block:: python
 
-  status = session.oms_delete(cref)
+  status = oms.delete(cref)
 
 #END#
 

--- a/doc/UsersGuide/source/api/deleteConnection.rst
+++ b/doc/UsersGuide/source/api/deleteConnection.rst
@@ -15,7 +15,7 @@ Deletes the connection between connectors `crefA` and `crefB`.
 #PYTHON#
 .. code-block:: python
 
-  status = session.oms_deleteConnection(crefA, crefB)
+  status = oms.deleteConnection(crefA, crefB)
 
 #END#
 

--- a/doc/UsersGuide/source/api/deleteConnectorFromBus.rst
+++ b/doc/UsersGuide/source/api/deleteConnectorFromBus.rst
@@ -15,7 +15,7 @@ Deletes a connector from a given bus.
 #PYTHON#
 .. code-block:: python
 
-  status = session.oms_deleteConnectorFromBus(busCref, connectorCref)
+  status = oms.deleteConnectorFromBus(busCref, connectorCref)
 
 #END#
 

--- a/doc/UsersGuide/source/api/deleteConnectorFromTLMBus.rst
+++ b/doc/UsersGuide/source/api/deleteConnectorFromTLMBus.rst
@@ -15,7 +15,7 @@ Deletes a connector from a given TLM bus.
 #PYTHON#
 .. code-block:: python
 
-  status = session.oms_deleteConnectorFromTLMBus(busCref, connectorCref)
+  status = oms.deleteConnectorFromTLMBus(busCref, connectorCref)
 
 #END#
 

--- a/doc/UsersGuide/source/api/export.rst
+++ b/doc/UsersGuide/source/api/export.rst
@@ -15,7 +15,7 @@ Exports a composite model to a SPP file.
 #PYTHON#
 .. code-block:: python
 
-  status = session.oms_export(cref, filename)
+  status = oms.export(cref, filename)
 
 #END#
 

--- a/doc/UsersGuide/source/api/exportDependencyGraphs.rst
+++ b/doc/UsersGuide/source/api/exportDependencyGraphs.rst
@@ -15,7 +15,7 @@ Export the dependency graphs of a given model to dot files.
 #PYTHON#
 .. code-block:: python
 
-  status = session.oms_exportDependencyGraphs(cref, initialization, simulation)
+  status = oms.exportDependencyGraphs(cref, initialization, simulation)
 
 #END#
 

--- a/doc/UsersGuide/source/api/freeMemory.rst
+++ b/doc/UsersGuide/source/api/freeMemory.rst
@@ -17,7 +17,7 @@ function.
 #PYTHON#
 .. code-block:: python
 
-  session.oms_freeMemory(obj)
+  oms.freeMemory(obj)
 
 #END#
 

--- a/doc/UsersGuide/source/api/getBoolean.rst
+++ b/doc/UsersGuide/source/api/getBoolean.rst
@@ -15,7 +15,7 @@ Get boolean value of given signal.
 #PYTHON#
 .. code-block:: python
 
-  value, status = session.oms_getBoolean(cref)
+  value, status = oms.getBoolean(cref)
 
 #END#
 

--- a/doc/UsersGuide/source/api/getInteger.rst
+++ b/doc/UsersGuide/source/api/getInteger.rst
@@ -15,7 +15,7 @@ Get integer value of given signal.
 #PYTHON#
 .. code-block:: python
 
-  value, status = session.oms_getInteger(cref)
+  value, status = oms.getInteger(cref)
 
 #END#
 

--- a/doc/UsersGuide/source/api/getReal.rst
+++ b/doc/UsersGuide/source/api/getReal.rst
@@ -15,7 +15,7 @@ Get real value.
 #PYTHON#
 .. code-block:: python
 
-  value, status = session.oms_getReal(cref)
+  value, status = oms.getReal(cref)
 
 #END#
 

--- a/doc/UsersGuide/source/api/getStartTime.rst
+++ b/doc/UsersGuide/source/api/getStartTime.rst
@@ -15,7 +15,7 @@ Get the start time from the model.
 #PYTHON#
 .. code-block:: python
 
-  startTime, status = session.oms_getStartTime(cref)
+  startTime, status = oms.getStartTime(cref)
 
 #END#
 

--- a/doc/UsersGuide/source/api/getStopTime.rst
+++ b/doc/UsersGuide/source/api/getStopTime.rst
@@ -15,7 +15,7 @@ Get the stop time from the model.
 #PYTHON#
 .. code-block:: python
 
-  stopTime, status = session.oms_getStopTime(cref)
+  stopTime, status = oms.getStopTime(cref)
 
 #END#
 

--- a/doc/UsersGuide/source/api/getSubModelPath.rst
+++ b/doc/UsersGuide/source/api/getSubModelPath.rst
@@ -15,7 +15,7 @@ Returns the path of a given component.
 #PYTHON#
 .. code-block:: python
 
-  path, status = session.oms_getSubModelPath(cref)
+  path, status = oms.getSubModelPath(cref)
 
 #END#
 

--- a/doc/UsersGuide/source/api/getVersion.rst
+++ b/doc/UsersGuide/source/api/getVersion.rst
@@ -15,8 +15,8 @@ Returns the library's version string.
 #PYTHON#
 .. code-block:: python
 
-  session = OMSimulator()
-  session.oms_getVersion()
+  oms = OMSimulator()
+  oms.getVersion()
 
 #END#
 

--- a/doc/UsersGuide/source/api/import.rst
+++ b/doc/UsersGuide/source/api/import.rst
@@ -8,21 +8,21 @@ Imports a composite model from a SSP file.
 #LUA#
 .. code-block:: lua
 
-  cref, status = oms_import(filename)
+  cref, status = oms_importFile(filename)
 
 #END#
 
 #PYTHON#
 .. code-block:: python
 
-  cref, status = session.oms_import(filename)
+  cref, status = oms.importFile(filename)
 
 #END#
 
 #CAPI#
 .. code-block:: c
 
-  oms_status_enu_t oms_import(const char* filename, char** cref);
+  oms_status_enu_t oms_importFile(const char* filename, char** cref);
 
 #END#
 

--- a/doc/UsersGuide/source/api/importString.rst
+++ b/doc/UsersGuide/source/api/importString.rst
@@ -15,7 +15,7 @@ Imports a composite model from a string.
 #PYTHON#
 .. code-block:: python
 
-  cref, oms_status_enu_t session.oms_importString(contents)
+  cref, oms_status_enu_t oms.importString(contents)
 
 #END#
 

--- a/doc/UsersGuide/source/api/initialize.rst
+++ b/doc/UsersGuide/source/api/initialize.rst
@@ -15,7 +15,7 @@ Initializes a composite model.
 #PYTHON#
 .. code-block:: python
 
-  status = session.oms_initialize(cref)
+  status = oms.initialize(cref)
 
 #END#
 

--- a/doc/UsersGuide/source/api/instantiate.rst
+++ b/doc/UsersGuide/source/api/instantiate.rst
@@ -15,7 +15,7 @@ Instantiates a given composite model.
 #PYTHON#
 .. code-block:: python
 
-  status = session.oms_instantiate(cref)
+  status = oms.instantiate(cref)
 
 #END#
 

--- a/doc/UsersGuide/source/api/list.rst
+++ b/doc/UsersGuide/source/api/list.rst
@@ -19,7 +19,7 @@ caller doesn't need to call free.
 #PYTHON#
 .. code-block:: python
 
-  contents, status = session.oms_list(cref)
+  contents, status = oms.list(cref)
 
 #END#
 

--- a/doc/UsersGuide/source/api/listUnconnectedConnectors.rst
+++ b/doc/UsersGuide/source/api/listUnconnectedConnectors.rst
@@ -15,7 +15,7 @@ Lists all unconnected connectors of a given system.
 #PYTHON#
 .. code-block:: python
 
-  contents, status = session.oms_listUnconnectedConnectors(cref)
+  contents, status = oms.listUnconnectedConnectors(cref)
 
 #END#
 

--- a/doc/UsersGuide/source/api/newModel.rst
+++ b/doc/UsersGuide/source/api/newModel.rst
@@ -15,7 +15,7 @@ Creates a new and yet empty composite model.
 #PYTHON#
 .. code-block:: python
 
-  status = session.oms_newModel(cref)
+  status = oms.newModel(cref)
 
 #END#
 

--- a/doc/UsersGuide/source/api/parseModelName.rst
+++ b/doc/UsersGuide/source/api/parseModelName.rst
@@ -19,7 +19,7 @@ doesn't need to call free.
 #PYTHON#
 .. code-block:: python
 
-  ident, status = session.oms_parseModelName(contents)
+  ident, status = oms.parseModelName(contents)
 
 #END#
 

--- a/doc/UsersGuide/source/api/removeSignalsFromResults.rst
+++ b/doc/UsersGuide/source/api/removeSignalsFromResults.rst
@@ -15,7 +15,7 @@ Removes all variables that match the given regex to the result file.
 #PYTHON#
 .. code-block:: python
 
-  status = session.oms_removeSignalsFromResults(cref, regex)
+  status = oms.removeSignalsFromResults(cref, regex)
 
 #END#
 

--- a/doc/UsersGuide/source/api/rename.rst
+++ b/doc/UsersGuide/source/api/rename.rst
@@ -15,7 +15,7 @@ Renames a model, system, or component.
 #PYTHON#
 .. code-block:: python
 
-  status = session.oms_rename(cref, newCref)
+  status = oms.rename(cref, newCref)
 
 #END#
 

--- a/doc/UsersGuide/source/api/reset.rst
+++ b/doc/UsersGuide/source/api/reset.rst
@@ -17,7 +17,7 @@ The FMUs go into the same state as after instantiation.
 #PYTHON#
 .. code-block:: python
 
-  status = session.oms_reset(cref)
+  status = oms.reset(cref)
 
 #END#
 

--- a/doc/UsersGuide/source/api/setBoolean.rst
+++ b/doc/UsersGuide/source/api/setBoolean.rst
@@ -15,7 +15,7 @@ Set boolean value of given signal.
 #PYTHON#
 .. code-block:: python
 
-  status = session.oms_setBoolean(cref, value)
+  status = oms.setBoolean(cref, value)
 
 #END#
 

--- a/doc/UsersGuide/source/api/setFixedStepSize.rst
+++ b/doc/UsersGuide/source/api/setFixedStepSize.rst
@@ -17,7 +17,7 @@ systems.
 #PYTHON#
 .. code-block:: python
 
-  status = session.oms_setFixedStepSize(cref, stepSize)
+  status = oms.setFixedStepSize(cref, stepSize)
 
 #END#
 

--- a/doc/UsersGuide/source/api/setInteger.rst
+++ b/doc/UsersGuide/source/api/setInteger.rst
@@ -15,7 +15,7 @@ Set integer value of given signal.
 #PYTHON#
 .. code-block:: python
 
-  status = session.oms_setInteger(cref, value)
+  status = oms.setInteger(cref, value)
 
 #END#
 

--- a/doc/UsersGuide/source/api/setLogFile.rst
+++ b/doc/UsersGuide/source/api/setLogFile.rst
@@ -18,7 +18,7 @@ filename="" to redirect to std streams and proper filename to redirect to file.
 #PYTHON#
 .. code-block:: python
 
-  status = session.oms_setLogFile(filename)
+  status = oms.setLogFile(filename)
 
 #END#
 

--- a/doc/UsersGuide/source/api/setLoggingLevel.rst
+++ b/doc/UsersGuide/source/api/setLoggingLevel.rst
@@ -17,7 +17,7 @@ Enables/Disables debug logging (logDebug and logTrace).
 #PYTHON#
 .. code-block:: python
 
-  session.oms_setLoggingLevel(logLevel)
+  oms.setLoggingLevel(logLevel)
 
 #END#
 

--- a/doc/UsersGuide/source/api/setMaxLogFileSize.rst
+++ b/doc/UsersGuide/source/api/setMaxLogFileSize.rst
@@ -16,7 +16,7 @@ will continue on stdout.
 #PYTHON#
 .. code-block:: python
 
-  session.oms_setMaxLogFileSize(size)
+  oms.setMaxLogFileSize(size)
 
 #END#
 

--- a/doc/UsersGuide/source/api/setReal.rst
+++ b/doc/UsersGuide/source/api/setReal.rst
@@ -15,7 +15,7 @@ Set real value of given signal.
 #PYTHON#
 .. code-block:: python
 
-  status = session.oms_setReal(cref, value)
+  status = oms.setReal(cref, value)
 
 #END#
 

--- a/doc/UsersGuide/source/api/setResultFile.rst
+++ b/doc/UsersGuide/source/api/setResultFile.rst
@@ -16,8 +16,8 @@ Set the result file of the simulation.
 #PYTHON#
 .. code-block:: python
 
-  status = session.oms_setResultFile(cref, filename)
-  status = session.oms_setResultFile(cref, filename, bufferSize)
+  status = oms.setResultFile(cref, filename)
+  status = oms.setResultFile(cref, filename, bufferSize)
 
 #END#
 

--- a/doc/UsersGuide/source/api/setSignalFilter.rst
+++ b/doc/UsersGuide/source/api/setSignalFilter.rst
@@ -14,7 +14,7 @@ setSignalFilter
 #PYTHON#
 .. code-block:: python
 
-  status = session.oms_setSignalFilter(cref, regex)
+  status = oms.setSignalFilter(cref, regex)
 
 #END#
 

--- a/doc/UsersGuide/source/api/setSolver.rst
+++ b/doc/UsersGuide/source/api/setSolver.rst
@@ -15,7 +15,7 @@ Sets the solver method for the given system.
 #PYTHON#
 .. code-block:: python
 
-  status = session.oms_setSolver(cref, solver)
+  status = oms.setSolver(cref, solver)
 
 #END#
 

--- a/doc/UsersGuide/source/api/setStartTime.rst
+++ b/doc/UsersGuide/source/api/setStartTime.rst
@@ -15,7 +15,7 @@ Set the start time of the simulation.
 #PYTHON#
 .. code-block:: python
 
-  status = session.oms_setStartTime(cref, startTime)
+  status = oms.setStartTime(cref, startTime)
 
 #END#
 

--- a/doc/UsersGuide/source/api/setStopTime.rst
+++ b/doc/UsersGuide/source/api/setStopTime.rst
@@ -15,7 +15,7 @@ Set the stop time of the simulation.
 #PYTHON#
 .. code-block:: python
 
-  status = session.oms_setStopTime(cref, stopTime)
+  status = oms.setStopTime(cref, stopTime)
 
 #END#
 

--- a/doc/UsersGuide/source/api/setTempDirectory.rst
+++ b/doc/UsersGuide/source/api/setTempDirectory.rst
@@ -15,7 +15,7 @@ Set new temp directory.
 #PYTHON#
 .. code-block:: python
 
-  status = session.oms_setTempDirectory(newTempDir)
+  status = oms.setTempDirectory(newTempDir)
 
 #END#
 

--- a/doc/UsersGuide/source/api/setTolerance.rst
+++ b/doc/UsersGuide/source/api/setTolerance.rst
@@ -15,7 +15,7 @@ Sets the tolerance for a given system or component.
 #PYTHON#
 .. code-block:: python
 
-  status = session.oms_setTolerance(cref, tolerance)
+  status = oms.setTolerance(cref, tolerance)
 
 #END#
 

--- a/doc/UsersGuide/source/api/setWorkingDirectory.rst
+++ b/doc/UsersGuide/source/api/setWorkingDirectory.rst
@@ -15,7 +15,7 @@ Set a new working directory.
 #PYTHON#
 .. code-block:: python
 
-  status = session.oms_setWorkingDirectory(newWorkingDir)
+  status = oms.setWorkingDirectory(newWorkingDir)
 
 #END#
 

--- a/doc/UsersGuide/source/api/simulate.rst
+++ b/doc/UsersGuide/source/api/simulate.rst
@@ -15,7 +15,7 @@ Simulates a composite model.
 #PYTHON#
 .. code-block:: python
 
-  status = session.oms_simulate(cref)
+  status = oms.simulate(cref)
 
 #END#
 

--- a/doc/UsersGuide/source/api/stepUntil.rst
+++ b/doc/UsersGuide/source/api/stepUntil.rst
@@ -15,7 +15,7 @@ Simulates a composite model until a given time value.
 #PYTHON#
 .. code-block:: python
 
-  status = session.oms_stepUntil(cref, stopTime)
+  status = oms.stepUntil(cref, stopTime)
 
 #END#
 

--- a/doc/UsersGuide/source/api/terminate.rst
+++ b/doc/UsersGuide/source/api/terminate.rst
@@ -15,7 +15,7 @@ Terminates a given composite model.
 #PYTHON#
 .. code-block:: python
 
-  status = session.oms_terminate(cref)
+  status = oms.terminate(cref)
 
 #END#
 

--- a/src/OMSimulatorLib/OMSimulator.cpp
+++ b/src/OMSimulatorLib/OMSimulator.cpp
@@ -170,7 +170,7 @@ oms_status_enu_t oms_export(const char* cref_, const char* filename)
   return oms::Scope::GetInstance().exportModel(oms::ComRef(cref_), std::string(filename));
 }
 
-oms_status_enu_t oms_import(const char* filename, char** cref)
+oms_status_enu_t oms_importFile(const char* filename, char** cref)
 {
   return oms::Scope::GetInstance().importModel(std::string(filename), cref);
 }
@@ -988,7 +988,7 @@ oms_status_enu_t oms_RunFile(const char* filename_)
   else if (type == ".ssp")
   {
     char* cref;
-    oms_import(filename.c_str(), &cref);
+    oms_importFile(filename.c_str(), &cref);
 
     if (oms::Flags::ResultFile() != "<default>")
       oms_setResultFile(cref, oms::Flags::ResultFile().c_str(), 1);

--- a/src/OMSimulatorLib/OMSimulator.h
+++ b/src/OMSimulatorLib/OMSimulator.h
@@ -98,7 +98,7 @@ OMSAPI oms_status_enu_t OMSCALL oms_getSystemType(const char* cref, oms_system_e
 OMSAPI oms_status_enu_t OMSCALL oms_getTLMBus(const char* cref, oms_tlmbusconnector_t** tlmBusConnector);
 OMSAPI oms_status_enu_t OMSCALL oms_getTLMVariableTypes(oms_tlm_domain_t domain, const int dimensions, const oms_tlm_interpolation_t interpolation, char ***types, char ***descriptions);
 OMSAPI const char* OMSCALL oms_getVersion();
-OMSAPI oms_status_enu_t OMSCALL oms_import(const char* filename, char** cref);
+OMSAPI oms_status_enu_t OMSCALL oms_importFile(const char* filename, char** cref);
 OMSAPI oms_status_enu_t OMSCALL oms_importString(const char* contents, char** cref);
 OMSAPI oms_status_enu_t OMSCALL oms_initialize(const char* cref);
 OMSAPI oms_status_enu_t OMSCALL oms_instantiate(const char* cref);

--- a/src/OMSimulatorLua/OMSimulatorLua.c
+++ b/src/OMSimulatorLua/OMSimulatorLua.c
@@ -198,8 +198,8 @@ static int OMSimulatorLua_oms_export(lua_State *L)
   return 1;
 }
 
-//oms_status_enu_t oms_import(const char* filename, const char** cref);
-static int OMSimulatorLua_oms_import(lua_State *L)
+//oms_status_enu_t oms_importFile(const char* filename, const char** cref);
+static int OMSimulatorLua_oms_importFile(lua_State *L)
 {
   if (lua_gettop(L) != 1)
     return luaL_error(L, "expecting exactly 1 argument");
@@ -207,7 +207,7 @@ static int OMSimulatorLua_oms_import(lua_State *L)
 
   const char* filename = lua_tostring(L, 1);
   char* cref = NULL;
-  oms_status_enu_t status = oms_import(filename, &cref);
+  oms_status_enu_t status = oms_importFile(filename, &cref);
 
   lua_pushstring(L, cref ? cref : "");
   lua_pushinteger(L, status);
@@ -1289,7 +1289,7 @@ DLLEXPORT int luaopen_OMSimulatorLua(lua_State *L)
   REGISTER_LUA_CALL(oms_getStopTime);
   REGISTER_LUA_CALL(oms_getSystemType);
   REGISTER_LUA_CALL(oms_getVersion);
-  REGISTER_LUA_CALL(oms_import);
+  REGISTER_LUA_CALL(oms_importFile);
   REGISTER_LUA_CALL(oms_importString);
   REGISTER_LUA_CALL(oms_initialize);
   REGISTER_LUA_CALL(oms_instantiate);

--- a/src/OMSimulatorPython/OMSimulator.py
+++ b/src/OMSimulatorPython/OMSimulator.py
@@ -11,11 +11,11 @@ class OMSimulator:
     else:
       self.obj=cdll.LoadLibrary("libOMSimulator.so")
 
-    self.oms_system()
-    self.oms_causality()
-    self.oms_signal_type()
-    self.oms_tlm_interpolation()
-    self.oms_tlm_domain()
+    self.system()
+    self.causality()
+    self.signal_type()
+    self.tlm_interpolation()
+    self.tlm_domain()
 
     self.obj.oms_getVersion.argtypes = None
     self.obj.oms_getVersion.restype = ctypes.c_char_p
@@ -50,8 +50,8 @@ class OMSimulator:
     self.obj.oms_export.argtypes = [ctypes.c_char_p, ctypes.c_char_p]
     self.obj.oms_export.restype = ctypes.c_int
 
-    self.obj.oms_import.argtypes = [ctypes.c_char_p]
-    self.obj.oms_import.restype = ctypes.c_int
+    self.obj.oms_importFile.argtypes = [ctypes.c_char_p]
+    self.obj.oms_importFile.restype = ctypes.c_int
 
     self.obj.oms_list.argtypes = [ctypes.c_char_p]
     self.obj.oms_list.restype = ctypes.c_int
@@ -171,154 +171,154 @@ class OMSimulator:
     self.obj.oms_setFixedStepSize.restype = ctypes.c_int
 
   ## define enum types for accesing typedef enum from c
-  def oms_system(self):
-    self.oms_system_none = 0
-    self.oms_system_tlm = 1
-    self.oms_system_wc = 2
-    self.oms_system_sc = 3
-  def oms_causality(self):
+  def system(self):
+    self.system_none = 0
+    self.system_tlm = 1
+    self.system_wc = 2
+    self.system_sc = 3
+  def causality(self):
     self.input = 0
     self.output = 1
     self.parameter = 2
     self.bidir = 3
     self.undefined = 4
-  def oms_signal_type(self):
-    self.oms_signal_type_real = 0
-    self.oms_signal_type_integer = 1
-    self.oms_signal_type_boolean = 2
-    self.oms_signal_type_string = 3
-    self.oms_signal_type_enum = 4
-    self.oms_signal_type_bus = 5
-  def oms_tlm_interpolation(self):
+  def signal_type(self):
+    self.signal_type_real = 0
+    self.signal_type_integer = 1
+    self.signal_type_boolean = 2
+    self.signal_type_string = 3
+    self.signal_type_enum = 4
+    self.signal_type_bus = 5
+  def tlm_interpolation(self):
     self.default = 0
     self.coarsegrained = 1
     self.finegrained = 2
-  def oms_tlm_domain(self):
-    self.oms_tlm_domain_input = 0
-    self.oms_tlm_domain_output = 1
-    self.oms_tlm_domain_mechanical = 2
-    self.oms_tlm_domain_rotational = 3
-    self.oms_tlm_domain_hydraulic = 4
-    self.oms_tlm_domain_electric = 5
+  def tlm_domain(self):
+    self.tlm_domain_input = 0
+    self.tlm_domain_output = 1
+    self.tlm_domain_mechanical = 2
+    self.tlm_domain_rotational = 3
+    self.tlm_domain_hydraulic = 4
+    self.tlm_domain_electric = 5
 
-  def oms_getVersion(self):
+  def getVersion(self):
     return self.checkstring(self.obj.oms_getVersion())
-  def oms_getSystemType(self, cref):
+  def getSystemType(self, cref):
     type = ctypes.c_int()
     status = self.obj.oms_getSystemType(self.checkstring(cref), ctypes.byref(type))
     return [status, type.value]
-  def oms_setLogFile(self, filename):
+  def setLogFile(self, filename):
     return self.obj.oms_setLogFile(self.checkstring(filename))
-  def oms_setLoggingInterval(self, cref, loggingInterval):
+  def setLoggingInterval(self, cref, loggingInterval):
     return self.obj.oms_setLoggingInterval(self.checkstring(cref), loggingInterval)
-  def oms_setMaxLogFileSize(self, size):
+  def setMaxLogFileSize(self, size):
     return self.obj.oms_setMaxLogFileSize(size)
-  def oms_setTempDirectory(self, newTempDir):
+  def setTempDirectory(self, newTempDir):
     return self.obj.oms_setTempDirectory(self.checkstring(newTempDir))
-  def oms_setWorkingDirectory(self, path):
+  def setWorkingDirectory(self, path):
     return self.obj.oms_setWorkingDirectory(self.checkstring(path))
-  def oms_newModel(self, cref):
+  def newModel(self, cref):
     return self.obj.oms_newModel(self.checkstring(cref))
-  def oms_rename(self, cref, newcref):
+  def rename(self, cref, newcref):
     return self.obj.oms_rename(self.checkstring(cref), self.checkstring(newcref))
-  def oms_delete(self, cref):
+  def delete(self, cref):
     return self.obj.oms_delete(self.checkstring(cref))
-  def oms_export(self, cref, filename):
+  def export(self, cref, filename):
     return self.obj.oms_export(self.checkstring(cref), self.checkstring(filename))
-  def oms_import(self, filename):
+  def importFile(self, filename):
     contents = ctypes.c_char_p()
-    status = self.obj.oms_import(self.checkstring(filename), ctypes.byref(contents))
+    status = self.obj.oms_importFile(self.checkstring(filename), ctypes.byref(contents))
     return [status, contents.value]
-  def oms_list(self, ident):
+  def list(self, ident):
     contents = ctypes.c_char_p()
     status = self.obj.oms_list(self.checkstring(ident), ctypes.byref(contents))
     #self.obj.oms_freeMemory(contents)
     return [status, contents.value]
-  def oms_parseModelName(self, ident):
+  def parseModelName(self, ident):
     contents = ctypes.c_char_p()
     status = self.obj.oms_parseModelName(self.checkstring(ident), ctypes.byref(contents))
     #self.obj.oms_freeMemory(contents)
     return [status, contents.value]
-  def oms_importString(self, ident):
+  def importString(self, ident):
     contents = ctypes.c_char_p()
     status = self.obj.oms_importString(self.checkstring(ident), ctypes.byref(contents))
     #self.obj.oms_freeMemory(contents)
     return [status, contents.value]
-  def oms_addSystem(self, ident, type):
+  def addSystem(self, ident, type):
     return self.obj.oms_addSystem(self.checkstring(ident), type)
-  def oms_copySystem(self, source, target):
+  def copySystem(self, source, target):
     return self.obj.oms_copySystem(self.checkstring(source), self.checkstring(target))
-  def oms_addSubModel(self, cref, fmuPath):
+  def addSubModel(self, cref, fmuPath):
     return self.obj.oms_addSubModel(self.checkstring(cref), self.checkstring(fmuPath))
-  def oms_addConnector(self, cref, causality, type):
+  def addConnector(self, cref, causality, type):
     return self.obj.oms_addConnector(self.checkstring(cref), causality, type)
-  def oms_setCommandLineOption(self, cmd):
+  def setCommandLineOption(self, cmd):
     return self.obj.oms_setCommandLineOption(self.checkstring(cmd))
-  def oms_addConnection(self, crefA, crefB):
+  def addConnection(self, crefA, crefB):
     return self.obj.oms_addConnection(self.checkstring(crefA), self.checkstring(crefB))
-  def oms_deleteConnection(self, crefA, crefB):
+  def deleteConnection(self, crefA, crefB):
     return self.obj.oms_deleteConnection(self.checkstring(crefA), self.checkstring(crefB))
-  def oms_addBus(self, crefA):
+  def addBus(self, crefA):
     return self.obj.oms_addBus(self.checkstring(crefA))
-  def oms_addConnectorToBus(self, busCref, connectorCref):
+  def addConnectorToBus(self, busCref, connectorCref):
     return self.obj.oms_addConnectorToBus(self.checkstring(busCref), self.checkstring(connectorCref))
-  def oms_deleteConnectorFromBus(self, busCref, connectorCref):
+  def deleteConnectorFromBus(self, busCref, connectorCref):
     return self.obj.oms_deleteConnectorFromBus(self.checkstring(busCref), self.checkstring(connectorCref))
-  def oms_addTLMBus(self, cref, domain, dimensions, interpolation):
+  def addTLMBus(self, cref, domain, dimensions, interpolation):
     return self.obj.oms_addTLMBus(self.checkstring(cref), self.checkstring(domain), dimensions, interpolation)
-  def oms_addConnectorToTLMBus(self, busCref, connectorCref, type):
+  def addConnectorToTLMBus(self, busCref, connectorCref, type):
     return self.obj.oms_addConnectorToTLMBus(self.checkstring(busCref), self.checkstring(connectorCref), self.checkstring(type))
-  def oms_deleteConnectorFromTLMBus(self, busCref, connectorCref):
+  def deleteConnectorFromTLMBus(self, busCref, connectorCref):
     return self.obj.oms_deleteConnectorFromTLMBus(self.checkstring(busCref), self.checkstring(connectorCref))
-  def oms_addTLMConnection(self, crefA, crefB, delay, alpha, linearimpedance, angularimpedance):
+  def addTLMConnection(self, crefA, crefB, delay, alpha, linearimpedance, angularimpedance):
     return self.obj.oms_addTLMConnection(self.checkstring(crefA), self.checkstring(crefB), delay, alpha, linearimpedance, angularimpedance)
-  def oms_addExternalModel(self, cref, path, startscript):
+  def addExternalModel(self, cref, path, startscript):
     return self.obj.oms_addExternalModel(self.checkstring(cref), self.checkstring(path), self.checkstring(startscript))
-  def oms_instantiate(self, cref):
+  def instantiate(self, cref):
     return self.obj.oms_instantiate(self.checkstring(cref))
-  def oms_initialize(self, cref):
+  def initialize(self, cref):
     return self.obj.oms_initialize(self.checkstring(cref))
-  def oms_simulate(self, cref):
+  def simulate(self, cref):
     return self.obj.oms_simulate(self.checkstring(cref))
-  def oms_stepUntil(self, cref, stopTime):
+  def stepUntil(self, cref, stopTime):
     return self.obj.oms_stepUntil(self.checkstring(cref), stopTime)
-  def oms_terminate(self, cref):
+  def terminate(self, cref):
     return self.obj.oms_terminate(self.checkstring(cref))
-  def oms_reset(self, cref):
+  def reset(self, cref):
     return self.obj.oms_reset(self.checkstring(cref))
-  def oms_setTLMSocketData(self, cref, address, managerPort, monitorPort):
+  def setTLMSocketData(self, cref, address, managerPort, monitorPort):
     return self.obj.oms_setTLMSocketData(self.checkstring(cref), self.checkstring(address), managerPort, monitorPort)
-  def oms_setTLMPositionAndOrientation(self, cref, x1, x2, x3, A11, A12, A13, A21, A22, A23, A31, A32, A33):
+  def setTLMPositionAndOrientation(self, cref, x1, x2, x3, A11, A12, A13, A21, A22, A23, A31, A32, A33):
     return self.obj.oms_setTLMPositionAndOrientation(self.checkstring(cref), x1, x2, x3, A11, A12, A13, A21, A22, A23, A31, A32, A33)
-  def oms_exportDependencyGraphs(self, cref, initialization, simulation):
+  def exportDependencyGraphs(self, cref, initialization, simulation):
     return self.obj.oms_exportDependencyGraphs(self.checkstring(cref), self.checkstring(initialization), self.checkstring(simulation))
-  def oms_getReal(self, cref):
+  def getReal(self, cref):
     value = ctypes.c_double()
     status = self.obj.oms_getReal(self.checkstring(cref), ctypes.byref(value))
     return [value.value, status]
-  def oms_setReal(self, signal, value):
+  def setReal(self, signal, value):
     return self.obj.oms_setReal(self.checkstring(signal), value)
-  def oms_setResultFile(self, cref, filename, bufferSize):
+  def setResultFile(self, cref, filename, bufferSize):
     return self.obj.oms_setResultFile(self.checkstring(cref), self.checkstring(filename), bufferSize)
-  def oms_setSignalFilter(self, cref, regex):
+  def setSignalFilter(self, cref, regex):
     return self.obj.oms_setSignalFilter(self.checkstring(cref), self.checkstring(regex))
-  def oms_addSignalsToResults(self, cref, regex):
+  def addSignalsToResults(self, cref, regex):
     return self.obj.oms_addSignalsToResults(self.checkstring(cref), self.checkstring(regex))
-  def oms_removeSignalsFromResults(self, cref, regex):
+  def removeSignalsFromResults(self, cref, regex):
     return self.obj.oms_removeSignalsFromResults(self.checkstring(cref), self.checkstring(regex))
-  def oms_getStartTime(self, cref):
+  def getStartTime(self, cref):
     startTime = ctypes.c_double()
     status = self.obj.oms_getStartTime(self.checkstring(cref), ctypes.byref(startTime))
     return [startTime.value, status]
-  def oms_setStartTime(self, cref, startTime):
+  def setStartTime(self, cref, startTime):
     return self.obj.oms_setStartTime(self.checkstring(cref), startTime)
-  def oms_getStopTime(self, cref):
+  def getStopTime(self, cref):
     stopTime = ctypes.c_double()
     status = self.obj.oms_getStopTime(self.checkstring(cref), ctypes.byref(stopTime))
     return [stopTime.value, status]
-  def oms_setStopTime(self, cref, stopTime):
+  def setStopTime(self, cref, stopTime):
     return self.obj.oms_setStopTime(self.checkstring(cref), stopTime)
-  def oms_setFixedStepSize(self, cref, stepSize):
+  def setFixedStepSize(self, cref, stepSize):
     return self.obj.oms_setFixedStepSize(self.checkstring(cref), stepSize)
   def checkstring(self, ident):
     if isinstance(ident, bytes):


### PR DESCRIPTION
It changes also `oms_import` to `oms_importFile`, because import is a keyword in Python.