### PR TITLE
Make a static build using Alpine Linux

### DIFF
--- a/.CI/alpine/Dockerfile
+++ b/.CI/alpine/Dockerfile
@@ -1,0 +1,4 @@
+# We need gcc 8 for filesystem support
+FROM alpine:edge
+
+RUN apk add -U libtool automake g++ boost-dev boost-static git cmake make readline-dev musl-dev

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,6 +162,7 @@ ENDIF()
 ##########################
 # Configuration for OMTLMSimulatorLib
 option(OMTLM "Enable the OMTLMSimulator module." ON)
+option(BUILD_SHARED "Build and link using shared libraries." ON)
 IF(OMTLM)
 set(OMTLMSIMULATOR_INCLUDEDIR ${PROJECT_SOURCE_DIR}/OMTLMSimulator/common)
 set(OMTLMSIMULATORLIB_INCLUDEDIR ${PROJECT_SOURCE_DIR}/OMTLMSimulator/common/OMTLMSimulatorLib)

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,8 @@ OMSYSIDENT ?= ON
 OMTLM ?= ON
 # Option to enable AddressSanitizer
 ASAN ?= OFF
+# Statically link dependencies as much as possible
+STATIC ?= OFF
 # Option to switch between Debug and Release builds
 BUILD_TYPE ?= Release
 
@@ -77,6 +79,11 @@ else
 endif
 	FEXT=.so
 	CMAKE_FPIC=-DCMAKE_C_FLAGS="-fPIC"
+endif
+
+ifeq ($(STATIC),ON)
+  # Do not use -DBoost_USE_STATIC_LIBS=ON; it messes up -static in alpine/musl
+  CMAKE_STATIC=-DBUILD_SHARED=OFF
 endif
 
 # use cmake from above if is set, otherwise cmake
@@ -195,7 +202,7 @@ $(BUILD_DIR)/Makefile: RegEx CMakeLists.txt
 	@echo
 	$(eval STD_REGEX := $(shell 3rdParty/RegEx/OMSRegEx$(EEXT)))
 	$(MKDIR) $(BUILD_DIR)
-	cd $(BUILD_DIR) && $(CMAKE) $(CMAKE_TARGET) ../.. -DABI=$(ABI) -DSTD_REGEX=$(STD_REGEX) -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -DOMSYSIDENT:BOOL=$(OMSYSIDENT) -DOMTLM:BOOL=$(OMTLM) -DASAN:BOOL=$(ASAN) -DCMAKE_BUILD_TYPE=$(BUILD_TYPE) $(CMAKE_BOOST_ROOT) $(CMAKE_INSTALL_PREFIX) $(HOST_SHORT) $(EXTRA_CMAKE)
+	cd $(BUILD_DIR) && $(CMAKE) $(CMAKE_TARGET) ../.. -DABI=$(ABI) -DSTD_REGEX=$(STD_REGEX) -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -DOMSYSIDENT:BOOL=$(OMSYSIDENT) -DOMTLM:BOOL=$(OMTLM) -DASAN:BOOL=$(ASAN) -DCMAKE_BUILD_TYPE=$(BUILD_TYPE) $(CMAKE_BOOST_ROOT) $(CMAKE_INSTALL_PREFIX) $(HOST_SHORT) $(EXTRA_CMAKE) $(CMAKE_STATIC)
 
 config-fmil: 3rdParty/FMIL/$(INSTALL_DIR)/lib/libfmilib.a
 3rdParty/FMIL/$(INSTALL_DIR)/lib/libfmilib.a: 3rdParty/FMIL/$(BUILD_DIR)/Makefile

--- a/src/OMSimulator/CMakeLists.txt
+++ b/src/OMSimulator/CMakeLists.txt
@@ -41,5 +41,8 @@ ENDIF ()
 
 add_definitions(-DOMS_STATIC)
 target_link_libraries(OMSimulator OMSimulatorLib_static lua ${OMSYSIDENT_OPTION})
+IF (NOT BUILD_SHARED)
+target_link_libraries(OMSimulator -static)
+ENDIF ()
 
 install(TARGETS OMSimulator DESTINATION bin)

--- a/src/OMSimulatorLib/CMakeLists.txt
+++ b/src/OMSimulatorLib/CMakeLists.txt
@@ -143,7 +143,7 @@ IF (WIN32 AND MSVC)
 ENDIF ()
 
 target_link_libraries(OMSimulatorLib fmilib sundials_kinsol sundials_cvode sundials_nvecserial minizip ${LIB_ATOMIC} ${Boost_LIBRARIES} ${OMTLM_LINKFLAGS} ${CMAKE_DL_LIBS} ${CMAKE_THREAD_LIBS_INIT})
-target_link_libraries(OMSimulatorLib_static fmilib sundials_kinsol sundials_cvode sundials_nvecserial minizip ${LIB_ATOMIC} ${Boost_LIBRARIES} ${OMTLM_LINKFLAGS} ${CMAKE_DL_LIBS} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(OMSimulatorLib_static fmilib sundials_kinsol sundials_cvode sundials_nvecserial minizip ${CMAKE_DL_LIBS} ${LIB_ATOMIC} ${CMAKE_THREAD_LIBS_INIT} ${Boost_LIBRARIES} ${OMTLM_LINKFLAGS})
 IF (WIN32 AND MINGW)
   target_link_libraries(OMSimulatorLib shlwapi)
   target_link_libraries(OMSimulatorLib_static shlwapi)


### PR DESCRIPTION
Alpine Linux uses MUSL libc, which is much easier to statically link
than GNU libc. libOMSimulator.so is not compiled due to Boost .a-files
not being compiled with -fPIC.

### Related Issues

#559 