### PR TITLE
Fix asynchronous simulation

### DIFF
--- a/src/OMSimulatorLib/Model.cpp
+++ b/src/OMSimulatorLib/Model.cpp
@@ -464,24 +464,14 @@ oms_status_enu_t oms::Model::initialize()
 
 oms_status_enu_t oms::Model::simulate_asynchronous(void (*cb)(const char* cref, double time, oms_status_enu_t status))
 {
-  clock.tic();
   if (!validState(oms_modelState_simulation))
-  {
-    clock.toc();
     return logError_ModelInWrongState(this);
-  }
 
   if (!system)
-  {
-    clock.toc();
     return logError("Model doesn't contain a system");
-  }
 
   std::thread([=]{system->stepUntil(stopTime, cb);}).detach();
-  emit(stopTime, true);
-  clock.toc();
-
-  return oms_status_ok;
+  return oms_status_pending;
 }
 
 oms_status_enu_t oms::Model::simulate()


### PR DESCRIPTION
### Related Issues

Asynchronous simulation in OMEdit isn't working.

### Purpose

Fix writing simulation results if running the simulation asynchronously.

### Type of Change

<!--- Please delete options that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)