### PR TITLE
Clean up after OMSysIdent test runs

### DIFF
--- a/src/OMSysIdentLib/test_HelloWorld_cs_Fit.c
+++ b/src/OMSysIdentLib/test_HelloWorld_cs_Fit.c
@@ -60,7 +60,7 @@ int test_HelloWorld_cs_Fit()
   //std::cout << version << std::endl;
 
   oms_setLogFile("test_HelloWorld_cs_Fit.log");
-  status = oms_setTempDirectory(".");
+  status = oms_setTempDirectory("./test_HelloWorld_cs_Fit/");
   ASSERT(status == oms_status_ok);
 
   status = oms_newModel(MODELIDENT);

--- a/src/OMSysIdentLib/test_Lin2DimODE_cs_Fit.cpp
+++ b/src/OMSysIdentLib/test_Lin2DimODE_cs_Fit.cpp
@@ -109,7 +109,7 @@ int test_Lin2DimODE_cs_Fit()
   }
 
   oms_setLogFile("test_Lin2DimODE_cs_Fit.log");
-  status = oms_setTempDirectory(".");
+  status = oms_setTempDirectory("./test_Lin2DimODE_cs_Fit/");
   ASSERT(status == oms_status_ok);
 
   const char* oms_modelident = MODELIDENT;

--- a/testsuite/OMSysIdent/HelloWorldWithInput_cs_Fit.lua
+++ b/testsuite/OMSysIdent/HelloWorldWithInput_cs_Fit.lua
@@ -1,5 +1,10 @@
 -- status: correct
--- teardown_command: rm -f HelloWorldWithInput_cs_Fit.log HelloWorldWithInput_cs_Fit_res.csv
+-- teardown_command: rm -rf HelloWorldWithInput_cs_Fit/ HelloWorldWithInput_cs_Fit.log HelloWorldWithInput_cs_Fit_res.csv
+-- linux: yes
+-- mingw: no
+-- win: no
+-- mac: no
+
 
 oms_setLogFile("HelloWorldWithInput_cs_Fit.log")
 status = oms_setTempDirectory("./HelloWorldWithInput_cs_Fit/")

--- a/testsuite/OMSysIdent/HelloWorld_cs_Fit.lua
+++ b/testsuite/OMSysIdent/HelloWorld_cs_Fit.lua
@@ -1,5 +1,9 @@
 -- status: correct
--- teardown_command: rm -f HelloWorld_cs_Fit.log HelloWorld_cs_Fit_res.mat
+-- teardown_command: rm -rf HelloWorld_cs_Fit/ HelloWorld_cs_Fit.log HelloWorld_cs_Fit_res.mat
+-- linux: yes
+-- mingw: no
+-- win: no
+-- mac: no
 
 -- Uncomment below if script shall be executed by a standard Lua interpreter
 -- require("package")

--- a/testsuite/OMSysIdent/HelloWorld_cs_Fit.py
+++ b/testsuite/OMSysIdent/HelloWorld_cs_Fit.py
@@ -1,5 +1,5 @@
 ## status: correct
-## teardown_command: rm HelloWorld_cs_Fit_py.log HelloWorld_cs_Fit_res.mat
+## teardown_command: rm -rf HelloWorld_cs_Fit_py/ HelloWorld_cs_Fit_py.log HelloWorld_cs_Fit_res.mat
 
 from OMSimulator import OMSimulator
 from OMSysIdent import OMSysIdent

--- a/testsuite/OMSysIdent/HelloWorld_cs_Fit.py
+++ b/testsuite/OMSysIdent/HelloWorld_cs_Fit.py
@@ -1,5 +1,9 @@
 ## status: correct
 ## teardown_command: rm -rf HelloWorld_cs_Fit_py/ HelloWorld_cs_Fit_py.log HelloWorld_cs_Fit_res.mat
+## linux: yes
+## mingw: no
+## win: no
+## mac: no
 
 from OMSimulator import OMSimulator
 from OMSysIdent import OMSysIdent

--- a/testsuite/OMSysIdent/runCTests.py
+++ b/testsuite/OMSysIdent/runCTests.py
@@ -1,8 +1,12 @@
 ## status: correct
-## teardown_command: rm test_HelloWorld_cs_Fit.log test_HelloWorld_cs_Fit_res.mat test_Lin2DimODE_cs_Fit.log test_Lin2DimODE_cs_Fit_res.mat
+## teardown_command: rm -rf test_HelloWorld_cs_Fit/ test_HelloWorld_cs_Fit.log test_HelloWorld_cs_Fit_res.mat test_Lin2DimODE_cs_Fit/ test_Lin2DimODE_cs_Fit.log test_Lin2DimODE_cs_Fit_res.mat
+
+# Python Wrapper for executing ctest, which in turn executes test examples.
+# As of 2019-06-21 there are two examples which are executed:
+# - ../../src/OMSysIdentLib/test_HelloWorld_cs_Fit.c
+# - ../../src/OMSysIdentLib/test_Lin2DimODE_cs_Fit.cpp
 
 import os
-
 
 ctestpath = '../../build/linux'
 logfilename = 'ctest.log'

--- a/testsuite/OMSysIdent/runCTests.py
+++ b/testsuite/OMSysIdent/runCTests.py
@@ -1,5 +1,9 @@
 ## status: correct
 ## teardown_command: rm -rf test_HelloWorld_cs_Fit/ test_HelloWorld_cs_Fit.log test_HelloWorld_cs_Fit_res.mat test_Lin2DimODE_cs_Fit/ test_Lin2DimODE_cs_Fit.log test_Lin2DimODE_cs_Fit_res.mat
+## linux: yes
+## mingw: no
+## win: no
+## mac: no
 
 # Python Wrapper for executing ctest, which in turn executes test examples.
 # As of 2019-06-21 there are two examples which are executed:


### PR DESCRIPTION
### Related Issues

#693

### Purpose

Clean up the generated temporary files after running the OMSysIdent tests.

### Approach

Using the `teardown_command` functionality for removing respective files after a test run.
