### PR TITLE
Allow hyphens in crefs

### DIFF
--- a/src/OMSimulatorLib/ComRef.cpp
+++ b/src/OMSimulatorLib/ComRef.cpp
@@ -33,7 +33,7 @@
 #include <assert.h>
 #include <RegEx.h>
 
-const oms_regex re_ident("^[a-zA-Z][a-zA-Z0-9_]*$");
+const oms_regex re_ident("^[a-zA-Z][a-zA-Z0-9_-]*$");
 
 oms::ComRef::ComRef()
 {


### PR DESCRIPTION
### Related Issues

* #751

### Purpose

OMSimulator is much stricter on crefs than the SSP specification. This PR will at least allow hyphens within crefs.
