### PR TITLE
Sequential initialization of TLM submodels

### DIFF
--- a/src/OMSimulatorLib/TLM/SystemTLM.cpp
+++ b/src/OMSimulatorLib/TLM/SystemTLM.cpp
@@ -263,16 +263,13 @@ oms_status_enu_t oms::SystemTLM::stepUntil(double stopTime, void (*cb)(const cha
 
   std::thread *masterThread = new std::thread(&omtlm_simulate, model);
 
-  logInfo("Connecting submodels to manager (threaded)");
+  logInfo("Connecting submodels to manager (sequential)");
   std::string server = address + ":" + std::to_string(actualManagerPort);
-  std::vector<std::thread> fmiConnectThreads;
   for(auto it = getSubSystems().begin(); it!=getSubSystems().end(); ++it) {
     System* subsystem = it->second;
     ComRef syscref = subsystem->getCref();
-    fmiConnectThreads.push_back(std::thread(&oms::SystemTLM::connectToSockets, this, syscref, server));
+    connectToSockets(syscref, server);
   }
-  for(auto &thread : fmiConnectThreads)
-    thread.join();
   for(auto it = getSubSystems().begin(); it!=getSubSystems().end(); ++it) {
     if(find(connectedsubsystems.begin(), connectedsubsystems.end(), it->second->getCref()) == connectedsubsystems.end())
       return logError("Failed to connect TLM subsystem: "+std::string(it->second->getCref()));


### PR DESCRIPTION
### Related Issues

Related to #618 and #623.

### Purpose

Avoid race conditions and ensure thread safety in initialization of TLM models.

### Approach

Make initialization sequential.

### Type of Change

- Bug fix (non-breaking change which fixes an issue)

### Checklist

- I have performed a self-review of my own code