### PR TITLE
Python wrapper to integrate ctest into CI (closes #693)

### DIFF
--- a/testsuite/OMSysIdent/Makefile
+++ b/testsuite/OMSysIdent/Makefile
@@ -4,6 +4,7 @@ TESTFILES = \
 HelloWorld_cs_Fit.lua \
 HelloWorldWithInput_cs_Fit.lua \
 HelloWorld_cs_Fit.py \
+runCTests.py \
 
 # Run make failingtest
 FAILINGTESTFILES = \

--- a/testsuite/OMSysIdent/runCTests.py
+++ b/testsuite/OMSysIdent/runCTests.py
@@ -1,0 +1,30 @@
+## status: correct
+## teardown_command: rm test_HelloWorld_cs_Fit.log test_HelloWorld_cs_Fit_res.mat test_Lin2DimODE_cs_Fit.log test_Lin2DimODE_cs_Fit_res.mat
+
+import os
+
+
+ctestpath = '../../build/linux'
+logfilename = 'ctest.log'
+cwdpath = os.getcwd()
+
+if os.path.exists(logfilename):
+  os.remove(logfilename)
+
+os.chdir(ctestpath)
+# Redirect stdout into file
+myCmd = 'ctest --output-on-failure > ' + cwdpath + '/' + logfilename
+os.system(myCmd)
+os.chdir(cwdpath)
+
+lineList = [line.rstrip('\n') for line in open(logfilename)]
+if lineList[6] == '100% tests passed, 0 tests failed out of 2':
+    print(lineList[6])
+else:
+    for line in lineList:
+        print(line)
+
+
+## Result:
+## 100% tests passed, 0 tests failed out of 2
+## endResult


### PR DESCRIPTION
### Related Issues

 #693

### Purpose

Integrate OMSysIdent C/C++ examples into CI tests. These tests can be executed using `ctest`, but they are not part of the CI test suite.

### Approach

Wrap the `ctest` execution within a Python script in a way so that the existing CI test suite can be used without modification.
