### PR TITLE
Strip prefix "model.root.fmu." for isolated FMUs

### DIFF
--- a/src/OMSimulatorLib/Model.h
+++ b/src/OMSimulatorLib/Model.h
@@ -100,6 +100,9 @@ namespace oms
 
     bool validState(int validStates) const {return (modelState & validStates);}
 
+    bool isIsolatedFMUModel() const {return isolatedFMU;}
+    void setIsolatedFMUModel() {isolatedFMU = true;}
+
   private:
     Model(const ComRef& cref, const std::string& tempDir);
 
@@ -131,6 +134,7 @@ namespace oms
     Clock clock;
 
     bool cancelSim;
+    bool isolatedFMU = false;
   };
 }
 

--- a/src/OMSimulatorLib/OMSimulator.cpp
+++ b/src/OMSimulatorLib/OMSimulator.cpp
@@ -977,6 +977,11 @@ oms_status_enu_t oms_RunFile(const char* filename_)
     status = oms_newModel(modelName.c_str());
     if (oms_status_ok != status) return logError("oms_newModel failed");
 
+    oms::Model* model = oms::Scope::GetInstance().getModel(oms::ComRef(modelName));
+    if (!model)
+      return logError_ModelNotInScope(oms::ComRef(modelName));
+    model->setIsolatedFMUModel();
+
     if (kind == oms_fmi_kind_me_and_cs)
       status = oms_addSystem(systemName.c_str(), oms::Flags::DefaultModeIsCS() ? oms_system_wc : oms_system_sc);
     else

--- a/src/OMSimulatorLib/ResultWriter.cpp
+++ b/src/OMSimulatorLib/ResultWriter.cpp
@@ -31,6 +31,8 @@
 
 #include "ResultWriter.h"
 #include "Flags.h"
+#include "Model.h"
+#include "Scope.h"
 
 oms::ResultWriter::ResultWriter(unsigned int bufferSize)
   : bufferSize(bufferSize),
@@ -52,11 +54,17 @@ unsigned int oms::ResultWriter::addSignal(const ComRef& name, const std::string&
   signal.description = description;
   signal.type = type;
 
-  if (Flags::StripRoot())
+  oms::Model* model = oms::Scope::GetInstance().getModel(name.front());
+  if (Flags::StripRoot() || (model && model->isIsolatedFMUModel()))
   {
     signal.name.pop_front();
     signal.name.pop_front();
+    if (model && model->isIsolatedFMUModel())
+      signal.name.pop_front();
   }
+
+  if (signal.name.isEmpty())
+    return 0;
 
   signals.push_back(signal);
   return (unsigned int) signals.size();
@@ -70,11 +78,17 @@ void oms::ResultWriter::addParameter(const ComRef& name, const std::string& desc
   parameter.signal.type = type;
   parameter.value = value;
 
-  if (Flags::StripRoot())
+  oms::Model* model = oms::Scope::GetInstance().getModel(name.front());
+  if (Flags::StripRoot() || (model && model->isIsolatedFMUModel()))
   {
     parameter.signal.name.pop_front();
     parameter.signal.name.pop_front();
+    if (model && model->isIsolatedFMUModel())
+      parameter.signal.name.pop_front();
   }
+
+  if (parameter.signal.name.isEmpty())
+    return;
 
   parameters.push_back(parameter);
 }


### PR DESCRIPTION
### Purpose

Strip the meaningless prefix "model.root.fmu." when simulating a single FMU from command line.
