### PR TITLE
disable flipped causality check in DirectedGraph

### DIFF
--- a/src/OMSimulatorLib/DirectedGraph.cpp
+++ b/src/OMSimulatorLib/DirectedGraph.cpp
@@ -261,11 +261,13 @@ void oms::DirectedGraph::calculateSortedConnections()
     for (int j = 0; j < components[i].size(); ++j)
     {
       // flip causality checks for connectors (top-level crefs)
-      bool outA = nodes[edges[components[i][j]].first].getName().isValidIdent() ? nodes[edges[components[i][j]].first].isInput() : nodes[edges[components[i][j]].first].isOutput();
-      bool inB = nodes[edges[components[i][j]].second].getName().isValidIdent() ? nodes[edges[components[i][j]].second].isOutput() : nodes[edges[components[i][j]].second].isInput();
+      //bool outA = nodes[edges[components[i][j]].first].getName().isValidIdent() ? nodes[edges[components[i][j]].first].isInput() : nodes[edges[components[i][j]].first].isOutput();
+      //bool inB = nodes[edges[components[i][j]].second].getName().isValidIdent() ? nodes[edges[components[i][j]].second].isOutput() : nodes[edges[components[i][j]].second].isInput();
 
-      if (outA && inB)
-        SCC.push_back(std::pair<int, int>(edges[components[i][j]]));
+      SCC.push_back(std::pair<int, int>(edges[components[i][j]]));
+
+      /*if (outA && inB)
+        SCC.push_back(std::pair<int, int>(edges[components[i][j]]));*/
     }
 
     if (SCC.size() > 0)


### PR DESCRIPTION
### Purpose

This is a test attempt, to disable causality check at directedGraph and see the expected behaviour
