### PR TITLE
Fix deletion of associated connections

### DIFF
--- a/src/OMSimulatorLib/ComRef.cpp
+++ b/src/OMSimulatorLib/ComRef.cpp
@@ -92,6 +92,17 @@ bool oms::ComRef::isEmpty() const
   return (cref[0] == '\0');
 }
 
+bool oms::ComRef::isRootOf(ComRef child) const
+{
+  ComRef root(*this);
+  while (!root.isEmpty())
+  {
+    if (child.pop_front() != root.pop_front())
+      return false;
+  }
+  return true;
+}
+
 oms::ComRef oms::ComRef::front() const
 {
   for (int i=0; cref[i]; ++i)

--- a/src/OMSimulatorLib/ComRef.h
+++ b/src/OMSimulatorLib/ComRef.h
@@ -55,6 +55,7 @@ namespace oms
     static bool isValidIdent(const std::string& ident);
     bool isValidIdent() const;
     bool isEmpty() const;
+    bool isRootOf(ComRef child) const;
 
     ComRef front() const;
     ComRef pop_front();

--- a/src/OMSimulatorLib/Connection.cpp
+++ b/src/OMSimulatorLib/Connection.cpp
@@ -186,5 +186,5 @@ bool oms::Connection::isEqual(const oms::Connection& connection) const
 
 bool oms::Connection::containsSignal(const oms::ComRef& signal)
 {
-  return signal == oms::ComRef(this->conA) || signal == oms::ComRef(this->conB);
+  return signal.isRootOf(oms::ComRef(this->conA)) || signal.isRootOf(oms::ComRef(this->conB));
 }

--- a/src/OMSimulatorLib/OMSimulator.cpp
+++ b/src/OMSimulatorLib/OMSimulator.cpp
@@ -155,14 +155,13 @@ oms_status_enu_t oms_delete(const char* cref)
   oms::ComRef tail(cref);
   oms::ComRef front = tail.pop_front();
 
+  if (tail.isEmpty())
+    return oms::Scope::GetInstance().deleteModel(front);
+
   oms::Model* model = oms::Scope::GetInstance().getModel(front);
   if (!model)
     return logError_ModelNotInScope(front);
-
-  if (tail.isEmpty())
-    return oms::Scope::GetInstance().deleteModel(front);
-  else
-    return model->delete_(tail);
+  return model->delete_(tail);
 }
 
 oms_status_enu_t oms_export(const char* cref_, const char* filename)

--- a/src/OMSimulatorLib/System.cpp
+++ b/src/OMSimulatorLib/System.cpp
@@ -491,7 +491,7 @@ oms_status_enu_t oms::System::importFromSSD(const pugi::xml_node& node)
         connectors.back() = oms::Connector::NewConnector(*itConnectors);
         if (connectors.back())
         {
-          exportConnectors[getFullCref() + connectors.back()->getName()] = true;
+          exportConnectors[connectors.back()->getName()] = true;
           connectors.push_back(NULL);
         }
         else
@@ -1388,6 +1388,7 @@ oms_status_enu_t oms::System::delete_(const oms::ComRef& cref)
     auto component = components.find(front);
     if (component != components.end())
     {
+      logInfo("Delete " + std::string(front));
       deleteAllConectionsTo(front);
       delete component->second;
       components.erase(component);
@@ -1397,7 +1398,8 @@ oms_status_enu_t oms::System::delete_(const oms::ComRef& cref)
     for (int i=0; i<connectors.size()-1; ++i)
       if (connectors[i]->getName() == front)
       {
-        exportConnectors.erase(getFullCref() + front);
+        deleteAllConectionsTo(front);
+        exportConnectors.erase(front);
         delete connectors[i];
         connectors.pop_back();   // last element is always NULL
         connectors[i] = connectors.back();


### PR DESCRIPTION
### Related Issues

`oms_delete` didn't remove associated connections if it was used to delete a component.

### Type of Change

<!--- Please delete options that are not relevant. -->

- Bug fix (non-breaking change which fixes an issue)
