### PR TITLE
Override OMTLM=OFF for MacOS platform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ ifeq ($(detected_OS),Darwin)
 	CERES := OFF
 	LIBXML2 := OFF
 	OMSYSIDENT := OFF
+	OMTLM := OFF
 	export ABI := MAC64
 	FEXT=.dylib
 	CMAKE_FPIC=-DCMAKE_C_FLAGS="-fPIC"


### PR DESCRIPTION
The testing forces disabling of TLM for MacOS (since it does not
compile). For the OpenModelica glue project, it is better to auto-
detect this.