### PR TITLE
Reduce port numbers for two TLM test models

### DIFF
--- a/testsuite/tlm/tlm3d.lua
+++ b/testsuite/tlm/tlm3d.lua
@@ -170,7 +170,7 @@ oms_addConnectorToTLMBus("model.tlm3d.wc2.P","model.tlm3d.wc2.t3", "effort6");
 
 oms_addTLMConnection("model.tlm3d.wc1.P","model.tlm3d.wc2.P", 0.00001, 0.9, 10000, 100);
 
-oms_setTLMSocketData("model.tlm3d","127.0.1.1",13511,13611)
+oms_setTLMSocketData("model.tlm3d","127.0.1.1",11511,12511)
 
 oms_setStartTime("model",0);
 oms_setStopTime("model",0.1);

--- a/testsuite/tlm/tlmexternal.lua
+++ b/testsuite/tlm/tlmexternal.lua
@@ -35,7 +35,7 @@ oms_addTLMConnection("model.tlmexternal.adder.x2", "model.tlmexternal.source1.y"
 oms_addTLMConnection("model.tlmexternal.gain.y", "model.tlmexternal.adder.y",     0,0,0,0)
 
 -- simulation parameters
-oms_setTLMSocketData("model.tlmexternal","127.0.1.1",13311,13411)
+oms_setTLMSocketData("model.tlmexternal","127.0.1.1",11411,12411)
 oms_setStartTime("model", 0.5)
 oms_setStopTime("model", 4)
 


### PR DESCRIPTION
### Purpose

TLM 3D test model seem to run forever on Jenkins. It is using the highest port number.

### Approach

Test and reduce initial port number.