### PR TITLE
API for fetching external model interface data

### DIFF
--- a/src/OMSimulatorLib/OMSimulator.h
+++ b/src/OMSimulatorLib/OMSimulator.h
@@ -83,6 +83,7 @@ OMSAPI oms_status_enu_t OMSCALL oms_deleteConnectorFromTLMBus(const char* busCre
 OMSAPI oms_status_enu_t OMSCALL oms_export(const char* cref, const char* filename);
 OMSAPI oms_status_enu_t OMSCALL oms_exportDependencyGraphs(const char* cref, const char* initialization, const char* simulation);
 OMSAPI oms_status_enu_t OMSCALL oms_extractFMIKind(const char* filename, oms_fmi_kind_enu_t* kind);
+OMSAPI oms_status_enu_t OMSCALL oms_fetchExternalModelInterfaces(const char* cref, char*** names, char*** domains, int** dimensions);
 OMSAPI void OMSCALL oms_freeMemory(void* obj);
 OMSAPI oms_status_enu_t OMSCALL oms_getBoolean(const char* cref, bool* value);
 OMSAPI oms_status_enu_t OMSCALL oms_getBus(const char* cref, oms_busconnector_t** busConnector);

--- a/src/OMSimulatorLib/TLM/SystemTLM.h
+++ b/src/OMSimulatorLib/TLM/SystemTLM.h
@@ -52,6 +52,7 @@ namespace oms
     oms_status_enu_t importFromSSD_SimulationInformation(const pugi::xml_node& node);
     oms_status_enu_t setSocketData(const std::string& address, int managerPort, int monitorPort);
     oms_status_enu_t setPositionAndOrientation(const ComRef &cref, std::vector<double> x, std::vector<double> A);
+    oms_status_enu_t fetchInterfaces(const ComRef &cref, std::vector<std::string> &name, std::vector<int> &dimensions, std::vector<std::string> &domain);
 
     oms_status_enu_t instantiate();
     oms_status_enu_t initialize();
@@ -112,6 +113,7 @@ namespace oms
     double logStep = 1e-2;
     std::map<TLMBusConnector*, int> busLogIds;
     std::map<Connector*, int> connectorLogIds;
+    std::string singleModel;
 
     // simulation information
   };


### PR DESCRIPTION
### Related PRs
OpenModelica/OMTLMSimulator#119

### Purpose

External models are not loaded as model files. Thus, interfaces needs to be fetched through socket communication. This adds an API function for this, which returns a list of names, domains and dimensions for all interfaces in an external model.

### Approach

The existing API for this in OMTLMSimulator i used. The external tool is instructed by sockets to write an XML file, which OMSimulator in turn reads. 