### PR TITLE
Fix segmentation fault if shared object couldn't be loaded

### DIFF
--- a/src/OMSimulatorLib/ComponentFMUCS.cpp
+++ b/src/OMSimulatorLib/ComponentFMUCS.cpp
@@ -429,7 +429,7 @@ oms_status_enu_t oms::ComponentFMUCS::instantiate()
   // load the FMU shared library
   jmstatus = fmi2_import_create_dllfmu(fmu, fmi2_fmu_kind_cs, &callbackFunctions);
   if (jm_status_error == jmstatus)
-    return logError("Could not load the FMU; it may be corrupted or may not support your platform");
+    return logError("Could not load \"" + getPath() + "\" which is associated with \"" + std::string(getFullCref()) + "\"; it may be corrupted or may not support your platform");
 
   jmstatus = fmi2_import_instantiate(fmu, getCref().c_str(), fmi2_cosimulation, NULL, fmi2_false);
   if (jm_status_error == jmstatus)

--- a/src/OMSimulatorLib/ComponentFMUCS.cpp
+++ b/src/OMSimulatorLib/ComponentFMUCS.cpp
@@ -429,7 +429,7 @@ oms_status_enu_t oms::ComponentFMUCS::instantiate()
   // load the FMU shared library
   jmstatus = fmi2_import_create_dllfmu(fmu, fmi2_fmu_kind_cs, &callbackFunctions);
   if (jm_status_error == jmstatus)
-    return logError("Could not create the DLL loading mechanism (C-API). Error: " + std::string(fmi2_import_get_last_error(fmu)));
+    return logError("Could not load the FMU; it may be corrupted or may not support your platform");
 
   jmstatus = fmi2_import_instantiate(fmu, getCref().c_str(), fmi2_cosimulation, NULL, fmi2_false);
   if (jm_status_error == jmstatus)

--- a/src/OMSimulatorLib/ComponentFMUME.cpp
+++ b/src/OMSimulatorLib/ComponentFMUME.cpp
@@ -443,7 +443,7 @@ oms_status_enu_t oms::ComponentFMUME::instantiate()
   // load the FMU shared library
   jmstatus = fmi2_import_create_dllfmu(fmu, fmi2_fmu_kind_me, &callbackFunctions);
   if (jm_status_error == jmstatus)
-    return logError("Could not create the DLL loading mechanism (C-API). Error: " + std::string(fmi2_import_get_last_error(fmu)));
+    return logError("Could not load the FMU; it may be corrupted or may not support your platform");
 
   jmstatus = fmi2_import_instantiate(fmu, getCref().c_str(), fmi2_model_exchange, NULL, fmi2_false);
   if (jm_status_error == jmstatus)

--- a/src/OMSimulatorLib/ComponentFMUME.cpp
+++ b/src/OMSimulatorLib/ComponentFMUME.cpp
@@ -443,7 +443,7 @@ oms_status_enu_t oms::ComponentFMUME::instantiate()
   // load the FMU shared library
   jmstatus = fmi2_import_create_dllfmu(fmu, fmi2_fmu_kind_me, &callbackFunctions);
   if (jm_status_error == jmstatus)
-    return logError("Could not load the FMU; it may be corrupted or may not support your platform");
+    return logError("Could not load \"" + getPath() + "\" which is associated with \"" + std::string(getFullCref()) + "\"; it may be corrupted or may not support your platform");
 
   jmstatus = fmi2_import_instantiate(fmu, getCref().c_str(), fmi2_model_exchange, NULL, fmi2_false);
   if (jm_status_error == jmstatus)

--- a/src/OMSimulatorLib/Model.cpp
+++ b/src/OMSimulatorLib/Model.cpp
@@ -490,10 +490,8 @@ oms_status_enu_t oms::Model::instantiate()
 
   modelState = oms_modelState_enterInstantiation;
   if (oms_status_ok != system->instantiate())
-  {
-    terminate();
     return oms_status_error;
-  }
+
   modelState = oms_modelState_instantiated;
 
   return oms_status_ok;
@@ -632,8 +630,8 @@ oms_status_enu_t oms::Model::terminate()
   if (validState(oms_modelState_virgin))
     return oms_status_ok;
 
-  if (validState(oms_modelState_instantiated) && oms_status_ok != system->initialize())
-    return logError_Termination(system->getFullCref());
+  if (validState(oms_modelState_enterInstantiation))
+    return logError_ModelInWrongState(this);
 
   if (!system)
     return logError("Model doesn't contain a system");

--- a/src/OMSimulatorLib/SystemSC.cpp
+++ b/src/OMSimulatorLib/SystemSC.cpp
@@ -174,7 +174,7 @@ oms_status_enu_t oms::SystemSC::instantiate()
 {
   time = getModel()->getStartTime();
 
-  // there shouldn't be any substem
+  // there shouldn't be any subsystem
   for (const auto& subsystem : getSubSystems())
     if (oms_status_ok != subsystem.second->instantiate())
       return oms_status_error;


### PR DESCRIPTION
### Related Issues

* #742 

### Purpose

OMSimulator tries to unload a shared object even if it couldn't be loaded in the first place. This causes segmentation fault and OMEdit to crash.

### Approach

Unload the shared object only if is has been loaded in the first place 😀 
