### PR TITLE
Prepare namespaces to handle different version of ssp

### DIFF
--- a/src/OMSimulatorLib/BusConnector.cpp
+++ b/src/OMSimulatorLib/BusConnector.cpp
@@ -27,12 +27,12 @@ oms::BusConnector::~BusConnector()
 
 oms_status_enu_t oms::BusConnector::exportToSSD(pugi::xml_node &root) const
 {
-  pugi::xml_node bus_node = root.append_child(oms::bus);
+  pugi::xml_node bus_node = root.append_child(oms::ssp::Draft20180219::bus);
   bus_node.append_attribute("name") = name;
 
-  pugi::xml_node signals_node = bus_node.append_child(oms::signals);
+  pugi::xml_node signals_node = bus_node.append_child(oms::ssp::Draft20180219::signals);
   for(auto& connector : conrefs) {
-    pugi::xml_node signal_node = signals_node.append_child(oms::signal);
+    pugi::xml_node signal_node = signals_node.append_child(oms::ssp::Draft20180219::signal);
     signal_node.append_attribute("name") = connector.c_str();
   }
 

--- a/src/OMSimulatorLib/ComponentFMUCS.cpp
+++ b/src/OMSimulatorLib/ComponentFMUCS.cpp
@@ -261,7 +261,7 @@ oms::Component* oms::ComponentFMUCS::NewComponent(const pugi::xml_node& node, om
   for(pugi::xml_node_iterator it = node.begin(); it != node.end(); ++it)
   {
     std::string name = it->name();
-    if(name == oms::ssd::ssd_connectors)
+    if(name == oms::ssp::Draft20180219::ssd::connectors)
     {
       // import connectors
       for(pugi::xml_node_iterator itConnectors = (*it).begin(); itConnectors != (*it).end(); ++itConnectors)
@@ -269,7 +269,7 @@ oms::Component* oms::ComponentFMUCS::NewComponent(const pugi::xml_node& node, om
         component->connectors.push_back(oms::Connector::NewConnector(*itConnectors));
       }
     }
-    else if(name == oms::ssd::ssd_element_geometry)
+    else if(name == oms::ssp::Draft20180219::ssd::element_geometry)
     {
       oms::ssd::ElementGeometry geometry;
       geometry.importFromSSD(*it);
@@ -294,9 +294,9 @@ oms_status_enu_t oms::ComponentFMUCS::exportToSSD(pugi::xml_node& node) const
 #if !defined(NO_TLM)
   if (tlmbusconnectors[0])
   {
-    pugi::xml_node annotations_node = node.append_child(oms::ssd::ssd_annotations);
-    pugi::xml_node annotation_node = annotations_node.append_child(oms::ssd::ssd_annotation);
-    annotation_node.append_attribute("type") = oms::annotation_type;
+    pugi::xml_node annotations_node = node.append_child(oms::ssp::Draft20180219::ssd::annotations);
+    pugi::xml_node annotation_node = annotations_node.append_child(oms::ssp::Draft20180219::ssd::annotation);
+    annotation_node.append_attribute("type") = oms::ssp::Draft20180219::annotation_type;
     for (const auto& tlmbusconnector : tlmbusconnectors)
       if (tlmbusconnector)
         tlmbusconnector->exportToSSD(annotation_node);
@@ -306,7 +306,7 @@ oms_status_enu_t oms::ComponentFMUCS::exportToSSD(pugi::xml_node& node) const
   node.append_attribute("name") = this->getCref().c_str();
   node.append_attribute("type") = "application/x-fmu-sharedlibrary";
   node.append_attribute("source") = getPath().c_str();
-  pugi::xml_node node_connectors = node.append_child(oms::ssd::ssd_connectors);
+  pugi::xml_node node_connectors = node.append_child(oms::ssp::Draft20180219::ssd::connectors);
 
   if (element.getGeometry())
     element.getGeometry()->exportToSSD(node);

--- a/src/OMSimulatorLib/ComponentFMUME.cpp
+++ b/src/OMSimulatorLib/ComponentFMUME.cpp
@@ -263,7 +263,7 @@ oms::Component* oms::ComponentFMUME::NewComponent(const pugi::xml_node& node, om
   for(pugi::xml_node_iterator it = node.begin(); it != node.end(); ++it)
   {
     std::string name = it->name();
-    if(name == oms::ssd::ssd_connectors)
+    if(name == oms::ssp::Draft20180219::ssd::connectors)
     {
       // import connectors
       for(pugi::xml_node_iterator itConnectors = (*it).begin(); itConnectors != (*it).end(); ++itConnectors)
@@ -271,7 +271,7 @@ oms::Component* oms::ComponentFMUME::NewComponent(const pugi::xml_node& node, om
         component->connectors.push_back(oms::Connector::NewConnector(*itConnectors));
       }
     }
-    else if(name == oms::ssd::ssd_element_geometry)
+    else if(name == oms::ssp::Draft20180219::ssd::element_geometry)
     {
       oms::ssd::ElementGeometry geometry;
       geometry.importFromSSD(*it);
@@ -296,9 +296,9 @@ oms_status_enu_t oms::ComponentFMUME::exportToSSD(pugi::xml_node& node) const
 #if !defined(NO_TLM)
   if (tlmbusconnectors[0])
   {
-    pugi::xml_node annotations_node = node.append_child(oms::ssd::ssd_annotations);
-    pugi::xml_node annotation_node = annotations_node.append_child(oms::ssd::ssd_annotation);
-    annotation_node.append_attribute("type") = oms::annotation_type;
+    pugi::xml_node annotations_node = node.append_child(oms::ssp::Draft20180219::ssd::annotations);
+    pugi::xml_node annotation_node = annotations_node.append_child(oms::ssp::Draft20180219::ssd::annotation);
+    annotation_node.append_attribute("type") = oms::ssp::Draft20180219::annotation_type;
     for (const auto& tlmbusconnector : tlmbusconnectors)
       if (tlmbusconnector)
         tlmbusconnector->exportToSSD(annotation_node);
@@ -308,7 +308,7 @@ oms_status_enu_t oms::ComponentFMUME::exportToSSD(pugi::xml_node& node) const
   node.append_attribute("name") = this->getCref().c_str();
   node.append_attribute("type") = "application/x-fmu-sharedlibrary";
   node.append_attribute("source") = getPath().c_str();
-  pugi::xml_node node_connectors = node.append_child(oms::ssd::ssd_connectors);
+  pugi::xml_node node_connectors = node.append_child(oms::ssp::Draft20180219::ssd::connectors);
 
   if (element.getGeometry())
     element.getGeometry()->exportToSSD(node);

--- a/src/OMSimulatorLib/ComponentTable.cpp
+++ b/src/OMSimulatorLib/ComponentTable.cpp
@@ -131,7 +131,7 @@ oms::Component* oms::ComponentTable::NewComponent(const pugi::xml_node& node, om
   for(pugi::xml_node_iterator it = node.begin(); it != node.end(); ++it)
   {
     std::string name = it->name();
-    if(name == oms::ssd::ssd_connectors)
+    if(name == oms::ssp::Draft20180219::ssd::connectors)
     {
       // import connectors
       for(pugi::xml_node_iterator itConnectors = (*it).begin(); itConnectors != (*it).end(); ++itConnectors)
@@ -140,7 +140,7 @@ oms::Component* oms::ComponentTable::NewComponent(const pugi::xml_node& node, om
         component->exportSeries[component->connectors.back()->getName()] = true;
       }
     }
-    else if(name == oms::ssd::ssd_element_geometry)
+    else if(name == oms::ssp::Draft20180219::ssd::element_geometry)
     {
       oms::ssd::ElementGeometry geometry;
       geometry.importFromSSD(*it);
@@ -165,7 +165,7 @@ oms_status_enu_t oms::ComponentTable::exportToSSD(pugi::xml_node& node) const
   node.append_attribute("name") = this->getCref().c_str();
   node.append_attribute("type") = "application/table";
   node.append_attribute("source") = getPath().c_str();
-  pugi::xml_node node_connectors = node.append_child(oms::ssd::ssd_connectors);
+  pugi::xml_node node_connectors = node.append_child(oms::ssp::Draft20180219::ssd::connectors);
 
   if (element.getGeometry())
     element.getGeometry()->exportToSSD(node);

--- a/src/OMSimulatorLib/Connection.cpp
+++ b/src/OMSimulatorLib/Connection.cpp
@@ -113,9 +113,9 @@ oms_status_enu_t oms::Connection::exportToSSD(pugi::xml_node &root) const
 {
   pugi::xml_node node;
   if(type == oms_connection_single)
-    node = root.append_child(oms::ssd::ssd_connection);
+    node = root.append_child(oms::ssp::Draft20180219::ssd::connection);
   else if(type == oms_connection_bus || type == oms_connection_tlm)
-    node = root.append_child(oms::bus_connection);
+    node = root.append_child(oms::ssp::Draft20180219::bus_connection);
 
   ComRef startConnectorRef(conA);
   ComRef startElementRef = startConnectorRef.pop_front();

--- a/src/OMSimulatorLib/Connector.cpp
+++ b/src/OMSimulatorLib/Connector.cpp
@@ -97,7 +97,7 @@ oms::Connector* oms::Connector::NewConnector(const pugi::xml_node& node)
     causality = oms_causality_parameter;
   else
   {
-    logError("Failed to import " + std::string(oms::ssd::ssd_connector) + ":causality");
+    logError("Failed to import " + std::string(oms::ssp::Draft20180219::ssd::connector) + ":causality");
     return NULL;
   }
   oms_signal_type_enu_t type = oms_signal_type_real;
@@ -111,20 +111,20 @@ oms::Connector* oms::Connector::NewConnector(const pugi::xml_node& node)
     type = oms_signal_type_enum;
   else
   {
-    logError("Failed to import " + std::string(oms::ssd::ssd_connector) + ":type");
+    logError("Failed to import " + std::string(oms::ssp::Draft20180219::ssd::connector) + ":type");
     return NULL;
   }
 
   Connector* connector = new Connector(causality, type, cref);
   if (!connector)
   {
-    logError("Failed to import " + std::string(oms::ssd::ssd_connector));
+    logError("Failed to import " + std::string(oms::ssp::Draft20180219::ssd::connector));
     return NULL;
   }
   else
   {
     // Load connector geometry
-    pugi::xml_node connectorGeometryNode = node.child(oms::ssd::ssd_connector_geometry);
+    pugi::xml_node connectorGeometryNode = node.child(oms::ssp::Draft20180219::ssd::connector_geometry);
     if (connectorGeometryNode)
     {
       oms::ssd::ConnectorGeometry geometry(0.0, 0.0);
@@ -138,7 +138,7 @@ oms::Connector* oms::Connector::NewConnector(const pugi::xml_node& node)
 
 oms_status_enu_t oms::Connector::exportToSSD(pugi::xml_node &root) const
 {
-  pugi::xml_node node = root.append_child(oms::ssd::ssd_connector);
+  pugi::xml_node node = root.append_child(oms::ssp::Draft20180219::ssd::connector);
   node.append_attribute("name") = std::string(getName()).c_str();
   switch (this->causality)
   {

--- a/src/OMSimulatorLib/Model.cpp
+++ b/src/OMSimulatorLib/Model.cpp
@@ -228,7 +228,7 @@ oms_status_enu_t oms::Model::list(const oms::ComRef& cref, char** contents)
   // list model
   if (cref.isEmpty())
   {
-    pugi::xml_node node = doc.append_child(oms::ssd::ssd_system_structure_description);
+    pugi::xml_node node = doc.append_child(oms::ssp::Draft20180219::ssd::system_structure_description);
     exportToSSD(node);
   }
   else
@@ -240,7 +240,7 @@ oms_status_enu_t oms::Model::list(const oms::ComRef& cref, char** contents)
     System* subsystem = getSystem(cref);
     if (subsystem)
     {
-      pugi::xml_node node = doc.append_child(oms::ssd::ssd_system);
+      pugi::xml_node node = doc.append_child(oms::ssp::Draft20180219::ssd::system);
       subsystem->exportToSSD(node);
     }
     else
@@ -250,7 +250,7 @@ oms_status_enu_t oms::Model::list(const oms::ComRef& cref, char** contents)
       if (!component)
         return logError("error");
 
-      pugi::xml_node node = doc.append_child(oms::ssd::ssd_system);
+      pugi::xml_node node = doc.append_child(oms::ssp::Draft20180219::ssd::system);
       component->exportToSSD(node);
     }
   }
@@ -293,12 +293,12 @@ oms_status_enu_t oms::Model::exportToSSD(pugi::xml_node& node) const
 
   if (system)
   {
-    pugi::xml_node system_node = node.append_child(oms::ssd::ssd_system);
+    pugi::xml_node system_node = node.append_child(oms::ssp::Draft20180219::ssd::system);
     if (oms_status_ok != system->exportToSSD(system_node))
       return logError("export of system failed");
   }
 
-  pugi::xml_node default_experiment = node.append_child(oms::ssd::ssd_default_experiment);
+  pugi::xml_node default_experiment = node.append_child(oms::ssp::Draft20180219::ssd::default_experiment);
   default_experiment.append_attribute("startTime") = std::to_string(startTime).c_str();
   default_experiment.append_attribute("stopTime") = std::to_string(stopTime).c_str();
 
@@ -310,19 +310,19 @@ oms_status_enu_t oms::Model::importFromSSD(const pugi::xml_node& node)
   for(pugi::xml_node_iterator it = node.begin(); it != node.end(); ++it)
   {
     std::string name = it->name();
-    if (name == oms::ssd::ssd_system)
+    if (name == oms::ssp::Draft20180219::ssd::system)
     {
       ComRef systemCref = ComRef(it->attribute("name").as_string());
 
       // lochel: I guess that can somehow be improved
       oms_system_enu_t systemType = oms_system_tlm;
-      if (std::string(it->child(oms::ssd::ssd_simulation_information).child("VariableStepSolver").attribute("description").as_string()) != "")
+      if (std::string(it->child(oms::ssp::Draft20180219::ssd::simulation_information).child("VariableStepSolver").attribute("description").as_string()) != "")
         systemType = oms_system_sc;
-      if (std::string(it->child(oms::ssd::ssd_simulation_information).child("FixedStepSolver").attribute("description").as_string()) != "")
+      if (std::string(it->child(oms::ssp::Draft20180219::ssd::simulation_information).child("FixedStepSolver").attribute("description").as_string()) != "")
         systemType = oms_system_sc;
-      if (std::string(it->child(oms::ssd::ssd_simulation_information).child("VariableStepMaster").attribute("description").as_string()) != "")
+      if (std::string(it->child(oms::ssp::Draft20180219::ssd::simulation_information).child("VariableStepMaster").attribute("description").as_string()) != "")
         systemType = oms_system_wc;
-      if (std::string(it->child(oms::ssd::ssd_simulation_information).child("FixedStepMaster").attribute("description").as_string()) != "")
+      if (std::string(it->child(oms::ssp::Draft20180219::ssd::simulation_information).child("FixedStepMaster").attribute("description").as_string()) != "")
         systemType = oms_system_wc;
 
       if (oms_status_ok != addSystem(systemCref, systemType))
@@ -335,7 +335,7 @@ oms_status_enu_t oms::Model::importFromSSD(const pugi::xml_node& node)
       if (oms_status_ok != system->importFromSSD(*it))
         return oms_status_error;
     }
-    else if (name == oms::ssd::ssd_default_experiment)
+    else if (name == oms::ssp::Draft20180219::ssd::default_experiment)
     {
       startTime = it->attribute("startTime").as_double(0.0);
       stopTime = it->attribute("stopTime").as_double(1.0);
@@ -363,7 +363,7 @@ oms_status_enu_t oms::Model::exportToFile(const std::string& filename) const
   declarationNode.append_attribute("version") = "1.0";
   declarationNode.append_attribute("encoding") = "UTF-8";
 
-  pugi::xml_node node = doc.append_child(oms::ssd::ssd_system_structure_description);
+  pugi::xml_node node = doc.append_child(oms::ssp::Draft20180219::ssd::system_structure_description);
   exportToSSD(node);
 
   filesystem::path ssdPath = filesystem::path(tempDir) / "SystemStructure.ssd";

--- a/src/OMSimulatorLib/System.cpp
+++ b/src/OMSimulatorLib/System.cpp
@@ -389,29 +389,29 @@ oms_status_enu_t oms::System::exportToSSD(pugi::xml_node& node) const
   if (oms_status_ok != element.getGeometry()->exportToSSD(node))
     return logError("export of system ElementGeometry failed");
 
-  pugi::xml_node elements_node = node.append_child(oms::ssd::ssd_elements);
+  pugi::xml_node elements_node = node.append_child(oms::ssp::Draft20180219::ssd::elements);
 
   for (const auto& subsystem : subsystems)
   {
-    pugi::xml_node system_node = elements_node.append_child(oms::ssd::ssd_system);
+    pugi::xml_node system_node = elements_node.append_child(oms::ssp::Draft20180219::ssd::system);
     if (oms_status_ok != subsystem.second->exportToSSD(system_node))
       return logError("export of system failed");
   }
 
   for (const auto& component : components)
   {
-    pugi::xml_node component_node = elements_node.append_child(oms::ssd::ssd_component);
+    pugi::xml_node component_node = elements_node.append_child(oms::ssp::Draft20180219::ssd::component);
     if (oms_status_ok != component.second->exportToSSD(component_node))
       return logError("export of component failed");
   }
 
-  pugi::xml_node connectors_node = node.append_child(oms::ssd::ssd_connectors);
+  pugi::xml_node connectors_node = node.append_child(oms::ssp::Draft20180219::ssd::connectors);
   for(const auto& connector : connectors)
     if (connector)
       connector->exportToSSD(connectors_node);
 
   std::vector<oms::Connection*> busconnections;
-  pugi::xml_node connections_node = node.append_child(oms::ssd::ssd_connections);
+  pugi::xml_node connections_node = node.append_child(oms::ssp::Draft20180219::ssd::connections);
   for (const auto& connection : connections)
     if (connection && connection->getType() == oms_connection_single)
       connection->exportToSSD(connections_node);
@@ -424,9 +424,9 @@ oms_status_enu_t oms::System::exportToSSD(pugi::xml_node& node) const
   if (busconnectors[0] || !busconnections.empty())
 #endif
   {
-    pugi::xml_node annotations_node = node.append_child(oms::ssd::ssd_annotations);
-    pugi::xml_node annotation_node = annotations_node.append_child(oms::ssd::ssd_annotation);
-    annotation_node.append_attribute("type") = oms::annotation_type;
+    pugi::xml_node annotations_node = node.append_child(oms::ssp::Draft20180219::ssd::annotations);
+    pugi::xml_node annotation_node = annotations_node.append_child(oms::ssp::Draft20180219::ssd::annotation);
+    annotation_node.append_attribute("type") = oms::ssp::Draft20180219::annotation_type;
     for (const auto& busconnector : busconnectors)
       if (busconnector)
         busconnector->exportToSSD(annotation_node);
@@ -437,7 +437,7 @@ oms_status_enu_t oms::System::exportToSSD(pugi::xml_node& node) const
 #endif
     if (!busconnections.empty())
     {
-      pugi::xml_node busconnections_node = annotation_node.append_child(oms::bus_connections);
+      pugi::xml_node busconnections_node = annotation_node.append_child(oms::ssp::Draft20180219::bus_connections);
       for (const auto& busconnection : busconnections)
         busconnection->exportToSSD(busconnections_node);
     }
@@ -451,18 +451,18 @@ oms_status_enu_t oms::System::importFromSSD(const pugi::xml_node& node)
   for(pugi::xml_node_iterator it = node.begin(); it != node.end(); ++it)
   {
     std::string name = it->name();
-    if (name == oms::ssd::ssd_simulation_information)
+    if (name == oms::ssp::Draft20180219::ssd::simulation_information)
     {
       if (oms_status_ok != importFromSSD_SimulationInformation(*it))
-        return logError("Failed to import " + std::string(oms::ssd::ssd_simulation_information));
+        return logError("Failed to import " + std::string(oms::ssp::Draft20180219::ssd::simulation_information));
     }
-    else if (name == oms::ssd::ssd_element_geometry)
+    else if (name == oms::ssp::Draft20180219::ssd::element_geometry)
     {
       oms::ssd::ElementGeometry geometry;
       geometry.importFromSSD(*it);
       setGeometry(geometry);
     }
-    else if (name == oms::ssd::ssd_connections)
+    else if (name == oms::ssp::Draft20180219::ssd::connections)
     {
       for(pugi::xml_node_iterator itConnectors = (*it).begin(); itConnectors != (*it).end(); ++itConnectors)
       {
@@ -477,16 +477,16 @@ oms_status_enu_t oms::System::importFromSSD(const pugi::xml_node& node)
         if (!endElement.isEmpty())
           crefB = endElement + endConnector;
         if (oms_status_ok != addConnection(crefA, crefB))
-          return logError("Failed to import " + std::string(oms::ssd::ssd_connection));
+          return logError("Failed to import " + std::string(oms::ssp::Draft20180219::ssd::connection));
         else
         {
           // Load connection geometry
           if (oms_status_ok != importFromSSD_ConnectionGeometry(*itConnectors, crefA, crefB))
-            return logError("Failed to import " + std::string(oms::ssd::ssd_connection_geometry));
+            return logError("Failed to import " + std::string(oms::ssp::Draft20180219::ssd::connection_geometry));
         }
       }
     }
-    else if (name == oms::ssd::ssd_connectors)
+    else if (name == oms::ssp::Draft20180219::ssd::connectors)
     {
       for(pugi::xml_node_iterator itConnectors = (*it).begin(); itConnectors != (*it).end(); ++itConnectors)
       {
@@ -501,24 +501,24 @@ oms_status_enu_t oms::System::importFromSSD(const pugi::xml_node& node)
         element.setConnectors(&connectors[0]);
       }
     }
-    else if (name == oms::ssd::ssd_elements)
+    else if (name == oms::ssp::Draft20180219::ssd::elements)
     {
       for(pugi::xml_node_iterator itElements = (*it).begin(); itElements != (*it).end(); ++itElements)
       {
         name = itElements->name();
-        if (name == oms::ssd::ssd_system)
+        if (name == oms::ssp::Draft20180219::ssd::system)
         {
           ComRef systemCref = ComRef(itElements->attribute("name").as_string());
 
           // lochel: I guess that can somehow be improved
           oms_system_enu_t systemType = oms_system_tlm;
-          if (std::string(itElements->child(oms::ssd::ssd_simulation_information).child("VariableStepSolver").attribute("description").as_string()) != "")
+          if (std::string(itElements->child(oms::ssp::Draft20180219::ssd::simulation_information).child("VariableStepSolver").attribute("description").as_string()) != "")
             systemType = oms_system_sc;
-          if (std::string(itElements->child(oms::ssd::ssd_simulation_information).child("FixedStepSolver").attribute("description").as_string()) != "")
+          if (std::string(itElements->child(oms::ssp::Draft20180219::ssd::simulation_information).child("FixedStepSolver").attribute("description").as_string()) != "")
             systemType = oms_system_sc;
-          if (std::string(itElements->child(oms::ssd::ssd_simulation_information).child("VariableStepMaster").attribute("description").as_string()) != "")
+          if (std::string(itElements->child(oms::ssp::Draft20180219::ssd::simulation_information).child("VariableStepMaster").attribute("description").as_string()) != "")
             systemType = oms_system_wc;
-          if (std::string(itElements->child(oms::ssd::ssd_simulation_information).child("FixedStepMaster").attribute("description").as_string()) != "")
+          if (std::string(itElements->child(oms::ssp::Draft20180219::ssd::simulation_information).child("FixedStepMaster").attribute("description").as_string()) != "")
             systemType = oms_system_wc;
 
           if (oms_status_ok != addSubSystem(systemCref, systemType))
@@ -531,7 +531,7 @@ oms_status_enu_t oms::System::importFromSSD(const pugi::xml_node& node)
           if (oms_status_ok != system->importFromSSD(*itElements))
             return oms_status_error;
         }
-        else if (name == oms::ssd::ssd_component)
+        else if (name == oms::ssp::Draft20180219::ssd::component)
         {
           Component* component = NULL;
           std::string type = itElements->attribute("type").as_string();
@@ -550,14 +550,14 @@ oms_status_enu_t oms::System::importFromSSD(const pugi::xml_node& node)
           else if (itElements->attribute("type") == nullptr) {
               std::string name = itElements->attribute("name").as_string();
               std::string source = itElements->attribute("source").as_string();
-              pugi::xml_node simulationInformationNode = itElements->child(oms::ssd::ssd_simulation_information);
+              pugi::xml_node simulationInformationNode = itElements->child(oms::ssp::Draft20180219::ssd::simulation_information);
               if(simulationInformationNode) {
-                  pugi::xml_node annotationsNode = simulationInformationNode.child(oms::ssd::ssd_annotations);
+                  pugi::xml_node annotationsNode = simulationInformationNode.child(oms::ssp::Draft20180219::ssd::annotations);
                   if(annotationsNode) {
-                      for (pugi::xml_node annotationNode = annotationsNode.child(oms::ssd::ssd_annotation); annotationNode; annotationNode = annotationNode.next_sibling(oms::ssd::ssd_annotation)) {
+                      for (pugi::xml_node annotationNode = annotationsNode.child(oms::ssp::Draft20180219::ssd::annotation); annotationNode; annotationNode = annotationNode.next_sibling(oms::ssp::Draft20180219::ssd::annotation)) {
                           std::string type = annotationNode.attribute("type").as_string() ;
-                          if(oms::annotation_type == type) {
-                              pugi::xml_node externalModelNode = annotationNode.child(oms::external_model);
+                          if(oms::ssp::Draft20180219::annotation_type == type) {
+                              pugi::xml_node externalModelNode = annotationNode.child(oms::ssp::Draft20180219::external_model);
                               if(externalModelNode) {
                                   std::string startScript = externalModelNode.attribute("startscript").as_string();
                                   component = oms::ExternalModel::NewComponent(name,this,source,startScript);
@@ -566,12 +566,12 @@ oms_status_enu_t oms::System::importFromSSD(const pugi::xml_node& node)
                       }
                   }
               }
-              pugi::xml_node annotationsNode = itElements->child(oms::ssd::ssd_annotations);
+              pugi::xml_node annotationsNode = itElements->child(oms::ssp::Draft20180219::ssd::annotations);
               if(annotationsNode) {
-                  for (pugi::xml_node annotationNode = annotationsNode.child(oms::ssd::ssd_annotation); annotationNode; annotationNode = annotationNode.next_sibling(oms::ssd::ssd_annotation)) {
+                  for (pugi::xml_node annotationNode = annotationsNode.child(oms::ssp::Draft20180219::ssd::annotation); annotationNode; annotationNode = annotationNode.next_sibling(oms::ssp::Draft20180219::ssd::annotation)) {
                       std::string type = annotationNode.attribute("type").as_string() ;
-                      if(oms::annotation_type == type) {
-                          pugi::xml_node busNode = annotationNode.child(oms::bus);
+                      if(oms::ssp::Draft20180219::annotation_type == type) {
+                          pugi::xml_node busNode = annotationNode.child(oms::ssp::Draft20180219::bus);
                           //Load TLM bus connector for external model
                           std::string busname = busNode.attribute("name").as_string();
                           std::string domainstr = busNode.attribute("domain").as_string();
@@ -624,15 +624,15 @@ oms_status_enu_t oms::System::importFromSSD(const pugi::xml_node& node)
           return logError("wrong xml schema detected: " + name);
       }
     }
-    else if (name == oms::ssd::ssd_annotations)
+    else if (name == oms::ssp::Draft20180219::ssd::annotations)
     {
-      pugi::xml_node annotation_node = it->child(oms::ssd::ssd_annotation);
-      if (annotation_node && std::string(annotation_node.attribute("type").as_string()) == oms::annotation_type)
+      pugi::xml_node annotation_node = it->child(oms::ssp::Draft20180219::ssd::annotation);
+      if (annotation_node && std::string(annotation_node.attribute("type").as_string()) == oms::ssp::Draft20180219::annotation_type)
       {
         for(pugi::xml_node_iterator itAnnotations = annotation_node.begin(); itAnnotations != annotation_node.end(); ++itAnnotations)
         {
           name = itAnnotations->name();
-          if (std::string(name) == oms::bus)
+          if (std::string(name) == oms::ssp::Draft20180219::bus)
           {
             //Load bus connector
             std::string busname = itAnnotations->attribute("name").as_string();
@@ -676,13 +676,13 @@ oms_status_enu_t oms::System::importFromSSD(const pugi::xml_node& node)
             }
 
             //Load bus connector signals
-            pugi::xml_node signals_node = itAnnotations->child(oms::signals);
+            pugi::xml_node signals_node = itAnnotations->child(oms::ssp::Draft20180219::signals);
             if (signals_node)
             {
               for(pugi::xml_node_iterator itSignals = signals_node.begin(); itSignals != signals_node.end(); ++itSignals)
               {
                 name = itSignals->name();
-                if (name == oms::signal)
+                if (name == oms::ssp::Draft20180219::signal)
                 {
                   std::string signalname = itSignals->attribute("name").as_string();
                   if (std::string(itAnnotations->attribute("type").as_string()) == "tlm")
@@ -697,7 +697,7 @@ oms_status_enu_t oms::System::importFromSSD(const pugi::xml_node& node)
             }
 
             // Load bus connector geometry
-            pugi::xml_node connectorGeometryNode = itAnnotations->child(oms::ssd::ssd_connector_geometry);
+            pugi::xml_node connectorGeometryNode = itAnnotations->child(oms::ssp::Draft20180219::ssd::connector_geometry);
             if (connectorGeometryNode)
             {
               oms::ssd::ConnectorGeometry geometry(0.0, 0.0);
@@ -720,7 +720,7 @@ oms_status_enu_t oms::System::importFromSSD(const pugi::xml_node& node)
               }
             }
           }
-          else if (std::string(name) == oms::bus_connections)
+          else if (std::string(name) == oms::ssp::Draft20180219::bus_connections)
           {
             //Load bus connections
             for(pugi::xml_node_iterator itConnection = itAnnotations->begin(); itConnection != itAnnotations->end(); ++itConnection)
@@ -753,12 +753,12 @@ oms_status_enu_t oms::System::importFromSSD(const pugi::xml_node& node)
               }
               // Load the bus connection geometry
               if (oms_status_ok != status)
-                return logError("Failed to import " + std::string(oms::bus_connection));
+                return logError("Failed to import " + std::string(oms::ssp::Draft20180219::bus_connection));
               else
               {
                 // Load connection geometry
                 if (oms_status_ok != importFromSSD_ConnectionGeometry(*itConnection, element1+connector1, element2+connector2))
-                  return logError("Failed to import " + std::string(oms::ssd::ssd_connection_geometry));
+                  return logError("Failed to import " + std::string(oms::ssp::Draft20180219::ssd::connection_geometry));
               }
             }
           }
@@ -1788,7 +1788,7 @@ oms_status_enu_t oms::System::setRealInputDerivatives(const oms::ComRef &cref, i
 
 oms_status_enu_t oms::System::importFromSSD_ConnectionGeometry(const pugi::xml_node& node, const ComRef& crefA, const ComRef& crefB)
 {
-  pugi::xml_node connectionGeometryNode = node.child(oms::ssd::ssd_connection_geometry);
+  pugi::xml_node connectionGeometryNode = node.child(oms::ssp::Draft20180219::ssd::connection_geometry);
   if (connectionGeometryNode)
   {
     oms::Connection *connection = getConnection(crefA, crefB);

--- a/src/OMSimulatorLib/SystemSC.cpp
+++ b/src/OMSimulatorLib/SystemSC.cpp
@@ -139,7 +139,7 @@ oms_status_enu_t oms::SystemSC::setSolverMethod(std::string solver)
 
 oms_status_enu_t oms::SystemSC::exportToSSD_SimulationInformation(pugi::xml_node& node) const
 {
-  pugi::xml_node node_simulation_information = node.append_child(oms::ssd::ssd_simulation_information);
+  pugi::xml_node node_simulation_information = node.append_child(oms::ssp::Draft20180219::ssd::simulation_information);
 
   pugi::xml_node node_solver = node_simulation_information.append_child("VariableStepSolver");
   node_solver.append_attribute("description") = getSolverName().c_str();

--- a/src/OMSimulatorLib/SystemWC.cpp
+++ b/src/OMSimulatorLib/SystemWC.cpp
@@ -105,7 +105,7 @@ oms_status_enu_t oms::SystemWC::setSolverMethod(std::string solver)
 
 oms_status_enu_t oms::SystemWC::exportToSSD_SimulationInformation(pugi::xml_node& node) const
 {
-  pugi::xml_node node_simulation_information = node.append_child(oms::ssd::ssd_simulation_information);
+  pugi::xml_node node_simulation_information = node.append_child(oms::ssp::Draft20180219::ssd::simulation_information);
 
   pugi::xml_node node_solver = node_simulation_information.append_child("FixedStepMaster");
   node_solver.append_attribute("description") = getSolverName().c_str();

--- a/src/OMSimulatorLib/TLM/ExternalModel.cpp
+++ b/src/OMSimulatorLib/TLM/ExternalModel.cpp
@@ -91,9 +91,9 @@ oms_status_enu_t oms::ExternalModel::exportToSSD(pugi::xml_node& node) const
 {
   if (tlmbusconnectors[0])
   {
-    pugi::xml_node annotations_node = node.append_child(oms::ssd::ssd_annotations);
-    pugi::xml_node annotation_node = annotations_node.append_child(oms::ssd::ssd_annotation);
-    annotation_node.append_attribute("type") = oms::annotation_type;
+    pugi::xml_node annotations_node = node.append_child(oms::ssp::Draft20180219::ssd::annotations);
+    pugi::xml_node annotation_node = annotations_node.append_child(oms::ssp::Draft20180219::ssd::annotation);
+    annotation_node.append_attribute("type") = oms::ssp::Draft20180219::annotation_type;
     for (const auto& tlmbusconnector : tlmbusconnectors)
       if (tlmbusconnector)
         tlmbusconnector->exportToSSD(annotation_node);
@@ -101,11 +101,11 @@ oms_status_enu_t oms::ExternalModel::exportToSSD(pugi::xml_node& node) const
 
   node.append_attribute("name") = this->getCref().c_str();
   node.append_attribute("source") = this->getPath().c_str();
-  pugi::xml_node siminfo_node = node.append_child(oms::ssd::ssd_simulation_information);
-  pugi::xml_node annotations_node = siminfo_node.append_child(oms::ssd::ssd_annotations);
-  pugi::xml_node annotation_node = annotations_node.append_child(oms::ssd::ssd_annotation);
-  annotation_node.append_attribute("type") = oms::annotation_type;
-  pugi::xml_node externalmodel_node = annotation_node.append_child(oms::external_model);
+  pugi::xml_node siminfo_node = node.append_child(oms::ssp::Draft20180219::ssd::simulation_information);
+  pugi::xml_node annotations_node = siminfo_node.append_child(oms::ssp::Draft20180219::ssd::annotations);
+  pugi::xml_node annotation_node = annotations_node.append_child(oms::ssp::Draft20180219::ssd::annotation);
+  annotation_node.append_attribute("type") = oms::ssp::Draft20180219::annotation_type;
+  pugi::xml_node externalmodel_node = annotation_node.append_child(oms::ssp::Draft20180219::external_model);
   externalmodel_node.append_attribute("startscript") = externalModelInfo.getStartScript().c_str();
 
   return oms_status_ok;

--- a/src/OMSimulatorLib/TLM/SystemTLM.cpp
+++ b/src/OMSimulatorLib/TLM/SystemTLM.cpp
@@ -80,14 +80,14 @@ oms::System* oms::SystemTLM::NewSystem(const oms::ComRef& cref, oms::Model* pare
 
 oms_status_enu_t oms::SystemTLM::exportToSSD_SimulationInformation(pugi::xml_node& node) const
 {
-  pugi::xml_node node_simulation_information = node.append_child(oms::ssd::ssd_simulation_information);
+  pugi::xml_node node_simulation_information = node.append_child(oms::ssp::Draft20180219::ssd::simulation_information);
 
-  pugi::xml_node node_annotations = node_simulation_information.append_child(oms::ssd::ssd_annotations);
+  pugi::xml_node node_annotations = node_simulation_information.append_child(oms::ssp::Draft20180219::ssd::annotations);
 
-  pugi::xml_node node_annotation = node_annotations.append_child(oms::ssd::ssd_annotation);
-  node_annotation.append_attribute("type") = oms::annotation_type;
+  pugi::xml_node node_annotation = node_annotations.append_child(oms::ssp::Draft20180219::ssd::annotation);
+  node_annotation.append_attribute("type") = oms::ssp::Draft20180219::annotation_type;
 
-  pugi::xml_node node_tlm = node_annotation.append_child(oms::tlm_master);
+  pugi::xml_node node_tlm = node_annotation.append_child(oms::ssp::Draft20180219::tlm_master);
   node_tlm.append_attribute("ip") = address.c_str();
   node_tlm.append_attribute("managerport") = std::to_string(desiredManagerPort).c_str();
   node_tlm.append_attribute("monitorport") = std::to_string(desiredMonitorPort).c_str();
@@ -97,9 +97,9 @@ oms_status_enu_t oms::SystemTLM::exportToSSD_SimulationInformation(pugi::xml_nod
 
 oms_status_enu_t oms::SystemTLM::importFromSSD_SimulationInformation(const pugi::xml_node& node)
 {
-  pugi::xml_node annotationsNode = node.child(oms::ssd::ssd_annotations);
+  pugi::xml_node annotationsNode = node.child(oms::ssp::Draft20180219::ssd::annotations);
   if(annotationsNode) {
-    pugi::xml_node annotationNode = annotationsNode.child(oms::ssd::ssd_annotation);
+    pugi::xml_node annotationNode = annotationsNode.child(oms::ssp::Draft20180219::ssd::annotation);
     if(annotationNode && std::string(annotationNode.attribute("type").as_string()) == "org.openmodelica") {
       pugi::xml_node tlmmasterNode = annotationNode.child("oms:TlmMaster");
       for (auto it = tlmmasterNode.attributes_begin(); it != tlmmasterNode.attributes_end(); ++it)

--- a/src/OMSimulatorLib/TLM/TLMBusConnector.cpp
+++ b/src/OMSimulatorLib/TLM/TLMBusConnector.cpp
@@ -48,7 +48,7 @@ oms::TLMBusConnector::~TLMBusConnector()
 
 oms_status_enu_t oms::TLMBusConnector::exportToSSD(pugi::xml_node &root) const
 {
-  pugi::xml_node bus_node = root.append_child(oms::bus);
+  pugi::xml_node bus_node = root.append_child(oms::ssp::Draft20180219::bus);
   bus_node.append_attribute("name") = name;
   bus_node.append_attribute("type") = "tlm";
   bus_node.append_attribute("domain") = getDomainString().c_str();
@@ -60,9 +60,9 @@ oms_status_enu_t oms::TLMBusConnector::exportToSSD(pugi::xml_node &root) const
   else if(interpolation == oms_tlm_fine_grained)
     bus_node.append_attribute("interpolation") = "finegrained";
 
-  pugi::xml_node signals_node = bus_node.append_child(oms::signals);
+  pugi::xml_node signals_node = bus_node.append_child(oms::ssp::Draft20180219::signals);
   for(auto& connector : connectors) {
-    pugi::xml_node signal_node = signals_node.append_child(oms::signal);
+    pugi::xml_node signal_node = signals_node.append_child(oms::ssp::Draft20180219::signal);
     signal_node.append_attribute("name") = connector.second.c_str();
     signal_node.append_attribute("type") = connector.first.c_str();
   }

--- a/src/OMSimulatorLib/ssd/ConnectionGeometry.cpp
+++ b/src/OMSimulatorLib/ssd/ConnectionGeometry.cpp
@@ -139,7 +139,7 @@ oms_status_enu_t oms::ssd::ConnectionGeometry::exportToSSD(pugi::xml_node& root)
   // export ssd:ConnectionGeometry
   if (getLength() > 0)
   {
-    pugi::xml_node node = root.append_child(oms::ssd::ssd_connection_geometry);
+    pugi::xml_node node = root.append_child(oms::ssp::Draft20180219::ssd::connection_geometry);
     const double* pointsX = getPointsX();
     const double* pointsY = getPointsY();
     std::string pointsXStr, pointsYStr;

--- a/src/OMSimulatorLib/ssd/ConnectorGeometry.cpp
+++ b/src/OMSimulatorLib/ssd/ConnectorGeometry.cpp
@@ -73,7 +73,7 @@ oms::ssd::ConnectorGeometry& oms::ssd::ConnectorGeometry::operator=(oms::ssd::Co
 
 oms_status_enu_t oms::ssd::ConnectorGeometry::exportToSSD(pugi::xml_node& root) const
 {
-  pugi::xml_node node = root.append_child(oms::ssd::ssd_connector_geometry);
+  pugi::xml_node node = root.append_child(oms::ssp::Draft20180219::ssd::connector_geometry);
   node.append_attribute("x") = std::to_string(x).c_str();
   node.append_attribute("y") = std::to_string(y).c_str();
 

--- a/src/OMSimulatorLib/ssd/ElementGeometry.cpp
+++ b/src/OMSimulatorLib/ssd/ElementGeometry.cpp
@@ -136,7 +136,7 @@ oms_status_enu_t oms::ssd::ElementGeometry::exportToSSD(pugi::xml_node& root) co
   // export ssd:ElementGeometry
   if (x1 != 0.0 || y1 != 0.0 || x2 != 0.0 || y2 != 0.0 || rotation != 0.0 || hasIconSource() || iconRotation != 0.0 || getIconFlip() || getIconFixedAspectRatio())
   {
-    pugi::xml_node node = root.append_child(oms::ssd::ssd_element_geometry);
+    pugi::xml_node node = root.append_child(oms::ssp::Draft20180219::ssd::element_geometry);
     node.append_attribute("x1") = std::to_string(x1).c_str();
     node.append_attribute("y1") = std::to_string(y1).c_str();
     node.append_attribute("x2") = std::to_string(x2).c_str();

--- a/src/OMSimulatorLib/ssd/Tags.cpp
+++ b/src/OMSimulatorLib/ssd/Tags.cpp
@@ -31,29 +31,29 @@
 
 #include "Tags.h"
 
-const char* oms::annotation_type                        = "org.openmodelica";
-const char* oms::tlm_master                             = "oms:TlmMaster";
-const char* oms::bus                                    = "oms:Bus";
-const char* oms::signals                                = "oms:Signals";
-const char* oms::signal                                 = "oms:Signal";
-const char* oms::bus_connections                        = "oms:Connections";
-const char* oms::bus_connection                         = "oms:Connection";
-const char* oms::external_model                         = "oms:ExternalModel";
+const char* oms::ssp::Draft20180219::annotation_type                   = "org.openmodelica";
+const char* oms::ssp::Draft20180219::tlm_master                        = "oms:TlmMaster";
+const char* oms::ssp::Draft20180219::bus                               = "oms:Bus";
+const char* oms::ssp::Draft20180219::signals                           = "oms:Signals";
+const char* oms::ssp::Draft20180219::signal                            = "oms:Signal";
+const char* oms::ssp::Draft20180219::bus_connections                   = "oms:Connections";
+const char* oms::ssp::Draft20180219::bus_connection                    = "oms:Connection";
+const char* oms::ssp::Draft20180219::external_model                    = "oms:ExternalModel";
 
-const char* oms::ssd::ssd_annotation                   = "ssd:Annotation";
-const char* oms::ssd::ssd_annotations                  = "ssd:Annotations";
-const char* oms::ssd::ssd_component                    = "ssd:Component";
-const char* oms::ssd::ssd_connection                   = "ssd:Connection";
-const char* oms::ssd::ssd_connection_geometry          = "ssd:ConnectionGeometry";
-const char* oms::ssd::ssd_connections                  = "ssd:Connections";
-const char* oms::ssd::ssd_connector                    = "ssd:Connector";
-const char* oms::ssd::ssd_connector_geometry           = "ssd:ConnectorGeometry";
-const char* oms::ssd::ssd_connectors                   = "ssd:Connectors";
-const char* oms::ssd::ssd_default_experiment           = "ssd:DefaultExperiment";
-const char* oms::ssd::ssd_element_geometry             = "ssd:ElementGeometry";
-const char* oms::ssd::ssd_elements                     = "ssd:Elements";
-const char* oms::ssd::ssd_enumerations                 = "ssd:Enumerations";
-const char* oms::ssd::ssd_simulation_information       = "ssd:SimulationInformation";
-const char* oms::ssd::ssd_system                       = "ssd:System";
-const char* oms::ssd::ssd_system_structure_description = "ssd:SystemStructureDescription";
-const char* oms::ssd::ssd_units                        = "ssd:Units";
+const char* oms::ssp::Draft20180219::ssd::annotation                   = "ssd:Annotation";
+const char* oms::ssp::Draft20180219::ssd::annotations                  = "ssd:Annotations";
+const char* oms::ssp::Draft20180219::ssd::component                    = "ssd:Component";
+const char* oms::ssp::Draft20180219::ssd::connection                   = "ssd:Connection";
+const char* oms::ssp::Draft20180219::ssd::connection_geometry          = "ssd:ConnectionGeometry";
+const char* oms::ssp::Draft20180219::ssd::connections                  = "ssd:Connections";
+const char* oms::ssp::Draft20180219::ssd::connector                    = "ssd:Connector";
+const char* oms::ssp::Draft20180219::ssd::connector_geometry           = "ssd:ConnectorGeometry";
+const char* oms::ssp::Draft20180219::ssd::connectors                   = "ssd:Connectors";
+const char* oms::ssp::Draft20180219::ssd::default_experiment           = "ssd:DefaultExperiment";
+const char* oms::ssp::Draft20180219::ssd::element_geometry             = "ssd:ElementGeometry";
+const char* oms::ssp::Draft20180219::ssd::elements                     = "ssd:Elements";
+const char* oms::ssp::Draft20180219::ssd::enumerations                 = "ssd:Enumerations";
+const char* oms::ssp::Draft20180219::ssd::simulation_information       = "ssd:SimulationInformation";
+const char* oms::ssp::Draft20180219::ssd::system                       = "ssd:System";
+const char* oms::ssp::Draft20180219::ssd::system_structure_description = "ssd:SystemStructureDescription";
+const char* oms::ssp::Draft20180219::ssd::units                        = "ssd:Units";

--- a/src/OMSimulatorLib/ssd/Tags.h
+++ b/src/OMSimulatorLib/ssd/Tags.h
@@ -34,35 +34,45 @@
 
 namespace oms
 {
-  extern const char* annotation_type;
-  extern const char* tlm_master;
-  extern const char* bus;
-  extern const char* signals;
-  extern const char* signal;
-  extern const char* bus_connections;
-  extern const char* bus_connection;
-  extern const char* external_model;
-
-  namespace ssd
+  namespace ssp
   {
-    extern const char* ssd_annotation;
-    extern const char* ssd_annotations;
-    extern const char* ssd_annotation;
-    extern const char* ssd_component;
-    extern const char* ssd_connection_geometry;
-    extern const char* ssd_connection;
-    extern const char* ssd_connections;
-    extern const char* ssd_connector_geometry;
-    extern const char* ssd_connector;
-    extern const char* ssd_connectors;
-    extern const char* ssd_default_experiment;
-    extern const char* ssd_element_geometry;
-    extern const char* ssd_elements;
-    extern const char* ssd_enumerations;
-    extern const char* ssd_simulation_information;
-    extern const char* ssd_system_structure_description;
-    extern const char* ssd_system;
-    extern const char* ssd_units;
+    namespace Version1_0
+    {
+    }
+
+    namespace Draft20180219
+    {
+      extern const char* annotation_type;
+      extern const char* tlm_master;
+      extern const char* bus;
+      extern const char* signals;
+      extern const char* signal;
+      extern const char* bus_connections;
+      extern const char* bus_connection;
+      extern const char* external_model;
+
+      namespace ssd
+      {
+        extern const char* annotation;
+        extern const char* annotations;
+        extern const char* annotation;
+        extern const char* component;
+        extern const char* connection_geometry;
+        extern const char* connection;
+        extern const char* connections;
+        extern const char* connector_geometry;
+        extern const char* connector;
+        extern const char* connectors;
+        extern const char* default_experiment;
+        extern const char* element_geometry;
+        extern const char* elements;
+        extern const char* enumerations;
+        extern const char* simulation_information;
+        extern const char* system_structure_description;
+        extern const char* system;
+        extern const char* units;
+      }
+    }
   }
 }
 


### PR DESCRIPTION
### Related Issues

#723 

### Purpose

Prepare the code base to handle different version of ssp.

### Approach

Introducing different namespaces for each version.
