### PR TITLE
Add oms_setRealInputDerivative to the API

### DIFF
--- a/doc/UsersGuide/source/api/setRealInputDerivative.rst
+++ b/doc/UsersGuide/source/api/setRealInputDerivative.rst
@@ -1,0 +1,32 @@
+#CAPTION#
+setRealInputDerivative
+----------------------
+
+Sets the first order derivative of a real input signal.
+
+This can only be used for CS-FMU real input signals.
+#END#
+
+#LUA#
+.. code-block:: lua
+
+  status = oms_setRealInputDerivative(cref, value)
+
+#END#
+
+#PYTHON#
+.. code-block:: python
+
+  status = oms.setRealInputDerivative(cref, value)
+
+#END#
+
+#CAPI#
+.. code-block:: c
+
+  oms_status_enu_t oms_setRealInputDerivative(const char* cref, double value);
+
+#END#
+
+#DESCRIPTION#
+#END#

--- a/src/OMSimulatorLib/Logging.h
+++ b/src/OMSimulatorLib/Logging.h
@@ -142,7 +142,8 @@ private:
 #define logError_NotImplemented                              logError("Not implemented")
 #define logError_OnlyForExternalModels                       logError("Only available for TLM sub models (aka external models)")
 #define logError_OnlyForModel                                logError("Only implemented for model identifiers")
-#define logError_OnlyForTlmSystem                            logError("Only available for TLM systems")
+#define logError_OnlyForSystemTLM                            logError("Only available for TLM systems")
+#define logError_OnlyForSystemWC                             logError("Only available for WC systems")
 #define logError_ResetFailed(system)                         logError("failed to reset system \"" + std::string(system) + "\" to instantiation mode")
 #define logError_SubSystemNotInSystem(system, subsystem)     logError("System \"" + std::string(system) + "\" does not contain subsystem \"" + std::string(subsystem) + "\"")
 #define logError_SystemNotInModel(model, system)             logError("Model \"" + std::string(model) + "\" does not contain system \"" + std::string(system) + "\"")
@@ -153,4 +154,5 @@ private:
 #define logError_UnknownTLMVariableType(vartype)             logError("Unknown TLM variable type: \""+vartype+"\"")
 #define logError_VariableTypeAlreadyInTLMBus(cref,vartype)   logError("TLM bus connector \"" + std::string(cref) + "\" already contains a variable with type \"" + vartype + "\"")
 #define logError_WrongSchema(name)                           logError("Wrong xml schema detected. Unexpected tag \"" + name + "\"")
+
 #endif

--- a/src/OMSimulatorLib/OMSimulator.cpp
+++ b/src/OMSimulatorLib/OMSimulator.cpp
@@ -42,6 +42,7 @@
 #include "ResultReader.h"
 #include "Scope.h"
 #include "System.h"
+#include "SystemWC.h"
 #if !defined(NO_TLM)
   #include "SystemTLM.h"
   #include "TLMBusConnector.h"
@@ -1051,7 +1052,7 @@ oms_status_enu_t oms_setTLMSocketData(const char *cref, const char *address, int
     return logError_SystemNotInModel(model->getCref(), front);
 
   if (system->getType() != oms_system_tlm)
-    return logError_OnlyForTlmSystem;
+    return logError_OnlyForSystemTLM;
 
   oms::SystemTLM* tlmsystem = reinterpret_cast<oms::SystemTLM*>(system);
   return tlmsystem->setSocketData(address, managerPort, monitorPort);
@@ -1076,7 +1077,7 @@ oms_status_enu_t oms_setTLMPositionAndOrientation(const char *cref, double x1, d
     return logError_SystemNotInModel(model->getCref(), front);
 
   if (system->getType() != oms_system_tlm)
-    return logError_OnlyForTlmSystem;
+    return logError_OnlyForSystemTLM;
 
   oms::SystemTLM* tlmsystem = reinterpret_cast<oms::SystemTLM*>(system);
   std::vector<double> x = {x1,x2,x3};
@@ -1188,6 +1189,27 @@ oms_status_enu_t oms_setReal(const char* cref, double value)
     return logError_SystemNotInModel(model->getCref(), front);
 
   return system->setReal(tail, value);
+}
+
+oms_status_enu_t oms_setRealInputDerivative(const char* cref, double value)
+{
+  oms::ComRef tail(cref);
+  oms::ComRef front = tail.pop_front();
+
+  oms::Model* model = oms::Scope::GetInstance().getModel(front);
+  if (!model)
+    return logError_ModelNotInScope(front);
+
+  front = tail.pop_front();
+  oms::System* system = model->getSystem(front);
+  if (!system)
+    return logError_SystemNotInModel(model->getCref(), front);
+
+  if (system->getType() != oms_system_wc)
+    return logError_OnlyForSystemWC;
+
+  oms::SystemWC* systemWC = reinterpret_cast<oms::SystemWC*>(system);
+  return systemWC->setRealInputDerivative(tail, value);
 }
 
 oms_status_enu_t oms_setInteger(const char* cref, int value)

--- a/src/OMSimulatorLib/OMSimulator.h
+++ b/src/OMSimulatorLib/OMSimulator.h
@@ -128,6 +128,7 @@ OMSAPI oms_status_enu_t OMSCALL oms_setLoggingInterval(const char* cref, double 
 OMSAPI oms_status_enu_t OMSCALL oms_setLoggingLevel(int logLevel);
 OMSAPI void OMSCALL oms_setMaxLogFileSize(const unsigned long size);
 OMSAPI oms_status_enu_t OMSCALL oms_setReal(const char* cref, double value);
+OMSAPI oms_status_enu_t OMSCALL oms_setRealInputDerivative(const char* cref, double value);
 OMSAPI oms_status_enu_t OMSCALL oms_setResultFile(const char* cref, const char* filename, int bufferSize);
 OMSAPI oms_status_enu_t OMSCALL oms_setSignalFilter(const char* cref, const char* regex);
 OMSAPI oms_status_enu_t OMSCALL oms_setSolver(const char* cref, oms_solver_enu_t solver);

--- a/src/OMSimulatorLib/System.cpp
+++ b/src/OMSimulatorLib/System.cpp
@@ -949,7 +949,7 @@ oms_status_enu_t oms::System::addTLMConnection(const oms::ComRef& crefA, const o
 {
 #if !defined(NO_TLM)
   if (type != oms_system_tlm)
-    return logError_OnlyForTlmSystem;
+    return logError_OnlyForSystemTLM;
 
   oms::ComRef tailA(crefA);
   oms::ComRef headA = tailA.pop_front();
@@ -1183,7 +1183,7 @@ oms_status_enu_t oms::System::addExternalModel(const oms::ComRef& cref, std::str
 {
 #if !defined(NO_TLM)
   if (type != oms_system_tlm)
-    return logError_OnlyForTlmSystem;
+    return logError_OnlyForSystemTLM;
 
   if (!cref.isValidIdent())
     return oms_status_error;

--- a/src/OMSimulatorLib/SystemWC.cpp
+++ b/src/OMSimulatorLib/SystemWC.cpp
@@ -324,6 +324,11 @@ oms_status_enu_t oms::SystemWC::setRealInputDerivative(const ComRef& cref, doubl
   return oms_status_error;
 }
 
+oms_status_enu_t oms::SystemWC::setRealInputDerivative(const ComRef& cref, double value)
+{
+  return setRealInputDerivative(cref, &value, 1);
+}
+
 oms_status_enu_t oms::SystemWC::updateInputs(oms::DirectedGraph& graph)
 {
   CallClock callClock(clock);

--- a/src/OMSimulatorLib/SystemWC.h
+++ b/src/OMSimulatorLib/SystemWC.h
@@ -67,6 +67,7 @@ namespace oms
 
     oms_status_enu_t getRealOutputDerivative(const ComRef& cref, double*& value, unsigned int& order);
     oms_status_enu_t setRealInputDerivative(const ComRef& cref, double* value, unsigned int order);
+    oms_status_enu_t setRealInputDerivative(const ComRef& cref, double value);
     unsigned int getMaxOutputDerivativeOrder();
 
   protected:

--- a/src/OMSimulatorLua/OMSimulatorLua.c
+++ b/src/OMSimulatorLua/OMSimulatorLua.c
@@ -558,7 +558,7 @@ static int OMSimulatorLua_oms_setInteger(lua_State *L)
   return 1;
 }
 
-//oms_status_enu_t oms_setReal(const char* cref, double* value);
+// oms_status_enu_t oms_setReal(const char* cref, double value);
 static int OMSimulatorLua_oms_setReal(lua_State *L)
 {
   if (lua_gettop(L) != 2)
@@ -570,6 +570,22 @@ static int OMSimulatorLua_oms_setReal(lua_State *L)
   double value = lua_tonumber(L, 2);
 
   oms_status_enu_t status = oms_setReal(cref, value);
+  lua_pushinteger(L, status);
+  return 1;
+}
+
+// OMSAPI oms_status_enu_t OMSCALL oms_setRealInputDerivative(const char* cref, double value);
+static int OMSimulatorLua_oms_setRealInputDerivative(lua_State *L)
+{
+  if (lua_gettop(L) != 2)
+    return luaL_error(L, "expecting exactly 2 arguments");
+  luaL_checktype(L, 1, LUA_TSTRING);
+  luaL_checktype(L, 2, LUA_TNUMBER);
+
+  const char* cref = lua_tostring(L, 1);
+  double value = lua_tonumber(L, 2);
+
+  oms_status_enu_t status = oms_setRealInputDerivative(cref, value);
   lua_pushinteger(L, status);
   return 1;
 }
@@ -1134,7 +1150,6 @@ static int OMSimulatorLua_omsi_freeSysIdentModel(lua_State *L)
   return 0;
 }
 
-//void oms_setReal(void* model, const char* var, double value);
 // oms_status_enu_t omsi_initialize(void* simodel, size_t nSeries, const double* time, size_t nTime, char const* const* inputvars, size_t nInputvars, char const* const* measurementvars, size_t nMeasurementvars);
 static int OMSimulatorLua_omsi_initialize(lua_State *L)
 {
@@ -1409,6 +1424,7 @@ DLLEXPORT int luaopen_OMSimulatorLua(lua_State *L)
   REGISTER_LUA_CALL(oms_setLoggingLevel);
   REGISTER_LUA_CALL(oms_setMaxLogFileSize);
   REGISTER_LUA_CALL(oms_setReal);
+  REGISTER_LUA_CALL(oms_setRealInputDerivative);
   REGISTER_LUA_CALL(oms_setResultFile);
   REGISTER_LUA_CALL(oms_setSignalFilter);
   REGISTER_LUA_CALL(oms_setSolver);

--- a/src/OMSimulatorPython/OMSimulator.py
+++ b/src/OMSimulatorPython/OMSimulator.py
@@ -151,6 +151,8 @@ class OMSimulator:
     self.obj.oms_setMaxLogFileSize.restype = None
     self.obj.oms_setReal.argtypes = [ctypes.c_char_p, ctypes.c_double]
     self.obj.oms_setReal.restype = ctypes.c_int
+    self.obj.oms_setRealInputDerivative.argtypes = [ctypes.c_char_p, ctypes.c_double]
+    self.obj.oms_setRealInputDerivative.restype = ctypes.c_int
     self.obj.oms_setResultFile.argtypes = [ctypes.c_char_p, ctypes.c_char_p, ctypes.c_int]
     self.obj.oms_setResultFile.restype = ctypes.c_int
     self.obj.oms_setSignalFilter.argtypes = [ctypes.c_char_p, ctypes.c_char_p]
@@ -308,6 +310,8 @@ class OMSimulator:
     return [value.value, status]
   def setReal(self, signal, value):
     return self.obj.oms_setReal(self.checkstring(signal), value)
+  def setRealInputDerivative(self, signal, value):
+    return self.obj.oms_setRealInputDerivative(self.checkstring(signal), value)
   def setInteger(self, signal, value):
     return self.obj.oms_setInteger(self.checkstring(signal), value)
   def setBoolean(self, signal, value):


### PR DESCRIPTION
### Purpose

Add `oms_setRealInputDerivative` to the API, to make it possible to test new master algorithm from the Lua/Python scripting before implementing them in C.

### Type of Change

<!--- Please delete options that are not relevant. -->

- Code refactoring (non-breaking change which improves maintainability)
- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

### Checklist

<!--- Please delete options that are not relevant. -->

- I have performed a self-review of my own code
- I have made corresponding changes to the documentation
- My changes generate no new warnings
