### PR TITLE
fix <ssd:annotation> tag to <ssc:annotation>

### DIFF
--- a/src/OMSimulatorLib/ComponentFMUCS.cpp
+++ b/src/OMSimulatorLib/ComponentFMUCS.cpp
@@ -306,7 +306,7 @@ oms_status_enu_t oms::ComponentFMUCS::exportToSSD(pugi::xml_node& node, pugi::xm
   if (tlmbusconnectors[0])
   {
     pugi::xml_node annotations_node = node.append_child(oms::ssp::Draft20180219::ssd::annotations);
-    pugi::xml_node annotation_node = annotations_node.append_child(oms::ssp::Draft20180219::ssd::annotation);
+    pugi::xml_node annotation_node = annotations_node.append_child(oms::ssp::Draft20180219::ssc::annotation);
     annotation_node.append_attribute("type") = oms::ssp::Draft20180219::annotation_type;
     for (const auto& tlmbusconnector : tlmbusconnectors)
       if (tlmbusconnector)

--- a/src/OMSimulatorLib/ComponentFMUCS.cpp
+++ b/src/OMSimulatorLib/ComponentFMUCS.cpp
@@ -306,7 +306,7 @@ oms_status_enu_t oms::ComponentFMUCS::exportToSSD(pugi::xml_node& node, pugi::xm
   if (tlmbusconnectors[0])
   {
     pugi::xml_node annotations_node = node.append_child(oms::ssp::Draft20180219::ssd::annotations);
-    pugi::xml_node annotation_node = annotations_node.append_child(oms::ssp::Draft20180219::ssc::annotation);
+    pugi::xml_node annotation_node = annotations_node.append_child(oms::ssp::Version1_0::ssc::annotation);
     annotation_node.append_attribute("type") = oms::ssp::Draft20180219::annotation_type;
     for (const auto& tlmbusconnector : tlmbusconnectors)
       if (tlmbusconnector)

--- a/src/OMSimulatorLib/ComponentFMUME.cpp
+++ b/src/OMSimulatorLib/ComponentFMUME.cpp
@@ -308,7 +308,7 @@ oms_status_enu_t oms::ComponentFMUME::exportToSSD(pugi::xml_node& node, pugi::xm
   if (tlmbusconnectors[0])
   {
     pugi::xml_node annotations_node = node.append_child(oms::ssp::Draft20180219::ssd::annotations);
-    pugi::xml_node annotation_node = annotations_node.append_child(oms::ssp::Draft20180219::ssc::annotation);
+    pugi::xml_node annotation_node = annotations_node.append_child(oms::ssp::Version1_0::ssc::annotation);
     annotation_node.append_attribute("type") = oms::ssp::Draft20180219::annotation_type;
     for (const auto& tlmbusconnector : tlmbusconnectors)
       if (tlmbusconnector)

--- a/src/OMSimulatorLib/ComponentFMUME.cpp
+++ b/src/OMSimulatorLib/ComponentFMUME.cpp
@@ -308,7 +308,7 @@ oms_status_enu_t oms::ComponentFMUME::exportToSSD(pugi::xml_node& node, pugi::xm
   if (tlmbusconnectors[0])
   {
     pugi::xml_node annotations_node = node.append_child(oms::ssp::Draft20180219::ssd::annotations);
-    pugi::xml_node annotation_node = annotations_node.append_child(oms::ssp::Draft20180219::ssd::annotation);
+    pugi::xml_node annotation_node = annotations_node.append_child(oms::ssp::Draft20180219::ssc::annotation);
     annotation_node.append_attribute("type") = oms::ssp::Draft20180219::annotation_type;
     for (const auto& tlmbusconnector : tlmbusconnectors)
       if (tlmbusconnector)

--- a/src/OMSimulatorLib/Logging.h
+++ b/src/OMSimulatorLib/Logging.h
@@ -155,5 +155,6 @@ private:
 #define logError_UnknownTLMVariableType(vartype)             logError("Unknown TLM variable type: \""+vartype+"\"")
 #define logError_VariableTypeAlreadyInTLMBus(cref,vartype)   logError("TLM bus connector \"" + std::string(cref) + "\" already contains a variable with type \"" + vartype + "\"")
 #define logError_WrongSchema(name)                           logError("Wrong xml schema detected. Unexpected tag \"" + name + "\"")
+#define logWarning_deprecated                                logWarning("Wrong/deprecated content detected but successfully loaded. Please re-export the SSP file to avoid this message.")
 
 #endif

--- a/src/OMSimulatorLib/Model.cpp
+++ b/src/OMSimulatorLib/Model.cpp
@@ -369,7 +369,7 @@ oms_status_enu_t oms::Model::exportToSSD(pugi::xml_node& node, pugi::xml_node& s
 
   // export openmodelica_default_experiment as vendor annotations
   pugi::xml_node node_annotations = default_experiment.append_child(oms::ssp::Draft20180219::ssd::annotations);
-  pugi::xml_node node_annotation = node_annotations.append_child(oms::ssp::Draft20180219::ssc::annotation);
+  pugi::xml_node node_annotation = node_annotations.append_child(oms::ssp::Version1_0::ssc::annotation);
   node_annotation.append_attribute("type") =  oms::ssp::Draft20180219::annotation_type;
   pugi::xml_node oms_simulation_information = node_annotation.append_child(oms::ssp::Version1_0::simulation_information);
   //pugi::xml_node oms_default_experiment = oms_simulation_information.append_child("DefaultExperiment");
@@ -412,7 +412,14 @@ oms_status_enu_t oms::Model::importFromSSD(const pugi::xml_node& node)
 
       // import oms::DefaultExperiment from oms:simulationInformation
       pugi::xml_node annotations = it->child(oms::ssp::Draft20180219::ssd::annotations);
-      pugi::xml_node annotation_node = annotations.child(oms::ssp::Draft20180219::ssc::annotation);
+      pugi::xml_node annotation_node;
+      annotation_node = it->child(oms::ssp::Version1_0::ssc::annotation);
+
+      // check for ssd:annotation to support older version, which is a bug
+      if(!annotation_node)
+      {
+        annotation_node = it->child(oms::ssp::Draft20180219::ssd::annotation);
+      }
 
       if (annotation_node && std::string(annotation_node.attribute("type").as_string()) == oms::ssp::Draft20180219::annotation_type)
       {
@@ -452,7 +459,15 @@ oms_system_enu_t oms::Model::getSystemType(const pugi::xml_node& node, const std
     /* from Version "1.0" simulationInformation is handled in vendor annotation */
     if (name == oms::ssp::Draft20180219::ssd::annotations  && sspVersion == "1.0")
     {
-      pugi::xml_node annotation_node = itElements->child(oms::ssp::Draft20180219::ssc::annotation);
+      pugi::xml_node annotation_node;
+      annotation_node = itElements->child(oms::ssp::Version1_0::ssc::annotation);
+
+      // check for ssd:annotation to support older version, which is a bug
+      if (!annotation_node)
+      {
+        annotation_node = itElements->child(oms::ssp::Draft20180219::ssd::annotation);
+      }
+
       if (annotation_node && std::string(annotation_node.attribute("type").as_string()) == oms::ssp::Draft20180219::annotation_type)
       {
         for(pugi::xml_node_iterator itAnnotations = annotation_node.begin(); itAnnotations != annotation_node.end(); ++itAnnotations)

--- a/src/OMSimulatorLib/Model.cpp
+++ b/src/OMSimulatorLib/Model.cpp
@@ -369,7 +369,7 @@ oms_status_enu_t oms::Model::exportToSSD(pugi::xml_node& node, pugi::xml_node& s
 
   // export openmodelica_default_experiment as vendor annotations
   pugi::xml_node node_annotations = default_experiment.append_child(oms::ssp::Draft20180219::ssd::annotations);
-  pugi::xml_node node_annotation = node_annotations.append_child(oms::ssp::Draft20180219::ssd::annotation);
+  pugi::xml_node node_annotation = node_annotations.append_child(oms::ssp::Draft20180219::ssc::annotation);
   node_annotation.append_attribute("type") =  oms::ssp::Draft20180219::annotation_type;
   pugi::xml_node oms_simulation_information = node_annotation.append_child(oms::ssp::Version1_0::simulation_information);
   //pugi::xml_node oms_default_experiment = oms_simulation_information.append_child("DefaultExperiment");
@@ -412,7 +412,7 @@ oms_status_enu_t oms::Model::importFromSSD(const pugi::xml_node& node)
 
       // import oms::DefaultExperiment from oms:simulationInformation
       pugi::xml_node annotations = it->child(oms::ssp::Draft20180219::ssd::annotations);
-      pugi::xml_node annotation_node = annotations.child(oms::ssp::Draft20180219::ssd::annotation);
+      pugi::xml_node annotation_node = annotations.child(oms::ssp::Draft20180219::ssc::annotation);
 
       if (annotation_node && std::string(annotation_node.attribute("type").as_string()) == oms::ssp::Draft20180219::annotation_type)
       {
@@ -452,7 +452,7 @@ oms_system_enu_t oms::Model::getSystemType(const pugi::xml_node& node, const std
     /* from Version "1.0" simulationInformation is handled in vendor annotation */
     if (name == oms::ssp::Draft20180219::ssd::annotations  && sspVersion == "1.0")
     {
-      pugi::xml_node annotation_node = itElements->child(oms::ssp::Draft20180219::ssd::annotation);
+      pugi::xml_node annotation_node = itElements->child(oms::ssp::Draft20180219::ssc::annotation);
       if (annotation_node && std::string(annotation_node.attribute("type").as_string()) == oms::ssp::Draft20180219::annotation_type)
       {
         for(pugi::xml_node_iterator itAnnotations = annotation_node.begin(); itAnnotations != annotation_node.end(); ++itAnnotations)

--- a/src/OMSimulatorLib/Model.cpp
+++ b/src/OMSimulatorLib/Model.cpp
@@ -413,12 +413,12 @@ oms_status_enu_t oms::Model::importFromSSD(const pugi::xml_node& node)
       // import oms::DefaultExperiment from oms:simulationInformation
       pugi::xml_node annotations = it->child(oms::ssp::Draft20180219::ssd::annotations);
       pugi::xml_node annotation_node;
-      annotation_node = it->child(oms::ssp::Version1_0::ssc::annotation);
+      annotation_node = annotations.child(oms::ssp::Version1_0::ssc::annotation);
 
       // check for ssd:annotation to support older version, which is a bug
       if(!annotation_node)
       {
-        annotation_node = it->child(oms::ssp::Draft20180219::ssd::annotation);
+        annotation_node = annotations.child(oms::ssp::Draft20180219::ssd::annotation);
       }
 
       if (annotation_node && std::string(annotation_node.attribute("type").as_string()) == oms::ssp::Draft20180219::annotation_type)

--- a/src/OMSimulatorLib/Model.cpp
+++ b/src/OMSimulatorLib/Model.cpp
@@ -385,6 +385,12 @@ oms_status_enu_t oms::Model::exportToSSD(pugi::xml_node& node, pugi::xml_node& s
 oms_status_enu_t oms::Model::importFromSSD(const pugi::xml_node& node)
 {
   std::string sspVersion = node.attribute("version").as_string();
+
+  if(sspVersion == "Draft20180219")
+  {
+    logWarning("Wrong/deprecated content detected but successfully loaded. Please re-export the SSP file to avoid this message.");
+  }
+
   for(pugi::xml_node_iterator it = node.begin(); it != node.end(); ++it)
   {
     std::string name = it->name();
@@ -419,6 +425,7 @@ oms_status_enu_t oms::Model::importFromSSD(const pugi::xml_node& node)
       if(!annotation_node)
       {
         annotation_node = annotations.child(oms::ssp::Draft20180219::ssd::annotation);
+        logWarning("Wrong/deprecated content detected but successfully loaded. Please re-export the SSP file to avoid this message.");
       }
 
       if (annotation_node && std::string(annotation_node.attribute("type").as_string()) == oms::ssp::Draft20180219::annotation_type)
@@ -466,6 +473,7 @@ oms_system_enu_t oms::Model::getSystemType(const pugi::xml_node& node, const std
       if (!annotation_node)
       {
         annotation_node = itElements->child(oms::ssp::Draft20180219::ssd::annotation);
+        logWarning("Wrong/deprecated content detected but successfully loaded. Please re-export the SSP file to avoid this message.");
       }
 
       if (annotation_node && std::string(annotation_node.attribute("type").as_string()) == oms::ssp::Draft20180219::annotation_type)

--- a/src/OMSimulatorLib/Model.cpp
+++ b/src/OMSimulatorLib/Model.cpp
@@ -388,7 +388,7 @@ oms_status_enu_t oms::Model::importFromSSD(const pugi::xml_node& node)
 
   if(sspVersion == "Draft20180219")
   {
-    logWarning("Wrong/deprecated content detected but successfully loaded. Please re-export the SSP file to avoid this message.");
+    logWarning_deprecated;
   }
 
   for(pugi::xml_node_iterator it = node.begin(); it != node.end(); ++it)
@@ -425,7 +425,7 @@ oms_status_enu_t oms::Model::importFromSSD(const pugi::xml_node& node)
       if(!annotation_node)
       {
         annotation_node = annotations.child(oms::ssp::Draft20180219::ssd::annotation);
-        logWarning("Wrong/deprecated content detected but successfully loaded. Please re-export the SSP file to avoid this message.");
+        logWarning_deprecated;
       }
 
       if (annotation_node && std::string(annotation_node.attribute("type").as_string()) == oms::ssp::Draft20180219::annotation_type)
@@ -473,7 +473,7 @@ oms_system_enu_t oms::Model::getSystemType(const pugi::xml_node& node, const std
       if (!annotation_node)
       {
         annotation_node = itElements->child(oms::ssp::Draft20180219::ssd::annotation);
-        logWarning("Wrong/deprecated content detected but successfully loaded. Please re-export the SSP file to avoid this message.");
+        logWarning_deprecated;
       }
 
       if (annotation_node && std::string(annotation_node.attribute("type").as_string()) == oms::ssp::Draft20180219::annotation_type)

--- a/src/OMSimulatorLib/Parameters.cpp
+++ b/src/OMSimulatorLib/Parameters.cpp
@@ -140,7 +140,7 @@ oms_status_enu_t oms::Parameters::importFromSSD(const pugi::xml_node& node, cons
       // inline ParameterBindings
       if (parameterBindingNode.child(oms::ssp::Version1_0::ssv::parameter_set))
       {
-        logWarning("Wrong/deprecated content detected but successfully loaded. Please re-export the SSP file to avoid this message.");
+        logWarning_deprecated;
       }
       pugi::xml_node parameterValues = parameterBindingNode.child(oms::ssp::Version1_0::ssd::parameter_values);
       pugi::xml_node parameterSet = parameterValues.child(oms::ssp::Version1_0::ssv::parameter_set);

--- a/src/OMSimulatorLib/System.cpp
+++ b/src/OMSimulatorLib/System.cpp
@@ -652,6 +652,7 @@ oms_status_enu_t oms::System::importFromSSD(const pugi::xml_node& node, const st
                   else
                   {
                     annotationNodeString = oms::ssp::Draft20180219::ssd::annotation;
+                    logWarning("Wrong/deprecated content detected but successfully loaded. Please re-export the SSP file to avoid this message.");
                   }
 
                   for (pugi::xml_node annotationNode = annotationNode.child(annotationNodeString); annotationNode; annotationNode = annotationNode.next_sibling(annotationNodeString)) {
@@ -731,6 +732,7 @@ oms_status_enu_t oms::System::importFromSSD(const pugi::xml_node& node, const st
       if(!annotation_node)
       {
         annotation_node = it->child(oms::ssp::Draft20180219::ssd::annotation);
+        logWarning("Wrong/deprecated content detected but successfully loaded. Please re-export the SSP file to avoid this message.");
       }
 
       if (annotation_node && std::string(annotation_node.attribute("type").as_string()) == oms::ssp::Draft20180219::annotation_type)

--- a/src/OMSimulatorLib/System.cpp
+++ b/src/OMSimulatorLib/System.cpp
@@ -444,7 +444,7 @@ oms_status_enu_t oms::System::exportToSSD(pugi::xml_node& node, pugi::xml_node& 
 #endif
   {
     pugi::xml_node annotations_node = node.append_child(oms::ssp::Draft20180219::ssd::annotations);
-    pugi::xml_node annotation_node = annotations_node.append_child(oms::ssp::Draft20180219::ssd::annotation);
+    pugi::xml_node annotation_node = annotations_node.append_child(oms::ssp::Draft20180219::ssc::annotation);
     annotation_node.append_attribute("type") = oms::ssp::Draft20180219::annotation_type;
     for (const auto& busconnector : busconnectors)
       if (busconnector)
@@ -625,7 +625,7 @@ oms_status_enu_t oms::System::importFromSSD(const pugi::xml_node& node, const st
                 if(simulationInformationNode && sspVersion == "Draft20180219") {
                   pugi::xml_node annotationsNode = simulationInformationNode.child(oms::ssp::Draft20180219::ssd::annotations);
                   if(annotationsNode) {
-                    for (pugi::xml_node annotationNode = annotationsNode.child(oms::ssp::Draft20180219::ssd::annotation); annotationNode; annotationNode = annotationNode.next_sibling(oms::ssp::Draft20180219::ssd::annotation)) {
+                    for (pugi::xml_node annotationNode = annotationsNode.child(oms::ssp::Draft20180219::ssc::annotation); annotationNode; annotationNode = annotationNode.next_sibling(oms::ssp::Draft20180219::ssc::annotation)) {
                       std::string type = annotationNode.attribute("type").as_string() ;
                       if(oms::ssp::Draft20180219::annotation_type == type) {
                         pugi::xml_node externalModelNode = annotationNode.child(oms::ssp::Draft20180219::external_model);
@@ -642,7 +642,7 @@ oms_status_enu_t oms::System::importFromSSD(const pugi::xml_node& node, const st
 
               pugi::xml_node annotationsNode = itElements->child(oms::ssp::Draft20180219::ssd::annotations);
               if(annotationsNode) {
-                  for (pugi::xml_node annotationNode = annotationsNode.child(oms::ssp::Draft20180219::ssd::annotation); annotationNode; annotationNode = annotationNode.next_sibling(oms::ssp::Draft20180219::ssd::annotation)) {
+                  for (pugi::xml_node annotationNode = annotationsNode.child(oms::ssp::Draft20180219::ssc::annotation); annotationNode; annotationNode = annotationNode.next_sibling(oms::ssp::Draft20180219::ssc::annotation)) {
                       std::string type = annotationNode.attribute("type").as_string() ;
                       if(oms::ssp::Draft20180219::annotation_type == type) {
 
@@ -712,7 +712,7 @@ oms_status_enu_t oms::System::importFromSSD(const pugi::xml_node& node, const st
     }
     else if (name == oms::ssp::Draft20180219::ssd::annotations)
     {
-      pugi::xml_node annotation_node = it->child(oms::ssp::Draft20180219::ssd::annotation);
+      pugi::xml_node annotation_node = it->child(oms::ssp::Draft20180219::ssc::annotation);
       if (annotation_node && std::string(annotation_node.attribute("type").as_string()) == oms::ssp::Draft20180219::annotation_type)
       {
         for(pugi::xml_node_iterator itAnnotations = annotation_node.begin(); itAnnotations != annotation_node.end(); ++itAnnotations)

--- a/src/OMSimulatorLib/System.cpp
+++ b/src/OMSimulatorLib/System.cpp
@@ -625,6 +625,10 @@ oms_status_enu_t oms::System::importFromSSD(const pugi::xml_node& node, const st
                 if(simulationInformationNode && sspVersion == "Draft20180219") {
                   pugi::xml_node annotationsNode = simulationInformationNode.child(oms::ssp::Draft20180219::ssd::annotations);
                   if(annotationsNode) {
+                    if (annotationsNode.child(oms::ssp::Draft20180219::ssd::annotation))
+                    {
+                      logWarning_deprecated;
+                    }
                     for (pugi::xml_node annotationNode = annotationsNode.child(oms::ssp::Draft20180219::ssd::annotation); annotationNode; annotationNode = annotationNode.next_sibling(oms::ssp::Draft20180219::ssd::annotation)) {
                       std::string type = annotationNode.attribute("type").as_string() ;
                       if(oms::ssp::Draft20180219::annotation_type == type) {
@@ -652,7 +656,7 @@ oms_status_enu_t oms::System::importFromSSD(const pugi::xml_node& node, const st
                   else
                   {
                     annotationNodeString = oms::ssp::Draft20180219::ssd::annotation;
-                    logWarning("Wrong/deprecated content detected but successfully loaded. Please re-export the SSP file to avoid this message.");
+                    logWarning_deprecated;
                   }
 
                   for (pugi::xml_node annotationNode = annotationNode.child(annotationNodeString); annotationNode; annotationNode = annotationNode.next_sibling(annotationNodeString)) {
@@ -732,7 +736,7 @@ oms_status_enu_t oms::System::importFromSSD(const pugi::xml_node& node, const st
       if(!annotation_node)
       {
         annotation_node = it->child(oms::ssp::Draft20180219::ssd::annotation);
-        logWarning("Wrong/deprecated content detected but successfully loaded. Please re-export the SSP file to avoid this message.");
+        logWarning_deprecated;
       }
 
       if (annotation_node && std::string(annotation_node.attribute("type").as_string()) == oms::ssp::Draft20180219::annotation_type)

--- a/src/OMSimulatorLib/System.cpp
+++ b/src/OMSimulatorLib/System.cpp
@@ -444,7 +444,7 @@ oms_status_enu_t oms::System::exportToSSD(pugi::xml_node& node, pugi::xml_node& 
 #endif
   {
     pugi::xml_node annotations_node = node.append_child(oms::ssp::Draft20180219::ssd::annotations);
-    pugi::xml_node annotation_node = annotations_node.append_child(oms::ssp::Draft20180219::ssc::annotation);
+    pugi::xml_node annotation_node = annotations_node.append_child(oms::ssp::Version1_0::ssc::annotation);
     annotation_node.append_attribute("type") = oms::ssp::Draft20180219::annotation_type;
     for (const auto& busconnector : busconnectors)
       if (busconnector)
@@ -625,7 +625,7 @@ oms_status_enu_t oms::System::importFromSSD(const pugi::xml_node& node, const st
                 if(simulationInformationNode && sspVersion == "Draft20180219") {
                   pugi::xml_node annotationsNode = simulationInformationNode.child(oms::ssp::Draft20180219::ssd::annotations);
                   if(annotationsNode) {
-                    for (pugi::xml_node annotationNode = annotationsNode.child(oms::ssp::Draft20180219::ssc::annotation); annotationNode; annotationNode = annotationNode.next_sibling(oms::ssp::Draft20180219::ssc::annotation)) {
+                    for (pugi::xml_node annotationNode = annotationsNode.child(oms::ssp::Draft20180219::ssd::annotation); annotationNode; annotationNode = annotationNode.next_sibling(oms::ssp::Draft20180219::ssd::annotation)) {
                       std::string type = annotationNode.attribute("type").as_string() ;
                       if(oms::ssp::Draft20180219::annotation_type == type) {
                         pugi::xml_node externalModelNode = annotationNode.child(oms::ssp::Draft20180219::external_model);
@@ -642,7 +642,19 @@ oms_status_enu_t oms::System::importFromSSD(const pugi::xml_node& node, const st
 
               pugi::xml_node annotationsNode = itElements->child(oms::ssp::Draft20180219::ssd::annotations);
               if(annotationsNode) {
-                  for (pugi::xml_node annotationNode = annotationsNode.child(oms::ssp::Draft20180219::ssc::annotation); annotationNode; annotationNode = annotationNode.next_sibling(oms::ssp::Draft20180219::ssc::annotation)) {
+                  const char* annotationNodeString = "";
+                  pugi::xml_node annotationNodeChild;
+                  annotationNodeChild = annotationsNode.child(oms::ssp::Version1_0::ssc::annotation);
+                  if(annotationNodeChild)
+                  {
+                    annotationNodeString = oms::ssp::Version1_0::ssc::annotation;
+                  }
+                  else
+                  {
+                    annotationNodeString = oms::ssp::Draft20180219::ssd::annotation;
+                  }
+
+                  for (pugi::xml_node annotationNode = annotationNode.child(annotationNodeString); annotationNode; annotationNode = annotationNode.next_sibling(annotationNodeString)) {
                       std::string type = annotationNode.attribute("type").as_string() ;
                       if(oms::ssp::Draft20180219::annotation_type == type) {
 
@@ -712,7 +724,15 @@ oms_status_enu_t oms::System::importFromSSD(const pugi::xml_node& node, const st
     }
     else if (name == oms::ssp::Draft20180219::ssd::annotations)
     {
-      pugi::xml_node annotation_node = it->child(oms::ssp::Draft20180219::ssc::annotation);
+      pugi::xml_node annotation_node;
+      annotation_node = it->child(oms::ssp::Version1_0::ssc::annotation);
+
+      // check for ssd:annotation to support older version, which is a bug
+      if(!annotation_node)
+      {
+        annotation_node = it->child(oms::ssp::Draft20180219::ssd::annotation);
+      }
+
       if (annotation_node && std::string(annotation_node.attribute("type").as_string()) == oms::ssp::Draft20180219::annotation_type)
       {
         for(pugi::xml_node_iterator itAnnotations = annotation_node.begin(); itAnnotations != annotation_node.end(); ++itAnnotations)

--- a/src/OMSimulatorLib/SystemSC.cpp
+++ b/src/OMSimulatorLib/SystemSC.cpp
@@ -140,7 +140,7 @@ oms_status_enu_t oms::SystemSC::setSolverMethod(std::string solver)
 oms_status_enu_t oms::SystemSC::exportToSSD_SimulationInformation(pugi::xml_node& node) const
 {
   pugi::xml_node node_annotations = node.append_child(oms::ssp::Draft20180219::ssd::annotations);
-  pugi::xml_node node_annotation = node_annotations.append_child(oms::ssp::Draft20180219::ssd::annotation);
+  pugi::xml_node node_annotation = node_annotations.append_child(oms::ssp::Draft20180219::ssc::annotation);
   node_annotation.append_attribute("type") = oms::ssp::Draft20180219::annotation_type;
 
   /* ssd:SimulationInformation should be added as vendor specific annotations from Version 1.0 */

--- a/src/OMSimulatorLib/SystemSC.cpp
+++ b/src/OMSimulatorLib/SystemSC.cpp
@@ -140,7 +140,7 @@ oms_status_enu_t oms::SystemSC::setSolverMethod(std::string solver)
 oms_status_enu_t oms::SystemSC::exportToSSD_SimulationInformation(pugi::xml_node& node) const
 {
   pugi::xml_node node_annotations = node.append_child(oms::ssp::Draft20180219::ssd::annotations);
-  pugi::xml_node node_annotation = node_annotations.append_child(oms::ssp::Draft20180219::ssc::annotation);
+  pugi::xml_node node_annotation = node_annotations.append_child(oms::ssp::Version1_0::ssc::annotation);
   node_annotation.append_attribute("type") = oms::ssp::Draft20180219::annotation_type;
 
   /* ssd:SimulationInformation should be added as vendor specific annotations from Version 1.0 */

--- a/src/OMSimulatorLib/SystemWC.cpp
+++ b/src/OMSimulatorLib/SystemWC.cpp
@@ -106,7 +106,7 @@ oms_status_enu_t oms::SystemWC::setSolverMethod(std::string solver)
 oms_status_enu_t oms::SystemWC::exportToSSD_SimulationInformation(pugi::xml_node& node) const
 {
   pugi::xml_node node_annotations = node.append_child(oms::ssp::Draft20180219::ssd::annotations);
-  pugi::xml_node node_annotation = node_annotations.append_child(oms::ssp::Draft20180219::ssd::annotation);
+  pugi::xml_node node_annotation = node_annotations.append_child(oms::ssp::Draft20180219::ssc::annotation);
   node_annotation.append_attribute("type") =  oms::ssp::Draft20180219::annotation_type;
 
   /* ssd:SimulationInformation should be added as vendor specific annotations from Version 1.0 */

--- a/src/OMSimulatorLib/SystemWC.cpp
+++ b/src/OMSimulatorLib/SystemWC.cpp
@@ -106,7 +106,7 @@ oms_status_enu_t oms::SystemWC::setSolverMethod(std::string solver)
 oms_status_enu_t oms::SystemWC::exportToSSD_SimulationInformation(pugi::xml_node& node) const
 {
   pugi::xml_node node_annotations = node.append_child(oms::ssp::Draft20180219::ssd::annotations);
-  pugi::xml_node node_annotation = node_annotations.append_child(oms::ssp::Draft20180219::ssc::annotation);
+  pugi::xml_node node_annotation = node_annotations.append_child(oms::ssp::Version1_0::ssc::annotation);
   node_annotation.append_attribute("type") =  oms::ssp::Draft20180219::annotation_type;
 
   /* ssd:SimulationInformation should be added as vendor specific annotations from Version 1.0 */

--- a/src/OMSimulatorLib/TLM/ExternalModel.cpp
+++ b/src/OMSimulatorLib/TLM/ExternalModel.cpp
@@ -90,7 +90,7 @@ oms_status_enu_t oms::ExternalModel::getRealParameter(const std::string &var, do
 oms_status_enu_t oms::ExternalModel::exportToSSD(pugi::xml_node& node, pugi::xml_node& ssvNode) const
 {
   pugi::xml_node annotations_node = node.append_child(oms::ssp::Draft20180219::ssd::annotations);
-  pugi::xml_node annotation_node = annotations_node.append_child(oms::ssp::Draft20180219::ssc::annotation);
+  pugi::xml_node annotation_node = annotations_node.append_child(oms::ssp::Version1_0::ssc::annotation);
   annotation_node.append_attribute("type") = oms::ssp::Draft20180219::annotation_type;
 
   if (tlmbusconnectors[0])

--- a/src/OMSimulatorLib/TLM/ExternalModel.cpp
+++ b/src/OMSimulatorLib/TLM/ExternalModel.cpp
@@ -90,7 +90,7 @@ oms_status_enu_t oms::ExternalModel::getRealParameter(const std::string &var, do
 oms_status_enu_t oms::ExternalModel::exportToSSD(pugi::xml_node& node, pugi::xml_node& ssvNode) const
 {
   pugi::xml_node annotations_node = node.append_child(oms::ssp::Draft20180219::ssd::annotations);
-  pugi::xml_node annotation_node = annotations_node.append_child(oms::ssp::Draft20180219::ssd::annotation);
+  pugi::xml_node annotation_node = annotations_node.append_child(oms::ssp::Draft20180219::ssc::annotation);
   annotation_node.append_attribute("type") = oms::ssp::Draft20180219::annotation_type;
 
   if (tlmbusconnectors[0])

--- a/src/OMSimulatorLib/TLM/SystemTLM.cpp
+++ b/src/OMSimulatorLib/TLM/SystemTLM.cpp
@@ -110,7 +110,7 @@ oms_status_enu_t oms::SystemTLM::importFromSSD_SimulationInformation(const pugi:
     if(!annotationNode)
     {
       annotationNode = annotationsNode.child(oms::ssp::Draft20180219::ssd::annotation);
-      logWarning("Wrong/deprecated content detected but successfully loaded. Please re-export the SSP file to avoid this message.");
+      logWarning_deprecated;
     }
 
     if(annotationNode && std::string(annotationNode.attribute("type").as_string()) == "org.openmodelica") {

--- a/src/OMSimulatorLib/TLM/SystemTLM.cpp
+++ b/src/OMSimulatorLib/TLM/SystemTLM.cpp
@@ -110,6 +110,7 @@ oms_status_enu_t oms::SystemTLM::importFromSSD_SimulationInformation(const pugi:
     if(!annotationNode)
     {
       annotationNode = annotationsNode.child(oms::ssp::Draft20180219::ssd::annotation);
+      logWarning("Wrong/deprecated content detected but successfully loaded. Please re-export the SSP file to avoid this message.");
     }
 
     if(annotationNode && std::string(annotationNode.attribute("type").as_string()) == "org.openmodelica") {

--- a/src/OMSimulatorLib/TLM/SystemTLM.cpp
+++ b/src/OMSimulatorLib/TLM/SystemTLM.cpp
@@ -81,7 +81,7 @@ oms::System* oms::SystemTLM::NewSystem(const oms::ComRef& cref, oms::Model* pare
 oms_status_enu_t oms::SystemTLM::exportToSSD_SimulationInformation(pugi::xml_node& node) const
 {
   pugi::xml_node node_annotations = node.append_child(oms::ssp::Draft20180219::ssd::annotations);
-  pugi::xml_node node_annotation = node_annotations.append_child(oms::ssp::Draft20180219::ssc::annotation);
+  pugi::xml_node node_annotation = node_annotations.append_child(oms::ssp::Version1_0::ssc::annotation);
   node_annotation.append_attribute("type") = oms::ssp::Draft20180219::annotation_type;
 
   /* ssd:SimulationInformation should be added as vendor specific annotations from Version 1.0 */
@@ -101,8 +101,17 @@ oms_status_enu_t oms::SystemTLM::importFromSSD_SimulationInformation(const pugi:
   pugi::xml_node annotationsNode = node.child(oms::ssp::Draft20180219::ssd::annotations);
 
   /*  To handle version = "Draft20180219"*/
-  if(annotationsNode) {
-    pugi::xml_node annotationNode = annotationsNode.child(oms::ssp::Draft20180219::ssc::annotation);
+  if(annotationsNode)
+  {
+    pugi::xml_node annotationNode;
+    annotationNode = annotationsNode.child(oms::ssp::Version1_0::ssc::annotation);
+
+    // check for ssd:annotation to support older version, which is a bug
+    if(!annotationNode)
+    {
+      annotationNode = annotationsNode.child(oms::ssp::Draft20180219::ssd::annotation);
+    }
+
     if(annotationNode && std::string(annotationNode.attribute("type").as_string()) == "org.openmodelica") {
       importFromSSD_SimulationInformationHelper(annotationNode);
     }

--- a/src/OMSimulatorLib/TLM/SystemTLM.cpp
+++ b/src/OMSimulatorLib/TLM/SystemTLM.cpp
@@ -81,7 +81,7 @@ oms::System* oms::SystemTLM::NewSystem(const oms::ComRef& cref, oms::Model* pare
 oms_status_enu_t oms::SystemTLM::exportToSSD_SimulationInformation(pugi::xml_node& node) const
 {
   pugi::xml_node node_annotations = node.append_child(oms::ssp::Draft20180219::ssd::annotations);
-  pugi::xml_node node_annotation = node_annotations.append_child(oms::ssp::Draft20180219::ssd::annotation);
+  pugi::xml_node node_annotation = node_annotations.append_child(oms::ssp::Draft20180219::ssc::annotation);
   node_annotation.append_attribute("type") = oms::ssp::Draft20180219::annotation_type;
 
   /* ssd:SimulationInformation should be added as vendor specific annotations from Version 1.0 */
@@ -102,7 +102,7 @@ oms_status_enu_t oms::SystemTLM::importFromSSD_SimulationInformation(const pugi:
 
   /*  To handle version = "Draft20180219"*/
   if(annotationsNode) {
-    pugi::xml_node annotationNode = annotationsNode.child(oms::ssp::Draft20180219::ssd::annotation);
+    pugi::xml_node annotationNode = annotationsNode.child(oms::ssp::Draft20180219::ssc::annotation);
     if(annotationNode && std::string(annotationNode.attribute("type").as_string()) == "org.openmodelica") {
       importFromSSD_SimulationInformationHelper(annotationNode);
     }

--- a/src/OMSimulatorLib/ssd/Tags.cpp
+++ b/src/OMSimulatorLib/ssd/Tags.cpp
@@ -40,7 +40,7 @@ const char* oms::ssp::Draft20180219::bus_connections                   = "oms:Co
 const char* oms::ssp::Draft20180219::bus_connection                    = "oms:Connection";
 const char* oms::ssp::Draft20180219::external_model                    = "oms:ExternalModel";
 
-const char* oms::ssp::Draft20180219::ssc::annotation                   = "ssc:Annotation";
+const char* oms::ssp::Draft20180219::ssd::annotation                   = "ssd:Annotation";
 const char* oms::ssp::Draft20180219::ssd::annotations                  = "ssd:Annotations";
 const char* oms::ssp::Draft20180219::ssd::component                    = "ssd:Component";
 const char* oms::ssp::Draft20180219::ssd::connection                   = "ssd:Connection";
@@ -84,3 +84,5 @@ const char* oms::ssp::Version1_0::ssv::boolean_type                    = "ssv:Bo
 const char* oms::ssp::Version1_0::ssv::string_type                     = "ssv:String";
 const char* oms::ssp::Version1_0::ssv::enumeration_type                = "ssv:Enumeration";
 const char* oms::ssp::Version1_0::ssv::binary_type                     = "ssv:Binary";
+
+const char* oms::ssp::Version1_0::ssc::annotation                      = "ssc:Annotation";

--- a/src/OMSimulatorLib/ssd/Tags.cpp
+++ b/src/OMSimulatorLib/ssd/Tags.cpp
@@ -40,7 +40,7 @@ const char* oms::ssp::Draft20180219::bus_connections                   = "oms:Co
 const char* oms::ssp::Draft20180219::bus_connection                    = "oms:Connection";
 const char* oms::ssp::Draft20180219::external_model                    = "oms:ExternalModel";
 
-const char* oms::ssp::Draft20180219::ssd::annotation                   = "ssd:Annotation";
+const char* oms::ssp::Draft20180219::ssc::annotation                   = "ssc:Annotation";
 const char* oms::ssp::Draft20180219::ssd::annotations                  = "ssd:Annotations";
 const char* oms::ssp::Draft20180219::ssd::component                    = "ssd:Component";
 const char* oms::ssp::Draft20180219::ssd::connection                   = "ssd:Connection";

--- a/src/OMSimulatorLib/ssd/Tags.h
+++ b/src/OMSimulatorLib/ssd/Tags.h
@@ -87,9 +87,7 @@ namespace oms
 
       namespace ssd
       {
-        extern const char* annotation;
         extern const char* annotations;
-        extern const char* annotation;
         extern const char* component;
         extern const char* connection_geometry;
         extern const char* connection;
@@ -105,6 +103,11 @@ namespace oms
         extern const char* system_structure_description;
         extern const char* system;
         extern const char* units;
+      }
+
+      namespace ssc
+      {
+        extern const char* annotation;
       }
     }
   }

--- a/src/OMSimulatorLib/ssd/Tags.h
+++ b/src/OMSimulatorLib/ssd/Tags.h
@@ -71,6 +71,7 @@ namespace oms
         extern const char* string_type;
         extern const char* enumeration_type;
         extern const char* binary_type;
+        extern const char* annotation;
       }
     }
 
@@ -87,6 +88,7 @@ namespace oms
 
       namespace ssd
       {
+        extern const char* annotation;
         extern const char* annotations;
         extern const char* component;
         extern const char* connection_geometry;
@@ -105,10 +107,6 @@ namespace oms
         extern const char* units;
       }
 
-      namespace ssc
-      {
-        extern const char* annotation;
-      }
     }
   }
 }

--- a/testsuite/OMSimulator/deleteConnector.lua
+++ b/testsuite/OMSimulator/deleteConnector.lua
@@ -57,11 +57,11 @@ print(src)
 -- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="deleteConnector" version="1.0">
 -- 	<ssd:System name="Root">
 -- 		<ssd:Annotations>
--- 			<ssd:Annotation type="org.openmodelica">
+-- 			<ssc:Annotation type="org.openmodelica">
 -- 				<oms:SimulationInformation>
 -- 					<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
 -- 				</oms:SimulationInformation>
--- 			</ssd:Annotation>
+-- 			</ssc:Annotation>
 -- 		</ssd:Annotations>
 -- 		<ssd:Connectors>
 -- 			<ssd:Connector name="C1" kind="input">
@@ -74,11 +74,11 @@ print(src)
 -- 		<ssd:Elements>
 -- 			<ssd:System name="System2">
 -- 				<ssd:Annotations>
--- 					<ssd:Annotation type="org.openmodelica">
+-- 					<ssc:Annotation type="org.openmodelica">
 -- 						<oms:SimulationInformation>
 -- 							<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
 -- 						</oms:SimulationInformation>
--- 					</ssd:Annotation>
+-- 					</ssc:Annotation>
 -- 				</ssd:Annotations>
 -- 				<ssd:Connectors>
 -- 					<ssd:Connector name="C3" kind="output">
@@ -109,11 +109,11 @@ print(src)
 -- 			</ssd:System>
 -- 			<ssd:System name="System1">
 -- 				<ssd:Annotations>
--- 					<ssd:Annotation type="org.openmodelica">
+-- 					<ssc:Annotation type="org.openmodelica">
 -- 						<oms:SimulationInformation>
 -- 							<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
 -- 						</oms:SimulationInformation>
--- 					</ssd:Annotation>
+-- 					</ssc:Annotation>
 -- 				</ssd:Annotations>
 -- 				<ssd:Connectors>
 -- 					<ssd:Connector name="C1" kind="input">
@@ -164,9 +164,9 @@ print(src)
 -- 	</ssd:System>
 -- 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
 -- 		<ssd:Annotations>
--- 			<ssd:Annotation type="org.openmodelica">
+-- 			<ssc:Annotation type="org.openmodelica">
 -- 				<oms:SimulationInformation resultFile="deleteConnector_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter="" />
--- 			</ssd:Annotation>
+-- 			</ssc:Annotation>
 -- 		</ssd:Annotations>
 -- 	</ssd:DefaultExperiment>
 -- </ssd:SystemStructureDescription>
@@ -177,11 +177,11 @@ print(src)
 -- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="deleteConnector" version="1.0">
 -- 	<ssd:System name="Root">
 -- 		<ssd:Annotations>
--- 			<ssd:Annotation type="org.openmodelica">
+-- 			<ssc:Annotation type="org.openmodelica">
 -- 				<oms:SimulationInformation>
 -- 					<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
 -- 				</oms:SimulationInformation>
--- 			</ssd:Annotation>
+-- 			</ssc:Annotation>
 -- 		</ssd:Annotations>
 -- 		<ssd:Connectors>
 -- 			<ssd:Connector name="C2" kind="output">
@@ -191,11 +191,11 @@ print(src)
 -- 		<ssd:Elements>
 -- 			<ssd:System name="System2">
 -- 				<ssd:Annotations>
--- 					<ssd:Annotation type="org.openmodelica">
+-- 					<ssc:Annotation type="org.openmodelica">
 -- 						<oms:SimulationInformation>
 -- 							<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
 -- 						</oms:SimulationInformation>
--- 					</ssd:Annotation>
+-- 					</ssc:Annotation>
 -- 				</ssd:Annotations>
 -- 				<ssd:Connectors>
 -- 					<ssd:Connector name="C4" kind="output">
@@ -220,11 +220,11 @@ print(src)
 -- 			</ssd:System>
 -- 			<ssd:System name="System1">
 -- 				<ssd:Annotations>
--- 					<ssd:Annotation type="org.openmodelica">
+-- 					<ssc:Annotation type="org.openmodelica">
 -- 						<oms:SimulationInformation>
 -- 							<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
 -- 						</oms:SimulationInformation>
--- 					</ssd:Annotation>
+-- 					</ssc:Annotation>
 -- 				</ssd:Annotations>
 -- 				<ssd:Connectors>
 -- 					<ssd:Connector name="C1" kind="input">
@@ -235,7 +235,7 @@ print(src)
 -- 					</ssd:Connector>
 -- 				</ssd:Connectors>
 -- 				<ssd:Elements>
--- 					<ssd:Component name="Gain" type="application/x-fmu-sharedlibrary" source="resources/0001_Gain.fmu">
+-- 					<ssd:Component name="Gain" type="application/x-fmu-sharedlibrary" source="resources\0001_Gain.fmu">
 -- 						<ssd:Connectors>
 -- 							<ssd:Connector name="u" kind="input">
 -- 								<ssc:Real />
@@ -257,9 +257,9 @@ print(src)
 -- 	</ssd:System>
 -- 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
 -- 		<ssd:Annotations>
--- 			<ssd:Annotation type="org.openmodelica">
+-- 			<ssc:Annotation type="org.openmodelica">
 -- 				<oms:SimulationInformation resultFile="deleteConnector_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter="" />
--- 			</ssd:Annotation>
+-- 			</ssc:Annotation>
 -- 		</ssd:Annotations>
 -- 	</ssd:DefaultExperiment>
 -- </ssd:SystemStructureDescription>

--- a/testsuite/OMSimulator/deleteConnector.lua
+++ b/testsuite/OMSimulator/deleteConnector.lua
@@ -235,7 +235,7 @@ print(src)
 -- 					</ssd:Connector>
 -- 				</ssd:Connectors>
 -- 				<ssd:Elements>
--- 					<ssd:Component name="Gain" type="application/x-fmu-sharedlibrary" source="resources\0001_Gain.fmu">
+-- 					<ssd:Component name="Gain" type="application/x-fmu-sharedlibrary" source="resources/0001_Gain.fmu">
 -- 						<ssd:Connectors>
 -- 							<ssd:Connector name="u" kind="input">
 -- 								<ssc:Real />

--- a/testsuite/OMSimulator/import_export.lua
+++ b/testsuite/OMSimulator/import_export.lua
@@ -197,21 +197,21 @@ printStatus(status, 0)
 -- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="test" version="1.0">
 --     <ssd:System name="eoo">
 --         <ssd:Annotations>
---             <ssd:Annotation type="org.openmodelica">
+--             <ssc:Annotation type="org.openmodelica">
 --                 <oms:SimulationInformation>
 --                     <oms:TlmMaster ip="127.0.1.1" managerport="11111" monitorport="11121" />
 --                 </oms:SimulationInformation>
---             </ssd:Annotation>
+--             </ssc:Annotation>
 --         </ssd:Annotations>
 --         <ssd:Connectors />
 --         <ssd:Elements>
 --             <ssd:System name="foo2">
 --                 <ssd:Annotations>
---                     <ssd:Annotation type="org.openmodelica">
+--                     <ssc:Annotation type="org.openmodelica">
 --                         <oms:SimulationInformation>
 --                             <oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
 --                         </oms:SimulationInformation>
---                     </ssd:Annotation>
+--                     </ssc:Annotation>
 --                 </ssd:Annotations>
 --                 <ssd:Connectors>
 --                     <ssd:Connector name="f" kind="input">
@@ -233,7 +233,7 @@ printStatus(status, 0)
 --                 <ssd:Elements />
 --                 <ssd:Connections />
 --                 <ssd:Annotations>
---                     <ssd:Annotation type="org.openmodelica">
+--                     <ssc:Annotation type="org.openmodelica">
 --                         <oms:Bus name="bus">
 --                             <oms:Signals>
 --                                 <oms:Signal name="u1" />
@@ -247,16 +247,16 @@ printStatus(status, 0)
 --                                 <oms:Signal name="x" type="state" />
 --                             </oms:Signals>
 --                         </oms:Bus>
---                     </ssd:Annotation>
+--                     </ssc:Annotation>
 --                 </ssd:Annotations>
 --             </ssd:System>
 --             <ssd:System name="foo">
 --                 <ssd:Annotations>
---                     <ssd:Annotation type="org.openmodelica">
+--                     <ssc:Annotation type="org.openmodelica">
 --                         <oms:SimulationInformation>
 --                             <oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
 --                         </oms:SimulationInformation>
---                     </ssd:Annotation>
+--                     </ssc:Annotation>
 --                 </ssd:Annotations>
 --                 <ssd:Connectors>
 --                     <ssd:Connector name="f" kind="input">
@@ -278,11 +278,11 @@ printStatus(status, 0)
 --                 <ssd:Elements>
 --                     <ssd:System name="goo">
 --                         <ssd:Annotations>
---                             <ssd:Annotation type="org.openmodelica">
+--                             <ssc:Annotation type="org.openmodelica">
 --                                 <oms:SimulationInformation>
 --                                     <oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
 --                                 </oms:SimulationInformation>
---                             </ssd:Annotation>
+--                             </ssc:Annotation>
 --                         </ssd:Annotations>
 --                         <ssd:Connectors />
 --                         <ssd:Elements />
@@ -317,7 +317,7 @@ printStatus(status, 0)
 --                 </ssd:Elements>
 --                 <ssd:Connections />
 --                 <ssd:Annotations>
---                     <ssd:Annotation type="org.openmodelica">
+--                     <ssc:Annotation type="org.openmodelica">
 --                         <oms:Bus name="bus">
 --                             <oms:Signals>
 --                                 <oms:Signal name="y1" />
@@ -331,7 +331,7 @@ printStatus(status, 0)
 --                                 <oms:Signal name="x" type="state" />
 --                             </oms:Signals>
 --                         </oms:Bus>
---                     </ssd:Annotation>
+--                     </ssc:Annotation>
 --                 </ssd:Annotations>
 --             </ssd:System>
 --         </ssd:Elements>
@@ -340,19 +340,19 @@ printStatus(status, 0)
 --             <ssd:Connection startElement="foo" startConnector="y2" endElement="foo2" endConnector="u2" />
 --         </ssd:Connections>
 --         <ssd:Annotations>
---             <ssd:Annotation type="org.openmodelica">
+--             <ssc:Annotation type="org.openmodelica">
 --                 <oms:Connections>
 --                     <oms:Connection startElement="foo" startConnector="tlm" endElement="foo2" endConnector="tlm" delay="0.001000" alpha="0.300000" linearimpedance="100.000000" angularimpedance="0.000000" />
 --                     <oms:Connection startElement="foo" startConnector="bus" endElement="foo2" endConnector="bus" />
 --                 </oms:Connections>
---             </ssd:Annotation>
+--             </ssc:Annotation>
 --         </ssd:Annotations>
 --     </ssd:System>
 --     <ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
 --         <ssd:Annotations>
---             <ssd:Annotation type="org.openmodelica">
+--             <ssc:Annotation type="org.openmodelica">
 --                 <oms:SimulationInformation resultFile="test_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter="" />
---             </ssd:Annotation>
+--             </ssc:Annotation>
 --         </ssd:Annotations>
 --     </ssd:DefaultExperiment>
 -- </ssd:SystemStructureDescription>
@@ -365,21 +365,21 @@ printStatus(status, 0)
 -- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="test" version="1.0">
 --     <ssd:System name="eoo">
 --         <ssd:Annotations>
---             <ssd:Annotation type="org.openmodelica">
+--             <ssc:Annotation type="org.openmodelica">
 --                 <oms:SimulationInformation>
 --                     <oms:TlmMaster ip="" managerport="0" monitorport="0" />
 --                 </oms:SimulationInformation>
---             </ssd:Annotation>
+--             </ssc:Annotation>
 --         </ssd:Annotations>
 --         <ssd:Connectors />
 --         <ssd:Elements>
 --             <ssd:System name="foo2">
 --                 <ssd:Annotations>
---                     <ssd:Annotation type="org.openmodelica">
+--                     <ssc:Annotation type="org.openmodelica">
 --                         <oms:SimulationInformation>
 --                             <oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
 --                         </oms:SimulationInformation>
---                     </ssd:Annotation>
+--                     </ssc:Annotation>
 --                 </ssd:Annotations>
 --                 <ssd:Connectors>
 --                     <ssd:Connector name="f" kind="input">
@@ -401,7 +401,7 @@ printStatus(status, 0)
 --                 <ssd:Elements />
 --                 <ssd:Connections />
 --                 <ssd:Annotations>
---                     <ssd:Annotation type="org.openmodelica">
+--                     <ssc:Annotation type="org.openmodelica">
 --                         <oms:Bus name="bus">
 --                             <oms:Signals>
 --                                 <oms:Signal name="u1" />
@@ -415,16 +415,16 @@ printStatus(status, 0)
 --                                 <oms:Signal name="x" type="state" />
 --                             </oms:Signals>
 --                         </oms:Bus>
---                     </ssd:Annotation>
+--                     </ssc:Annotation>
 --                 </ssd:Annotations>
 --             </ssd:System>
 --             <ssd:System name="foo">
 --                 <ssd:Annotations>
---                     <ssd:Annotation type="org.openmodelica">
+--                     <ssc:Annotation type="org.openmodelica">
 --                         <oms:SimulationInformation>
 --                             <oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
 --                         </oms:SimulationInformation>
---                     </ssd:Annotation>
+--                     </ssc:Annotation>
 --                 </ssd:Annotations>
 --                 <ssd:Connectors>
 --                     <ssd:Connector name="f" kind="input">
@@ -446,11 +446,11 @@ printStatus(status, 0)
 --                 <ssd:Elements>
 --                     <ssd:System name="goo">
 --                         <ssd:Annotations>
---                             <ssd:Annotation type="org.openmodelica">
+--                             <ssc:Annotation type="org.openmodelica">
 --                                 <oms:SimulationInformation>
 --                                     <oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
 --                                 </oms:SimulationInformation>
---                             </ssd:Annotation>
+--                             </ssc:Annotation>
 --                         </ssd:Annotations>
 --                         <ssd:Connectors />
 --                         <ssd:Elements />
@@ -485,7 +485,7 @@ printStatus(status, 0)
 --                 </ssd:Elements>
 --                 <ssd:Connections />
 --                 <ssd:Annotations>
---                     <ssd:Annotation type="org.openmodelica">
+--                     <ssc:Annotation type="org.openmodelica">
 --                         <oms:Bus name="bus">
 --                             <oms:Signals>
 --                                 <oms:Signal name="y1" />
@@ -499,7 +499,7 @@ printStatus(status, 0)
 --                                 <oms:Signal name="x" type="state" />
 --                             </oms:Signals>
 --                         </oms:Bus>
---                     </ssd:Annotation>
+--                     </ssc:Annotation>
 --                 </ssd:Annotations>
 --             </ssd:System>
 --         </ssd:Elements>
@@ -508,19 +508,19 @@ printStatus(status, 0)
 --             <ssd:Connection startElement="foo" startConnector="y2" endElement="foo2" endConnector="u2" />
 --         </ssd:Connections>
 --         <ssd:Annotations>
---             <ssd:Annotation type="org.openmodelica">
+--             <ssc:Annotation type="org.openmodelica">
 --                 <oms:Connections>
 --                     <oms:Connection startElement="foo" startConnector="tlm" endElement="foo2" endConnector="tlm" delay="0.001000" alpha="0.300000" linearimpedance="100.000000" angularimpedance="0.000000" />
 --                     <oms:Connection startElement="foo" startConnector="bus" endElement="foo2" endConnector="bus" />
 --                 </oms:Connections>
---             </ssd:Annotation>
+--             </ssc:Annotation>
 --         </ssd:Annotations>
 --     </ssd:System>
 --     <ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
 --         <ssd:Annotations>
---             <ssd:Annotation type="org.openmodelica">
+--             <ssc:Annotation type="org.openmodelica">
 --                 <oms:SimulationInformation resultFile="test_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter="" />
---             </ssd:Annotation>
+--             </ssc:Annotation>
 --         </ssd:Annotations>
 --     </ssd:DefaultExperiment>
 -- </ssd:SystemStructureDescription>

--- a/testsuite/OMSimulator/import_export.py
+++ b/testsuite/OMSimulator/import_export.py
@@ -196,21 +196,21 @@ printStatus(status, 0)
 ## <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="test" version="1.0">
 ##     <ssd:System name="eoo">
 ##         <ssd:Annotations>
-##             <ssd:Annotation type="org.openmodelica">
+##             <ssc:Annotation type="org.openmodelica">
 ##                 <oms:SimulationInformation>
 ##                     <oms:TlmMaster ip="127.0.1.1" managerport="11111" monitorport="11121" />
 ##                 </oms:SimulationInformation>
-##             </ssd:Annotation>
+##             </ssc:Annotation>
 ##         </ssd:Annotations>
 ##         <ssd:Connectors />
 ##         <ssd:Elements>
 ##             <ssd:System name="foo2">
 ##                 <ssd:Annotations>
-##                     <ssd:Annotation type="org.openmodelica">
+##                     <ssc:Annotation type="org.openmodelica">
 ##                         <oms:SimulationInformation>
 ##                             <oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
 ##                         </oms:SimulationInformation>
-##                     </ssd:Annotation>
+##                     </ssc:Annotation>
 ##                 </ssd:Annotations>
 ##                 <ssd:Connectors>
 ##                     <ssd:Connector name="f" kind="input">
@@ -232,7 +232,7 @@ printStatus(status, 0)
 ##                 <ssd:Elements />
 ##                 <ssd:Connections />
 ##                 <ssd:Annotations>
-##                     <ssd:Annotation type="org.openmodelica">
+##                     <ssc:Annotation type="org.openmodelica">
 ##                         <oms:Bus name="bus">
 ##                             <oms:Signals>
 ##                                 <oms:Signal name="u1" />
@@ -246,16 +246,16 @@ printStatus(status, 0)
 ##                                 <oms:Signal name="x" type="state" />
 ##                             </oms:Signals>
 ##                         </oms:Bus>
-##                     </ssd:Annotation>
+##                     </ssc:Annotation>
 ##                 </ssd:Annotations>
 ##             </ssd:System>
 ##             <ssd:System name="foo">
 ##                 <ssd:Annotations>
-##                     <ssd:Annotation type="org.openmodelica">
+##                     <ssc:Annotation type="org.openmodelica">
 ##                         <oms:SimulationInformation>
 ##                             <oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
 ##                         </oms:SimulationInformation>
-##                     </ssd:Annotation>
+##                     </ssc:Annotation>
 ##                 </ssd:Annotations>
 ##                 <ssd:Connectors>
 ##                     <ssd:Connector name="f" kind="input">
@@ -277,11 +277,11 @@ printStatus(status, 0)
 ##                 <ssd:Elements>
 ##                     <ssd:System name="goo">
 ##                         <ssd:Annotations>
-##                             <ssd:Annotation type="org.openmodelica">
+##                             <ssc:Annotation type="org.openmodelica">
 ##                                 <oms:SimulationInformation>
 ##                                     <oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
 ##                                 </oms:SimulationInformation>
-##                             </ssd:Annotation>
+##                             </ssc:Annotation>
 ##                         </ssd:Annotations>
 ##                         <ssd:Connectors />
 ##                         <ssd:Elements />
@@ -316,7 +316,7 @@ printStatus(status, 0)
 ##                 </ssd:Elements>
 ##                 <ssd:Connections />
 ##                 <ssd:Annotations>
-##                     <ssd:Annotation type="org.openmodelica">
+##                     <ssc:Annotation type="org.openmodelica">
 ##                         <oms:Bus name="bus">
 ##                             <oms:Signals>
 ##                                 <oms:Signal name="y1" />
@@ -330,7 +330,7 @@ printStatus(status, 0)
 ##                                 <oms:Signal name="x" type="state" />
 ##                             </oms:Signals>
 ##                         </oms:Bus>
-##                     </ssd:Annotation>
+##                     </ssc:Annotation>
 ##                 </ssd:Annotations>
 ##             </ssd:System>
 ##         </ssd:Elements>
@@ -339,19 +339,19 @@ printStatus(status, 0)
 ##             <ssd:Connection startElement="foo" startConnector="y2" endElement="foo2" endConnector="u2" />
 ##         </ssd:Connections>
 ##         <ssd:Annotations>
-##             <ssd:Annotation type="org.openmodelica">
+##             <ssc:Annotation type="org.openmodelica">
 ##                 <oms:Connections>
 ##                     <oms:Connection startElement="foo" startConnector="tlm" endElement="foo2" endConnector="tlm" delay="0.001000" alpha="0.300000" linearimpedance="100.000000" angularimpedance="0.000000" />
 ##                     <oms:Connection startElement="foo" startConnector="bus" endElement="foo2" endConnector="bus" />
 ##                 </oms:Connections>
-##             </ssd:Annotation>
+##             </ssc:Annotation>
 ##         </ssd:Annotations>
 ##     </ssd:System>
 ##     <ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
 ##         <ssd:Annotations>
-##             <ssd:Annotation type="org.openmodelica">
+##             <ssc:Annotation type="org.openmodelica">
 ##                 <oms:SimulationInformation resultFile="test_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter="" />
-##             </ssd:Annotation>
+##             </ssc:Annotation>
 ##         </ssd:Annotations>
 ##     </ssd:DefaultExperiment>
 ## </ssd:SystemStructureDescription>

--- a/testsuite/OMSimulator/import_export.py
+++ b/testsuite/OMSimulator/import_export.py
@@ -364,21 +364,21 @@ printStatus(status, 0)
 ## <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="test" version="1.0">
 ##     <ssd:System name="eoo">
 ##         <ssd:Annotations>
-##             <ssd:Annotation type="org.openmodelica">
+##             <ssc:Annotation type="org.openmodelica">
 ##                 <oms:SimulationInformation>
 ##                     <oms:TlmMaster ip="" managerport="0" monitorport="0" />
 ##                 </oms:SimulationInformation>
-##             </ssd:Annotation>
+##             </ssc:Annotation>
 ##         </ssd:Annotations>
 ##         <ssd:Connectors />
 ##         <ssd:Elements>
 ##             <ssd:System name="foo2">
 ##                 <ssd:Annotations>
-##                     <ssd:Annotation type="org.openmodelica">
+##                     <ssc:Annotation type="org.openmodelica">
 ##                         <oms:SimulationInformation>
 ##                             <oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
 ##                         </oms:SimulationInformation>
-##                     </ssd:Annotation>
+##                     </ssc:Annotation>
 ##                 </ssd:Annotations>
 ##                 <ssd:Connectors>
 ##                     <ssd:Connector name="f" kind="input">
@@ -400,7 +400,7 @@ printStatus(status, 0)
 ##                 <ssd:Elements />
 ##                 <ssd:Connections />
 ##                 <ssd:Annotations>
-##                     <ssd:Annotation type="org.openmodelica">
+##                     <ssc:Annotation type="org.openmodelica">
 ##                         <oms:Bus name="bus">
 ##                             <oms:Signals>
 ##                                 <oms:Signal name="u1" />
@@ -414,16 +414,16 @@ printStatus(status, 0)
 ##                                 <oms:Signal name="x" type="state" />
 ##                             </oms:Signals>
 ##                         </oms:Bus>
-##                     </ssd:Annotation>
+##                     </ssc:Annotation>
 ##                 </ssd:Annotations>
 ##             </ssd:System>
 ##             <ssd:System name="foo">
 ##                 <ssd:Annotations>
-##                     <ssd:Annotation type="org.openmodelica">
+##                     <ssc:Annotation type="org.openmodelica">
 ##                         <oms:SimulationInformation>
 ##                             <oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
 ##                         </oms:SimulationInformation>
-##                     </ssd:Annotation>
+##                     </ssc:Annotation>
 ##                 </ssd:Annotations>
 ##                 <ssd:Connectors>
 ##                     <ssd:Connector name="f" kind="input">
@@ -445,11 +445,11 @@ printStatus(status, 0)
 ##                 <ssd:Elements>
 ##                     <ssd:System name="goo">
 ##                         <ssd:Annotations>
-##                             <ssd:Annotation type="org.openmodelica">
+##                             <ssc:Annotation type="org.openmodelica">
 ##                                 <oms:SimulationInformation>
 ##                                     <oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
 ##                                 </oms:SimulationInformation>
-##                             </ssd:Annotation>
+##                             </ssc:Annotation>
 ##                         </ssd:Annotations>
 ##                         <ssd:Connectors />
 ##                         <ssd:Elements />
@@ -484,7 +484,7 @@ printStatus(status, 0)
 ##                 </ssd:Elements>
 ##                 <ssd:Connections />
 ##                 <ssd:Annotations>
-##                     <ssd:Annotation type="org.openmodelica">
+##                     <ssc:Annotation type="org.openmodelica">
 ##                         <oms:Bus name="bus">
 ##                             <oms:Signals>
 ##                                 <oms:Signal name="y1" />
@@ -498,7 +498,7 @@ printStatus(status, 0)
 ##                                 <oms:Signal name="x" type="state" />
 ##                             </oms:Signals>
 ##                         </oms:Bus>
-##                     </ssd:Annotation>
+##                     </ssc:Annotation>
 ##                 </ssd:Annotations>
 ##             </ssd:System>
 ##         </ssd:Elements>
@@ -507,19 +507,19 @@ printStatus(status, 0)
 ##             <ssd:Connection startElement="foo" startConnector="y2" endElement="foo2" endConnector="u2" />
 ##         </ssd:Connections>
 ##         <ssd:Annotations>
-##             <ssd:Annotation type="org.openmodelica">
+##             <ssc:Annotation type="org.openmodelica">
 ##                 <oms:Connections>
 ##                     <oms:Connection startElement="foo" startConnector="tlm" endElement="foo2" endConnector="tlm" delay="0.001000" alpha="0.300000" linearimpedance="100.000000" angularimpedance="0.000000" />
 ##                     <oms:Connection startElement="foo" startConnector="bus" endElement="foo2" endConnector="bus" />
 ##                 </oms:Connections>
-##             </ssd:Annotation>
+##             </ssc:Annotation>
 ##         </ssd:Annotations>
 ##     </ssd:System>
 ##     <ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
 ##         <ssd:Annotations>
-##             <ssd:Annotation type="org.openmodelica">
+##             <ssc:Annotation type="org.openmodelica">
 ##                 <oms:SimulationInformation resultFile="test_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter="" />
-##             </ssd:Annotation>
+##             </ssc:Annotation>
 ##         </ssd:Annotations>
 ##     </ssd:DefaultExperiment>
 ## </ssd:SystemStructureDescription>

--- a/testsuite/OMSimulator/import_export_parameters_inline.lua
+++ b/testsuite/OMSimulator/import_export_parameters_inline.lua
@@ -122,11 +122,11 @@ oms_delete("import_export_parameters")
 -- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="import_export_parameters" version="1.0">
 -- 	<ssd:System name="co_sim">
 -- 		<ssd:Annotations>
--- 			<ssd:Annotation type="org.openmodelica">
+-- 			<ssc:Annotation type="org.openmodelica">
 -- 				<oms:SimulationInformation>
 -- 					<oms:FixedStepMaster description="oms-ma" stepSize="0.001000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
 -- 				</oms:SimulationInformation>
--- 			</ssd:Annotation>
+-- 			</ssc:Annotation>
 -- 		</ssd:Annotations>
 -- 		<ssd:Connectors>
 -- 			<ssd:Connector name="Input_cref" kind="input">
@@ -164,11 +164,11 @@ oms_delete("import_export_parameters")
 -- 		<ssd:Elements>
 -- 			<ssd:System name="foo">
 -- 				<ssd:Annotations>
--- 					<ssd:Annotation type="org.openmodelica">
+-- 					<ssc:Annotation type="org.openmodelica">
 -- 						<oms:SimulationInformation>
 -- 							<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
 -- 						</oms:SimulationInformation>
--- 					</ssd:Annotation>
+-- 					</ssc:Annotation>
 -- 				</ssd:Annotations>
 -- 				<ssd:Connectors>
 -- 					<ssd:Connector name="F_cref" kind="parameter">
@@ -296,9 +296,9 @@ oms_delete("import_export_parameters")
 -- 	</ssd:System>
 -- 	<ssd:DefaultExperiment startTime="0.000000" stopTime="4.000000">
 -- 		<ssd:Annotations>
--- 			<ssd:Annotation type="org.openmodelica">
+-- 			<ssc:Annotation type="org.openmodelica">
 -- 				<oms:SimulationInformation resultFile="import_export_parameters_inline.mat" loggingInterval="0.000000" bufferSize="100" signalFilter="" />
--- 			</ssd:Annotation>
+-- 			</ssc:Annotation>
 -- 		</ssd:Annotations>
 -- 	</ssd:DefaultExperiment>
 -- </ssd:SystemStructureDescription>

--- a/testsuite/OMSimulator/import_export_parameters_to_ssv.lua
+++ b/testsuite/OMSimulator/import_export_parameters_to_ssv.lua
@@ -122,11 +122,11 @@ oms_delete("import_export_parameters")
 -- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="import_export_parameters" version="1.0">
 -- 	<ssd:System name="co_sim">
 -- 		<ssd:Annotations>
--- 			<ssd:Annotation type="org.openmodelica">
+-- 			<ssc:Annotation type="org.openmodelica">
 -- 				<oms:SimulationInformation>
 -- 					<oms:FixedStepMaster description="oms-ma" stepSize="0.001000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
 -- 				</oms:SimulationInformation>
--- 			</ssd:Annotation>
+-- 			</ssc:Annotation>
 -- 		</ssd:Annotations>
 -- 		<ssd:Connectors>
 -- 			<ssd:Connector name="Input_cref" kind="input">
@@ -148,11 +148,11 @@ oms_delete("import_export_parameters")
 -- 		<ssd:Elements>
 -- 			<ssd:System name="foo">
 -- 				<ssd:Annotations>
--- 					<ssd:Annotation type="org.openmodelica">
+-- 					<ssc:Annotation type="org.openmodelica">
 -- 						<oms:SimulationInformation>
 -- 							<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
 -- 						</oms:SimulationInformation>
--- 					</ssd:Annotation>
+-- 					</ssc:Annotation>
 -- 				</ssd:Annotations>
 -- 				<ssd:Connectors>
 -- 					<ssd:Connector name="F_cref" kind="parameter">
@@ -238,9 +238,9 @@ oms_delete("import_export_parameters")
 -- 	</ssd:System>
 -- 	<ssd:DefaultExperiment startTime="0.000000" stopTime="4.000000">
 -- 		<ssd:Annotations>
--- 			<ssd:Annotation type="org.openmodelica">
+-- 			<ssc:Annotation type="org.openmodelica">
 -- 				<oms:SimulationInformation resultFile="import_export_parameters.mat" loggingInterval="0.000000" bufferSize="100" signalFilter="" />
--- 			</ssd:Annotation>
+-- 			</ssc:Annotation>
 -- 		</ssd:Annotations>
 -- 	</ssd:DefaultExperiment>
 -- </ssd:SystemStructureDescription>

--- a/testsuite/api/buses.lua
+++ b/testsuite/api/buses.lua
@@ -106,21 +106,21 @@ printStatus(status, 0)
 -- <?xml version="1.0"?>
 -- <ssd:System name="tlm">
 -- 	<ssd:Annotations>
--- 		<ssd:Annotation type="org.openmodelica">
+-- 		<ssc:Annotation type="org.openmodelica">
 -- 			<oms:SimulationInformation>
 -- 				<oms:TlmMaster ip="" managerport="0" monitorport="0" />
 -- 			</oms:SimulationInformation>
--- 		</ssd:Annotation>
+-- 		</ssc:Annotation>
 -- 	</ssd:Annotations>
 -- 	<ssd:Connectors />
 -- 	<ssd:Elements>
 -- 		<ssd:System name="wc2">
 -- 			<ssd:Annotations>
--- 				<ssd:Annotation type="org.openmodelica">
+-- 				<ssc:Annotation type="org.openmodelica">
 -- 					<oms:SimulationInformation>
 -- 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
 -- 					</oms:SimulationInformation>
--- 				</ssd:Annotation>
+-- 				</ssc:Annotation>
 -- 			</ssd:Annotations>
 -- 			<ssd:Connectors>
 -- 				<ssd:Connector name="y1" kind="output">
@@ -136,23 +136,23 @@ printStatus(status, 0)
 -- 			<ssd:Elements />
 -- 			<ssd:Connections />
 -- 			<ssd:Annotations>
--- 				<ssd:Annotation type="org.openmodelica">
+-- 				<ssc:Annotation type="org.openmodelica">
 -- 					<oms:Bus name="bus2">
 -- 						<oms:Signals>
 -- 							<oms:Signal name="y1" />
 -- 							<oms:Signal name="y2" />
 -- 						</oms:Signals>
 -- 					</oms:Bus>
--- 				</ssd:Annotation>
+-- 				</ssc:Annotation>
 -- 			</ssd:Annotations>
 -- 		</ssd:System>
 -- 		<ssd:System name="wc1">
 -- 			<ssd:Annotations>
--- 				<ssd:Annotation type="org.openmodelica">
+-- 				<ssc:Annotation type="org.openmodelica">
 -- 					<oms:SimulationInformation>
 -- 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
 -- 					</oms:SimulationInformation>
--- 				</ssd:Annotation>
+-- 				</ssc:Annotation>
 -- 			</ssd:Annotations>
 -- 			<ssd:Connectors>
 -- 				<ssd:Connector name="u1" kind="input">
@@ -168,7 +168,7 @@ printStatus(status, 0)
 -- 			<ssd:Elements />
 -- 			<ssd:Connections />
 -- 			<ssd:Annotations>
--- 				<ssd:Annotation type="org.openmodelica">
+-- 				<ssc:Annotation type="org.openmodelica">
 -- 					<oms:Bus name="bus1">
 -- 						<oms:Signals>
 -- 							<oms:Signal name="u1" />
@@ -176,7 +176,7 @@ printStatus(status, 0)
 -- 							<oms:Signal name="y" />
 -- 						</oms:Signals>
 -- 					</oms:Bus>
--- 				</ssd:Annotation>
+-- 				</ssc:Annotation>
 -- 			</ssd:Annotations>
 -- 		</ssd:System>
 -- 	</ssd:Elements>
@@ -185,11 +185,11 @@ printStatus(status, 0)
 -- 		<ssd:Connection startElement="wc2" startConnector="y2" endElement="wc1" endConnector="u2" />
 -- 	</ssd:Connections>
 -- 	<ssd:Annotations>
--- 		<ssd:Annotation type="org.openmodelica">
+-- 		<ssc:Annotation type="org.openmodelica">
 -- 			<oms:Connections>
 -- 				<oms:Connection startElement="wc1" startConnector="bus1" endElement="wc2" endConnector="bus2" />
 -- 			</oms:Connections>
--- 		</ssd:Annotation>
+-- 		</ssc:Annotation>
 -- 	</ssd:Annotations>
 -- </ssd:System>
 -- 
@@ -197,21 +197,21 @@ printStatus(status, 0)
 -- <?xml version="1.0"?>
 -- <ssd:System name="tlm">
 -- 	<ssd:Annotations>
--- 		<ssd:Annotation type="org.openmodelica">
+-- 		<ssc:Annotation type="org.openmodelica">
 -- 			<oms:SimulationInformation>
 -- 				<oms:TlmMaster ip="" managerport="0" monitorport="0" />
 -- 			</oms:SimulationInformation>
--- 		</ssd:Annotation>
+-- 		</ssc:Annotation>
 -- 	</ssd:Annotations>
 -- 	<ssd:Connectors />
 -- 	<ssd:Elements>
 -- 		<ssd:System name="wc2">
 -- 			<ssd:Annotations>
--- 				<ssd:Annotation type="org.openmodelica">
+-- 				<ssc:Annotation type="org.openmodelica">
 -- 					<oms:SimulationInformation>
 -- 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
 -- 					</oms:SimulationInformation>
--- 				</ssd:Annotation>
+-- 				</ssc:Annotation>
 -- 			</ssd:Annotations>
 -- 			<ssd:Connectors>
 -- 				<ssd:Connector name="y1" kind="output">
@@ -227,23 +227,23 @@ printStatus(status, 0)
 -- 			<ssd:Elements />
 -- 			<ssd:Connections />
 -- 			<ssd:Annotations>
--- 				<ssd:Annotation type="org.openmodelica">
+-- 				<ssc:Annotation type="org.openmodelica">
 -- 					<oms:Bus name="bus2">
 -- 						<oms:Signals>
 -- 							<oms:Signal name="y1" />
 -- 							<oms:Signal name="y2" />
 -- 						</oms:Signals>
 -- 					</oms:Bus>
--- 				</ssd:Annotation>
+-- 				</ssc:Annotation>
 -- 			</ssd:Annotations>
 -- 		</ssd:System>
 -- 		<ssd:System name="wc1">
 -- 			<ssd:Annotations>
--- 				<ssd:Annotation type="org.openmodelica">
+-- 				<ssc:Annotation type="org.openmodelica">
 -- 					<oms:SimulationInformation>
 -- 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
 -- 					</oms:SimulationInformation>
--- 				</ssd:Annotation>
+-- 				</ssc:Annotation>
 -- 			</ssd:Annotations>
 -- 			<ssd:Connectors>
 -- 				<ssd:Connector name="u1" kind="input">
@@ -259,14 +259,14 @@ printStatus(status, 0)
 -- 			<ssd:Elements />
 -- 			<ssd:Connections />
 -- 			<ssd:Annotations>
--- 				<ssd:Annotation type="org.openmodelica">
+-- 				<ssc:Annotation type="org.openmodelica">
 -- 					<oms:Bus name="bus1">
 -- 						<oms:Signals>
 -- 							<oms:Signal name="u1" />
 -- 							<oms:Signal name="u2" />
 -- 						</oms:Signals>
 -- 					</oms:Bus>
--- 				</ssd:Annotation>
+-- 				</ssc:Annotation>
 -- 			</ssd:Annotations>
 -- 		</ssd:System>
 -- 	</ssd:Elements>
@@ -275,11 +275,11 @@ printStatus(status, 0)
 -- 		<ssd:Connection startElement="wc2" startConnector="y2" endElement="wc1" endConnector="u2" />
 -- 	</ssd:Connections>
 -- 	<ssd:Annotations>
--- 		<ssd:Annotation type="org.openmodelica">
+-- 		<ssc:Annotation type="org.openmodelica">
 -- 			<oms:Connections>
 -- 				<oms:Connection startElement="wc1" startConnector="bus1" endElement="wc2" endConnector="bus2" />
 -- 			</oms:Connections>
--- 		</ssd:Annotation>
+-- 		</ssc:Annotation>
 -- 	</ssd:Annotations>
 -- </ssd:System>
 -- 

--- a/testsuite/api/buses.py
+++ b/testsuite/api/buses.py
@@ -105,21 +105,21 @@ printStatus(status, 0)
 ## <?xml version="1.0"?>
 ## <ssd:System name="tlm">
 ## 	<ssd:Annotations>
-## 		<ssd:Annotation type="org.openmodelica">
+## 		<ssc:Annotation type="org.openmodelica">
 ## 			<oms:SimulationInformation>
 ## 				<oms:TlmMaster ip="" managerport="0" monitorport="0" />
 ## 			</oms:SimulationInformation>
-## 		</ssd:Annotation>
+## 		</ssc:Annotation>
 ## 	</ssd:Annotations>
 ## 	<ssd:Connectors />
 ## 	<ssd:Elements>
 ## 		<ssd:System name="wc2">
 ## 			<ssd:Annotations>
-## 				<ssd:Annotation type="org.openmodelica">
+## 				<ssc:Annotation type="org.openmodelica">
 ## 					<oms:SimulationInformation>
 ## 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
 ## 					</oms:SimulationInformation>
-## 				</ssd:Annotation>
+## 				</ssc:Annotation>
 ## 			</ssd:Annotations>
 ## 			<ssd:Connectors>
 ## 				<ssd:Connector name="y1" kind="output">
@@ -135,23 +135,23 @@ printStatus(status, 0)
 ## 			<ssd:Elements />
 ## 			<ssd:Connections />
 ## 			<ssd:Annotations>
-## 				<ssd:Annotation type="org.openmodelica">
+## 				<ssc:Annotation type="org.openmodelica">
 ## 					<oms:Bus name="bus2">
 ## 						<oms:Signals>
 ## 							<oms:Signal name="y1" />
 ## 							<oms:Signal name="y2" />
 ## 						</oms:Signals>
 ## 					</oms:Bus>
-## 				</ssd:Annotation>
+## 				</ssc:Annotation>
 ## 			</ssd:Annotations>
 ## 		</ssd:System>
 ## 		<ssd:System name="wc1">
 ## 			<ssd:Annotations>
-## 				<ssd:Annotation type="org.openmodelica">
+## 				<ssc:Annotation type="org.openmodelica">
 ## 					<oms:SimulationInformation>
 ## 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
 ## 					</oms:SimulationInformation>
-## 				</ssd:Annotation>
+## 				</ssc:Annotation>
 ## 			</ssd:Annotations>
 ## 			<ssd:Connectors>
 ## 				<ssd:Connector name="u1" kind="input">
@@ -167,7 +167,7 @@ printStatus(status, 0)
 ## 			<ssd:Elements />
 ## 			<ssd:Connections />
 ## 			<ssd:Annotations>
-## 				<ssd:Annotation type="org.openmodelica">
+## 				<ssc:Annotation type="org.openmodelica">
 ## 					<oms:Bus name="bus1">
 ## 						<oms:Signals>
 ## 							<oms:Signal name="u1" />
@@ -175,7 +175,7 @@ printStatus(status, 0)
 ## 							<oms:Signal name="y" />
 ## 						</oms:Signals>
 ## 					</oms:Bus>
-## 				</ssd:Annotation>
+## 				</ssc:Annotation>
 ## 			</ssd:Annotations>
 ## 		</ssd:System>
 ## 	</ssd:Elements>
@@ -184,11 +184,11 @@ printStatus(status, 0)
 ## 		<ssd:Connection startElement="wc2" startConnector="y2" endElement="wc1" endConnector="u2" />
 ## 	</ssd:Connections>
 ## 	<ssd:Annotations>
-## 		<ssd:Annotation type="org.openmodelica">
+## 		<ssc:Annotation type="org.openmodelica">
 ## 			<oms:Connections>
 ## 				<oms:Connection startElement="wc1" startConnector="bus1" endElement="wc2" endConnector="bus2" />
 ## 			</oms:Connections>
-## 		</ssd:Annotation>
+## 		</ssc:Annotation>
 ## 	</ssd:Annotations>
 ## </ssd:System>
 ## 
@@ -196,21 +196,21 @@ printStatus(status, 0)
 ## <?xml version="1.0"?>
 ## <ssd:System name="tlm">
 ## 	<ssd:Annotations>
-## 		<ssd:Annotation type="org.openmodelica">
+## 		<ssc:Annotation type="org.openmodelica">
 ## 			<oms:SimulationInformation>
 ## 				<oms:TlmMaster ip="" managerport="0" monitorport="0" />
 ## 			</oms:SimulationInformation>
-## 		</ssd:Annotation>
+## 		</ssc:Annotation>
 ## 	</ssd:Annotations>
 ## 	<ssd:Connectors />
 ## 	<ssd:Elements>
 ## 		<ssd:System name="wc2">
 ## 			<ssd:Annotations>
-## 				<ssd:Annotation type="org.openmodelica">
+## 				<ssc:Annotation type="org.openmodelica">
 ## 					<oms:SimulationInformation>
 ## 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
 ## 					</oms:SimulationInformation>
-## 				</ssd:Annotation>
+## 				</ssc:Annotation>
 ## 			</ssd:Annotations>
 ## 			<ssd:Connectors>
 ## 				<ssd:Connector name="y1" kind="output">
@@ -226,23 +226,23 @@ printStatus(status, 0)
 ## 			<ssd:Elements />
 ## 			<ssd:Connections />
 ## 			<ssd:Annotations>
-## 				<ssd:Annotation type="org.openmodelica">
+## 				<ssc:Annotation type="org.openmodelica">
 ## 					<oms:Bus name="bus2">
 ## 						<oms:Signals>
 ## 							<oms:Signal name="y1" />
 ## 							<oms:Signal name="y2" />
 ## 						</oms:Signals>
 ## 					</oms:Bus>
-## 				</ssd:Annotation>
+## 				</ssc:Annotation>
 ## 			</ssd:Annotations>
 ## 		</ssd:System>
 ## 		<ssd:System name="wc1">
 ## 			<ssd:Annotations>
-## 				<ssd:Annotation type="org.openmodelica">
+## 				<ssc:Annotation type="org.openmodelica">
 ## 					<oms:SimulationInformation>
 ## 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
 ## 					</oms:SimulationInformation>
-## 				</ssd:Annotation>
+## 				</ssc:Annotation>
 ## 			</ssd:Annotations>
 ## 			<ssd:Connectors>
 ## 				<ssd:Connector name="u1" kind="input">
@@ -258,14 +258,14 @@ printStatus(status, 0)
 ## 			<ssd:Elements />
 ## 			<ssd:Connections />
 ## 			<ssd:Annotations>
-## 				<ssd:Annotation type="org.openmodelica">
+## 				<ssc:Annotation type="org.openmodelica">
 ## 					<oms:Bus name="bus1">
 ## 						<oms:Signals>
 ## 							<oms:Signal name="u1" />
 ## 							<oms:Signal name="u2" />
 ## 						</oms:Signals>
 ## 					</oms:Bus>
-## 				</ssd:Annotation>
+## 				</ssc:Annotation>
 ## 			</ssd:Annotations>
 ## 		</ssd:System>
 ## 	</ssd:Elements>
@@ -274,11 +274,11 @@ printStatus(status, 0)
 ## 		<ssd:Connection startElement="wc2" startConnector="y2" endElement="wc1" endConnector="u2" />
 ## 	</ssd:Connections>
 ## 	<ssd:Annotations>
-## 		<ssd:Annotation type="org.openmodelica">
+## 		<ssc:Annotation type="org.openmodelica">
 ## 			<oms:Connections>
 ## 				<oms:Connection startElement="wc1" startConnector="bus1" endElement="wc2" endConnector="bus2" />
 ## 			</oms:Connections>
-## 		</ssd:Annotation>
+## 		</ssc:Annotation>
 ## 	</ssd:Annotations>
 ## </ssd:System>
 ## 

--- a/testsuite/api/connections.lua
+++ b/testsuite/api/connections.lua
@@ -95,21 +95,21 @@ printStatus(status, 0)
 -- <?xml version="1.0"?>
 -- <ssd:System name="wc">
 -- 	<ssd:Annotations>
--- 		<ssd:Annotation type="org.openmodelica">
+-- 		<ssc:Annotation type="org.openmodelica">
 -- 			<oms:SimulationInformation>
 -- 				<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
 -- 			</oms:SimulationInformation>
--- 		</ssd:Annotation>
+-- 		</ssc:Annotation>
 -- 	</ssd:Annotations>
 -- 	<ssd:Connectors />
 -- 	<ssd:Elements>
 -- 		<ssd:System name="sc2">
 -- 			<ssd:Annotations>
--- 				<ssd:Annotation type="org.openmodelica">
+-- 				<ssc:Annotation type="org.openmodelica">
 -- 					<oms:SimulationInformation>
 -- 						<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
 -- 					</oms:SimulationInformation>
--- 				</ssd:Annotation>
+-- 				</ssc:Annotation>
 -- 			</ssd:Annotations>
 -- 			<ssd:Connectors>
 -- 				<ssd:Connector name="y1" kind="output">
@@ -127,11 +127,11 @@ printStatus(status, 0)
 -- 		</ssd:System>
 -- 		<ssd:System name="sc1">
 -- 			<ssd:Annotations>
--- 				<ssd:Annotation type="org.openmodelica">
+-- 				<ssc:Annotation type="org.openmodelica">
 -- 					<oms:SimulationInformation>
 -- 						<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
 -- 					</oms:SimulationInformation>
--- 				</ssd:Annotation>
+-- 				</ssc:Annotation>
 -- 			</ssd:Annotations>
 -- 			<ssd:Connectors>
 -- 				<ssd:Connector name="u1" kind="input">
@@ -157,21 +157,21 @@ printStatus(status, 0)
 -- <?xml version="1.0"?>
 -- <ssd:System name="wc">
 -- 	<ssd:Annotations>
--- 		<ssd:Annotation type="org.openmodelica">
+-- 		<ssc:Annotation type="org.openmodelica">
 -- 			<oms:SimulationInformation>
 -- 				<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
 -- 			</oms:SimulationInformation>
--- 		</ssd:Annotation>
+-- 		</ssc:Annotation>
 -- 	</ssd:Annotations>
 -- 	<ssd:Connectors />
 -- 	<ssd:Elements>
 -- 		<ssd:System name="sc2">
 -- 			<ssd:Annotations>
--- 				<ssd:Annotation type="org.openmodelica">
+-- 				<ssc:Annotation type="org.openmodelica">
 -- 					<oms:SimulationInformation>
 -- 						<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
 -- 					</oms:SimulationInformation>
--- 				</ssd:Annotation>
+-- 				</ssc:Annotation>
 -- 			</ssd:Annotations>
 -- 			<ssd:Connectors>
 -- 				<ssd:Connector name="y1" kind="output">
@@ -189,11 +189,11 @@ printStatus(status, 0)
 -- 		</ssd:System>
 -- 		<ssd:System name="sc1">
 -- 			<ssd:Annotations>
--- 				<ssd:Annotation type="org.openmodelica">
+-- 				<ssc:Annotation type="org.openmodelica">
 -- 					<oms:SimulationInformation>
 -- 						<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
 -- 					</oms:SimulationInformation>
--- 				</ssd:Annotation>
+-- 				</ssc:Annotation>
 -- 			</ssd:Annotations>
 -- 			<ssd:Connectors>
 -- 				<ssd:Connector name="u1" kind="input">

--- a/testsuite/api/connections.py
+++ b/testsuite/api/connections.py
@@ -95,21 +95,21 @@ printStatus(status, 0)
 ## <?xml version="1.0"?>
 ## <ssd:System name="wc">
 ## 	<ssd:Annotations>
-## 		<ssd:Annotation type="org.openmodelica">
+## 		<ssc:Annotation type="org.openmodelica">
 ## 			<oms:SimulationInformation>
 ## 				<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
 ## 			</oms:SimulationInformation>
-## 		</ssd:Annotation>
+## 		</ssc:Annotation>
 ## 	</ssd:Annotations>
 ## 	<ssd:Connectors />
 ## 	<ssd:Elements>
 ## 		<ssd:System name="sc2">
 ## 			<ssd:Annotations>
-## 				<ssd:Annotation type="org.openmodelica">
+## 				<ssc:Annotation type="org.openmodelica">
 ## 					<oms:SimulationInformation>
 ## 						<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
 ## 					</oms:SimulationInformation>
-## 				</ssd:Annotation>
+## 				</ssc:Annotation>
 ## 			</ssd:Annotations>
 ## 			<ssd:Connectors>
 ## 				<ssd:Connector name="y1" kind="output">
@@ -127,11 +127,11 @@ printStatus(status, 0)
 ## 		</ssd:System>
 ## 		<ssd:System name="sc1">
 ## 			<ssd:Annotations>
-## 				<ssd:Annotation type="org.openmodelica">
+## 				<ssc:Annotation type="org.openmodelica">
 ## 					<oms:SimulationInformation>
 ## 						<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
 ## 					</oms:SimulationInformation>
-## 				</ssd:Annotation>
+## 				</ssc:Annotation>
 ## 			</ssd:Annotations>
 ## 			<ssd:Connectors>
 ## 				<ssd:Connector name="u1" kind="input">
@@ -157,21 +157,21 @@ printStatus(status, 0)
 ## <?xml version="1.0"?>
 ## <ssd:System name="wc">
 ## 	<ssd:Annotations>
-## 		<ssd:Annotation type="org.openmodelica">
+## 		<ssc:Annotation type="org.openmodelica">
 ## 			<oms:SimulationInformation>
 ## 				<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
 ## 			</oms:SimulationInformation>
-## 		</ssd:Annotation>
+## 		</ssc:Annotation>
 ## 	</ssd:Annotations>
 ## 	<ssd:Connectors />
 ## 	<ssd:Elements>
 ## 		<ssd:System name="sc2">
 ## 			<ssd:Annotations>
-## 				<ssd:Annotation type="org.openmodelica">
+## 				<ssc:Annotation type="org.openmodelica">
 ## 					<oms:SimulationInformation>
 ## 						<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
 ## 					</oms:SimulationInformation>
-## 				</ssd:Annotation>
+## 				</ssc:Annotation>
 ## 			</ssd:Annotations>
 ## 			<ssd:Connectors>
 ## 				<ssd:Connector name="y1" kind="output">
@@ -189,11 +189,11 @@ printStatus(status, 0)
 ## 		</ssd:System>
 ## 		<ssd:System name="sc1">
 ## 			<ssd:Annotations>
-## 				<ssd:Annotation type="org.openmodelica">
+## 				<ssc:Annotation type="org.openmodelica">
 ## 					<oms:SimulationInformation>
 ## 						<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
 ## 					</oms:SimulationInformation>
-## 				</ssd:Annotation>
+## 				</ssc:Annotation>
 ## 			</ssd:Annotations>
 ## 			<ssd:Connectors>
 ## 				<ssd:Connector name="u1" kind="input">

--- a/testsuite/api/test01.lua
+++ b/testsuite/api/test01.lua
@@ -90,11 +90,11 @@ printStatus(status, 3)
 -- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="test" version="1.0">
 -- 	<ssd:System name="foo">
 -- 		<ssd:Annotations>
--- 			<ssd:Annotation type="org.openmodelica">
+-- 			<ssc:Annotation type="org.openmodelica">
 -- 				<oms:SimulationInformation>
 -- 					<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
 -- 				</oms:SimulationInformation>
--- 			</ssd:Annotation>
+-- 			</ssc:Annotation>
 -- 		</ssd:Annotations>
 -- 		<ssd:Connectors />
 -- 		<ssd:Elements>
@@ -115,9 +115,9 @@ printStatus(status, 3)
 -- 	</ssd:System>
 -- 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
 -- 		<ssd:Annotations>
--- 			<ssd:Annotation type="org.openmodelica">
+-- 			<ssc:Annotation type="org.openmodelica">
 -- 				<oms:SimulationInformation resultFile="test_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter="" />
--- 			</ssd:Annotation>
+-- 			</ssc:Annotation>
 -- 		</ssd:Annotations>
 -- 	</ssd:DefaultExperiment>
 -- </ssd:SystemStructureDescription>
@@ -125,21 +125,21 @@ printStatus(status, 3)
 -- <?xml version="1.0"?>
 -- <ssd:System name="foo">
 -- 	<ssd:Annotations>
--- 		<ssd:Annotation type="org.openmodelica">
+-- 		<ssc:Annotation type="org.openmodelica">
 -- 			<oms:SimulationInformation>
 -- 				<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
 -- 			</oms:SimulationInformation>
--- 		</ssd:Annotation>
+-- 		</ssc:Annotation>
 -- 	</ssd:Annotations>
 -- 	<ssd:Connectors />
 -- 	<ssd:Elements>
 -- 		<ssd:System name="goo">
 -- 			<ssd:Annotations>
--- 				<ssd:Annotation type="org.openmodelica">
+-- 				<ssc:Annotation type="org.openmodelica">
 -- 					<oms:SimulationInformation>
 -- 						<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
 -- 					</oms:SimulationInformation>
--- 				</ssd:Annotation>
+-- 				</ssc:Annotation>
 -- 			</ssd:Annotations>
 -- 			<ssd:Connectors />
 -- 			<ssd:Elements />
@@ -152,11 +152,11 @@ printStatus(status, 3)
 -- <?xml version="1.0"?>
 -- <ssd:System name="goo">
 -- 	<ssd:Annotations>
--- 		<ssd:Annotation type="org.openmodelica">
+-- 		<ssc:Annotation type="org.openmodelica">
 -- 			<oms:SimulationInformation>
 -- 				<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
 -- 			</oms:SimulationInformation>
--- 		</ssd:Annotation>
+-- 		</ssc:Annotation>
 -- 	</ssd:Annotations>
 -- 	<ssd:Connectors />
 -- 	<ssd:Elements />
@@ -173,10 +173,10 @@ printStatus(status, 3)
 -- <?xml version="1.0"?>
 -- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="test" version="1.0">
 -- 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
--- 		<ssd:Annotations>
+-- 		<ssc:Annotations>
 -- 			<ssd:Annotation type="org.openmodelica">
 -- 				<oms:SimulationInformation resultFile="test_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter="" />
--- 			</ssd:Annotation>
+-- 			</ssc:Annotation>
 -- 		</ssd:Annotations>
 -- 	</ssd:DefaultExperiment>
 -- </ssd:SystemStructureDescription>

--- a/testsuite/api/test01.lua
+++ b/testsuite/api/test01.lua
@@ -100,11 +100,11 @@ printStatus(status, 3)
 -- 		<ssd:Elements>
 -- 			<ssd:System name="goo">
 -- 				<ssd:Annotations>
--- 					<ssd:Annotation type="org.openmodelica">
+-- 					<ssc:Annotation type="org.openmodelica">
 -- 						<oms:SimulationInformation>
 -- 							<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
 -- 						</oms:SimulationInformation>
--- 					</ssd:Annotation>
+-- 					</ssc:Annotation>
 -- 				</ssd:Annotations>
 -- 				<ssd:Connectors />
 -- 				<ssd:Elements />
@@ -173,8 +173,8 @@ printStatus(status, 3)
 -- <?xml version="1.0"?>
 -- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="test" version="1.0">
 -- 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
--- 		<ssc:Annotations>
--- 			<ssd:Annotation type="org.openmodelica">
+-- 		<ssd:Annotations>
+-- 			<ssc:Annotation type="org.openmodelica">
 -- 				<oms:SimulationInformation resultFile="test_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter="" />
 -- 			</ssc:Annotation>
 -- 		</ssd:Annotations>

--- a/testsuite/api/test01.py
+++ b/testsuite/api/test01.py
@@ -89,21 +89,21 @@ printStatus(status, 3)
 ## <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="test" version="1.0">
 ## 	<ssd:System name="foo">
 ## 		<ssd:Annotations>
-## 			<ssd:Annotation type="org.openmodelica">
+## 			<ssc:Annotation type="org.openmodelica">
 ## 				<oms:SimulationInformation>
 ## 					<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
 ## 				</oms:SimulationInformation>
-## 			</ssd:Annotation>
+## 			</ssc:Annotation>
 ## 		</ssd:Annotations>
 ## 		<ssd:Connectors />
 ## 		<ssd:Elements>
 ## 			<ssd:System name="goo">
 ## 				<ssd:Annotations>
-## 					<ssd:Annotation type="org.openmodelica">
+## 					<ssc:Annotation type="org.openmodelica">
 ## 						<oms:SimulationInformation>
 ## 							<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
 ## 						</oms:SimulationInformation>
-## 					</ssd:Annotation>
+## 					</ssc:Annotation>
 ## 				</ssd:Annotations>
 ## 				<ssd:Connectors />
 ## 				<ssd:Elements />
@@ -114,9 +114,9 @@ printStatus(status, 3)
 ## 	</ssd:System>
 ## 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
 ## 		<ssd:Annotations>
-## 			<ssd:Annotation type="org.openmodelica">
+## 			<ssc:Annotation type="org.openmodelica">
 ## 				<oms:SimulationInformation resultFile="test_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter="" />
-## 			</ssd:Annotation>
+## 			</ssc:Annotation>
 ## 		</ssd:Annotations>
 ## 	</ssd:DefaultExperiment>
 ## </ssd:SystemStructureDescription>
@@ -124,21 +124,21 @@ printStatus(status, 3)
 ## <?xml version="1.0"?>
 ## <ssd:System name="foo">
 ## 	<ssd:Annotations>
-## 		<ssd:Annotation type="org.openmodelica">
+## 		<ssc:Annotation type="org.openmodelica">
 ## 			<oms:SimulationInformation>
 ## 				<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
 ## 			</oms:SimulationInformation>
-## 		</ssd:Annotation>
+## 		</ssc:Annotation>
 ## 	</ssd:Annotations>
 ## 	<ssd:Connectors />
 ## 	<ssd:Elements>
 ## 		<ssd:System name="goo">
 ## 			<ssd:Annotations>
-## 				<ssd:Annotation type="org.openmodelica">
+## 				<ssc:Annotation type="org.openmodelica">
 ## 					<oms:SimulationInformation>
 ## 						<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
 ## 					</oms:SimulationInformation>
-## 				</ssd:Annotation>
+## 				</ssc:Annotation>
 ## 			</ssd:Annotations>
 ## 			<ssd:Connectors />
 ## 			<ssd:Elements />
@@ -151,11 +151,11 @@ printStatus(status, 3)
 ## <?xml version="1.0"?>
 ## <ssd:System name="goo">
 ## 	<ssd:Annotations>
-## 		<ssd:Annotation type="org.openmodelica">
+## 		<ssc:Annotation type="org.openmodelica">
 ## 			<oms:SimulationInformation>
 ## 				<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
 ## 			</oms:SimulationInformation>
-## 		</ssd:Annotation>
+## 		</ssc:Annotation>
 ## 	</ssd:Annotations>
 ## 	<ssd:Connectors />
 ## 	<ssd:Elements />
@@ -173,9 +173,9 @@ printStatus(status, 3)
 ## <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="test" version="1.0">
 ## 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
 ## 		<ssd:Annotations>
-## 			<ssd:Annotation type="org.openmodelica">
+## 			<ssc:Annotation type="org.openmodelica">
 ## 				<oms:SimulationInformation resultFile="test_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter="" />
-## 			</ssd:Annotation>
+## 			</ssc:Annotation>
 ## 		</ssd:Annotations>
 ## 	</ssd:DefaultExperiment>
 ## </ssd:SystemStructureDescription>

--- a/testsuite/api/test03.lua
+++ b/testsuite/api/test03.lua
@@ -78,7 +78,7 @@ oms_delete("test")
 -- 		</ssd:Annotations>
 -- 		<ssd:Connectors />
 -- 		<ssd:Elements>
--- 			<ssd:Component name="source" type="application/x-fmu-sharedlibrary" source="resources\0001_source.fmu">
+-- 			<ssd:Component name="source" type="application/x-fmu-sharedlibrary" source="resources/0001_source.fmu">
 -- 				<ssd:Connectors>
 -- 					<ssd:Connector name="y" kind="output">
 -- 						<ssc:Real />
@@ -127,7 +127,7 @@ oms_delete("test")
 -- 		</ssd:Annotations>
 -- 		<ssd:Connectors />
 -- 		<ssd:Elements>
--- 			<ssd:Component name="source" type="application/x-fmu-sharedlibrary" source="resources\0001_source.fmu">
+-- 			<ssd:Component name="source" type="application/x-fmu-sharedlibrary" source="resources/0001_source.fmu">
 -- 				<ssd:Connectors>
 -- 					<ssd:Connector name="y" kind="output">
 -- 						<ssc:Real />

--- a/testsuite/api/test03.lua
+++ b/testsuite/api/test03.lua
@@ -70,15 +70,15 @@ oms_delete("test")
 -- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="test" version="1.0">
 -- 	<ssd:System name="eoo">
 -- 		<ssd:Annotations>
--- 			<ssd:Annotation type="org.openmodelica">
+-- 			<ssc:Annotation type="org.openmodelica">
 -- 				<oms:SimulationInformation>
 -- 					<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
 -- 				</oms:SimulationInformation>
--- 			</ssd:Annotation>
+-- 			</ssc:Annotation>
 -- 		</ssd:Annotations>
 -- 		<ssd:Connectors />
 -- 		<ssd:Elements>
--- 			<ssd:Component name="source" type="application/x-fmu-sharedlibrary" source="resources/0001_source.fmu">
+-- 			<ssd:Component name="source" type="application/x-fmu-sharedlibrary" source="resources\0001_source.fmu">
 -- 				<ssd:Connectors>
 -- 					<ssd:Connector name="y" kind="output">
 -- 						<ssc:Real />
@@ -106,9 +106,9 @@ oms_delete("test")
 -- 	</ssd:System>
 -- 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
 -- 		<ssd:Annotations>
--- 			<ssd:Annotation type="org.openmodelica">
+-- 			<ssc:Annotation type="org.openmodelica">
 -- 				<oms:SimulationInformation resultFile="test_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter="" />
--- 			</ssd:Annotation>
+-- 			</ssc:Annotation>
 -- 		</ssd:Annotations>
 -- 	</ssd:DefaultExperiment>
 -- </ssd:SystemStructureDescription>
@@ -119,15 +119,15 @@ oms_delete("test")
 -- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="test" version="1.0">
 -- 	<ssd:System name="eoo">
 -- 		<ssd:Annotations>
--- 			<ssd:Annotation type="org.openmodelica">
+-- 			<ssc:Annotation type="org.openmodelica">
 -- 				<oms:SimulationInformation>
 -- 					<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
 -- 				</oms:SimulationInformation>
--- 			</ssd:Annotation>
+-- 			</ssc:Annotation>
 -- 		</ssd:Annotations>
 -- 		<ssd:Connectors />
 -- 		<ssd:Elements>
--- 			<ssd:Component name="source" type="application/x-fmu-sharedlibrary" source="resources/0001_source.fmu">
+-- 			<ssd:Component name="source" type="application/x-fmu-sharedlibrary" source="resources\0001_source.fmu">
 -- 				<ssd:Connectors>
 -- 					<ssd:Connector name="y" kind="output">
 -- 						<ssc:Real />
@@ -155,9 +155,9 @@ oms_delete("test")
 -- 	</ssd:System>
 -- 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
 -- 		<ssd:Annotations>
--- 			<ssd:Annotation type="org.openmodelica">
+-- 			<ssc:Annotation type="org.openmodelica">
 -- 				<oms:SimulationInformation resultFile="test_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter="" />
--- 			</ssd:Annotation>
+-- 			</ssc:Annotation>
 -- 		</ssd:Annotations>
 -- 	</ssd:DefaultExperiment>
 -- </ssd:SystemStructureDescription>

--- a/testsuite/api/test_omsExport.lua
+++ b/testsuite/api/test_omsExport.lua
@@ -63,11 +63,11 @@ printStatus(status, 0)
 -- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="model" version="1.0">
 -- 	<ssd:System name="sc">
 -- 		<ssd:Annotations>
--- 			<ssd:Annotation type="org.openmodelica">
+-- 			<ssc:Annotation type="org.openmodelica">
 -- 				<oms:SimulationInformation>
 -- 					<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
 -- 				</oms:SimulationInformation>
--- 			</ssd:Annotation>
+-- 			</ssc:Annotation>
 -- 		</ssd:Annotations>
 -- 		<ssd:Connectors />
 -- 		<ssd:Elements />
@@ -75,9 +75,9 @@ printStatus(status, 0)
 -- 	</ssd:System>
 -- 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
 -- 		<ssd:Annotations>
--- 			<ssd:Annotation type="org.openmodelica">
+-- 			<ssc:Annotation type="org.openmodelica">
 -- 				<oms:SimulationInformation resultFile="model_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter="[AB]" />
--- 			</ssd:Annotation>
+-- 			</ssc:Annotation>
 -- 		</ssd:Annotations>
 -- 	</ssd:DefaultExperiment>
 -- </ssd:SystemStructureDescription>
@@ -91,11 +91,11 @@ printStatus(status, 0)
 -- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="model" version="1.0">
 -- 	<ssd:System name="sc">
 -- 		<ssd:Annotations>
--- 			<ssd:Annotation type="org.openmodelica">
+-- 			<ssc:Annotation type="org.openmodelica">
 -- 				<oms:SimulationInformation>
 -- 					<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
 -- 				</oms:SimulationInformation>
--- 			</ssd:Annotation>
+-- 			</ssc:Annotation>
 -- 		</ssd:Annotations>
 -- 		<ssd:Connectors />
 -- 		<ssd:Elements />
@@ -103,9 +103,9 @@ printStatus(status, 0)
 -- 	</ssd:System>
 -- 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
 -- 		<ssd:Annotations>
--- 			<ssd:Annotation type="org.openmodelica">
+-- 			<ssc:Annotation type="org.openmodelica">
 -- 				<oms:SimulationInformation resultFile="model_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter="[AB]" />
--- 			</ssd:Annotation>
+-- 			</ssc:Annotation>
 -- 		</ssd:Annotations>
 -- 	</ssd:DefaultExperiment>
 -- </ssd:SystemStructureDescription>

--- a/testsuite/api/test_omsExport.py
+++ b/testsuite/api/test_omsExport.py
@@ -63,11 +63,11 @@ printStatus(status, 0)
 ## <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="model" version="1.0">
 ## 	<ssd:System name="sc">
 ## 		<ssd:Annotations>
-## 			<ssd:Annotation type="org.openmodelica">
+## 			<ssc:Annotation type="org.openmodelica">
 ## 				<oms:SimulationInformation>
 ## 					<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
 ## 				</oms:SimulationInformation>
-## 			</ssd:Annotation>
+## 			</ssc:Annotation>
 ## 		</ssd:Annotations>
 ## 		<ssd:Connectors />
 ## 		<ssd:Elements />
@@ -75,9 +75,9 @@ printStatus(status, 0)
 ## 	</ssd:System>
 ## 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
 ## 		<ssd:Annotations>
-## 			<ssd:Annotation type="org.openmodelica">
+## 			<ssc:Annotation type="org.openmodelica">
 ## 				<oms:SimulationInformation resultFile="model_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter="[AB]" />
-## 			</ssd:Annotation>
+## 			</ssc:Annotation>
 ## 		</ssd:Annotations>
 ## 	</ssd:DefaultExperiment>
 ## </ssd:SystemStructureDescription>
@@ -91,11 +91,11 @@ printStatus(status, 0)
 ## <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="model" version="1.0">
 ## 	<ssd:System name="sc">
 ## 		<ssd:Annotations>
-## 			<ssd:Annotation type="org.openmodelica">
+## 			<ssc:Annotation type="org.openmodelica">
 ## 				<oms:SimulationInformation>
 ## 					<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
 ## 				</oms:SimulationInformation>
-## 			</ssd:Annotation>
+## 			</ssc:Annotation>
 ## 		</ssd:Annotations>
 ## 		<ssd:Connectors />
 ## 		<ssd:Elements />
@@ -103,9 +103,9 @@ printStatus(status, 0)
 ## 	</ssd:System>
 ## 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
 ## 		<ssd:Annotations>
-## 			<ssd:Annotation type="org.openmodelica">
+## 			<ssc:Annotation type="org.openmodelica">
 ## 				<oms:SimulationInformation resultFile="model_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter="[AB]" />
-## 			</ssd:Annotation>
+## 			</ssc:Annotation>
 ## 		</ssd:Annotations>
 ## 	</ssd:DefaultExperiment>
 ## </ssd:SystemStructureDescription>

--- a/testsuite/tlm/externalmodels.lua
+++ b/testsuite/tlm/externalmodels.lua
@@ -53,24 +53,24 @@ printStatus(status, 0)
 -- <?xml version="1.0"?>
 -- <ssd:System name="tlm">
 -- 	<ssd:Annotations>
--- 		<ssd:Annotation type="org.openmodelica">
+-- 		<ssc:Annotation type="org.openmodelica">
 -- 			<oms:SimulationInformation>
 -- 				<oms:TlmMaster ip="" managerport="0" monitorport="0" />
 -- 			</oms:SimulationInformation>
--- 		</ssd:Annotation>
+-- 		</ssc:Annotation>
 -- 	</ssd:Annotations>
 -- 	<ssd:Connectors />
 -- 	<ssd:Elements>
 -- 		<ssd:Component name="external" source="resources/external.mo">
 -- 			<ssd:Annotations>
--- 				<ssd:Annotation type="org.openmodelica">
+-- 				<ssc:Annotation type="org.openmodelica">
 -- 					<oms:Bus name="tlmbus" type="tlm" domain="mechanical" dimensions="1" interpolation="none">
 -- 						<oms:Signals />
 -- 					</oms:Bus>
 -- 					<oms:SimulationInformation>
 -- 						<oms:ExternalModel startscript="resources/startscript.sh" />
 -- 					</oms:SimulationInformation>
--- 				</ssd:Annotation>
+-- 				</ssc:Annotation>
 -- 			</ssd:Annotations>
 -- 		</ssd:Component>
 -- 	</ssd:Elements>

--- a/testsuite/tlm/externalmodels.py
+++ b/testsuite/tlm/externalmodels.py
@@ -53,24 +53,24 @@ printStatus(status, 0)
 ## <?xml version="1.0"?>
 ## <ssd:System name="tlm">
 ## 	<ssd:Annotations>
-## 		<ssd:Annotation type="org.openmodelica">
+## 		<ssc:Annotation type="org.openmodelica">
 ## 			<oms:SimulationInformation>
 ## 				<oms:TlmMaster ip="" managerport="0" monitorport="0" />
 ## 			</oms:SimulationInformation>
-## 		</ssd:Annotation>
+## 		</ssc:Annotation>
 ## 	</ssd:Annotations>
 ## 	<ssd:Connectors />
 ## 	<ssd:Elements>
 ## 		<ssd:Component name="external" source="resources/external.mo">
 ## 			<ssd:Annotations>
-## 				<ssd:Annotation type="org.openmodelica">
+## 				<ssc:Annotation type="org.openmodelica">
 ## 					<oms:Bus name="tlmbus" type="tlm" domain="mechanical" dimensions="1" interpolation="none">
 ## 						<oms:Signals />
 ## 					</oms:Bus>
 ## 					<oms:SimulationInformation>
 ## 						<oms:ExternalModel startscript="resources/startscript.sh" />
 ## 					</oms:SimulationInformation>
-## 				</ssd:Annotation>
+## 				</ssc:Annotation>
 ## 			</ssd:Annotations>
 ## 		</ssd:Component>
 ## 	</ssd:Elements>

--- a/testsuite/tlm/tlmbuses.lua
+++ b/testsuite/tlm/tlmbuses.lua
@@ -111,21 +111,21 @@ printStatus(status, 0)
 -- <?xml version="1.0"?>
 -- <ssd:System name="tlm">
 -- 	<ssd:Annotations>
--- 		<ssd:Annotation type="org.openmodelica">
+-- 		<ssc:Annotation type="org.openmodelica">
 -- 			<oms:SimulationInformation>
 -- 				<oms:TlmMaster ip="127.0.1.1" managerport="11111" monitorport="11121" />
 -- 			</oms:SimulationInformation>
--- 		</ssd:Annotation>
+-- 		</ssc:Annotation>
 -- 	</ssd:Annotations>
 -- 	<ssd:Connectors />
 -- 	<ssd:Elements>
 -- 		<ssd:System name="wc2">
 -- 			<ssd:Annotations>
--- 				<ssd:Annotation type="org.openmodelica">
+-- 				<ssc:Annotation type="org.openmodelica">
 -- 					<oms:SimulationInformation>
 -- 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
 -- 					</oms:SimulationInformation>
--- 				</ssd:Annotation>
+-- 				</ssc:Annotation>
 -- 			</ssd:Annotations>
 -- 			<ssd:Connectors>
 -- 				<ssd:Connector name="y" kind="input">
@@ -144,22 +144,22 @@ printStatus(status, 0)
 -- 			<ssd:Elements />
 -- 			<ssd:Connections />
 -- 			<ssd:Annotations>
--- 				<ssd:Annotation type="org.openmodelica">
+-- 				<ssc:Annotation type="org.openmodelica">
 -- 					<oms:Bus name="bus2" type="tlm" domain="output" dimensions="1" interpolation="none">
 -- 						<oms:Signals>
 -- 							<oms:Signal name="y" type="value" />
 -- 						</oms:Signals>
 -- 					</oms:Bus>
--- 				</ssd:Annotation>
+-- 				</ssc:Annotation>
 -- 			</ssd:Annotations>
 -- 		</ssd:System>
 -- 		<ssd:System name="wc1">
 -- 			<ssd:Annotations>
--- 				<ssd:Annotation type="org.openmodelica">
+-- 				<ssc:Annotation type="org.openmodelica">
 -- 					<oms:SimulationInformation>
 -- 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
 -- 					</oms:SimulationInformation>
--- 				</ssd:Annotation>
+-- 				</ssc:Annotation>
 -- 			</ssd:Annotations>
 -- 			<ssd:Connectors>
 -- 				<ssd:Connector name="y" kind="output">
@@ -178,7 +178,7 @@ printStatus(status, 0)
 -- 			<ssd:Elements />
 -- 			<ssd:Connections />
 -- 			<ssd:Annotations>
--- 				<ssd:Annotation type="org.openmodelica">
+-- 				<ssc:Annotation type="org.openmodelica">
 -- 					<oms:Bus name="bus1" type="tlm" domain="input" dimensions="1" interpolation="none">
 -- 						<oms:Signals>
 -- 							<oms:Signal name="y" type="value" />
@@ -191,17 +191,17 @@ printStatus(status, 0)
 -- 							<oms:Signal name="x" type="state" />
 -- 						</oms:Signals>
 -- 					</oms:Bus>
--- 				</ssd:Annotation>
+-- 				</ssc:Annotation>
 -- 			</ssd:Annotations>
 -- 		</ssd:System>
 -- 	</ssd:Elements>
 -- 	<ssd:Connections />
 -- 	<ssd:Annotations>
--- 		<ssd:Annotation type="org.openmodelica">
+-- 		<ssc:Annotation type="org.openmodelica">
 -- 			<oms:Connections>
 -- 				<oms:Connection startElement="wc1" startConnector="bus1" endElement="wc2" endConnector="bus2" delay="0.001000" alpha="0.300000" linearimpedance="100.000000" angularimpedance="0.000000" />
 -- 			</oms:Connections>
--- 		</ssd:Annotation>
+-- 		</ssc:Annotation>
 -- 	</ssd:Annotations>
 -- </ssd:System>
 -- 
@@ -209,21 +209,21 @@ printStatus(status, 0)
 -- <?xml version="1.0"?>
 -- <ssd:System name="tlm">
 -- 	<ssd:Annotations>
--- 		<ssd:Annotation type="org.openmodelica">
+-- 		<ssc:Annotation type="org.openmodelica">
 -- 			<oms:SimulationInformation>
 -- 				<oms:TlmMaster ip="127.0.1.1" managerport="11111" monitorport="11121" />
 -- 			</oms:SimulationInformation>
--- 		</ssd:Annotation>
+-- 		</ssc:Annotation>
 -- 	</ssd:Annotations>
 -- 	<ssd:Connectors />
 -- 	<ssd:Elements>
 -- 		<ssd:System name="wc2">
 -- 			<ssd:Annotations>
--- 				<ssd:Annotation type="org.openmodelica">
+-- 				<ssc:Annotation type="org.openmodelica">
 -- 					<oms:SimulationInformation>
 -- 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
 -- 					</oms:SimulationInformation>
--- 				</ssd:Annotation>
+-- 				</ssc:Annotation>
 -- 			</ssd:Annotations>
 -- 			<ssd:Connectors>
 -- 				<ssd:Connector name="y" kind="input">
@@ -242,22 +242,22 @@ printStatus(status, 0)
 -- 			<ssd:Elements />
 -- 			<ssd:Connections />
 -- 			<ssd:Annotations>
--- 				<ssd:Annotation type="org.openmodelica">
+-- 				<ssc:Annotation type="org.openmodelica">
 -- 					<oms:Bus name="bus2" type="tlm" domain="output" dimensions="1" interpolation="none">
 -- 						<oms:Signals>
 -- 							<oms:Signal name="y" type="value" />
 -- 						</oms:Signals>
 -- 					</oms:Bus>
--- 				</ssd:Annotation>
+-- 				</ssc:Annotation>
 -- 			</ssd:Annotations>
 -- 		</ssd:System>
 -- 		<ssd:System name="wc1">
 -- 			<ssd:Annotations>
--- 				<ssd:Annotation type="org.openmodelica">
+-- 				<ssc:Annotation type="org.openmodelica">
 -- 					<oms:SimulationInformation>
 -- 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
 -- 					</oms:SimulationInformation>
--- 				</ssd:Annotation>
+-- 				</ssc:Annotation>
 -- 			</ssd:Annotations>
 -- 			<ssd:Connectors>
 -- 				<ssd:Connector name="y" kind="output">
@@ -276,7 +276,7 @@ printStatus(status, 0)
 -- 			<ssd:Elements />
 -- 			<ssd:Connections />
 -- 			<ssd:Annotations>
--- 				<ssd:Annotation type="org.openmodelica">
+-- 				<ssc:Annotation type="org.openmodelica">
 -- 					<oms:Bus name="bus1" type="tlm" domain="input" dimensions="1" interpolation="none">
 -- 						<oms:Signals>
 -- 							<oms:Signal name="y" type="value" />
@@ -288,17 +288,17 @@ printStatus(status, 0)
 -- 							<oms:Signal name="v" type="flow" />
 -- 						</oms:Signals>
 -- 					</oms:Bus>
--- 				</ssd:Annotation>
+-- 				</ssc:Annotation>
 -- 			</ssd:Annotations>
 -- 		</ssd:System>
 -- 	</ssd:Elements>
 -- 	<ssd:Connections />
 -- 	<ssd:Annotations>
--- 		<ssd:Annotation type="org.openmodelica">
+-- 		<ssc:Annotation type="org.openmodelica">
 -- 			<oms:Connections>
 -- 				<oms:Connection startElement="wc1" startConnector="bus1" endElement="wc2" endConnector="bus2" delay="0.001000" alpha="0.300000" linearimpedance="100.000000" angularimpedance="0.000000" />
 -- 			</oms:Connections>
--- 		</ssd:Annotation>
+-- 		</ssc:Annotation>
 -- 	</ssd:Annotations>
 -- </ssd:System>
 -- 

--- a/testsuite/tlm/tlmbuses.py
+++ b/testsuite/tlm/tlmbuses.py
@@ -111,21 +111,21 @@ printStatus(status, 0)
 ## <?xml version="1.0"?>
 ## <ssd:System name="tlm">
 ## 	<ssd:Annotations>
-## 		<ssd:Annotation type="org.openmodelica">
+## 		<ssc:Annotation type="org.openmodelica">
 ## 			<oms:SimulationInformation>
 ## 				<oms:TlmMaster ip="127.0.1.1" managerport="11111" monitorport="11121" />
 ## 			</oms:SimulationInformation>
-## 		</ssd:Annotation>
+## 		</ssc:Annotation>
 ## 	</ssd:Annotations>
 ## 	<ssd:Connectors />
 ## 	<ssd:Elements>
 ## 		<ssd:System name="wc2">
 ## 			<ssd:Annotations>
-## 				<ssd:Annotation type="org.openmodelica">
+## 				<ssc:Annotation type="org.openmodelica">
 ## 					<oms:SimulationInformation>
 ## 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
 ## 					</oms:SimulationInformation>
-## 				</ssd:Annotation>
+## 				</ssc:Annotation>
 ## 			</ssd:Annotations>
 ## 			<ssd:Connectors>
 ## 				<ssd:Connector name="y" kind="input">
@@ -144,22 +144,22 @@ printStatus(status, 0)
 ## 			<ssd:Elements />
 ## 			<ssd:Connections />
 ## 			<ssd:Annotations>
-## 				<ssd:Annotation type="org.openmodelica">
+## 				<ssc:Annotation type="org.openmodelica">
 ## 					<oms:Bus name="bus2" type="tlm" domain="output" dimensions="1" interpolation="none">
 ## 						<oms:Signals>
 ## 							<oms:Signal name="y" type="value" />
 ## 						</oms:Signals>
 ## 					</oms:Bus>
-## 				</ssd:Annotation>
+## 				</ssc:Annotation>
 ## 			</ssd:Annotations>
 ## 		</ssd:System>
 ## 		<ssd:System name="wc1">
 ## 			<ssd:Annotations>
-## 				<ssd:Annotation type="org.openmodelica">
+## 				<ssc:Annotation type="org.openmodelica">
 ## 					<oms:SimulationInformation>
 ## 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
 ## 					</oms:SimulationInformation>
-## 				</ssd:Annotation>
+## 				</ssc:Annotation>
 ## 			</ssd:Annotations>
 ## 			<ssd:Connectors>
 ## 				<ssd:Connector name="y" kind="output">
@@ -178,7 +178,7 @@ printStatus(status, 0)
 ## 			<ssd:Elements />
 ## 			<ssd:Connections />
 ## 			<ssd:Annotations>
-## 				<ssd:Annotation type="org.openmodelica">
+## 				<ssc:Annotation type="org.openmodelica">
 ## 					<oms:Bus name="bus1" type="tlm" domain="input" dimensions="1" interpolation="none">
 ## 						<oms:Signals>
 ## 							<oms:Signal name="y" type="value" />
@@ -191,17 +191,17 @@ printStatus(status, 0)
 ## 							<oms:Signal name="x" type="state" />
 ## 						</oms:Signals>
 ## 					</oms:Bus>
-## 				</ssd:Annotation>
+## 				</ssc:Annotation>
 ## 			</ssd:Annotations>
 ## 		</ssd:System>
 ## 	</ssd:Elements>
 ## 	<ssd:Connections />
 ## 	<ssd:Annotations>
-## 		<ssd:Annotation type="org.openmodelica">
+## 		<ssc:Annotation type="org.openmodelica">
 ## 			<oms:Connections>
 ## 				<oms:Connection startElement="wc1" startConnector="bus1" endElement="wc2" endConnector="bus2" delay="0.001000" alpha="0.300000" linearimpedance="100.000000" angularimpedance="0.000000" />
 ## 			</oms:Connections>
-## 		</ssd:Annotation>
+## 		</ssc:Annotation>
 ## 	</ssd:Annotations>
 ## </ssd:System>
 ## 
@@ -209,21 +209,21 @@ printStatus(status, 0)
 ## <?xml version="1.0"?>
 ## <ssd:System name="tlm">
 ## 	<ssd:Annotations>
-## 		<ssd:Annotation type="org.openmodelica">
+## 		<ssc:Annotation type="org.openmodelica">
 ## 			<oms:SimulationInformation>
 ## 				<oms:TlmMaster ip="127.0.1.1" managerport="11111" monitorport="11121" />
 ## 			</oms:SimulationInformation>
-## 		</ssd:Annotation>
+## 		</ssc:Annotation>
 ## 	</ssd:Annotations>
 ## 	<ssd:Connectors />
 ## 	<ssd:Elements>
 ## 		<ssd:System name="wc2">
 ## 			<ssd:Annotations>
-## 				<ssd:Annotation type="org.openmodelica">
+## 				<ssc:Annotation type="org.openmodelica">
 ## 					<oms:SimulationInformation>
 ## 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
 ## 					</oms:SimulationInformation>
-## 				</ssd:Annotation>
+## 				</ssc:Annotation>
 ## 			</ssd:Annotations>
 ## 			<ssd:Connectors>
 ## 				<ssd:Connector name="y" kind="input">
@@ -242,22 +242,22 @@ printStatus(status, 0)
 ## 			<ssd:Elements />
 ## 			<ssd:Connections />
 ## 			<ssd:Annotations>
-## 				<ssd:Annotation type="org.openmodelica">
+## 				<ssc:Annotation type="org.openmodelica">
 ## 					<oms:Bus name="bus2" type="tlm" domain="output" dimensions="1" interpolation="none">
 ## 						<oms:Signals>
 ## 							<oms:Signal name="y" type="value" />
 ## 						</oms:Signals>
 ## 					</oms:Bus>
-## 				</ssd:Annotation>
+## 				</ssc:Annotation>
 ## 			</ssd:Annotations>
 ## 		</ssd:System>
 ## 		<ssd:System name="wc1">
 ## 			<ssd:Annotations>
-## 				<ssd:Annotation type="org.openmodelica">
+## 				<ssc:Annotation type="org.openmodelica">
 ## 					<oms:SimulationInformation>
 ## 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
 ## 					</oms:SimulationInformation>
-## 				</ssd:Annotation>
+## 				</ssc:Annotation>
 ## 			</ssd:Annotations>
 ## 			<ssd:Connectors>
 ## 				<ssd:Connector name="y" kind="output">
@@ -276,7 +276,7 @@ printStatus(status, 0)
 ## 			<ssd:Elements />
 ## 			<ssd:Connections />
 ## 			<ssd:Annotations>
-## 				<ssd:Annotation type="org.openmodelica">
+## 				<ssc:Annotation type="org.openmodelica">
 ## 					<oms:Bus name="bus1" type="tlm" domain="input" dimensions="1" interpolation="none">
 ## 						<oms:Signals>
 ## 							<oms:Signal name="y" type="value" />
@@ -288,17 +288,17 @@ printStatus(status, 0)
 ## 							<oms:Signal name="v" type="flow" />
 ## 						</oms:Signals>
 ## 					</oms:Bus>
-## 				</ssd:Annotation>
+## 				</ssc:Annotation>
 ## 			</ssd:Annotations>
 ## 		</ssd:System>
 ## 	</ssd:Elements>
 ## 	<ssd:Connections />
 ## 	<ssd:Annotations>
-## 		<ssd:Annotation type="org.openmodelica">
+## 		<ssc:Annotation type="org.openmodelica">
 ## 			<oms:Connections>
 ## 				<oms:Connection startElement="wc1" startConnector="bus1" endElement="wc2" endConnector="bus2" delay="0.001000" alpha="0.300000" linearimpedance="100.000000" angularimpedance="0.000000" />
 ## 			</oms:Connections>
-## 		</ssd:Annotation>
+## 		</ssc:Annotation>
 ## 	</ssd:Annotations>
 ## </ssd:System>
 ## 


### PR DESCRIPTION
### Purpose

This PR fixes the bug in <ssd:annotation> which should be of type <ssc:annotation> according to SSP Specification

### example
 ```
<ssd:Annotations>
    <ssc:Annotation type="org.openmodelica">
        <oms:SimulationInformation>
            <oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
        </oms:SimulationInformation>
    </ssc:Annotation>
</ssd:Annotations>
```

