### PR TITLE
Fix some issues with SSP import for SC systems

### DIFF
--- a/doc/UsersGuide/source/api/setTolerance.rst
+++ b/doc/UsersGuide/source/api/setTolerance.rst
@@ -2,7 +2,7 @@
 setTolerance
 ------------
 
-Sets the tolerance for a given system or component.
+Sets the tolerance for a given model, system, or component.
 #END#
 
 #LUA#

--- a/src/OMSimulatorLib/Connector.cpp
+++ b/src/OMSimulatorLib/Connector.cpp
@@ -107,6 +107,8 @@ oms::Connector* oms::Connector::NewConnector(const pugi::xml_node& node)
     type = oms_signal_type_integer;
   else if (typeString == "Boolean")
     type = oms_signal_type_boolean;
+  else if (typeString == "Enumeration")
+    type = oms_signal_type_enum;
   else
   {
     logError("Failed to import " + std::string(oms::ssd::ssd_connector) + ":type");

--- a/src/OMSimulatorLib/OMSimulator.cpp
+++ b/src/OMSimulatorLib/OMSimulator.cpp
@@ -1500,6 +1500,9 @@ oms_status_enu_t oms_setTolerance(const char* cref, double absoluteTolerance, do
   if (!model)
     return logError_ModelNotInScope(front);
 
+  if (tail.isEmpty())
+    return model->getTopLevelSystem()->setTolerance(absoluteTolerance, relativeTolerance);
+
   oms::System* system = model->getSystem(tail);
   if (system)
     return system->setTolerance(absoluteTolerance, relativeTolerance);

--- a/src/OMSimulatorLib/System.cpp
+++ b/src/OMSimulatorLib/System.cpp
@@ -536,7 +536,14 @@ oms_status_enu_t oms::System::importFromSSD(const pugi::xml_node& node)
           Component* component = NULL;
           std::string type = itElements->attribute("type").as_string();
           if ("application/x-fmu-sharedlibrary" == type)
-            component = ComponentFMUCS::NewComponent(*itElements, this);
+          {
+            if (getType() == oms_system_wc)
+              component = ComponentFMUCS::NewComponent(*itElements, this);
+            else if (getType() == oms_system_sc)
+              component = ComponentFMUME::NewComponent(*itElements, this);
+            else
+              return logError("wrong xml schema detected: " + name);
+          }
           else if ("application/table" == type)
             component = ComponentTable::NewComponent(*itElements, this);
 


### PR DESCRIPTION
### Purpose

* Fix importing enumeration connectors
* Make oms_setTolerance work for a model cref (using its top-level system)
* Fix importing FMUs, based on the system kind

### Type of Change

<!--- Please delete options that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

### Checklist

<!--- Please delete options that are not relevant. -->

- I have performed a self-review of my own code
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to the documentation
- My changes generate no new warnings