### PR TITLE
allow SSP Component attribute "type" as Optional

### DIFF
--- a/src/OMSimulatorLib/ComponentFMUCS.cpp
+++ b/src/OMSimulatorLib/ComponentFMUCS.cpp
@@ -249,7 +249,7 @@ oms::Component* oms::ComponentFMUCS::NewComponent(const pugi::xml_node& node, om
   std::string type = node.attribute("type").as_string();
   std::string source = node.attribute("source").as_string();
 
-  if (type != "application/x-fmu-sharedlibrary")
+  if (type != "application/x-fmu-sharedlibrary" && !type.empty())
   {
     logError("Unexpected component type: " + type);
     return NULL;

--- a/src/OMSimulatorLib/ComponentFMUME.cpp
+++ b/src/OMSimulatorLib/ComponentFMUME.cpp
@@ -251,7 +251,7 @@ oms::Component* oms::ComponentFMUME::NewComponent(const pugi::xml_node& node, om
   std::string type = node.attribute("type").as_string();
   std::string source = node.attribute("source").as_string();
 
-  if (type != "application/x-fmu-sharedlibrary")
+  if (type != "application/x-fmu-sharedlibrary" && !type.empty())
   {
     logError("Unexpected component type: " + type);
     return NULL;

--- a/src/OMSimulatorLib/System.cpp
+++ b/src/OMSimulatorLib/System.cpp
@@ -603,7 +603,8 @@ oms_status_enu_t oms::System::importFromSSD(const pugi::xml_node& node, const st
         {
           Component* component = NULL;
           std::string type = itElements->attribute("type").as_string();
-          if ("application/x-fmu-sharedlibrary" == type)
+          // allow component type to be empty, as type is optional according to SSP-1.0 and default type is application/x-fmu-sharedlibrary
+          if ("application/x-fmu-sharedlibrary" == type || type.empty())
           {
             if (getType() == oms_system_wc)
               component = ComponentFMUCS::NewComponent(*itElements, this, sspVersion);


### PR DESCRIPTION
### Related Issues

https://github.com/OpenModelica/OMSimulator/issues/759

### Purpose

This PR fixes the component attribute "type" as optional with the default value of application/x-fmu-sharedlibrary, according to SSP-1.0 specification

