### PR TITLE
Fix bug in TLMBusConnector::getActualBus

### DIFF
--- a/src/OMSimulatorLib/TLM/TLMBusConnector.cpp
+++ b/src/OMSimulatorLib/TLM/TLMBusConnector.cpp
@@ -342,7 +342,7 @@ oms::TLMBusConnector* oms::TLMBusConnector::getActualBus(ComRef cref, System *sy
       subcref = connections[i]->getSignalA();
     }
     else {
-      return this;
+      continue;
     }
 
     TLMBusConnector* subBus = system->getTLMBusConnector(subcref);
@@ -359,7 +359,7 @@ oms::TLMBusConnector* oms::TLMBusConnector::getActualBus(ComRef cref, System *sy
     }
   }
 
-  return nullptr; //Should never happen
+  return this;
 }
 
 std::vector<std::string> oms::TLMBusConnector::getVariableTypes(oms_tlm_domain_t domain, int dimensions, oms_tlm_interpolation_t interpolation)


### PR DESCRIPTION
### Purpose

Fix crash in some TLM test models due to non-connected TLM buses which didn't identify themselves as their "actual bus".

### Approach

Return self instead of nullptr if there are no connections in the system that contains the TLM bus.

### Type of Change

- Bug fix (non-breaking change which fixes an issue)

### Checklist

- I have performed a self-review of my own code
- My changes generate no new warnings