### PR TITLE
loadSnapshot must be called in virgin model state

### DIFF
--- a/doc/UsersGuide/source/api/loadSnapshot.rst
+++ b/doc/UsersGuide/source/api/loadSnapshot.rst
@@ -2,7 +2,7 @@
 loadSnapshot
 ------------
 
-Loads a snapshot to restore a previous model state.
+Loads a snapshot to restore a previous model state. The model must be in virgin model state, which means it must not be instantiated.
 #END#
 
 #LUA#

--- a/src/OMSimulatorLib/Model.cpp
+++ b/src/OMSimulatorLib/Model.cpp
@@ -123,6 +123,9 @@ oms_status_enu_t oms::Model::rename(const oms::ComRef& cref)
 
 oms_status_enu_t oms::Model::loadSnapshot(const char* snapshot)
 {
+  if (!validState(oms_modelState_virgin))
+    return logError_ModelInWrongState(this);
+
   pugi::xml_document doc;
   pugi::xml_parse_result result = doc.load(snapshot);
   if (!result)


### PR DESCRIPTION
### Purpose

This avoids calling loadSnapshot if the model is in read-only mode.

### Approach

If a model is instantiated then it will automatically become read-only until it gets terminated.
