### PR TITLE
Implement soft real-time for co-simulation

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,6 +10,7 @@ pipeline {
   parameters {
     booleanParam(name: 'MSVC64', defaultValue: false, description: 'Build with MSVC64 (often hangs)')
     booleanParam(name: 'MINGW32', defaultValue: false, description: 'Build with MINGW32 (does not link boost)')
+    string(name: 'RUNTESTS_FLAG', defaultValue: '-fast', description: 'runtests.pl flag')
   }
   stages {
     stage('build') {
@@ -490,7 +491,7 @@ void partest(cache=true, extraArgs='') {
   ${env.ASAN ? "" : "ulimit -v 6291456" /* Max 6GB per process */}
 
   cd testsuite/partest
-  ./runtests.pl ${env.ASAN ? "-asan": ""} -j${numPhysicalCPU()} -nocolour -with-xml ${extraArgs}
+  ./runtests.pl ${env.ASAN ? "-asan": ""} -j${numPhysicalCPU()} -nocolour -with-xml ${params.RUNTESTS_FLAG} ${extraArgs}
   CODE=\$?
   test \$CODE = 0 -o \$CODE = 7 || exit 1
   """

--- a/src/OMSimulatorLib/Flags.cpp
+++ b/src/OMSimulatorLib/Flags.cpp
@@ -67,6 +67,7 @@ void oms::Flags::setDefaults()
   intervals = 100;
   masterAlgorithm = oms_solver_wc_ma;
   progressBar = false;
+  realTime = false;
   resultFile = "<default>";
   solver = oms_solver_sc_cvode;
   startTime = 0.0;
@@ -247,6 +248,12 @@ oms_status_enu_t oms::Flags::Mode(const std::string& value)
 oms_status_enu_t oms::Flags::ProgressBar(const std::string& value)
 {
   GetInstance().progressBar = (value == "true");
+  return oms_status_ok;
+}
+
+oms_status_enu_t oms::Flags::RealTime(const std::string& value)
+{
+  GetInstance().realTime = (value == "true");
   return oms_status_ok;
 }
 

--- a/src/OMSimulatorLib/Flags.h
+++ b/src/OMSimulatorLib/Flags.h
@@ -59,6 +59,7 @@ namespace oms
     static bool IgnoreInitialUnknowns() {return GetInstance().ignoreInitialUnknowns;}
     static bool InputDerivatives() {return GetInstance().inputDerivatives;}
     static bool ProgressBar() {return GetInstance().progressBar;}
+    static bool RealTime() {return GetInstance().realTime;}
     static bool StripRoot() {return GetInstance().stripRoot;}
     static bool SuppressPath() {return GetInstance().suppressPath;}
     static bool WallTime() {return GetInstance().wallTime;}
@@ -76,6 +77,7 @@ namespace oms
     bool ignoreInitialUnknowns;
     bool inputDerivatives;
     bool progressBar;
+    bool realTime;
     bool stripRoot;
     bool suppressPath;
     bool wallTime;
@@ -120,6 +122,7 @@ namespace oms
       {"--logLevel", "", "0 default, 1 default+debug, 2 default+debug+trace", re_number, Flags::LogLevel, false},
       {"--mode", "-m", "Forces a certain FMI mode iff the FMU provides cs and me [arg: cs (default) or me]", re_mode, Flags::Mode, false},
       {"--progressBar", "", "", re_bool, Flags::ProgressBar, false},
+      {"--realTime", "", "Experimental feature for (soft) real-time co-simulation", re_bool, Flags::RealTime, false},
       {"--resultFile", "-r", "Specifies the name of the output result file", re_default, Flags::ResultFile, false},
       {"--setInputDerivatives", "", "", re_bool, Flags::SetInputDerivatives, false},
       {"--solver", "", "Specifies the integration method (euler, cvode)", re_default, Flags::Solver, false},
@@ -145,6 +148,7 @@ namespace oms
     static oms_status_enu_t LogLevel(const std::string& value);
     static oms_status_enu_t Mode(const std::string& value);
     static oms_status_enu_t ProgressBar(const std::string& value);
+    static oms_status_enu_t RealTime(const std::string& value);
     static oms_status_enu_t ResultFile(const std::string& value);
     static oms_status_enu_t SetInputDerivatives(const std::string& value);
     static oms_status_enu_t Solver(const std::string& value);

--- a/src/OMSimulatorLib/SystemWC.cpp
+++ b/src/OMSimulatorLib/SystemWC.cpp
@@ -38,6 +38,7 @@
 #include "ssd/Tags.h"
 #include "SystemTLM.h"
 #include "Types.h"
+#include <thread>
 
 oms::SystemWC::SystemWC(const ComRef& cref, Model* parentModel, System* parentSystem)
   : oms::System(cref, oms_system_wc, parentModel, parentSystem, oms_solver_wc_ma)
@@ -202,6 +203,7 @@ oms_status_enu_t oms::SystemWC::stepUntil(double stopTime, void (*cb)(const char
 {
   CallClock callClock(clock);
   ComRef modelName = this->getModel()->getCref();
+  auto start = std::chrono::steady_clock::now() + std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::duration<double>(time));
 
   double startTime=time;
 
@@ -237,6 +239,18 @@ oms_status_enu_t oms::SystemWC::stepUntil(double stopTime, void (*cb)(const char
           cb(modelName.c_str(), tNext, status);
         return status;
       }
+    }
+
+    if (Flags::RealTime())
+    {
+      auto now = std::chrono::steady_clock::now();
+      // seems a cast to a sufficient high resolution of time is necessary for avoiding truncation errors
+      auto next = start + std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::duration<double>(tNext));
+      std::chrono::duration<double> margin = std::chrono::duration<double>(next - now);
+      if (margin < std::chrono::duration<double>(0))
+        logWarning("real-time frame overrun, time=" + std::to_string(tNext) + "s, exceeded margin=" + std::to_string(margin.count()) + "s");
+      else
+        std::this_thread::sleep_until(next);
     }
 
     time = tNext;

--- a/testsuite/partest/runtests.pl
+++ b/testsuite/partest/runtests.pl
@@ -172,7 +172,7 @@ sub read_makefile {
   my $dir = shift;
   my $header = shift;
 
-  return if($fast == 1 and $dir =~ m"/OMSysIdent"); # Skip OMSysIdent if -fast is given.
+  return if($fast == 1 and $dir =~ m"/tlm"); # Skip tlm if -fast is given.
 
   open(my $in, "<", "$dir/Makefile") or die "Couldn't open $dir/Makefile: $!";
 


### PR DESCRIPTION
### Related Issues

#562

### Purpose

Re-add the soft real-time for co-simulation implementation which was available in oms2.

### Usage

Use the flag `--realTime=true` to enable the soft real-time mode for co-simulation.