### PR TITLE
Make model->getSystem("") returning the root system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@
 /install/
 
 # local files
-/TODO
 /OMSimulator.config
 /OMSimulator.creator
 /OMSimulator.creator.user

--- a/src/OMSimulatorLib/ComRef.cpp
+++ b/src/OMSimulatorLib/ComRef.cpp
@@ -32,6 +32,7 @@
 #include "ComRef.h"
 #include "Types.h"
 #include "Identifier.h"
+#include <assert.h>
 
 oms::ComRef::ComRef(const std::string& path)
 {
@@ -41,6 +42,7 @@ oms::ComRef::ComRef(const std::string& path)
 
 oms::ComRef::ComRef(const char* path)
 {
+  assert(path);
   cref = new char[strlen(path) + 1];
   strcpy(cref, path);
 }
@@ -52,19 +54,19 @@ oms::ComRef::~ComRef()
 
 oms::ComRef::ComRef(const oms::ComRef& copy)
 {
-  cref = new char[strlen(copy.c_str()) + 1];
-  strcpy(cref, copy.c_str());
+  cref = new char[strlen(copy.cref) + 1];
+  strcpy(cref, copy.cref);
 }
 
 oms::ComRef& oms::ComRef::operator=(const oms::ComRef& copy)
 {
   // check for self-assignment
-  if(&copy == this)
+  if (&copy == this)
     return *this;
 
   delete[] cref;
-  cref = new char[strlen(copy.c_str()) + 1];
-  strcpy(cref, copy.c_str());
+  cref = new char[strlen(copy.cref) + 1];
+  strcpy(cref, copy.cref);
 
   return *this;
 }
@@ -86,40 +88,41 @@ bool oms::ComRef::isValidIdent() const
 
 bool oms::ComRef::isEmpty() const
 {
-  return !(cref && cref[0] != '\0');
+  return (cref[0] == '\0');
 }
 
 oms::ComRef oms::ComRef::front() const
 {
-  int dot=0;
+  for (int i=0; cref[i]; ++i)
+  {
+    if (cref[i] == '.')
+    {
+      cref[i] = '\0';
+      oms::ComRef front(cref);
+      cref[i] = '.';
+      return front;
+    }
+  }
 
-  for(int i=0; cref[i] && dot==0; ++i)
-    if(cref[i] == '.')
-      dot = i;
-
-  if (dot)
-    cref[dot] = '\0';
-
-  oms::ComRef front(cref);
-
-  if (dot)
-    cref[dot] = '.';
-  return front;
+  return oms::ComRef(cref);
 }
 
 oms::ComRef oms::ComRef::pop_front()
 {
-  int i=0;
-  for(; cref[i]; ++i)
-    if(cref[i] == '.')
+  for (int i=0; cref[i]; ++i)
+  {
+    if (cref[i] == '.')
     {
       cref[i] = '\0';
-      i++;
-      break;
+      oms::ComRef front(cref);
+      cref[i] = '.';
+      *this = oms::ComRef(cref + i + 1);
+      return front;
     }
+  }
 
   oms::ComRef front(cref);
-  *this = oms::ComRef(cref + i);
+  *this = oms::ComRef("");
   return front;
 }
 

--- a/src/OMSimulatorLib/ComRef.h
+++ b/src/OMSimulatorLib/ComRef.h
@@ -63,7 +63,7 @@ namespace oms
     operator std::string() const {return std::string(cref);}
 
   private:
-    char* cref = NULL;
+    char* cref;
   };
 
   bool operator==(const ComRef& lhs, const ComRef& rhs);
@@ -76,14 +76,11 @@ namespace std
   template <>
   struct hash<oms::ComRef>
   {
-    std::size_t operator()(const oms::ComRef& cref) const
+    size_t operator()(const oms::ComRef& cref) const
     {
-      using std::size_t;
-      using std::hash;
-      using std::string;
-
-      return hash<string>()(string(cref));
+      return hash<std::string>()(std::string(cref));
     }
   };
 }
+
 #endif

--- a/src/OMSimulatorLib/Model.cpp
+++ b/src/OMSimulatorLib/Model.cpp
@@ -108,16 +108,14 @@ oms::System* oms::Model::getSystem(const oms::ComRef& cref)
   if (!system)
     return NULL;
 
+  if (cref.isEmpty())
+    return system;
+
   oms::ComRef tail(cref);
   oms::ComRef front = tail.pop_front();
 
   if (this->system->getCref() == front)
-  {
-    if (tail.isEmpty())
-      return system;
-    else
-      return system->getSystem(tail);
-  }
+    return system->getSystem(tail);
 
   return NULL;
 }

--- a/src/OMSimulatorLib/OMSimulator.cpp
+++ b/src/OMSimulatorLib/OMSimulator.cpp
@@ -329,14 +329,12 @@ oms_status_enu_t oms_getSystemType(const char* cref, oms_system_enu_t* type)
   *type = oms_system_none;
 
   oms::Model* model = oms::Scope::GetInstance().getModel(modelCref);
-  if (!model) {
+  if (!model)
     return logError_ModelNotInScope(modelCref);
-  }
 
   oms::System* system = model->getSystem(tail);
-  if (!system) {
+  if (!system)
     return logError_SystemNotInModel(modelCref, tail);
-  }
 
   *type = system->getType();
   return oms_status_ok;
@@ -1498,9 +1496,6 @@ oms_status_enu_t oms_setTolerance(const char* cref, double absoluteTolerance, do
   oms::Model* model = oms::Scope::GetInstance().getModel(front);
   if (!model)
     return logError_ModelNotInScope(front);
-
-  if (tail.isEmpty())
-    return model->getTopLevelSystem()->setTolerance(absoluteTolerance, relativeTolerance);
 
   oms::System* system = model->getSystem(tail);
   if (system)

--- a/src/OMSimulatorLib/System.cpp
+++ b/src/OMSimulatorLib/System.cpp
@@ -167,7 +167,8 @@ oms::ComRef oms::System::getFullCref() const
 
 oms::System* oms::System::getSystem(const oms::ComRef& cref)
 {
-  oms::System* system = NULL;
+  if (cref.isEmpty())
+    return this;
 
   oms::ComRef tail(cref);
   oms::ComRef front = tail.pop_front();
@@ -175,9 +176,6 @@ oms::System* oms::System::getSystem(const oms::ComRef& cref)
   auto it = subsystems.find(front);
   if (it == subsystems.end())
     return NULL;
-
-  if (tail.isEmpty())
-    return it->second;
 
   return it->second->getSystem(tail);
 }


### PR DESCRIPTION
### Purpose

All methods that require a system work now also for model crefs. E.g. `oms_setFixedStepSize("model", ...)` will set the step size for the root system.

### Type of Change

<!--- Please delete options that are not relevant. -->

- Code refactoring (non-breaking change which improves maintainability)
- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)