### PR TITLE
Handle derivatives that are NAN or INF

### DIFF
--- a/src/OMSimulatorLib/ComponentFMUCS.cpp
+++ b/src/OMSimulatorLib/ComponentFMUCS.cpp
@@ -680,6 +680,9 @@ oms_status_enu_t oms::ComponentFMUCS::setRealInputDerivative(const ComRef& cref,
 {
   CallClock callClock(clock);
 
+  if (!getFMUInfo()->getCanInterpolateInputs())
+    return oms_status_ok;
+
   int j=-1;
   for (size_t i = 0; i < allVariables.size(); i++)
   {
@@ -699,16 +702,7 @@ oms_status_enu_t oms::ComponentFMUCS::setRealInputDerivative(const ComRef& cref,
     return logError_UnknownSignal(getFullCref() + cref);
 
   fmi2_value_reference_t vr = allVariables[j].getValueReference();
-
-  unsigned int order = der.getMaxDerivativeOrder();
-  if (order > 0)
-  {
-    const double* value = der.getDerivatives();
-    if (fmi2_status_ok != fmi2_import_set_real_input_derivatives(fmu, &vr, 1, (fmi2_integer_t*)&order, value))
-      return oms_status_error;
-  }
-
-  return oms_status_ok;
+  return der.setRealInputDerivatives(fmu, vr);
 }
 
 oms_status_enu_t oms::ComponentFMUCS::setBoolean(const ComRef& cref, bool value)

--- a/src/OMSimulatorLib/FMUInfo.h
+++ b/src/OMSimulatorLib/FMUInfo.h
@@ -53,6 +53,7 @@ namespace oms
     std::string getPath() const {return std::string(path);}
     oms_fmi_kind_enu_t getKind() const {return fmiKind;}
 
+    bool getCanInterpolateInputs() const {return canInterpolateInputs;}
     unsigned int getMaxOutputDerivativeOrder() const {return maxOutputDerivativeOrder;}
     bool getCanGetAndSetFMUstate() const {return canGetAndSetFMUstate;}
 

--- a/src/OMSimulatorLib/SignalDerivative.h
+++ b/src/OMSimulatorLib/SignalDerivative.h
@@ -32,7 +32,9 @@
 #ifndef _OMS_SIGNAL_DERIVATIVE_H_
 #define _OMS_SIGNAL_DERIVATIVE_H_
 
+#include "Types.h"
 #include <fmilib.h>
+#include <string>
 
 namespace oms
 {
@@ -50,6 +52,9 @@ namespace oms
 
     const unsigned int getMaxDerivativeOrder() const {return order;}
     const double* getDerivatives() const {return values;}
+    oms_status_enu_t setRealInputDerivatives(fmi2_import_t* fmu, fmi2_value_reference_t vr) const;
+
+    operator std::string() const;
 
   private:
     unsigned int order;

--- a/src/OMSimulatorLib/SystemWC.cpp
+++ b/src/OMSimulatorLib/SystemWC.cpp
@@ -931,7 +931,7 @@ oms_status_enu_t oms::SystemWC::updateCanGetFMUs(oms::DirectedGraph& graph,std::
             SignalDerivative der;
             if (oms_status_ok == getRealOutputDerivative(graph.getNodes()[output].getName(), der))
             {
-              //logInfo(graph.getNodes()[output].getName() + " -> " + graph.getNodes()[input].getName() + ": " + std::to_string(derBuffer[0]));
+              //logInfo(graph.getNodes()[output].getName() + " -> " + graph.getNodes()[input].getName() + ": " + std::string(der));
               if (oms_status_ok != setRealInputDerivative(graph.getNodes()[input].getName(), der)) return oms_status_error;
             }
           }
@@ -1016,7 +1016,7 @@ oms_status_enu_t oms::SystemWC::updateCantGetFMUs(oms::DirectedGraph& graph,std:
             SignalDerivative der;
             if (oms_status_ok == getRealOutputDerivative(graph.getNodes()[output].getName(), der))
             {
-              //logDebug(graph.getNodes()[output].getName() + " -> " + graph.getNodes()[input].getName() + ": " + std::to_string(derBuffer[0]));
+              //logDebug(graph.getNodes()[output].getName() + " -> " + graph.getNodes()[input].getName() + ": " + std::string(der));
               if (oms_status_ok != setRealInputDerivative(graph.getNodes()[input].getName(), der)) return oms_status_error;
             }
           }
@@ -1078,7 +1078,7 @@ oms_status_enu_t oms::SystemWC::updateInputs(oms::DirectedGraph& graph)
           SignalDerivative der;
           if (oms_status_ok == getRealOutputDerivative(graph.getNodes()[output].getName(), der))
           {
-            //logInfo(graph.getNodes()[output].getName() + " -> " + graph.getNodes()[input].getName() + ": " + std::to_string(derBuffer[0]));
+            //logInfo(graph.getNodes()[output].getName() + " -> " + graph.getNodes()[input].getName() + ": " + std::string(der));
             if (oms_status_ok != setRealInputDerivative(graph.getNodes()[input].getName(), der)) return oms_status_error;
           }
         }


### PR DESCRIPTION
### Related Issues

#157 

### Purpose

Sometimes FMUs return NAN or INF as the output derivative.

### Approach

Override those derivatives with zero and print a warning.
