### PR TITLE
Add option to disabled --fetchAllVars

### DIFF
--- a/src/OMSimulatorLib/Component.h
+++ b/src/OMSimulatorLib/Component.h
@@ -69,7 +69,7 @@ namespace oms
     const std::string& getPath() const {return path;}
     oms_component_enu_t getType() const {return type;}
     virtual const FMUInfo* getFMUInfo() const {return NULL;}
-    void fetchAllVars() {fetchAllVars_ = true;}
+    void fetchAllVars(bool enableOption) {fetchAllVars_ = enableOption;}
     System* getParentSystem() const {return parentSystem;}
     Model* getModel() const;
     void setGeometry(const ssd::ElementGeometry& geometry) {element.setGeometry(&geometry);}

--- a/src/OMSimulatorLib/Flags.cpp
+++ b/src/OMSimulatorLib/Flags.cpp
@@ -165,7 +165,15 @@ oms_status_enu_t oms::Flags::ClearAllOptions(const std::string& value)
 
 oms_status_enu_t oms::Flags::FetchAllVars(const std::string& value)
 {
-  oms::ComRef tail(value);
+  std::string cref = value;
+  bool enableOption = true;
+  if (value[0] == '-' || value[0] == '+')
+  {
+    enableOption = (value[0] == '+');
+    cref = cref.substr(1);
+  }
+
+  oms::ComRef tail(cref);
   oms::ComRef front = tail.pop_front();
 
   oms::Model* model = oms::Scope::GetInstance().getModel(front);
@@ -184,8 +192,11 @@ oms_status_enu_t oms::Flags::FetchAllVars(const std::string& value)
   if (component->getType() != oms_component_fmu)
     return oms_status_error;
 
-  component->fetchAllVars();
-  logDebug("--fetchAllVars is enabled for " + value);
+  component->fetchAllVars(enableOption);
+  if (enableOption)
+    logDebug("--fetchAllVars is enabled for " + cref);
+  else
+    logDebug("--fetchAllVars is disabled for " + cref);
   return oms_status_ok;
 }
 


### PR DESCRIPTION
### Related Issues

#255 

### Purpose

Add option to disabled --fetchAllVars.

### Approach

This is implemented as command line option, e.g.:

```lua
oms_setCommandLineOption("--fetchAllVars=-model.root.fmu_name")
```