### PR TITLE
Catch filesystem exception

### DIFF
--- a/src/OMSimulatorLib/ComponentFMUCS.cpp
+++ b/src/OMSimulatorLib/ComponentFMUCS.cpp
@@ -57,8 +57,15 @@ oms::ComponentFMUCS::~ComponentFMUCS()
 
   if (!tempDir.empty() && filesystem::is_directory(tempDir))
   {
-    filesystem::remove_all(tempDir);
-    logDebug("removed working directory: \"" + tempDir + "\"");
+    try
+    {
+      filesystem::remove_all(tempDir);
+      logDebug("removed working directory: \"" + tempDir + "\"");
+    }
+    catch (const std::exception& e)
+    {
+      logWarning("working directory \"" + tempDir + "\" couldn't be removed: " + e.what());
+    }
   }
 }
 

--- a/src/OMSimulatorLib/ComponentFMUME.cpp
+++ b/src/OMSimulatorLib/ComponentFMUME.cpp
@@ -56,8 +56,15 @@ oms::ComponentFMUME::~ComponentFMUME()
 
   if (!tempDir.empty() && filesystem::is_directory(tempDir))
   {
-    filesystem::remove_all(tempDir);
-    logDebug("removed working directory: \"" + tempDir + "\"");
+    try
+    {
+      filesystem::remove_all(tempDir);
+      logDebug("removed working directory: \"" + tempDir + "\"");
+    }
+    catch (const std::exception& e)
+    {
+      logWarning("working directory \"" + tempDir + "\" couldn't be removed: " + e.what());
+    }
   }
 }
 


### PR DESCRIPTION
### Related Issues

#674

### Purpose

Don't crash if temp directory couldn't be removed.
