### PR TITLE
Use the unique FMU filename for their temp dir

### DIFF
--- a/src/OMSimulatorLib/Component.cpp
+++ b/src/OMSimulatorLib/Component.cpp
@@ -31,11 +31,11 @@
 
 #include "Component.h"
 
+#include "Flags.h"
 #include "Model.h"
 #include "System.h"
-#include <OMSFileSystem.h>
 #include "TLMBusConnector.h"
-
+#include <OMSFileSystem.h>
 
 void oms::fmiLogger(jm_callbacks* c, jm_string module, jm_log_level_enu_t log_level, jm_string message)
 {
@@ -223,23 +223,20 @@ oms_status_enu_t oms::Component::deleteConnector(const ComRef& cref)
 
 oms_status_enu_t oms::Component::deleteResources()
 {
-  filesystem::path temp_root(parentSystem->getModel()->getTempDirectory());
-  filesystem::path absResourcePath = temp_root / path;
-
-  // delete resources
-  //filesystem::remove(absResourcePath);
-
   // delete temp directory
-  if (!tempDir.empty() && filesystem::is_directory(tempDir))
+  if (Flags::DeleteTempFiles())
   {
-    try
+    if (!tempDir.empty() && filesystem::is_directory(tempDir))
     {
-      filesystem::remove_all(tempDir);
-      logDebug("removed temp directory: \"" + tempDir + "\"");
-    }
-    catch (const std::exception& e)
-    {
-      logWarning("temp directory \"" + tempDir + "\" couldn't be removed\n" + e.what());
+      try
+      {
+        filesystem::remove_all(tempDir);
+        logDebug("removed temp directory: \"" + tempDir + "\"");
+      }
+      catch (const std::exception& e)
+      {
+        logWarning("temp directory \"" + tempDir + "\" couldn't be removed\n" + e.what());
+      }
     }
   }
 

--- a/src/OMSimulatorLib/ComponentFMUCS.cpp
+++ b/src/OMSimulatorLib/ComponentFMUCS.cpp
@@ -70,11 +70,9 @@ oms::Component* oms::ComponentFMUCS::NewComponent(const oms::ComRef& cref, oms::
     return NULL;
   }
 
-  std::string id = parentSystem->getUniqueID() + "_";
-
   filesystem::path temp_root(parentSystem->getModel()->getTempDirectory());
   filesystem::path temp_temp = temp_root / "temp";
-  filesystem::path relFMUPath = parentSystem->copyResources() ? (filesystem::path("resources") / (id + std::string(cref) + ".fmu")) : filesystem::path(fmuPath);
+  filesystem::path relFMUPath = parentSystem->copyResources() ? (filesystem::path("resources") / (parentSystem->getUniqueID() + "_" + std::string(cref) + ".fmu")) : filesystem::path(fmuPath);
   filesystem::path absFMUPath = temp_root / relFMUPath;
 
   ComponentFMUCS* component = new ComponentFMUCS(cref, parentSystem, relFMUPath.string());
@@ -93,7 +91,7 @@ oms::Component* oms::ComponentFMUCS::NewComponent(const oms::ComRef& cref, oms::
     oms_copy_file(filesystem::path(fmuPath), absFMUPath);
 
   // set temp directory
-  filesystem::path tempDir = temp_temp / (id + std::string(cref));
+  filesystem::path tempDir = temp_temp / relFMUPath.stem();
   component->setTempDir(tempDir.string());
   if (!filesystem::is_directory(tempDir) && !filesystem::create_directory(tempDir))
   {

--- a/src/OMSimulatorLib/ComponentFMUME.cpp
+++ b/src/OMSimulatorLib/ComponentFMUME.cpp
@@ -69,11 +69,9 @@ oms::Component* oms::ComponentFMUME::NewComponent(const oms::ComRef& cref, oms::
     return NULL;
   }
 
-  std::string id = parentSystem->getUniqueID() + "_";
-
   filesystem::path temp_root(parentSystem->getModel()->getTempDirectory());
   filesystem::path temp_temp = temp_root / "temp";
-  filesystem::path relFMUPath = parentSystem->copyResources() ? (filesystem::path("resources") / (id + std::string(cref) + ".fmu")) : filesystem::path(fmuPath);
+  filesystem::path relFMUPath = parentSystem->copyResources() ? (filesystem::path("resources") / (parentSystem->getUniqueID() + "_" + std::string(cref) + ".fmu")) : filesystem::path(fmuPath);
   filesystem::path absFMUPath = temp_root / relFMUPath;
 
   ComponentFMUME* component = new ComponentFMUME(cref, parentSystem, relFMUPath.string());
@@ -92,7 +90,7 @@ oms::Component* oms::ComponentFMUME::NewComponent(const oms::ComRef& cref, oms::
     oms_copy_file(filesystem::path(fmuPath), absFMUPath);
 
   // set temp directory
-  filesystem::path tempDir = temp_temp / (id + std::string(cref));
+  filesystem::path tempDir = temp_temp / relFMUPath.stem();
   component->setTempDir(tempDir.string());
   if (!filesystem::is_directory(tempDir) && !filesystem::create_directory(tempDir))
   {

--- a/src/OMSimulatorLib/ComponentTable.cpp
+++ b/src/OMSimulatorLib/ComponentTable.cpp
@@ -71,10 +71,8 @@ oms::Component* oms::ComponentTable::NewComponent(const oms::ComRef& cref, oms::
   if (path.length() > 4)
     extension = path.substr(path.length() - 4);
 
-  std::string id = parentSystem->getUniqueID() + "_";
-
   filesystem::path temp_root(parentSystem->getModel()->getTempDirectory());
-  filesystem::path relPath = parentSystem->copyResources() ? (filesystem::path("resources") / (id + std::string(cref) + extension)) : filesystem::path(path);
+  filesystem::path relPath = parentSystem->copyResources() ? (filesystem::path("resources") / (parentSystem->getUniqueID() + "_" + std::string(cref) + extension)) : filesystem::path(path);
   filesystem::path absPath = temp_root / relPath;
 
   ComponentTable* component = new ComponentTable(cref, parentSystem, relPath.string());

--- a/src/OMSimulatorLib/Flags.cpp
+++ b/src/OMSimulatorLib/Flags.cpp
@@ -62,6 +62,7 @@ oms::Flags::~Flags()
 void oms::Flags::setDefaults()
 {
   defaultModeIsCS = false;
+  deleteTempFiles = true;
   emitEvents = true;
   ignoreInitialUnknowns = false;
   inputExtrapolation = false;
@@ -170,6 +171,12 @@ oms_status_enu_t oms::Flags::SetCommandLineOption(const std::string& cmd)
 oms_status_enu_t oms::Flags::ClearAllOptions(const std::string& value)
 {
   GetInstance().setDefaults();
+  return oms_status_ok;
+}
+
+oms_status_enu_t oms::Flags::DeleteTempFiles(const std::string& value)
+{
+  GetInstance().deleteTempFiles = (value == "true");
   return oms_status_ok;
 }
 

--- a/src/OMSimulatorLib/Flags.h
+++ b/src/OMSimulatorLib/Flags.h
@@ -56,6 +56,7 @@ namespace oms
     static oms_status_enu_t SetCommandLineOption(const std::string& cmd);
 
     static bool DefaultModeIsCS() {return GetInstance().defaultModeIsCS;}
+    static bool DeleteTempFiles() {return GetInstance().deleteTempFiles;}
     static bool EmitEvents() {return GetInstance().emitEvents;}
     static bool IgnoreInitialUnknowns() {return GetInstance().ignoreInitialUnknowns;}
     static bool InputExtrapolation() {return GetInstance().inputExtrapolation;}
@@ -77,8 +78,9 @@ namespace oms
     static unsigned int NumProcs() {return GetInstance().numProcs;}
 
   private:
-    bool emitEvents;
     bool defaultModeIsCS;
+    bool deleteTempFiles;
+    bool emitEvents;
     bool ignoreInitialUnknowns;
     bool inputExtrapolation;
     bool progressBar;
@@ -123,36 +125,38 @@ namespace oms
     const std::vector<Flag> flags = {
       {"", "", "FMU or SSP file", re_filename, Flags::Filename, false},
       {"--clearAllOptions", "", "Reset all flags to default values", re_void, Flags::ClearAllOptions, false},
-      {"--emitEvents", "", "Specifies whether events should be emitted or not", re_bool, Flags::EmitEvents, false},
+      {"--deleteTempFiles", "", "Deletes temp files as soon as they are no longer needed ([true], false)", re_bool, Flags::DeleteTempFiles, false},
+      {"--emitEvents", "", "Specifies whether events should be emitted or not ([true], false)", re_bool, Flags::EmitEvents, false},
       {"--fetchAllVars", "", "Workaround for certain FMUs that do not update all internal dependencies automatically", re_default, Flags::FetchAllVars, false},
       {"--help", "-h", "Displays the help text", re_void, Flags::Help, true},
-      {"--ignoreInitialUnknowns", "", "Ignore the initial unknowns from the modelDescription.xml", re_bool, Flags::IgnoreInitialUnknowns, false},
-      {"--inputExtrapolation", "", "Enables input extrapolation using derivative information", re_bool, Flags::InputExtrapolation, false},
+      {"--ignoreInitialUnknowns", "", "Ignore the initial unknowns from the modelDescription.xml (true, [false])", re_bool, Flags::IgnoreInitialUnknowns, false},
+      {"--inputExtrapolation", "", "Enables input extrapolation using derivative information (true, [false])", re_bool, Flags::InputExtrapolation, false},
       {"--intervals", "-i", "Specifies the number of communication points (arg > 1)", re_number, Flags::Intervals, false},
       {"--logFile", "-l", "Specifies the logfile (stdout is used if no log file is specified)", re_default, Flags::LogFile, false},
       {"--logLevel", "", "0 default, 1 debug, 2 debug+trace", re_number, Flags::LogLevel, false},
+      {"--maxEventIteration", "", "Specifies the max. number of iterations for handling a single event", re_number, Flags::MaxEventIteration, false},
       {"--mode", "-m", "Forces a certain FMI mode iff the FMU provides cs and me ([cs], me)", re_mode, Flags::Mode, false},
       {"--numProcs", "-n", "Specifies the max. number of processors to use (0=auto, 1=default)", re_number, Flags::NumProcs, false},
-      {"--maxEventIteration", "", "Specifies the max. number of iterations for handling a single event", re_number, Flags::MaxEventIteration, false},
-      {"--progressBar", "", "Shows a progress bar for the simulation progress in the terminal", re_bool, Flags::ProgressBar, false},
-      {"--realTime", "", "Experimental feature for (soft) real-time co-simulation", re_bool, Flags::RealTime, false},
+      {"--progressBar", "", "Shows a progress bar for the simulation progress in the terminal (true, [false])", re_bool, Flags::ProgressBar, false},
+      {"--realTime", "", "Experimental feature for (soft) real-time co-simulation (true, [false])", re_bool, Flags::RealTime, false},
       {"--resultFile", "-r", "Specifies the name of the output result file", re_default, Flags::ResultFile, false},
       {"--setInputDerivatives", "", "Deprecated; see '--inputExtrapolation'", re_bool, Flags::SetInputDerivatives, false},
       {"--solver", "", "Specifies the integration method (euler, [cvode])", re_default, Flags::Solver, false},
-      {"--solverStats", "", "Adds solver stats to the result file, e.g. step size (not supported for all solvers)", re_bool, Flags::SolverStats, false},
+      {"--solverStats", "", "Adds solver stats to the result file, e.g. step size; not supported for all solvers (true, [false])", re_bool, Flags::SolverStats, false},
       {"--startTime", "-s", "Specifies the start time", re_double, Flags::StartTime, false},
       {"--stopTime", "-t", "Specifies the stop time", re_double, Flags::StopTime, false},
-      {"--stripRoot", "", "Removes the root system prefix from all exported signals", re_bool, Flags::StripRoot, false},
-      {"--suppressPath", "", "Supresses path information in info messages; especially useful for testing", re_bool, Flags::SuppressPath, false},
+      {"--stripRoot", "", "Removes the root system prefix from all exported signals (true, [false])", re_bool, Flags::StripRoot, false},
+      {"--suppressPath", "", "Supresses path information in info messages; especially useful for testing (true, [false])", re_bool, Flags::SuppressPath, false},
       {"--tempDir", "", "Specifies the temp directory", re_default, Flags::TempDir, false},
       {"--timeout", "", "Specifies the maximum allowed time in seconds for running a simulation (0 disables)", re_number, Flags::Timeout, false},
       {"--tolerance", "", "Specifies the relative tolerance", re_double, Flags::Tolerance, false},
       {"--version", "-v", "Displays version information", re_void, Flags::Version, false},
-      {"--wallTime", "", "Add wall time information for to the result file", re_bool, Flags::WallTime, false},
+      {"--wallTime", "", "Add wall time information for to the result file (true, [false])", re_bool, Flags::WallTime, false},
       {"--workingDir", "", "Specifies the working directory", re_default, Flags::WorkingDir, false}
     };
 
     static oms_status_enu_t ClearAllOptions(const std::string& value);
+    static oms_status_enu_t DeleteTempFiles(const std::string& value);
     static oms_status_enu_t EmitEvents(const std::string& value);
     static oms_status_enu_t FetchAllVars(const std::string& value);
     static oms_status_enu_t Filename(const std::string& value);

--- a/src/OMSimulatorLib/Model.cpp
+++ b/src/OMSimulatorLib/Model.cpp
@@ -61,16 +61,19 @@ oms::Model::~Model()
     delete system;
 
   // delete temp directory
-  if (!tempDir.empty() && filesystem::is_directory(tempDir))
+  if (Flags::DeleteTempFiles())
   {
-    try
+    if (!tempDir.empty() && filesystem::is_directory(tempDir))
     {
-      filesystem::remove_all(tempDir);
-      logDebug("removed temp directory: \"" + tempDir + "\"");
-    }
-    catch (const std::exception& e)
-    {
-      logWarning("temp directory \"" + tempDir + "\" couldn't be removed\n" + e.what());
+      try
+      {
+        filesystem::remove_all(tempDir);
+        logDebug("removed temp directory: \"" + tempDir + "\"");
+      }
+      catch (const std::exception& e)
+      {
+        logWarning("temp directory \"" + tempDir + "\" couldn't be removed\n" + e.what());
+      }
     }
   }
 }

--- a/src/OMSimulatorLib/System.cpp
+++ b/src/OMSimulatorLib/System.cpp
@@ -1912,5 +1912,10 @@ ctpl::thread_pool& oms::System::getThreadPool()
 std::string oms::System::getUniqueID() const
 {
   static unsigned int id = 0;
-  return std::to_string(++id);
+  std::string str = std::to_string(++id);
+
+  while (str.length() < 4)
+    str = "0" + str;
+
+  return str;
 }

--- a/testsuite/OMSimulator/import_export.lua
+++ b/testsuite/OMSimulator/import_export.lua
@@ -248,7 +248,7 @@ printStatus(status, 0)
 -- 						<ssd:Connectors />
 -- 						<ssd:Connections />
 -- 					</ssd:System>
--- 					<ssd:Component name="T" type="application/table" source="resources/2_T.csv">
+-- 					<ssd:Component name="T" type="application/table" source="resources/0002_T.csv">
 -- 						<ssd:Connectors>
 -- 							<ssd:Connector name="time" kind="output" type="Real">
 -- 								<ssd:ConnectorGeometry x="1.000000" y="0.333333" />
@@ -258,7 +258,7 @@ printStatus(status, 0)
 -- 							</ssd:Connector>
 -- 						</ssd:Connectors>
 -- 					</ssd:Component>
--- 					<ssd:Component name="A" type="application/x-fmu-sharedlibrary" source="resources/1_A.fmu">
+-- 					<ssd:Component name="A" type="application/x-fmu-sharedlibrary" source="resources/0001_A.fmu">
 -- 						<ssd:Connectors>
 -- 							<ssd:Connector name="y" kind="output" type="Real">
 -- 								<ssd:ConnectorGeometry x="1.000000" y="0.500000" />
@@ -371,7 +371,7 @@ printStatus(status, 0)
 -- 						<ssd:Connectors />
 -- 						<ssd:Connections />
 -- 					</ssd:System>
--- 					<ssd:Component name="T" type="application/table" source="resources/2_T.csv">
+-- 					<ssd:Component name="T" type="application/table" source="resources/0002_T.csv">
 -- 						<ssd:Connectors>
 -- 							<ssd:Connector name="time" kind="output" type="Real">
 -- 								<ssd:ConnectorGeometry x="1.000000" y="0.333333" />
@@ -381,7 +381,7 @@ printStatus(status, 0)
 -- 							</ssd:Connector>
 -- 						</ssd:Connectors>
 -- 					</ssd:Component>
--- 					<ssd:Component name="A" type="application/x-fmu-sharedlibrary" source="resources/1_A.fmu">
+-- 					<ssd:Component name="A" type="application/x-fmu-sharedlibrary" source="resources/0001_A.fmu">
 -- 						<ssd:Connectors>
 -- 							<ssd:Connector name="y" kind="output" type="Real">
 -- 								<ssd:ConnectorGeometry x="1.000000" y="0.500000" />

--- a/testsuite/OMSimulator/import_export.py
+++ b/testsuite/OMSimulator/import_export.py
@@ -247,7 +247,7 @@ printStatus(status, 0)
 ## 						<ssd:Connectors />
 ## 						<ssd:Connections />
 ## 					</ssd:System>
-## 					<ssd:Component name="T" type="application/table" source="resources/2_T.csv">
+## 					<ssd:Component name="T" type="application/table" source="resources/0002_T.csv">
 ## 						<ssd:Connectors>
 ## 							<ssd:Connector name="time" kind="output" type="Real">
 ## 								<ssd:ConnectorGeometry x="1.000000" y="0.333333" />
@@ -257,7 +257,7 @@ printStatus(status, 0)
 ## 							</ssd:Connector>
 ## 						</ssd:Connectors>
 ## 					</ssd:Component>
-## 					<ssd:Component name="A" type="application/x-fmu-sharedlibrary" source="resources/1_A.fmu">
+## 					<ssd:Component name="A" type="application/x-fmu-sharedlibrary" source="resources/0001_A.fmu">
 ## 						<ssd:Connectors>
 ## 							<ssd:Connector name="y" kind="output" type="Real">
 ## 								<ssd:ConnectorGeometry x="1.000000" y="0.500000" />
@@ -370,7 +370,7 @@ printStatus(status, 0)
 ## 						<ssd:Connectors />
 ## 						<ssd:Connections />
 ## 					</ssd:System>
-## 					<ssd:Component name="T" type="application/table" source="resources/2_T.csv">
+## 					<ssd:Component name="T" type="application/table" source="resources/0002_T.csv">
 ## 						<ssd:Connectors>
 ## 							<ssd:Connector name="time" kind="output" type="Real">
 ## 								<ssd:ConnectorGeometry x="1.000000" y="0.333333" />
@@ -380,7 +380,7 @@ printStatus(status, 0)
 ## 							</ssd:Connector>
 ## 						</ssd:Connectors>
 ## 					</ssd:Component>
-## 					<ssd:Component name="A" type="application/x-fmu-sharedlibrary" source="resources/1_A.fmu">
+## 					<ssd:Component name="A" type="application/x-fmu-sharedlibrary" source="resources/0001_A.fmu">
 ## 						<ssd:Connectors>
 ## 							<ssd:Connector name="y" kind="output" type="Real">
 ## 								<ssd:ConnectorGeometry x="1.000000" y="0.500000" />

--- a/testsuite/api/test03.lua
+++ b/testsuite/api/test03.lua
@@ -73,7 +73,7 @@ oms_delete("test")
 -- 			<FixedStepMaster description="oms-ma" stepSize="0.100000" />
 -- 		</ssd:SimulationInformation>
 -- 		<ssd:Elements>
--- 			<ssd:Component name="source" type="application/x-fmu-sharedlibrary" source="resources/1_source.fmu">
+-- 			<ssd:Component name="source" type="application/x-fmu-sharedlibrary" source="resources/0001_source.fmu">
 -- 				<ssd:Connectors>
 -- 					<ssd:Connector name="y" kind="output" type="Real">
 -- 						<ssd:ConnectorGeometry x="1.000000" y="0.500000" />
@@ -101,7 +101,7 @@ oms_delete("test")
 -- 			<FixedStepMaster description="oms-ma" stepSize="0.100000" />
 -- 		</ssd:SimulationInformation>
 -- 		<ssd:Elements>
--- 			<ssd:Component name="source" type="application/x-fmu-sharedlibrary" source="resources/1_source.fmu">
+-- 			<ssd:Component name="source" type="application/x-fmu-sharedlibrary" source="resources/0001_source.fmu">
 -- 				<ssd:Connectors>
 -- 					<ssd:Connector name="y" kind="output" type="Real">
 -- 						<ssd:ConnectorGeometry x="1.000000" y="0.500000" />


### PR DESCRIPTION
Filenames of FMUs inside the resources directory are already unique. Therefore we should use the same names when extracting them into the temp directory.

The new flag `--deleteTempFiles` is mainly for testing, since all the directories are usually cleaned up automatically.