### PR TITLE
New flag to skip emitting events

### DIFF
--- a/src/OMSimulatorLib/Flags.cpp
+++ b/src/OMSimulatorLib/Flags.cpp
@@ -61,6 +61,7 @@ oms::Flags::~Flags()
 
 void oms::Flags::setDefaults()
 {
+  emitEvents = true;
   defaultModeIsCS = false;
   ignoreInitialUnknowns = false;
   inputExtrapolation = false;
@@ -168,6 +169,12 @@ oms_status_enu_t oms::Flags::SetCommandLineOption(const std::string& cmd)
 oms_status_enu_t oms::Flags::ClearAllOptions(const std::string& value)
 {
   GetInstance().setDefaults();
+  return oms_status_ok;
+}
+
+oms_status_enu_t oms::Flags::EmitEvents(const std::string& value)
+{
+  GetInstance().emitEvents = (value == "true");
   return oms_status_ok;
 }
 

--- a/src/OMSimulatorLib/Flags.h
+++ b/src/OMSimulatorLib/Flags.h
@@ -55,6 +55,7 @@ namespace oms
   public:
     static oms_status_enu_t SetCommandLineOption(const std::string& cmd);
 
+    static bool EmitEvents() {return GetInstance().emitEvents;}
     static bool DefaultModeIsCS() {return GetInstance().defaultModeIsCS;}
     static bool IgnoreInitialUnknowns() {return GetInstance().ignoreInitialUnknowns;}
     static bool InputExtrapolation() {return GetInstance().inputExtrapolation;}
@@ -75,6 +76,7 @@ namespace oms
     static unsigned int Intervals() {return GetInstance().intervals;}
 
   private:
+    bool emitEvents;
     bool defaultModeIsCS;
     bool ignoreInitialUnknowns;
     bool inputExtrapolation;
@@ -119,6 +121,7 @@ namespace oms
     const std::vector<Flag> flags = {
       {"", "", "FMU or SSP file", re_filename, Flags::Filename, false},
       {"--clearAllOptions", "", "Reset all flags to default values", re_void, Flags::ClearAllOptions, false},
+      {"--emitEvents", "", "Specifies whether events should be emitted or not", re_bool, Flags::EmitEvents, false},
       {"--fetchAllVars", "", "Workaround for certain FMUs that do not update all internal dependencies automatically", re_default, Flags::FetchAllVars, false},
       {"--help", "-h", "Displays the help text", re_void, Flags::Help, true},
       {"--ignoreInitialUnknowns", "", "Ignore the initial unknowns from the modelDescription.xml", re_bool, Flags::IgnoreInitialUnknowns, false},
@@ -147,6 +150,7 @@ namespace oms
     };
 
     static oms_status_enu_t ClearAllOptions(const std::string& value);
+    static oms_status_enu_t EmitEvents(const std::string& value);
     static oms_status_enu_t FetchAllVars(const std::string& value);
     static oms_status_enu_t Filename(const std::string& value);
     static oms_status_enu_t Help(const std::string& value);

--- a/src/OMSimulatorLib/SystemSC.cpp
+++ b/src/OMSimulatorLib/SystemSC.cpp
@@ -484,7 +484,7 @@ oms_status_enu_t oms::SystemSC::stepUntil(double stopTime, void (*cb)(const char
         logDebug("Event detected in FMU \"" + std::string(fmus[i]->getFullCref()) + "\" at time=" + std::to_string(time));
 
         // emit the left limit of the event (if it hasn't already been emitted)
-        if (isTopLevelSystem())
+        if (Flags::EmitEvents() && isTopLevelSystem())
           getModel()->emit(time, false);
 
         fmistatus = fmi2_import_enter_event_mode(fmus[i]->getFMU());
@@ -517,7 +517,7 @@ oms_status_enu_t oms::SystemSC::stepUntil(double stopTime, void (*cb)(const char
 
         // emit the right limit of the event
         updateInputs(outputsGraph);
-        if (isTopLevelSystem())
+        if (Flags::EmitEvents() && isTopLevelSystem())
           getModel()->emit(time, true);
 
         // restart event iteration from the beginning


### PR DESCRIPTION
### Related Issues

#675, requested by @meek1

### Purpose

Option to disable storing double data points for events.

The new flag is `--emitEvents=false` to disable event output. The flag is set to true by default.
