### PR TITLE
add openmodelica defaultexperiment as vendor specific annotations

### DIFF
--- a/doc/UsersGuide/source/api/getSignalFilter.rst
+++ b/doc/UsersGuide/source/api/getSignalFilter.rst
@@ -1,0 +1,37 @@
+#CAPTION#
+getSignalFilter
+-------------
+
+Gets the signal filter of the given model cref.
+#END#
+
+#LUA#
+.. code-block:: lua
+
+  # not available
+
+#END#
+
+#PYTHON#
+.. code-block:: python
+
+  # not available
+
+#END#
+
+#CAPI#
+.. code-block:: c
+
+  oms_status_enu_t oms_getSignalFilter(const char* cref, char** regex);
+
+#END#
+
+#OMC#
+.. code-block:: Modelica
+
+  # not available
+
+#END#
+
+#DESCRIPTION#
+#END#

--- a/doc/UsersGuide/source/api/getSystemType.rst
+++ b/doc/UsersGuide/source/api/getSystemType.rst
@@ -15,7 +15,7 @@ Gets the type of the given system.
 #PYTHON#
 .. code-block:: python
 
-  # not available
+  type, status = oms.getSystemType(cref)
 
 #END#
 

--- a/doc/UsersGuide/source/api/getSystemType.rst
+++ b/doc/UsersGuide/source/api/getSystemType.rst
@@ -8,7 +8,7 @@ Gets the type of the given system.
 #LUA#
 .. code-block:: lua
 
-  # not available
+  type, status = oms_getSystemType(cref)
 
 #END#
 

--- a/src/OMSimulatorLib/Model.cpp
+++ b/src/OMSimulatorLib/Model.cpp
@@ -827,6 +827,12 @@ oms_status_enu_t oms::Model::getResultFile(char** filename, int* bufferSize)
   return oms_status_ok;
 }
 
+oms_status_enu_t oms::Model::getSignalFilter(char** regex)
+{
+  *regex = (char*)this->signalFilter.c_str();
+
+  return oms_status_ok;
+}
 
 oms_status_enu_t oms::Model::addSignalsToResults(const char* regex)
 {
@@ -842,6 +848,7 @@ oms_status_enu_t oms::Model::removeSignalsFromResults(const char* regex)
   if (system)
     if (oms_status_ok != system->removeSignalsFromResults(regex))
       return oms_status_error;
+  this->signalFilter = ""; // set to empty after removing the regex
   return oms_status_ok;
 }
 

--- a/src/OMSimulatorLib/Model.cpp
+++ b/src/OMSimulatorLib/Model.cpp
@@ -834,10 +834,22 @@ oms_status_enu_t oms::Model::getSignalFilter(char** regex)
   return oms_status_ok;
 }
 
+oms_status_enu_t oms::Model::setSignalFilter(const char* regex)
+{
+  if (oms_status_ok != removeSignalsFromResults(".*"))
+    return oms_status_error;
+
+  if (oms_status_ok != system->addSignalsToResults(regex))
+    return oms_status_error;
+
+  this->signalFilter = regex;
+
+  return oms_status_ok;
+}
+
 oms_status_enu_t oms::Model::addSignalsToResults(const char* regex)
 {
   if (system)
-    this->signalFilter = regex;
     if (oms_status_ok != system->addSignalsToResults(regex))
       return oms_status_error;
   return oms_status_ok;
@@ -848,7 +860,6 @@ oms_status_enu_t oms::Model::removeSignalsFromResults(const char* regex)
   if (system)
     if (oms_status_ok != system->removeSignalsFromResults(regex))
       return oms_status_error;
-  this->signalFilter = ""; // set to empty after removing the regex
   return oms_status_ok;
 }
 

--- a/src/OMSimulatorLib/Model.h
+++ b/src/OMSimulatorLib/Model.h
@@ -74,7 +74,7 @@ namespace oms
     oms_status_enu_t importFromSSD(const pugi::xml_node& node);
     oms_status_enu_t exportToFile(const std::string& filename) const;
     oms_system_enu_t getSystemType(const pugi::xml_node& node, const std::string& sspVersion);
-    oms_system_enu_t getSystemTypeHelper(const pugi::xml_node& node);
+    oms_system_enu_t getSystemTypeHelper(const pugi::xml_node& node, const std::string& sspVersion);
     void copyResources(bool copy_resources) {this->copy_resources = copy_resources;}
     bool copyResources() {return copy_resources;}
 
@@ -147,7 +147,7 @@ namespace oms
     std::string resultFilename;             ///< default <name>_res.mat
     Clock clock;
 
-    std::string signalFilter="";
+    std::string signalFilter;
 
     bool cancelSim;
     bool isolatedFMU = false;

--- a/src/OMSimulatorLib/Model.h
+++ b/src/OMSimulatorLib/Model.h
@@ -147,6 +147,8 @@ namespace oms
     std::string resultFilename;             ///< default <name>_res.mat
     Clock clock;
 
+    std::string signalFilter="";
+
     bool cancelSim;
     bool isolatedFMU = false;
 

--- a/src/OMSimulatorLib/Model.h
+++ b/src/OMSimulatorLib/Model.h
@@ -103,6 +103,7 @@ namespace oms
     oms_status_enu_t emit(double time, bool force=false, bool* emitted=NULL);
     oms_status_enu_t addSignalsToResults(const char* regex);
     oms_status_enu_t removeSignalsFromResults(const char* regex);
+    oms_status_enu_t getSignalFilter(char** regex);
 
     oms_status_enu_t cancelSimulation_asynchronous();
     bool cancelSimulation() const {return cancelSim;}
@@ -147,7 +148,7 @@ namespace oms
     std::string resultFilename;             ///< default <name>_res.mat
     Clock clock;
 
-    std::string signalFilter;
+    std::string signalFilter = "";  // default set to empty
 
     bool cancelSim;
     bool isolatedFMU = false;

--- a/src/OMSimulatorLib/Model.h
+++ b/src/OMSimulatorLib/Model.h
@@ -103,6 +103,7 @@ namespace oms
     oms_status_enu_t emit(double time, bool force=false, bool* emitted=NULL);
     oms_status_enu_t addSignalsToResults(const char* regex);
     oms_status_enu_t removeSignalsFromResults(const char* regex);
+    oms_status_enu_t setSignalFilter(const char* regex);
     oms_status_enu_t getSignalFilter(char** regex);
 
     oms_status_enu_t cancelSimulation_asynchronous();

--- a/src/OMSimulatorLib/OMSimulator.cpp
+++ b/src/OMSimulatorLib/OMSimulator.cpp
@@ -1225,6 +1225,22 @@ oms_status_enu_t oms_getResultFile(const char* cref_, char** filename, int* buff
     return logError_OnlyForModel;
 }
 
+oms_status_enu_t oms_getSignalFilter(const char* cref_, char** regex)
+{
+  oms::ComRef cref(cref_);
+
+  if (cref.isValidIdent())
+  {
+    oms::Model* model = oms::Scope::GetInstance().getModel(cref);
+    if (!model)
+      return logError_ModelNotInScope(cref);
+
+    return model->getSignalFilter(regex);
+  }
+  else
+    return logError_OnlyForModel;
+}
+
 oms_status_enu_t oms_getSolver(const char* cref, oms_solver_enu_t* solver)
 {
   oms::ComRef tail(cref);

--- a/src/OMSimulatorLib/OMSimulator.cpp
+++ b/src/OMSimulatorLib/OMSimulator.cpp
@@ -1385,17 +1385,20 @@ oms_status_enu_t oms_setSignalFilter(const char* cref, const char* regex)
 {
   oms_status_enu_t status;
 
-  status = oms_removeSignalsFromResults(cref, ".*");
-  if (oms_status_ok != status) return status;
+  oms::ComRef tail(cref);
+  oms::ComRef front = tail.pop_front();
 
-  status = oms_addSignalsToResults(cref, regex);
-  if (oms_status_ok != status) return status;
+  oms::Model* model = oms::Scope::GetInstance().getModel(front);
+  if (!model)
+    return logError_ModelNotInScope(front);
 
-  return oms_status_ok;
+  return model->setSignalFilter(regex);
 }
 
 oms_status_enu_t oms_addSignalsToResults(const char* cref, const char* regex)
 {
+  logWarning("[oms_addSignalsToResults] will not update the signalFilters in ssp, use [oms_setSignalFilter]");
+
   oms::ComRef tail(cref);
   oms::ComRef front = tail.pop_front();
 
@@ -1408,6 +1411,8 @@ oms_status_enu_t oms_addSignalsToResults(const char* cref, const char* regex)
 
 oms_status_enu_t oms_removeSignalsFromResults(const char* cref, const char* regex)
 {
+  logWarning("[oms_removeSignalsFromResults] will not update the signalFilters in ssp, use [oms_setSignalFilter]");
+
   oms::ComRef tail(cref);
   oms::ComRef front = tail.pop_front();
 

--- a/src/OMSimulatorLib/OMSimulator.h
+++ b/src/OMSimulatorLib/OMSimulator.h
@@ -99,6 +99,7 @@ OMSAPI oms_status_enu_t OMSCALL oms_getInteger(const char* cref, int* value);
 OMSAPI oms_status_enu_t OMSCALL oms_getModelState(const char* cref, oms_modelState_enu_t* modelState);
 OMSAPI oms_status_enu_t OMSCALL oms_getReal(const char* cref, double* value);
 OMSAPI oms_status_enu_t OMSCALL oms_getResultFile(const char* cref, char** filename, int* bufferSize);
+OMSAPI oms_status_enu_t OMSCALL oms_getSignalFilter(const char* cref, char** regex);
 OMSAPI oms_status_enu_t OMSCALL oms_getSolver(const char* cref, oms_solver_enu_t* solver);
 OMSAPI oms_status_enu_t OMSCALL oms_getStartTime(const char* cref, double* startTime);
 OMSAPI oms_status_enu_t OMSCALL oms_getStopTime(const char* cref, double* stopTime);

--- a/src/OMSimulatorLib/System.cpp
+++ b/src/OMSimulatorLib/System.cpp
@@ -465,7 +465,7 @@ oms_status_enu_t oms::System::importFromSSD(const pugi::xml_node& node, const st
     std::string name = it->name();
     if (name == oms::ssp::Draft20180219::ssd::simulation_information && sspVersion == "Draft20180219")
     {
-      if (oms_status_ok != importFromSSD_SimulationInformation(*it))
+      if (oms_status_ok != importFromSSD_SimulationInformation(*it, sspVersion))
         return logError("Failed to import " + std::string(oms::ssp::Draft20180219::ssd::simulation_information));
     }
     else if (name == oms::ssp::Draft20180219::ssd::element_geometry)
@@ -662,7 +662,7 @@ oms_status_enu_t oms::System::importFromSSD(const pugi::xml_node& node, const st
           // check for oms:simulationInformation from version 1.0
           if (std::string(name) == oms::ssp::Version1_0::simulation_information && sspVersion == "1.0")
           {
-            if (oms_status_ok != importFromSSD_SimulationInformation(*itAnnotations))
+            if (oms_status_ok != importFromSSD_SimulationInformation(*itAnnotations, sspVersion))
               return logError("Failed to import " + std::string(oms::ssp::Version1_0::simulation_information));
           }
           if (std::string(name) == oms::ssp::Draft20180219::bus)

--- a/src/OMSimulatorLib/System.h
+++ b/src/OMSimulatorLib/System.h
@@ -83,7 +83,7 @@ namespace oms
     oms_status_enu_t exportToSSD(pugi::xml_node& node) const;
     oms_status_enu_t importFromSSD(const pugi::xml_node& node, const std::string& sspVersion);
     virtual oms_status_enu_t exportToSSD_SimulationInformation(pugi::xml_node& node) const = 0;
-    virtual oms_status_enu_t importFromSSD_SimulationInformation(const pugi::xml_node& node) = 0;
+    virtual oms_status_enu_t importFromSSD_SimulationInformation(const pugi::xml_node& node, const std::string& sspVersion) = 0;
     void setGeometry(const ssd::ElementGeometry& geometry) {element.setGeometry(&geometry);}
     oms_status_enu_t addConnector(const ComRef& cref, oms_causality_enu_t causality, oms_signal_type_enu_t type);
     Connector* getConnector(const ComRef& cref);

--- a/src/OMSimulatorLib/SystemSC.cpp
+++ b/src/OMSimulatorLib/SystemSC.cpp
@@ -146,7 +146,7 @@ oms_status_enu_t oms::SystemSC::exportToSSD_SimulationInformation(pugi::xml_node
   /* ssd:SimulationInformation should be added as vendor specific annotations from Version 1.0 */
   pugi::xml_node node_simulation_information = node_annotation.append_child(oms::ssp::Version1_0::simulation_information);
 
-  pugi::xml_node node_solver = node_simulation_information.append_child("VariableStepSolver");
+  pugi::xml_node node_solver = node_simulation_information.append_child(oms::ssp::Version1_0::VariableStepSolver);
   node_solver.append_attribute("description") = getSolverName().c_str();
   node_solver.append_attribute("absoluteTolerance") = std::to_string(absoluteTolerance).c_str();
   node_solver.append_attribute("relativeTolerance") = std::to_string(relativeTolerance).c_str();
@@ -157,16 +157,30 @@ oms_status_enu_t oms::SystemSC::exportToSSD_SimulationInformation(pugi::xml_node
   return oms_status_ok;
 }
 
-oms_status_enu_t oms::SystemSC::importFromSSD_SimulationInformation(const pugi::xml_node& node)
+oms_status_enu_t oms::SystemSC::importFromSSD_SimulationInformation(const pugi::xml_node& node, const std::string& sspVersion)
 {
-  std::string solverName = node.child("VariableStepSolver").attribute("description").as_string();
+  std::string solverName = "";
+  const char* VariableStepSolver = "";
+
+  if (sspVersion == "1.0")
+  {
+    solverName = node.child(oms::ssp::Version1_0::VariableStepSolver).attribute("description").as_string();
+    VariableStepSolver = oms::ssp::Version1_0::VariableStepSolver;
+  }
+  else
+  {
+    solverName = node.child("VariableStepSolver").attribute("description").as_string();
+    VariableStepSolver = "VariableStepSolver";
+  }
+
   if (oms_status_ok != setSolverMethod(solverName))
     return oms_status_error;
-  absoluteTolerance = node.child("VariableStepSolver").attribute("absoluteTolerance").as_double();
-  relativeTolerance = node.child("VariableStepSolver").attribute("relativeTolerance").as_double();
-  minimumStepSize = node.child("VariableStepSolver").attribute("minimumStepSize").as_double();
-  maximumStepSize = node.child("VariableStepSolver").attribute("maximumStepSize").as_double();
-  initialStepSize = node.child("VariableStepSolver").attribute("initialStepSize").as_double();
+
+  absoluteTolerance = node.child(VariableStepSolver).attribute("absoluteTolerance").as_double();
+  relativeTolerance = node.child(VariableStepSolver).attribute("relativeTolerance").as_double();
+  minimumStepSize = node.child(VariableStepSolver).attribute("minimumStepSize").as_double();
+  maximumStepSize = node.child(VariableStepSolver).attribute("maximumStepSize").as_double();
+  initialStepSize = node.child(VariableStepSolver).attribute("initialStepSize").as_double();
   return oms_status_ok;
 }
 

--- a/src/OMSimulatorLib/SystemSC.h
+++ b/src/OMSimulatorLib/SystemSC.h
@@ -52,7 +52,7 @@ namespace oms
 
     static System* NewSystem(const oms::ComRef& cref, Model* parentModel, System* parentSystem);
     oms_status_enu_t exportToSSD_SimulationInformation(pugi::xml_node& node) const;
-    oms_status_enu_t importFromSSD_SimulationInformation(const pugi::xml_node& node);
+    oms_status_enu_t importFromSSD_SimulationInformation(const pugi::xml_node& node, const std::string& sspVersion);
 
     oms_status_enu_t instantiate();
     oms_status_enu_t initialize();

--- a/src/OMSimulatorLib/SystemWC.cpp
+++ b/src/OMSimulatorLib/SystemWC.cpp
@@ -115,6 +115,8 @@ oms_status_enu_t oms::SystemWC::exportToSSD_SimulationInformation(pugi::xml_node
   pugi::xml_node node_solver = node_simulation_information.append_child("FixedStepMaster");
   node_solver.append_attribute("description") = getSolverName().c_str();
   node_solver.append_attribute("stepSize") = std::to_string(maximumStepSize).c_str();
+  node_solver.append_attribute("absoluteTolerance") = std::to_string(absoluteTolerance).c_str();
+  node_solver.append_attribute("relativeTolerance") = std::to_string(relativeTolerance).c_str();
 
   return oms_status_ok;
 }
@@ -126,6 +128,8 @@ oms_status_enu_t oms::SystemWC::importFromSSD_SimulationInformation(const pugi::
   if (oms_status_ok != setSolverMethod(solverName))
     return oms_status_error;
   initialStepSize = minimumStepSize=maximumStepSize = node.child("FixedStepMaster").attribute("stepSize").as_double();
+  absoluteTolerance = node.child("FixedStepMaster").attribute("absoluteTolerance").as_double();
+  relativeTolerance = node.child("FixedStepMaster").attribute("relativeTolerance").as_double();
   return oms_status_ok;
 }
 

--- a/src/OMSimulatorLib/SystemWC.cpp
+++ b/src/OMSimulatorLib/SystemWC.cpp
@@ -112,7 +112,7 @@ oms_status_enu_t oms::SystemWC::exportToSSD_SimulationInformation(pugi::xml_node
   /* ssd:SimulationInformation should be added as vendor specific annotations from Version 1.0 */
   pugi::xml_node node_simulation_information = node_annotation.append_child(oms::ssp::Version1_0::simulation_information);
 
-  pugi::xml_node node_solver = node_simulation_information.append_child("FixedStepMaster");
+  pugi::xml_node node_solver = node_simulation_information.append_child(oms::ssp::Version1_0::FixedStepMaster);
   node_solver.append_attribute("description") = getSolverName().c_str();
   node_solver.append_attribute("stepSize") = std::to_string(maximumStepSize).c_str();
   node_solver.append_attribute("absoluteTolerance") = std::to_string(absoluteTolerance).c_str();
@@ -121,15 +121,26 @@ oms_status_enu_t oms::SystemWC::exportToSSD_SimulationInformation(pugi::xml_node
   return oms_status_ok;
 }
 
-oms_status_enu_t oms::SystemWC::importFromSSD_SimulationInformation(const pugi::xml_node& node)
+oms_status_enu_t oms::SystemWC::importFromSSD_SimulationInformation(const pugi::xml_node& node, const std::string& sspVersion)
 {
-  std::string solverName = node.child("FixedStepMaster").attribute("description").as_string();
+  std::string solverName = "";
+  const char* FixedStepMaster = "";
+  if (sspVersion == "1.0")
+  {
+    solverName = node.child(oms::ssp::Version1_0::FixedStepMaster).attribute("description").as_string();
+    FixedStepMaster = oms::ssp::Version1_0::FixedStepMaster;
+  }
+  else
+  {
+    solverName = node.child("FixedStepMaster").attribute("description").as_string();
+    FixedStepMaster = "FixedStepMaster";
+  }
 
   if (oms_status_ok != setSolverMethod(solverName))
     return oms_status_error;
-  initialStepSize = minimumStepSize=maximumStepSize = node.child("FixedStepMaster").attribute("stepSize").as_double();
-  absoluteTolerance = node.child("FixedStepMaster").attribute("absoluteTolerance").as_double();
-  relativeTolerance = node.child("FixedStepMaster").attribute("relativeTolerance").as_double();
+  initialStepSize = minimumStepSize=maximumStepSize = node.child(FixedStepMaster).attribute("stepSize").as_double();
+  absoluteTolerance = node.child(FixedStepMaster).attribute("absoluteTolerance").as_double();
+  relativeTolerance = node.child(FixedStepMaster).attribute("relativeTolerance").as_double();
   return oms_status_ok;
 }
 

--- a/src/OMSimulatorLib/SystemWC.h
+++ b/src/OMSimulatorLib/SystemWC.h
@@ -51,7 +51,7 @@ namespace oms
 
     static System* NewSystem(const ComRef& cref, Model* parentModel, System* parentSystem);
     oms_status_enu_t exportToSSD_SimulationInformation(pugi::xml_node& node) const;
-    oms_status_enu_t importFromSSD_SimulationInformation(const pugi::xml_node& node);
+    oms_status_enu_t importFromSSD_SimulationInformation(const pugi::xml_node& node, const std::string& sspVersion);
 
     oms_status_enu_t instantiate();
     oms_status_enu_t initialize();

--- a/src/OMSimulatorLib/TLM/SystemTLM.cpp
+++ b/src/OMSimulatorLib/TLM/SystemTLM.cpp
@@ -96,7 +96,7 @@ oms_status_enu_t oms::SystemTLM::exportToSSD_SimulationInformation(pugi::xml_nod
   return oms_status_ok;
 }
 
-oms_status_enu_t oms::SystemTLM::importFromSSD_SimulationInformation(const pugi::xml_node& node)
+oms_status_enu_t oms::SystemTLM::importFromSSD_SimulationInformation(const pugi::xml_node& node, const std::string& sspVersion)
 {
   pugi::xml_node annotationsNode = node.child(oms::ssp::Draft20180219::ssd::annotations);
 

--- a/src/OMSimulatorLib/TLM/SystemTLM.h
+++ b/src/OMSimulatorLib/TLM/SystemTLM.h
@@ -49,7 +49,7 @@ namespace oms
 
     static System* NewSystem(const oms::ComRef& cref, Model* parentModel, System* parentSystem);
     oms_status_enu_t exportToSSD_SimulationInformation(pugi::xml_node& node) const;
-    oms_status_enu_t importFromSSD_SimulationInformation(const pugi::xml_node& node);
+    oms_status_enu_t importFromSSD_SimulationInformation(const pugi::xml_node& node, const std::string& sspVersion);
     oms_status_enu_t importFromSSD_SimulationInformationHelper(const pugi::xml_node& node);
     oms_status_enu_t setSocketData(const std::string& address, int managerPort, int monitorPort);
     oms_status_enu_t setPositionAndOrientation(const ComRef &cref, std::vector<double> x, std::vector<double> A);

--- a/src/OMSimulatorLib/ssd/Tags.cpp
+++ b/src/OMSimulatorLib/ssd/Tags.cpp
@@ -60,6 +60,8 @@ const char* oms::ssp::Draft20180219::ssd::units                        = "ssd:Un
 
 // version 1.0
 const char* oms::ssp::Version1_0::simulation_information               = "oms:SimulationInformation"; // simulation information must be handled in a vendor specific annotation
+const char* oms::ssp::Version1_0::FixedStepMaster                      = "oms:FixedStepMaster"; // WC-System
+const char* oms::ssp::Version1_0::VariableStepSolver                   = "oms:VariableStepSolver"; // SC-System
 
 const char* oms::ssp::Version1_0::ssd::parameter_bindings              = "ssd:ParameterBindings";
 const char* oms::ssp::Version1_0::ssd::parameter_binding               = "ssd:ParameterBinding";

--- a/src/OMSimulatorLib/ssd/Tags.h
+++ b/src/OMSimulatorLib/ssd/Tags.h
@@ -39,6 +39,8 @@ namespace oms
     namespace Version1_0
     {
       extern const char* simulation_information;
+      extern const char* FixedStepMaster;
+      extern const char* VariableStepSolver;
 
       namespace ssd
       {

--- a/src/OMSimulatorPython/OMSimulator.py.in
+++ b/src/OMSimulatorPython/OMSimulator.py.in
@@ -193,7 +193,7 @@ class OMSimulator:
   def getSystemType(self, cref):
     type = ctypes.c_int()
     status = self.obj.oms_getSystemType(self.checkstring(cref), ctypes.byref(type))
-    return [status, type.value]
+    return [type.value, status]
   def getVariableStepSize(self, cref):
     initialStepSize = ctypes.c_double()
     minimumStepSize = ctypes.c_double()
@@ -221,19 +221,19 @@ class OMSimulator:
   def importFile(self, filename):
     contents = ctypes.c_char_p()
     status = self.obj.oms_importFile(self.checkstring(filename), ctypes.byref(contents))
-    return [status, self.checkstring(contents.value)]
+    return [self.checkstring(contents.value), status]
   def list(self, ident):
     contents = ctypes.c_char_p()
     status = self.obj.oms_list(self.checkstring(ident), ctypes.byref(contents))
-    return [status, self.checkstring(contents.value)]
+    return [self.checkstring(contents.value), status]
   def listUnconnectedConnectors(self, ident):
     contents = ctypes.c_char_p()
     status = self.obj.oms_listUnconnectedConnectors(self.checkstring(ident), ctypes.byref(contents))
-    return [status, self.checkstring(contents.value)]
+    return [self.checkstring(contents.value), status]
   def parseModelName(self, ident):
     contents = ctypes.c_char_p()
     status = self.obj.oms_parseModelName(self.checkstring(ident), ctypes.byref(contents))
-    return [status, self.checkstring(contents.value)]
+    return [self.checkstring(contents.value), status]
   def addSystem(self, ident, type):
     return self.obj.oms_addSystem(self.checkstring(ident), type)
   def copySystem(self, source, target):

--- a/testsuite/OMSimulator/PI_Controller.lua
+++ b/testsuite/OMSimulator/PI_Controller.lua
@@ -1,7 +1,7 @@
 -- status: correct
 -- teardown_command: rm -rf PI_Controller-lua/ PI_Controller_init.dot PI_Controller_sim.dot PI_Controller_res.mat PI_Controller.ssp
 -- linux: yes
--- mingw: no
+-- mingw: yes
 -- win: no
 -- mac: no
 
@@ -114,7 +114,7 @@ oms_delete("PI_Controller")
 -- info:      PI_Controller.co_sim.limiter.uMax: 12.0
 -- info:      PI_Controller.co_sim.addSat.k2: -1.0
 -- info:      PI_Controller.co_sim.gainTrack.k: 0.1
--- info:    Result file: PI_Controller_res.mat (bufferSize=10)
+-- info:    Result file: PI_Controller.mat (bufferSize=100)
 -- info:    Initialization
 -- info:      limiter.u: 0.0
 -- info:      limiter.y: 0.0

--- a/testsuite/OMSimulator/import_export.lua
+++ b/testsuite/OMSimulator/import_export.lua
@@ -209,7 +209,7 @@ printStatus(status, 0)
 --                 <ssd:Annotations>
 --                     <ssd:Annotation type="org.openmodelica">
 --                         <oms:SimulationInformation>
---                             <FixedStepMaster description="oms-ma" stepSize="0.100000" />
+--                             <oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
 --                         </oms:SimulationInformation>
 --                     </ssd:Annotation>
 --                 </ssd:Annotations>
@@ -254,7 +254,7 @@ printStatus(status, 0)
 --                 <ssd:Annotations>
 --                     <ssd:Annotation type="org.openmodelica">
 --                         <oms:SimulationInformation>
---                             <FixedStepMaster description="oms-ma" stepSize="0.100000" />
+--                             <oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
 --                         </oms:SimulationInformation>
 --                     </ssd:Annotation>
 --                 </ssd:Annotations>
@@ -280,7 +280,7 @@ printStatus(status, 0)
 --                         <ssd:Annotations>
 --                             <ssd:Annotation type="org.openmodelica">
 --                                 <oms:SimulationInformation>
---                                     <VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+--                                     <oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
 --                                 </oms:SimulationInformation>
 --                             </ssd:Annotation>
 --                         </ssd:Annotations>
@@ -348,9 +348,15 @@ printStatus(status, 0)
 --             </ssd:Annotation>
 --         </ssd:Annotations>
 --     </ssd:System>
---     <ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000" />
+--     <ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
+--         <ssd:Annotations>
+--             <ssd:Annotation type="org.openmodelica">
+--                 <oms:SimulationInformation resultFile="test_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter="" />
+--             </ssd:Annotation>
+--         </ssd:Annotations>
+--     </ssd:DefaultExperiment>
 -- </ssd:SystemStructureDescription>
---
+-- 
 -- status:  [correct] ok
 -- status:  [correct] ok
 -- status:  [correct] ok
@@ -371,7 +377,7 @@ printStatus(status, 0)
 --                 <ssd:Annotations>
 --                     <ssd:Annotation type="org.openmodelica">
 --                         <oms:SimulationInformation>
---                             <FixedStepMaster description="oms-ma" stepSize="0.100000" />
+--                             <oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
 --                         </oms:SimulationInformation>
 --                     </ssd:Annotation>
 --                 </ssd:Annotations>
@@ -416,7 +422,7 @@ printStatus(status, 0)
 --                 <ssd:Annotations>
 --                     <ssd:Annotation type="org.openmodelica">
 --                         <oms:SimulationInformation>
---                             <FixedStepMaster description="oms-ma" stepSize="0.100000" />
+--                             <oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
 --                         </oms:SimulationInformation>
 --                     </ssd:Annotation>
 --                 </ssd:Annotations>
@@ -442,7 +448,7 @@ printStatus(status, 0)
 --                         <ssd:Annotations>
 --                             <ssd:Annotation type="org.openmodelica">
 --                                 <oms:SimulationInformation>
---                                     <VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+--                                     <oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
 --                                 </oms:SimulationInformation>
 --                             </ssd:Annotation>
 --                         </ssd:Annotations>
@@ -510,8 +516,14 @@ printStatus(status, 0)
 --             </ssd:Annotation>
 --         </ssd:Annotations>
 --     </ssd:System>
---     <ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000" />
+--     <ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
+--         <ssd:Annotations>
+--             <ssd:Annotation type="org.openmodelica">
+--                 <oms:SimulationInformation resultFile="test_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter="" />
+--             </ssd:Annotation>
+--         </ssd:Annotations>
+--     </ssd:DefaultExperiment>
 -- </ssd:SystemStructureDescription>
---
+-- 
 -- status:  [correct] ok
 -- endResult

--- a/testsuite/OMSimulator/import_export.py
+++ b/testsuite/OMSimulator/import_export.py
@@ -135,7 +135,7 @@ printStatus(status, 0)
 status = oms.addConnection("test.eoo.foo.bus", "test.eoo.foo2.bus")
 printStatus(status, 0)
 
-status, src = oms.list("test")
+src, status = oms.list("test")
 printStatus(status, 0)
 print(src)
 
@@ -145,10 +145,10 @@ printStatus(status, 0)
 status = oms.delete("test")
 printStatus(status, 0)
 
-status, model = oms.importFile("test-py.ssp")
+model, status = oms.importFile("test-py.ssp")
 printStatus(status, 0)
 
-status, src = oms.list(model)
+src, status = oms.list(model)
 printStatus(status, 0)
 print(src)
 

--- a/testsuite/OMSimulator/import_export.py
+++ b/testsuite/OMSimulator/import_export.py
@@ -208,7 +208,7 @@ printStatus(status, 0)
 ##                 <ssd:Annotations>
 ##                     <ssd:Annotation type="org.openmodelica">
 ##                         <oms:SimulationInformation>
-##                             <FixedStepMaster description="oms-ma" stepSize="0.100000" />
+##                             <oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
 ##                         </oms:SimulationInformation>
 ##                     </ssd:Annotation>
 ##                 </ssd:Annotations>
@@ -253,7 +253,7 @@ printStatus(status, 0)
 ##                 <ssd:Annotations>
 ##                     <ssd:Annotation type="org.openmodelica">
 ##                         <oms:SimulationInformation>
-##                             <FixedStepMaster description="oms-ma" stepSize="0.100000" />
+##                             <oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
 ##                         </oms:SimulationInformation>
 ##                     </ssd:Annotation>
 ##                 </ssd:Annotations>
@@ -279,7 +279,7 @@ printStatus(status, 0)
 ##                         <ssd:Annotations>
 ##                             <ssd:Annotation type="org.openmodelica">
 ##                                 <oms:SimulationInformation>
-##                                     <VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+##                                     <oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
 ##                                 </oms:SimulationInformation>
 ##                             </ssd:Annotation>
 ##                         </ssd:Annotations>
@@ -347,7 +347,13 @@ printStatus(status, 0)
 ##             </ssd:Annotation>
 ##         </ssd:Annotations>
 ##     </ssd:System>
-##     <ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000" />
+##     <ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
+##         <ssd:Annotations>
+##             <ssd:Annotation type="org.openmodelica">
+##                 <oms:SimulationInformation resultFile="test_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter="" />
+##             </ssd:Annotation>
+##         </ssd:Annotations>
+##     </ssd:DefaultExperiment>
 ## </ssd:SystemStructureDescription>
 ## 
 ## status:  [correct] ok
@@ -370,7 +376,7 @@ printStatus(status, 0)
 ##                 <ssd:Annotations>
 ##                     <ssd:Annotation type="org.openmodelica">
 ##                         <oms:SimulationInformation>
-##                             <FixedStepMaster description="oms-ma" stepSize="0.100000" />
+##                             <oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
 ##                         </oms:SimulationInformation>
 ##                     </ssd:Annotation>
 ##                 </ssd:Annotations>
@@ -415,7 +421,7 @@ printStatus(status, 0)
 ##                 <ssd:Annotations>
 ##                     <ssd:Annotation type="org.openmodelica">
 ##                         <oms:SimulationInformation>
-##                             <FixedStepMaster description="oms-ma" stepSize="0.100000" />
+##                             <oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
 ##                         </oms:SimulationInformation>
 ##                     </ssd:Annotation>
 ##                 </ssd:Annotations>
@@ -441,7 +447,7 @@ printStatus(status, 0)
 ##                         <ssd:Annotations>
 ##                             <ssd:Annotation type="org.openmodelica">
 ##                                 <oms:SimulationInformation>
-##                                     <VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+##                                     <oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
 ##                                 </oms:SimulationInformation>
 ##                             </ssd:Annotation>
 ##                         </ssd:Annotations>
@@ -509,7 +515,13 @@ printStatus(status, 0)
 ##             </ssd:Annotation>
 ##         </ssd:Annotations>
 ##     </ssd:System>
-##     <ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000" />
+##     <ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
+##         <ssd:Annotations>
+##             <ssd:Annotation type="org.openmodelica">
+##                 <oms:SimulationInformation resultFile="test_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter="" />
+##             </ssd:Annotation>
+##         </ssd:Annotations>
+##     </ssd:DefaultExperiment>
 ## </ssd:SystemStructureDescription>
 ## 
 ## status:  [correct] ok

--- a/testsuite/OMSimulator/import_export_parameters.lua
+++ b/testsuite/OMSimulator/import_export_parameters.lua
@@ -121,7 +121,7 @@ oms_delete("import_export_parameters")
 -- 		<ssd:Annotations>
 -- 			<ssd:Annotation type="org.openmodelica">
 -- 				<oms:SimulationInformation>
--- 					<FixedStepMaster description="oms-ma" stepSize="0.001000" />
+-- 					<oms:FixedStepMaster description="oms-ma" stepSize="0.001000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
 -- 				</oms:SimulationInformation>
 -- 			</ssd:Annotation>
 -- 		</ssd:Annotations>
@@ -161,7 +161,7 @@ oms_delete("import_export_parameters")
 -- 				<ssd:Annotations>
 -- 					<ssd:Annotation type="org.openmodelica">
 -- 						<oms:SimulationInformation>
--- 							<VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+-- 							<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
 -- 						</oms:SimulationInformation>
 -- 					</ssd:Annotation>
 -- 				</ssd:Annotations>
@@ -283,9 +283,15 @@ oms_delete("import_export_parameters")
 -- 			<ssd:Connection startElement="addP" startConnector="y" endElement="" endConnector="Output_cref" />
 -- 		</ssd:Connections>
 -- 	</ssd:System>
--- 	<ssd:DefaultExperiment startTime="0.000000" stopTime="4.000000" />
+-- 	<ssd:DefaultExperiment startTime="0.000000" stopTime="4.000000">
+-- 		<ssd:Annotations>
+-- 			<ssd:Annotation type="org.openmodelica">
+-- 				<oms:SimulationInformation resultFile="import_export_parameters.mat" loggingInterval="0.000000" bufferSize="100" signalFilter="" />
+-- 			</ssd:Annotation>
+-- 		</ssd:Annotations>
+-- 	</ssd:DefaultExperiment>
 -- </ssd:SystemStructureDescription>
---
+-- 
 -- info:    model doesn't contain any continuous state
 -- info:      Parameter settings
 -- info:      import_export_parameters.co_sim.addP.k1     : 10.0
@@ -298,7 +304,7 @@ oms_delete("import_export_parameters")
 -- info:      import_export_parameters.co_sim.T_cref      : 20.0
 -- info:      import_export_parameters.co_sim.k_cref      : 30.0
 -- info:      import_export_parameters.co_sim.Output_cref : 0.0
--- info:    Result file: import_export_parameters_res.mat (bufferSize=10)
+-- info:    Result file: import_export_parameters.mat (bufferSize=100)
 -- info:    Initialization
 -- info:      import_export_parameters.co_sim.addP.k1     : 30.0
 -- info:      import_export_parameters.co_sim.addP.k2     : -1.0

--- a/testsuite/api/buses.lua
+++ b/testsuite/api/buses.lua
@@ -86,6 +86,7 @@ print(src)
 status = oms_delete("model")
 printStatus(status, 0)
 
+
 -- Result:
 -- status:  [correct] ok
 -- status:  [correct] ok
@@ -117,7 +118,7 @@ printStatus(status, 0)
 -- 			<ssd:Annotations>
 -- 				<ssd:Annotation type="org.openmodelica">
 -- 					<oms:SimulationInformation>
--- 						<FixedStepMaster description="oms-ma" stepSize="0.100000" />
+-- 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
 -- 					</oms:SimulationInformation>
 -- 				</ssd:Annotation>
 -- 			</ssd:Annotations>
@@ -149,7 +150,7 @@ printStatus(status, 0)
 -- 			<ssd:Annotations>
 -- 				<ssd:Annotation type="org.openmodelica">
 -- 					<oms:SimulationInformation>
--- 						<FixedStepMaster description="oms-ma" stepSize="0.100000" />
+-- 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
 -- 					</oms:SimulationInformation>
 -- 				</ssd:Annotation>
 -- 			</ssd:Annotations>
@@ -208,7 +209,7 @@ printStatus(status, 0)
 -- 			<ssd:Annotations>
 -- 				<ssd:Annotation type="org.openmodelica">
 -- 					<oms:SimulationInformation>
--- 						<FixedStepMaster description="oms-ma" stepSize="0.100000" />
+-- 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
 -- 					</oms:SimulationInformation>
 -- 				</ssd:Annotation>
 -- 			</ssd:Annotations>
@@ -240,7 +241,7 @@ printStatus(status, 0)
 -- 			<ssd:Annotations>
 -- 				<ssd:Annotation type="org.openmodelica">
 -- 					<oms:SimulationInformation>
--- 						<FixedStepMaster description="oms-ma" stepSize="0.100000" />
+-- 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
 -- 					</oms:SimulationInformation>
 -- 				</ssd:Annotation>
 -- 			</ssd:Annotations>

--- a/testsuite/api/buses.py
+++ b/testsuite/api/buses.py
@@ -117,7 +117,7 @@ printStatus(status, 0)
 ## 			<ssd:Annotations>
 ## 				<ssd:Annotation type="org.openmodelica">
 ## 					<oms:SimulationInformation>
-## 						<FixedStepMaster description="oms-ma" stepSize="0.100000" />
+## 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
 ## 					</oms:SimulationInformation>
 ## 				</ssd:Annotation>
 ## 			</ssd:Annotations>
@@ -149,7 +149,7 @@ printStatus(status, 0)
 ## 			<ssd:Annotations>
 ## 				<ssd:Annotation type="org.openmodelica">
 ## 					<oms:SimulationInformation>
-## 						<FixedStepMaster description="oms-ma" stepSize="0.100000" />
+## 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
 ## 					</oms:SimulationInformation>
 ## 				</ssd:Annotation>
 ## 			</ssd:Annotations>
@@ -208,7 +208,7 @@ printStatus(status, 0)
 ## 			<ssd:Annotations>
 ## 				<ssd:Annotation type="org.openmodelica">
 ## 					<oms:SimulationInformation>
-## 						<FixedStepMaster description="oms-ma" stepSize="0.100000" />
+## 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
 ## 					</oms:SimulationInformation>
 ## 				</ssd:Annotation>
 ## 			</ssd:Annotations>
@@ -240,7 +240,7 @@ printStatus(status, 0)
 ## 			<ssd:Annotations>
 ## 				<ssd:Annotation type="org.openmodelica">
 ## 					<oms:SimulationInformation>
-## 						<FixedStepMaster description="oms-ma" stepSize="0.100000" />
+## 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
 ## 					</oms:SimulationInformation>
 ## 				</ssd:Annotation>
 ## 			</ssd:Annotations>

--- a/testsuite/api/buses.py
+++ b/testsuite/api/buses.py
@@ -74,13 +74,13 @@ printStatus(status, 0)
 status = oms.addConnection("model.tlm.wc2.bus2","model.tlm.wc1.bus1")
 printStatus(status, 3)
 
-status, src = oms.list("model.tlm")
+src, status = oms.list("model.tlm")
 print(src)
 
 status = oms.deleteConnectorFromBus("model.tlm.wc1.bus1","model.tlm.wc1.y")
 printStatus(status, 0)
 
-status, src = oms.list("model.tlm")
+src, status = oms.list("model.tlm")
 print(src)
 
 status = oms.delete("model")

--- a/testsuite/api/connections.lua
+++ b/testsuite/api/connections.lua
@@ -97,7 +97,7 @@ printStatus(status, 0)
 -- 	<ssd:Annotations>
 -- 		<ssd:Annotation type="org.openmodelica">
 -- 			<oms:SimulationInformation>
--- 				<FixedStepMaster description="oms-ma" stepSize="0.100000" />
+-- 				<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
 -- 			</oms:SimulationInformation>
 -- 		</ssd:Annotation>
 -- 	</ssd:Annotations>
@@ -107,7 +107,7 @@ printStatus(status, 0)
 -- 			<ssd:Annotations>
 -- 				<ssd:Annotation type="org.openmodelica">
 -- 					<oms:SimulationInformation>
--- 						<VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+-- 						<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
 -- 					</oms:SimulationInformation>
 -- 				</ssd:Annotation>
 -- 			</ssd:Annotations>
@@ -129,7 +129,7 @@ printStatus(status, 0)
 -- 			<ssd:Annotations>
 -- 				<ssd:Annotation type="org.openmodelica">
 -- 					<oms:SimulationInformation>
--- 						<VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+-- 						<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
 -- 					</oms:SimulationInformation>
 -- 				</ssd:Annotation>
 -- 			</ssd:Annotations>
@@ -152,14 +152,14 @@ printStatus(status, 0)
 -- 		<ssd:Connection startElement="sc2" startConnector="y1" endElement="sc1" endConnector="u1" />
 -- 	</ssd:Connections>
 -- </ssd:System>
---
+-- 
 -- status:  [correct] ok
 -- <?xml version="1.0"?>
 -- <ssd:System name="wc">
 -- 	<ssd:Annotations>
 -- 		<ssd:Annotation type="org.openmodelica">
 -- 			<oms:SimulationInformation>
--- 				<FixedStepMaster description="oms-ma" stepSize="0.100000" />
+-- 				<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
 -- 			</oms:SimulationInformation>
 -- 		</ssd:Annotation>
 -- 	</ssd:Annotations>
@@ -169,7 +169,7 @@ printStatus(status, 0)
 -- 			<ssd:Annotations>
 -- 				<ssd:Annotation type="org.openmodelica">
 -- 					<oms:SimulationInformation>
--- 						<VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+-- 						<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
 -- 					</oms:SimulationInformation>
 -- 				</ssd:Annotation>
 -- 			</ssd:Annotations>
@@ -191,7 +191,7 @@ printStatus(status, 0)
 -- 			<ssd:Annotations>
 -- 				<ssd:Annotation type="org.openmodelica">
 -- 					<oms:SimulationInformation>
--- 						<VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+-- 						<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
 -- 					</oms:SimulationInformation>
 -- 				</ssd:Annotation>
 -- 			</ssd:Annotations>
@@ -212,7 +212,7 @@ printStatus(status, 0)
 -- 	</ssd:Elements>
 -- 	<ssd:Connections />
 -- </ssd:System>
---
+-- 
 -- status:  [correct] ok
 -- info:    0 warnings
 -- info:    3 errors

--- a/testsuite/api/connections.py
+++ b/testsuite/api/connections.py
@@ -97,7 +97,7 @@ printStatus(status, 0)
 ## 	<ssd:Annotations>
 ## 		<ssd:Annotation type="org.openmodelica">
 ## 			<oms:SimulationInformation>
-## 				<FixedStepMaster description="oms-ma" stepSize="0.100000" />
+## 				<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
 ## 			</oms:SimulationInformation>
 ## 		</ssd:Annotation>
 ## 	</ssd:Annotations>
@@ -107,7 +107,7 @@ printStatus(status, 0)
 ## 			<ssd:Annotations>
 ## 				<ssd:Annotation type="org.openmodelica">
 ## 					<oms:SimulationInformation>
-## 						<VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+## 						<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
 ## 					</oms:SimulationInformation>
 ## 				</ssd:Annotation>
 ## 			</ssd:Annotations>
@@ -129,7 +129,7 @@ printStatus(status, 0)
 ## 			<ssd:Annotations>
 ## 				<ssd:Annotation type="org.openmodelica">
 ## 					<oms:SimulationInformation>
-## 						<VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+## 						<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
 ## 					</oms:SimulationInformation>
 ## 				</ssd:Annotation>
 ## 			</ssd:Annotations>
@@ -152,14 +152,14 @@ printStatus(status, 0)
 ## 		<ssd:Connection startElement="sc2" startConnector="y1" endElement="sc1" endConnector="u1" />
 ## 	</ssd:Connections>
 ## </ssd:System>
-##
+## 
 ## status:  [correct] ok
 ## <?xml version="1.0"?>
 ## <ssd:System name="wc">
 ## 	<ssd:Annotations>
 ## 		<ssd:Annotation type="org.openmodelica">
 ## 			<oms:SimulationInformation>
-## 				<FixedStepMaster description="oms-ma" stepSize="0.100000" />
+## 				<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
 ## 			</oms:SimulationInformation>
 ## 		</ssd:Annotation>
 ## 	</ssd:Annotations>
@@ -169,7 +169,7 @@ printStatus(status, 0)
 ## 			<ssd:Annotations>
 ## 				<ssd:Annotation type="org.openmodelica">
 ## 					<oms:SimulationInformation>
-## 						<VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+## 						<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
 ## 					</oms:SimulationInformation>
 ## 				</ssd:Annotation>
 ## 			</ssd:Annotations>
@@ -191,7 +191,7 @@ printStatus(status, 0)
 ## 			<ssd:Annotations>
 ## 				<ssd:Annotation type="org.openmodelica">
 ## 					<oms:SimulationInformation>
-## 						<VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+## 						<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
 ## 					</oms:SimulationInformation>
 ## 				</ssd:Annotation>
 ## 			</ssd:Annotations>
@@ -212,7 +212,7 @@ printStatus(status, 0)
 ## 	</ssd:Elements>
 ## 	<ssd:Connections />
 ## </ssd:System>
-##
+## 
 ## status:  [correct] ok
 ## info:    0 warnings
 ## info:    3 errors

--- a/testsuite/api/connections.py
+++ b/testsuite/api/connections.py
@@ -65,13 +65,13 @@ printStatus(status, 3)
 status = oms.addConnection("model.wc.sc1.u1", "model.wc.sc2.y3")
 printStatus(status, 3)
 
-status, src = oms.list("model.wc")
+src, status = oms.list("model.wc")
 print(src)
 
 status = oms.deleteConnection("model.wc.sc1.u1", "model.wc.sc2.y1")
 printStatus(status, 0)
 
-status, src = oms.list("model.wc")
+src, status = oms.list("model.wc")
 print(src)
 
 status = oms.delete("model")

--- a/testsuite/api/test01.lua
+++ b/testsuite/api/test01.lua
@@ -92,7 +92,7 @@ printStatus(status, 3)
 -- 		<ssd:Annotations>
 -- 			<ssd:Annotation type="org.openmodelica">
 -- 				<oms:SimulationInformation>
--- 					<FixedStepMaster description="oms-ma" stepSize="0.100000" />
+-- 					<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
 -- 				</oms:SimulationInformation>
 -- 			</ssd:Annotation>
 -- 		</ssd:Annotations>
@@ -102,7 +102,7 @@ printStatus(status, 3)
 -- 				<ssd:Annotations>
 -- 					<ssd:Annotation type="org.openmodelica">
 -- 						<oms:SimulationInformation>
--- 							<VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+-- 							<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
 -- 						</oms:SimulationInformation>
 -- 					</ssd:Annotation>
 -- 				</ssd:Annotations>
@@ -113,7 +113,13 @@ printStatus(status, 3)
 -- 		</ssd:Elements>
 -- 		<ssd:Connections />
 -- 	</ssd:System>
--- 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000" />
+-- 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
+-- 		<ssd:Annotations>
+-- 			<ssd:Annotation type="org.openmodelica">
+-- 				<oms:SimulationInformation resultFile="test_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter="" />
+-- 			</ssd:Annotation>
+-- 		</ssd:Annotations>
+-- 	</ssd:DefaultExperiment>
 -- </ssd:SystemStructureDescription>
 -- 
 -- <?xml version="1.0"?>
@@ -121,7 +127,7 @@ printStatus(status, 3)
 -- 	<ssd:Annotations>
 -- 		<ssd:Annotation type="org.openmodelica">
 -- 			<oms:SimulationInformation>
--- 				<FixedStepMaster description="oms-ma" stepSize="0.100000" />
+-- 				<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
 -- 			</oms:SimulationInformation>
 -- 		</ssd:Annotation>
 -- 	</ssd:Annotations>
@@ -131,7 +137,7 @@ printStatus(status, 3)
 -- 			<ssd:Annotations>
 -- 				<ssd:Annotation type="org.openmodelica">
 -- 					<oms:SimulationInformation>
--- 						<VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+-- 						<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
 -- 					</oms:SimulationInformation>
 -- 				</ssd:Annotation>
 -- 			</ssd:Annotations>
@@ -148,7 +154,7 @@ printStatus(status, 3)
 -- 	<ssd:Annotations>
 -- 		<ssd:Annotation type="org.openmodelica">
 -- 			<oms:SimulationInformation>
--- 				<VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+-- 				<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
 -- 			</oms:SimulationInformation>
 -- 		</ssd:Annotation>
 -- 	</ssd:Annotations>
@@ -166,7 +172,13 @@ printStatus(status, 3)
 -- status:  [correct] ok
 -- <?xml version="1.0"?>
 -- <ssd:SystemStructureDescription name="test" version="1.0">
--- 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000" />
+-- 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
+-- 		<ssd:Annotations>
+-- 			<ssd:Annotation type="org.openmodelica">
+-- 				<oms:SimulationInformation resultFile="test_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter="" />
+-- 			</ssd:Annotation>
+-- 		</ssd:Annotations>
+-- 	</ssd:DefaultExperiment>
 -- </ssd:SystemStructureDescription>
 -- 
 -- status:  [correct] ok

--- a/testsuite/api/test01.py
+++ b/testsuite/api/test01.py
@@ -41,13 +41,13 @@ printStatus(status, 0)
 status = oms.addSystem("test.foo.hoo", oms.system_wc)
 printStatus(status, 3)
 
-status, src = oms.list("test")
+src, status = oms.list("test")
 print(src)
 
-status, src = oms.list("test.foo")
+src, status = oms.list("test.foo")
 print(src)
 
-status, src = oms.list("test.foo.goo")
+src, status = oms.list("test.foo.goo")
 print(src)
 
 status = oms.newModel("test")
@@ -68,7 +68,7 @@ printStatus(status, 0)
 status = oms.newModel("test")
 printStatus(status, 0)
 
-status, src = oms.list("test")
+src, status = oms.list("test")
 print(src)
 
 status = oms.delete("test")

--- a/testsuite/api/test01.py
+++ b/testsuite/api/test01.py
@@ -91,7 +91,7 @@ printStatus(status, 3)
 ## 		<ssd:Annotations>
 ## 			<ssd:Annotation type="org.openmodelica">
 ## 				<oms:SimulationInformation>
-## 					<FixedStepMaster description="oms-ma" stepSize="0.100000" />
+## 					<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
 ## 				</oms:SimulationInformation>
 ## 			</ssd:Annotation>
 ## 		</ssd:Annotations>
@@ -101,7 +101,7 @@ printStatus(status, 3)
 ## 				<ssd:Annotations>
 ## 					<ssd:Annotation type="org.openmodelica">
 ## 						<oms:SimulationInformation>
-## 							<VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+## 							<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
 ## 						</oms:SimulationInformation>
 ## 					</ssd:Annotation>
 ## 				</ssd:Annotations>
@@ -112,7 +112,13 @@ printStatus(status, 3)
 ## 		</ssd:Elements>
 ## 		<ssd:Connections />
 ## 	</ssd:System>
-## 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000" />
+## 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
+## 		<ssd:Annotations>
+## 			<ssd:Annotation type="org.openmodelica">
+## 				<oms:SimulationInformation resultFile="test_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter="" />
+## 			</ssd:Annotation>
+## 		</ssd:Annotations>
+## 	</ssd:DefaultExperiment>
 ## </ssd:SystemStructureDescription>
 ## 
 ## <?xml version="1.0"?>
@@ -120,7 +126,7 @@ printStatus(status, 3)
 ## 	<ssd:Annotations>
 ## 		<ssd:Annotation type="org.openmodelica">
 ## 			<oms:SimulationInformation>
-## 				<FixedStepMaster description="oms-ma" stepSize="0.100000" />
+## 				<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
 ## 			</oms:SimulationInformation>
 ## 		</ssd:Annotation>
 ## 	</ssd:Annotations>
@@ -130,7 +136,7 @@ printStatus(status, 3)
 ## 			<ssd:Annotations>
 ## 				<ssd:Annotation type="org.openmodelica">
 ## 					<oms:SimulationInformation>
-## 						<VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+## 						<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
 ## 					</oms:SimulationInformation>
 ## 				</ssd:Annotation>
 ## 			</ssd:Annotations>
@@ -147,7 +153,7 @@ printStatus(status, 3)
 ## 	<ssd:Annotations>
 ## 		<ssd:Annotation type="org.openmodelica">
 ## 			<oms:SimulationInformation>
-## 				<VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+## 				<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
 ## 			</oms:SimulationInformation>
 ## 		</ssd:Annotation>
 ## 	</ssd:Annotations>
@@ -165,7 +171,13 @@ printStatus(status, 3)
 ## status:  [correct] ok
 ## <?xml version="1.0"?>
 ## <ssd:SystemStructureDescription name="test" version="1.0">
-## 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000" />
+## 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
+## 		<ssd:Annotations>
+## 			<ssd:Annotation type="org.openmodelica">
+## 				<oms:SimulationInformation resultFile="test_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter="" />
+## 			</ssd:Annotation>
+## 		</ssd:Annotations>
+## 	</ssd:DefaultExperiment>
 ## </ssd:SystemStructureDescription>
 ## 
 ## status:  [correct] ok

--- a/testsuite/api/test02.py
+++ b/testsuite/api/test02.py
@@ -39,7 +39,7 @@ def printType(t):
 status = oms.newModel("test")
 printStatus(status, 0)
 
-status, type = oms.getSystemType("test")
+type, status = oms.getSystemType("test")
 printType(type)
 printStatus(status, 3)
 
@@ -52,19 +52,19 @@ printStatus(status, 0)
 status = oms.addSystem("test.eoo.foo.goo", oms.system_sc)
 printStatus(status, 0)
 
-status, type = oms.getSystemType("test")
+type, status = oms.getSystemType("test")
 printType(type)
 printStatus(status, 3)
 
-status, type = oms.getSystemType("test.eoo")
+type, status = oms.getSystemType("test.eoo")
 printType(type)
 printStatus(status, 0)
 
-status, type = oms.getSystemType("test.eoo.foo")
+type, status = oms.getSystemType("test.eoo.foo")
 printType(type)
 printStatus(status, 0)
 
-status, type = oms.getSystemType("test.eoo.foo.goo")
+type, status = oms.getSystemType("test.eoo.foo.goo")
 printType(type)
 printStatus(status, 0)
 

--- a/testsuite/api/test03.lua
+++ b/testsuite/api/test03.lua
@@ -78,7 +78,7 @@ oms_delete("test")
 -- 		</ssd:Annotations>
 -- 		<ssd:Connectors />
 -- 		<ssd:Elements>
--- 			<ssd:Component name="source" type="application/x-fmu-sharedlibrary" source="resources\0001_source.fmu">
+-- 			<ssd:Component name="source" type="application/x-fmu-sharedlibrary" source="resources/0001_source.fmu">
 -- 				<ssd:Connectors>
 -- 					<ssd:Connector name="y" kind="output">
 -- 						<ssc:Real />
@@ -127,7 +127,7 @@ oms_delete("test")
 -- 		</ssd:Annotations>
 -- 		<ssd:Connectors />
 -- 		<ssd:Elements>
--- 			<ssd:Component name="source" type="application/x-fmu-sharedlibrary" source="resources\0001_source.fmu">
+-- 			<ssd:Component name="source" type="application/x-fmu-sharedlibrary" source="resources/0001_source.fmu">
 -- 				<ssd:Connectors>
 -- 					<ssd:Connector name="y" kind="output">
 -- 						<ssc:Real />

--- a/testsuite/api/test03.lua
+++ b/testsuite/api/test03.lua
@@ -72,13 +72,13 @@ oms_delete("test")
 -- 		<ssd:Annotations>
 -- 			<ssd:Annotation type="org.openmodelica">
 -- 				<oms:SimulationInformation>
--- 					<FixedStepMaster description="oms-ma" stepSize="0.100000" />
+-- 					<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
 -- 				</oms:SimulationInformation>
 -- 			</ssd:Annotation>
 -- 		</ssd:Annotations>
 -- 		<ssd:Connectors />
 -- 		<ssd:Elements>
--- 			<ssd:Component name="source" type="application/x-fmu-sharedlibrary" source="resources/0001_source.fmu">
+-- 			<ssd:Component name="source" type="application/x-fmu-sharedlibrary" source="resources\0001_source.fmu">
 -- 				<ssd:Connectors>
 -- 					<ssd:Connector name="y" kind="output">
 -- 						<ssc:Real />
@@ -104,7 +104,13 @@ oms_delete("test")
 -- 		</ssd:Elements>
 -- 		<ssd:Connections />
 -- 	</ssd:System>
--- 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000" />
+-- 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
+-- 		<ssd:Annotations>
+-- 			<ssd:Annotation type="org.openmodelica">
+-- 				<oms:SimulationInformation resultFile="test_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter="" />
+-- 			</ssd:Annotation>
+-- 		</ssd:Annotations>
+-- 	</ssd:DefaultExperiment>
 -- </ssd:SystemStructureDescription>
 -- 
 -- info:    Delete source
@@ -115,13 +121,13 @@ oms_delete("test")
 -- 		<ssd:Annotations>
 -- 			<ssd:Annotation type="org.openmodelica">
 -- 				<oms:SimulationInformation>
--- 					<FixedStepMaster description="oms-ma" stepSize="0.100000" />
+-- 					<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
 -- 				</oms:SimulationInformation>
 -- 			</ssd:Annotation>
 -- 		</ssd:Annotations>
 -- 		<ssd:Connectors />
 -- 		<ssd:Elements>
--- 			<ssd:Component name="source" type="application/x-fmu-sharedlibrary" source="resources/0001_source.fmu">
+-- 			<ssd:Component name="source" type="application/x-fmu-sharedlibrary" source="resources\0001_source.fmu">
 -- 				<ssd:Connectors>
 -- 					<ssd:Connector name="y" kind="output">
 -- 						<ssc:Real />
@@ -147,7 +153,13 @@ oms_delete("test")
 -- 		</ssd:Elements>
 -- 		<ssd:Connections />
 -- 	</ssd:System>
--- 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000" />
+-- 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
+-- 		<ssd:Annotations>
+-- 			<ssd:Annotation type="org.openmodelica">
+-- 				<oms:SimulationInformation resultFile="test_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter="" />
+-- 			</ssd:Annotation>
+-- 		</ssd:Annotations>
+-- 	</ssd:DefaultExperiment>
 -- </ssd:SystemStructureDescription>
 -- 
 -- info:    Result file: test_res.mat (bufferSize=10)

--- a/testsuite/api/test_omsExport.lua
+++ b/testsuite/api/test_omsExport.lua
@@ -33,6 +33,16 @@ printStatus(status, 0)
 status = oms_addSystem("model.sc", oms_system_sc)
 printStatus(status, 0)
 
+status = oms_setSignalFilter("model", "A")
+printStatus(status, 0)
+
+src, status = oms_list("model")
+printStatus(status, 0)
+print(src)
+
+status = oms_removeSignalsFromResults("model", "A")
+printStatus(status, 0)
+
 src, status = oms_list("model")
 printStatus(status, 0)
 print(src)
@@ -40,10 +50,9 @@ print(src)
 status= oms_export("model", "model.ssp")
 printStatus(status, 0)
 
-status = oms_export("model", "model.ssp")
-printStatus(status, 0)
 
 -- Result:
+-- status:  [correct] ok
 -- status:  [correct] ok
 -- status:  [correct] ok
 -- status:  [correct] ok
@@ -53,7 +62,7 @@ printStatus(status, 0)
 -- 		<ssd:Annotations>
 -- 			<ssd:Annotation type="org.openmodelica">
 -- 				<oms:SimulationInformation>
--- 					<VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+-- 					<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
 -- 				</oms:SimulationInformation>
 -- 			</ssd:Annotation>
 -- 		</ssd:Annotations>
@@ -61,9 +70,39 @@ printStatus(status, 0)
 -- 		<ssd:Elements />
 -- 		<ssd:Connections />
 -- 	</ssd:System>
--- 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000" />
+-- 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
+-- 		<ssd:Annotations>
+-- 			<ssd:Annotation type="org.openmodelica">
+-- 				<oms:SimulationInformation resultFile="model_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter="A" />
+-- 			</ssd:Annotation>
+-- 		</ssd:Annotations>
+-- 	</ssd:DefaultExperiment>
 -- </ssd:SystemStructureDescription>
 -- 
 -- status:  [correct] ok
+-- status:  [correct] ok
+-- <?xml version="1.0"?>
+-- <ssd:SystemStructureDescription name="model" version="1.0">
+-- 	<ssd:System name="sc">
+-- 		<ssd:Annotations>
+-- 			<ssd:Annotation type="org.openmodelica">
+-- 				<oms:SimulationInformation>
+-- 					<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+-- 				</oms:SimulationInformation>
+-- 			</ssd:Annotation>
+-- 		</ssd:Annotations>
+-- 		<ssd:Connectors />
+-- 		<ssd:Elements />
+-- 		<ssd:Connections />
+-- 	</ssd:System>
+-- 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
+-- 		<ssd:Annotations>
+-- 			<ssd:Annotation type="org.openmodelica">
+-- 				<oms:SimulationInformation resultFile="model_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter="" />
+-- 			</ssd:Annotation>
+-- 		</ssd:Annotations>
+-- 	</ssd:DefaultExperiment>
+-- </ssd:SystemStructureDescription>
+-- 
 -- status:  [correct] ok
 -- endResult

--- a/testsuite/api/test_omsExport.lua
+++ b/testsuite/api/test_omsExport.lua
@@ -33,7 +33,7 @@ printStatus(status, 0)
 status = oms_addSystem("model.sc", oms_system_sc)
 printStatus(status, 0)
 
-status = oms_setSignalFilter("model", "A")
+status = oms_setSignalFilter("model", "[AB]")
 printStatus(status, 0)
 
 src, status = oms_list("model")
@@ -41,6 +41,9 @@ printStatus(status, 0)
 print(src)
 
 status = oms_removeSignalsFromResults("model", "A")
+printStatus(status, 0)
+
+status = oms_addSignalsToResults("model", "Y")
 printStatus(status, 0)
 
 src, status = oms_list("model")
@@ -73,12 +76,15 @@ printStatus(status, 0)
 -- 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
 -- 		<ssd:Annotations>
 -- 			<ssd:Annotation type="org.openmodelica">
--- 				<oms:SimulationInformation resultFile="model_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter="A" />
+-- 				<oms:SimulationInformation resultFile="model_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter="[AB]" />
 -- 			</ssd:Annotation>
 -- 		</ssd:Annotations>
 -- 	</ssd:DefaultExperiment>
 -- </ssd:SystemStructureDescription>
 -- 
+-- warning: [oms_removeSignalsFromResults] will not update the signalFilters in ssp, use [oms_setSignalFilter]
+-- status:  [correct] ok
+-- warning: [oms_addSignalsToResults] will not update the signalFilters in ssp, use [oms_setSignalFilter]
 -- status:  [correct] ok
 -- status:  [correct] ok
 -- <?xml version="1.0"?>
@@ -98,11 +104,13 @@ printStatus(status, 0)
 -- 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
 -- 		<ssd:Annotations>
 -- 			<ssd:Annotation type="org.openmodelica">
--- 				<oms:SimulationInformation resultFile="model_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter="" />
+-- 				<oms:SimulationInformation resultFile="model_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter="[AB]" />
 -- 			</ssd:Annotation>
 -- 		</ssd:Annotations>
 -- 	</ssd:DefaultExperiment>
 -- </ssd:SystemStructureDescription>
 -- 
 -- status:  [correct] ok
+-- info:    2 warnings
+-- info:    0 errors
 -- endResult

--- a/testsuite/api/test_omsExport.py
+++ b/testsuite/api/test_omsExport.py
@@ -33,6 +33,19 @@ printStatus(status, 0)
 status = oms.addSystem("model.sc", oms.system_sc)
 printStatus(status, 0)
 
+status = oms.setSignalFilter("model", "[AB]")
+printStatus(status, 0)
+
+src, status = oms.list("model")
+printStatus(status, 0)
+print(src)
+
+status = oms.removeSignalsFromResults("model", "A")
+printStatus(status, 0)
+
+status = oms.addSignalsToResults("model", "Y")
+printStatus(status, 0)
+
 src, status = oms.list("model")
 printStatus(status, 0)
 print(src)
@@ -40,10 +53,9 @@ print(src)
 status= oms.export("model", "model.ssp")
 printStatus(status, 0)
 
-status = oms.export("model", "model.ssp")
-printStatus(status, 0)
 
 ## Result:
+## status:  [correct] ok
 ## status:  [correct] ok
 ## status:  [correct] ok
 ## status:  [wrong] <?xml version="1.0"?>
@@ -52,7 +64,7 @@ printStatus(status, 0)
 ## 		<ssd:Annotations>
 ## 			<ssd:Annotation type="org.openmodelica">
 ## 				<oms:SimulationInformation>
-## 					<VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+## 					<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
 ## 				</oms:SimulationInformation>
 ## 			</ssd:Annotation>
 ## 		</ssd:Annotations>
@@ -60,10 +72,45 @@ printStatus(status, 0)
 ## 		<ssd:Elements />
 ## 		<ssd:Connections />
 ## 	</ssd:System>
-## 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000" />
+## 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
+## 		<ssd:Annotations>
+## 			<ssd:Annotation type="org.openmodelica">
+## 				<oms:SimulationInformation resultFile="model_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter="[AB]" />
+## 			</ssd:Annotation>
+## 		</ssd:Annotations>
+## 	</ssd:DefaultExperiment>
+## </ssd:SystemStructureDescription>
+## 
+## 0
+## warning: [oms_removeSignalsFromResults] will not update the signalFilters in ssp, use [oms_setSignalFilter]
+## status:  [correct] ok
+## warning: [oms_addSignalsToResults] will not update the signalFilters in ssp, use [oms_setSignalFilter]
+## status:  [correct] ok
+## status:  [wrong] <?xml version="1.0"?>
+## <ssd:SystemStructureDescription name="model" version="1.0">
+## 	<ssd:System name="sc">
+## 		<ssd:Annotations>
+## 			<ssd:Annotation type="org.openmodelica">
+## 				<oms:SimulationInformation>
+## 					<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+## 				</oms:SimulationInformation>
+## 			</ssd:Annotation>
+## 		</ssd:Annotations>
+## 		<ssd:Connectors />
+## 		<ssd:Elements />
+## 		<ssd:Connections />
+## 	</ssd:System>
+## 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
+## 		<ssd:Annotations>
+## 			<ssd:Annotation type="org.openmodelica">
+## 				<oms:SimulationInformation resultFile="model_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter="[AB]" />
+## 			</ssd:Annotation>
+## 		</ssd:Annotations>
+## 	</ssd:DefaultExperiment>
 ## </ssd:SystemStructureDescription>
 ## 
 ## 0
 ## status:  [correct] ok
-## status:  [correct] ok
+## info:    2 warnings
+## info:    0 errors
 ## endResult

--- a/testsuite/api/test_omsExport.py
+++ b/testsuite/api/test_omsExport.py
@@ -36,7 +36,7 @@ printStatus(status, 0)
 status = oms.setSignalFilter("model", "[AB]")
 printStatus(status, 0)
 
-src, status = oms.list("model")
+(status, src) = oms.list("model")
 printStatus(status, 0)
 print(src)
 
@@ -46,7 +46,7 @@ printStatus(status, 0)
 status = oms.addSignalsToResults("model", "Y")
 printStatus(status, 0)
 
-src, status = oms.list("model")
+(status, src) = oms.list("model")
 printStatus(status, 0)
 print(src)
 
@@ -58,7 +58,8 @@ printStatus(status, 0)
 ## status:  [correct] ok
 ## status:  [correct] ok
 ## status:  [correct] ok
-## status:  [wrong] <?xml version="1.0"?>
+## status:  [correct] ok
+## <?xml version="1.0"?>
 ## <ssd:SystemStructureDescription name="model" version="1.0">
 ## 	<ssd:System name="sc">
 ## 		<ssd:Annotations>
@@ -81,12 +82,12 @@ printStatus(status, 0)
 ## 	</ssd:DefaultExperiment>
 ## </ssd:SystemStructureDescription>
 ## 
-## 0
 ## warning: [oms_removeSignalsFromResults] will not update the signalFilters in ssp, use [oms_setSignalFilter]
 ## status:  [correct] ok
 ## warning: [oms_addSignalsToResults] will not update the signalFilters in ssp, use [oms_setSignalFilter]
 ## status:  [correct] ok
-## status:  [wrong] <?xml version="1.0"?>
+## status:  [correct] ok
+## <?xml version="1.0"?>
 ## <ssd:SystemStructureDescription name="model" version="1.0">
 ## 	<ssd:System name="sc">
 ## 		<ssd:Annotations>
@@ -109,7 +110,6 @@ printStatus(status, 0)
 ## 	</ssd:DefaultExperiment>
 ## </ssd:SystemStructureDescription>
 ## 
-## 0
 ## status:  [correct] ok
 ## info:    2 warnings
 ## info:    0 errors

--- a/testsuite/api/test_omsExport.py
+++ b/testsuite/api/test_omsExport.py
@@ -36,7 +36,7 @@ printStatus(status, 0)
 status = oms.setSignalFilter("model", "[AB]")
 printStatus(status, 0)
 
-(status, src) = oms.list("model")
+(src, status) = oms.list("model")
 printStatus(status, 0)
 print(src)
 
@@ -46,7 +46,7 @@ printStatus(status, 0)
 status = oms.addSignalsToResults("model", "Y")
 printStatus(status, 0)
 
-(status, src) = oms.list("model")
+(src, status) = oms.list("model")
 printStatus(status, 0)
 print(src)
 

--- a/testsuite/tlm/externalmodels.py
+++ b/testsuite/tlm/externalmodels.py
@@ -39,7 +39,7 @@ printStatus(status, 0)
 
 status = oms.addTLMBus("model.tlm.external.tlmbus", oms.tlm_domain_mechanical, 1, oms.default)
 
-status, src = oms.list("model.tlm")
+src, status = oms.list("model.tlm")
 print(src)
 
 status = oms.delete("model")

--- a/testsuite/tlm/tlmbuses.lua
+++ b/testsuite/tlm/tlmbuses.lua
@@ -123,7 +123,7 @@ printStatus(status, 0)
 -- 			<ssd:Annotations>
 -- 				<ssd:Annotation type="org.openmodelica">
 -- 					<oms:SimulationInformation>
--- 						<FixedStepMaster description="oms-ma" stepSize="0.100000" />
+-- 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
 -- 					</oms:SimulationInformation>
 -- 				</ssd:Annotation>
 -- 			</ssd:Annotations>
@@ -157,7 +157,7 @@ printStatus(status, 0)
 -- 			<ssd:Annotations>
 -- 				<ssd:Annotation type="org.openmodelica">
 -- 					<oms:SimulationInformation>
--- 						<FixedStepMaster description="oms-ma" stepSize="0.100000" />
+-- 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
 -- 					</oms:SimulationInformation>
 -- 				</ssd:Annotation>
 -- 			</ssd:Annotations>
@@ -221,7 +221,7 @@ printStatus(status, 0)
 -- 			<ssd:Annotations>
 -- 				<ssd:Annotation type="org.openmodelica">
 -- 					<oms:SimulationInformation>
--- 						<FixedStepMaster description="oms-ma" stepSize="0.100000" />
+-- 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
 -- 					</oms:SimulationInformation>
 -- 				</ssd:Annotation>
 -- 			</ssd:Annotations>
@@ -255,7 +255,7 @@ printStatus(status, 0)
 -- 			<ssd:Annotations>
 -- 				<ssd:Annotation type="org.openmodelica">
 -- 					<oms:SimulationInformation>
--- 						<FixedStepMaster description="oms-ma" stepSize="0.100000" />
+-- 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
 -- 					</oms:SimulationInformation>
 -- 				</ssd:Annotation>
 -- 			</ssd:Annotations>

--- a/testsuite/tlm/tlmbuses.py
+++ b/testsuite/tlm/tlmbuses.py
@@ -86,7 +86,7 @@ print src
 status = oms.deleteConnectorFromTLMBus("model.tlm.wc1.bus2","model.tlm.wc1.x")
 printStatus(status, 0)
 
-status, src = oms.list("model.tlm")
+src, status = oms.list("model.tlm")
 print src
 
 status = oms.delete("model")
@@ -108,7 +108,103 @@ printStatus(status, 0)
 ## status:  [correct] ok
 ## status:  [correct] ok
 ## status:  [correct] ok
-## 0
+## <?xml version="1.0"?>
+## <ssd:System name="tlm">
+## 	<ssd:Annotations>
+## 		<ssd:Annotation type="org.openmodelica">
+## 			<oms:SimulationInformation>
+## 				<oms:TlmMaster ip="127.0.1.1" managerport="11111" monitorport="11121" />
+## 			</oms:SimulationInformation>
+## 		</ssd:Annotation>
+## 	</ssd:Annotations>
+## 	<ssd:Connectors />
+## 	<ssd:Elements>
+## 		<ssd:System name="wc2">
+## 			<ssd:Annotations>
+## 				<ssd:Annotation type="org.openmodelica">
+## 					<oms:SimulationInformation>
+## 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+## 					</oms:SimulationInformation>
+## 				</ssd:Annotation>
+## 			</ssd:Annotations>
+## 			<ssd:Connectors>
+## 				<ssd:Connector name="y" kind="input">
+## 					<ssc:Real />
+## 				</ssd:Connector>
+## 				<ssd:Connector name="x" kind="output">
+## 					<ssc:Real />
+## 				</ssd:Connector>
+## 				<ssd:Connector name="v" kind="output">
+## 					<ssc:Real />
+## 				</ssd:Connector>
+## 				<ssd:Connector name="f" kind="input">
+## 					<ssc:Real />
+## 				</ssd:Connector>
+## 			</ssd:Connectors>
+## 			<ssd:Elements />
+## 			<ssd:Connections />
+## 			<ssd:Annotations>
+## 				<ssd:Annotation type="org.openmodelica">
+## 					<oms:Bus name="bus2" type="tlm" domain="output" dimensions="1" interpolation="none">
+## 						<oms:Signals>
+## 							<oms:Signal name="y" type="value" />
+## 						</oms:Signals>
+## 					</oms:Bus>
+## 				</ssd:Annotation>
+## 			</ssd:Annotations>
+## 		</ssd:System>
+## 		<ssd:System name="wc1">
+## 			<ssd:Annotations>
+## 				<ssd:Annotation type="org.openmodelica">
+## 					<oms:SimulationInformation>
+## 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+## 					</oms:SimulationInformation>
+## 				</ssd:Annotation>
+## 			</ssd:Annotations>
+## 			<ssd:Connectors>
+## 				<ssd:Connector name="y" kind="output">
+## 					<ssc:Real />
+## 				</ssd:Connector>
+## 				<ssd:Connector name="x" kind="output">
+## 					<ssc:Real />
+## 				</ssd:Connector>
+## 				<ssd:Connector name="v" kind="output">
+## 					<ssc:Real />
+## 				</ssd:Connector>
+## 				<ssd:Connector name="f" kind="input">
+## 					<ssc:Real />
+## 				</ssd:Connector>
+## 			</ssd:Connectors>
+## 			<ssd:Elements />
+## 			<ssd:Connections />
+## 			<ssd:Annotations>
+## 				<ssd:Annotation type="org.openmodelica">
+## 					<oms:Bus name="bus1" type="tlm" domain="input" dimensions="1" interpolation="none">
+## 						<oms:Signals>
+## 							<oms:Signal name="y" type="value" />
+## 						</oms:Signals>
+## 					</oms:Bus>
+## 					<oms:Bus name="bus2" type="tlm" domain="mechanical" dimensions="1" interpolation="none">
+## 						<oms:Signals>
+## 							<oms:Signal name="f" type="effort" />
+## 							<oms:Signal name="v" type="flow" />
+## 							<oms:Signal name="x" type="state" />
+## 						</oms:Signals>
+## 					</oms:Bus>
+## 				</ssd:Annotation>
+## 			</ssd:Annotations>
+## 		</ssd:System>
+## 	</ssd:Elements>
+## 	<ssd:Connections />
+## 	<ssd:Annotations>
+## 		<ssd:Annotation type="org.openmodelica">
+## 			<oms:Connections>
+## 				<oms:Connection startElement="wc1" startConnector="bus1" endElement="wc2" endConnector="bus2" delay="0.001000" alpha="0.300000" linearimpedance="100.000000" angularimpedance="0.000000" />
+## 			</oms:Connections>
+## 		</ssd:Annotation>
+## 	</ssd:Annotations>
+## </ssd:System>
+## 
 ## status:  [correct] ok
 ## <?xml version="1.0"?>
 ## <ssd:System name="tlm">

--- a/testsuite/tlm/tlmbuses.py
+++ b/testsuite/tlm/tlmbuses.py
@@ -125,7 +125,7 @@ printStatus(status, 0)
 ## 			<ssd:Annotations>
 ## 				<ssd:Annotation type="org.openmodelica">
 ## 					<oms:SimulationInformation>
-## 						<FixedStepMaster description="oms-ma" stepSize="0.100000" />
+## 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
 ## 					</oms:SimulationInformation>
 ## 				</ssd:Annotation>
 ## 			</ssd:Annotations>
@@ -159,7 +159,7 @@ printStatus(status, 0)
 ## 			<ssd:Annotations>
 ## 				<ssd:Annotation type="org.openmodelica">
 ## 					<oms:SimulationInformation>
-## 						<FixedStepMaster description="oms-ma" stepSize="0.100000" />
+## 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
 ## 					</oms:SimulationInformation>
 ## 				</ssd:Annotation>
 ## 			</ssd:Annotations>


### PR DESCRIPTION
### Related Issues

https://github.com/OpenModelica/OMSimulator/issues/750

### Purpose
This PR adds the  OpenModelica default experiment set-ups as vendor specific annotation

### changed Files

Model.cpp  -- added new vendor specific annotation  <oms::simulationInformation > <DefaultExperiment /><oms::simulationInformation >, modified the code to handle import and export
Model.h    --- added a new variable to store the signal filter 
