### PR TITLE
Overwrite files when copying with MINGW

### DIFF
--- a/src/OMSimulatorLib/OMSFileSystem.cpp
+++ b/src/OMSimulatorLib/OMSFileSystem.cpp
@@ -98,7 +98,7 @@ void oms_copy_file(const filesystem::path &from, const filesystem::path &to)
   /* The MINGW implementation succeeds for filesystem::copy_file, but does not
      copy the entire file.
    */
-  if (!CopyFile(from.string().c_str(), to.string().c_str(), 1)) {
+  if (!CopyFile(from.string().c_str(), to.string().c_str(), 0 /* overwrite existing */)) {
     throw std::runtime_error(std::string("Failed to copy file: ") + from.string() + "  to: " + to.string());
   }
 #elif OMC_STD_FS == 1

--- a/testsuite/api/Makefile
+++ b/testsuite/api/Makefile
@@ -5,6 +5,8 @@ buses.lua \
 buses.py \
 connections.lua \
 connections.py \
+test_omsExport.lua \
+test_omsExport.py \
 test01.lua \
 test01.py \
 test02.lua \

--- a/testsuite/api/test_omsExport.lua
+++ b/testsuite/api/test_omsExport.lua
@@ -1,0 +1,65 @@
+-- status: correct
+-- teardown_command: rm -rf test_omsExport-lua/
+-- linux: yes
+-- linux32: yes
+-- mingw: yes
+-- win: yes
+-- mac: yes
+
+oms_setCommandLineOption("--suppressPath=true")
+oms_setTempDirectory("./test_omsExport-lua/")
+
+function printStatus(status, expected)
+  cmp = ""
+  if status == expected then
+    cmp = "correct"
+  else
+    cmp = "wrong"
+  end
+
+  if 0 == status then
+    status = "ok"
+  elseif 1 == status then
+    status = "warning"
+  elseif 3 == status then
+    status = "error"
+  end
+  print("status:  [" .. cmp .. "] " .. status)
+end
+
+status = oms_newModel("model")
+printStatus(status, 0)
+
+status = oms_addSystem("model.sc", oms_system_sc)
+printStatus(status, 0)
+
+src, status = oms_list("model")
+printStatus(status, 0)
+print(src)
+
+status= oms_export("model", "model.ssp")
+printStatus(status, 0)
+
+status = oms_export("model", "model.ssp")
+printStatus(status, 0)
+
+-- Result:
+-- status:  [correct] ok
+-- status:  [correct] ok
+-- status:  [correct] ok
+-- <?xml version="1.0"?>
+-- <ssd:SystemStructureDescription name="model" version="Draft20180219">
+-- 	<ssd:System name="sc">
+-- 		<ssd:SimulationInformation>
+-- 			<VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+-- 		</ssd:SimulationInformation>
+-- 		<ssd:Elements />
+-- 		<ssd:Connectors />
+-- 		<ssd:Connections />
+-- 	</ssd:System>
+-- 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000" />
+-- </ssd:SystemStructureDescription>
+--
+-- status:  [correct] ok
+-- status:  [correct] ok
+-- endResult

--- a/testsuite/api/test_omsExport.py
+++ b/testsuite/api/test_omsExport.py
@@ -1,0 +1,65 @@
+## status: correct
+## teardown_command: rm -rf test_omsExport-py/
+## linux: yes
+## linux32: yes
+## mingw: yes
+## win: yes
+## mac: no
+
+from OMSimulator import OMSimulator
+oms = OMSimulator()
+
+oms.setCommandLineOption("--suppressPath=true")
+oms.setTempDirectory("./test_omsExport-py/")
+
+def printStatus(status, expected):
+  cmp = ""
+  if status == expected:
+    cmp = "correct"
+  else:
+    cmp = "wrong"
+
+  if 0 == status:
+    status = "ok"
+  elif 1 == status:
+    status = "warning"
+  elif 3 == status:
+    status = "error"
+  print "status:  [%s] %s" % (cmp, status)
+
+status = oms.newModel("model")
+printStatus(status, 0)
+
+status = oms.addSystem("model.sc", oms.system_sc)
+printStatus(status, 0)
+
+src, status = oms.list("model")
+printStatus(status, 0)
+print(src)
+
+status= oms.export("model", "model.ssp")
+printStatus(status, 0)
+
+status = oms.export("model", "model.ssp")
+printStatus(status, 0)
+
+## Result:
+## status:  [correct] ok
+## status:  [correct] ok
+## status:  [wrong] <?xml version="1.0"?>
+## <ssd:SystemStructureDescription name="model" version="Draft20180219">
+## 	<ssd:System name="sc">
+## 		<ssd:SimulationInformation>
+## 			<VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+## 		</ssd:SimulationInformation>
+## 		<ssd:Elements />
+## 		<ssd:Connectors />
+## 		<ssd:Connections />
+## 	</ssd:System>
+## 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000" />
+## </ssd:SystemStructureDescription>
+##
+## 0
+## status:  [correct] ok
+## status:  [correct] ok
+## endResult


### PR DESCRIPTION
### Related Issues

Issue https://github.com/OpenModelica/OMSimulator/issues/715

### Purpose

Make `oms_copy_file` function consistent on MINGW and non MINGW systems

### Approach

Overwrite exisitng files when using `oms_copy_file`, so no error will be thrown.
