### PR TITLE
import Parameter bindings from SSP at Component Level

### DIFF
--- a/src/OMSimulatorLib/ComponentFMUCS.cpp
+++ b/src/OMSimulatorLib/ComponentFMUCS.cpp
@@ -278,7 +278,8 @@ oms::Component* oms::ComponentFMUCS::NewComponent(const pugi::xml_node& node, om
     }
     else if(name == oms::ssp::Version1_0::ssd::parameter_bindings)
     {
-      //TODO set the parameter bindings associated with the components
+      // set parameter bindings associated with the component
+      component->startValues.importFromSSD(*it, sspVersion);
     }
     else
     {

--- a/src/OMSimulatorLib/ComponentFMUME.cpp
+++ b/src/OMSimulatorLib/ComponentFMUME.cpp
@@ -280,7 +280,8 @@ oms::Component* oms::ComponentFMUME::NewComponent(const pugi::xml_node& node, om
     }
     else if(name == oms::ssp::Version1_0::ssd::parameter_bindings)
     {
-      //TODO set the parameter bindings associated with the components
+      // set parameter bindings associated with the component
+      component->startValues.importFromSSD(*it, sspVersion);
     }
     else
     {

--- a/src/OMSimulatorLib/Parameters.cpp
+++ b/src/OMSimulatorLib/Parameters.cpp
@@ -112,3 +112,55 @@ oms_status_enu_t oms::Parameters::exportToSSD(pugi::xml_node& node) const
 
   return oms_status_ok;
 }
+
+oms_status_enu_t oms::Parameters::importFromSSD(const pugi::xml_node& node, const std::string& sspVersion)
+{
+  for (pugi::xml_node parameterBindingNode = node.child(oms::ssp::Version1_0::ssd::parameter_binding); parameterBindingNode; parameterBindingNode = parameterBindingNode.next_sibling(oms::ssp::Version1_0::ssd::parameter_binding))
+  {
+    std::string ssvFile = parameterBindingNode.attribute("source").as_string() ;
+    if (!ssvFile.empty())
+    {
+      //TODO, parse ssv file and set the Parameters
+    }
+    else
+    {
+      // inline ParameterBindings
+      pugi::xml_node parameterSet = parameterBindingNode.child(oms::ssp::Version1_0::ssv::parameter_set);
+      std::string paramsetVersion = parameterSet.attribute("version").as_string();
+      pugi::xml_node parameters = parameterSet.child(oms::ssp::Version1_0::ssv::parameters);
+      if (parameters)
+      {
+        for(pugi::xml_node_iterator itparameters = parameters.begin(); itparameters != parameters.end(); ++itparameters)
+        {
+          std::string name = itparameters->name();
+          if (name == oms::ssp::Version1_0::ssv::parameter)
+          {
+            ComRef cref = ComRef(itparameters->attribute("name").as_string());
+            if (itparameters->child(oms::ssp::Version1_0::ssv::real_type))
+            {
+              double value = itparameters->child(oms::ssp::Version1_0::ssv::real_type).attribute("value").as_double();
+              setReal(cref, value);
+            }
+            else if(itparameters->child(oms::ssp::Version1_0::ssv::integer_type))
+            {
+              int value = itparameters->child(oms::ssp::Version1_0::ssv::integer_type).attribute("value").as_int();
+              setInteger(cref, value);
+            }
+            else if(itparameters->child(oms::ssp::Version1_0::ssv::boolean_type))
+            {
+              bool value = itparameters->child(oms::ssp::Version1_0::ssv::boolean_type).attribute("value").as_bool();
+              setBoolean(cref, value);
+            }
+            else
+            {
+              logError("Failed to import " + std::string(oms::ssp::Version1_0::ssv::parameter) + ":Unknown ParameterBinding-type");
+            }
+          }
+        }
+      }
+    }
+  }
+
+  return oms_status_ok;
+}
+

--- a/src/OMSimulatorLib/Parameters.h
+++ b/src/OMSimulatorLib/Parameters.h
@@ -34,7 +34,6 @@
 
 #include "ComRef.h"
 #include "Types.h"
-
 #include <pugixml.hpp>
 #include <map>
 
@@ -51,6 +50,8 @@ namespace oms
     oms_status_enu_t setBoolean(const ComRef& cref, bool value);
 
     oms_status_enu_t exportToSSD(pugi::xml_node& node) const;
+    oms_status_enu_t importFromSSD(const pugi::xml_node& node, const std::string& sspVersion);
+
 
     std::map<ComRef, double> realStartValues;  ///< parameters and start values defined before instantiating the FMU
     std::map<ComRef, int> integerStartValues;  ///< parameters and start values defined before instantiating the FMU

--- a/testsuite/OMSimulator/import_export_parameters.lua
+++ b/testsuite/OMSimulator/import_export_parameters.lua
@@ -29,6 +29,34 @@ oms_setResultFile("import_export_parameters", "import_export_parameters.mat", 10
 src, status = oms_list("import_export_parameters")
 print(src)
 
+oms_export("import_export_parameters", "import_export_parameters.ssp");
+oms_delete("import_export_parameters")
+
+oms_importFile("import_export_parameters.ssp");
+
+oms_instantiate("import_export_parameters")
+
+print("info:      Parameter settings")
+print("info:      import_export_parameters.co_sim.addP.k1: " .. oms_getReal("import_export_parameters.co_sim.addP.k1"))
+print("info:      import_export_parameters.co_sim.addP.k2: " .. oms_getReal("import_export_parameters.co_sim.addP.k2"))
+print("info:      import_export_parameters.co_sim.addI.k2: " .. oms_getReal("import_export_parameters.co_sim.addI.k2"))
+
+oms_initialize("import_export_parameters")
+print("info:    Initialization")
+print("info:      import_export_parameters.co_sim.addP.k1: " .. oms_getReal("import_export_parameters.co_sim.addP.k1"))
+print("info:      import_export_parameters.co_sim.addP.k2: " .. oms_getReal("import_export_parameters.co_sim.addP.k2"))
+print("info:      import_export_parameters.co_sim.addI.k2: " .. oms_getReal("import_export_parameters.co_sim.addI.k2"))
+
+oms_simulate("import_export_parameters")
+print("info:    Simulation")
+print("info:      import_export_parameters.co_sim.addP.k1: " .. oms_getReal("import_export_parameters.co_sim.addP.k1"))
+print("info:      import_export_parameters.co_sim.addP.k2: " .. oms_getReal("import_export_parameters.co_sim.addP.k2"))
+print("info:      import_export_parameters.co_sim.addI.k2: " .. oms_getReal("import_export_parameters.co_sim.addI.k2"))
+
+oms_terminate("import_export_parameters")
+oms_delete("import_export_parameters")
+
+
 
 -- Result:
 -- <?xml version="1.0"?>
@@ -139,5 +167,18 @@ print(src)
 -- 	</ssd:System>
 -- 	<ssd:DefaultExperiment startTime="0.000000" stopTime="4.000000" />
 -- </ssd:SystemStructureDescription>
---
+-- 
+-- info:      Parameter settings
+-- info:      import_export_parameters.co_sim.addP.k1: 10.0
+-- info:      import_export_parameters.co_sim.addP.k2: -1.0
+-- info:      import_export_parameters.co_sim.addI.k2: 2.0
+-- info:    Result file: import_export_parameters_res.mat (bufferSize=10)
+-- info:    Initialization
+-- info:      import_export_parameters.co_sim.addP.k1: 10.0
+-- info:      import_export_parameters.co_sim.addP.k2: -1.0
+-- info:      import_export_parameters.co_sim.addI.k2: 2.0
+-- info:    Simulation
+-- info:      import_export_parameters.co_sim.addP.k1: 10.0
+-- info:      import_export_parameters.co_sim.addP.k2: -1.0
+-- info:      import_export_parameters.co_sim.addI.k2: 2.0
 -- endResult


### PR DESCRIPTION

### Purpose

This PR will now import the parameter bindings set at component level from the  SSP file

### changes
Parameter.cpp  :  added new function importFromSSD which sets the parameter at component level