### PR TITLE
fix crefs in startValues

### DIFF
--- a/src/OMSimulatorLib/ComponentFMUCS.cpp
+++ b/src/OMSimulatorLib/ComponentFMUCS.cpp
@@ -479,15 +479,16 @@ oms_status_enu_t oms::ComponentFMUCS::instantiate()
 
 /*
  * function which returns validCrefs
- * (e.g). add.P => P
- * inline parameters should be returned as default value (e.g.) P => P
+ * (e.g) add.P => P
+ * (e.g) chassis.C.mChassis => C.mChassis
+ * inline parameters should be returned as default value (e.g.) P => P or C.mChassis => C.mChassis
  */
 oms::ComRef oms::ComponentFMUCS::getValidCref(ComRef cref)
 {
   oms::ComRef tail(cref);
   oms::ComRef head = tail.pop_front();
 
-  if (tail.isEmpty()) // check for inline parameter crefs, (e.g.) P => P
+  if (tail.isEmpty() || head != getCref()) // check for inline parameter crefs, (e.g.) P => P or C.mChassis => C.mChassis
     tail = cref;
   return tail;
 }

--- a/src/OMSimulatorLib/ComponentFMUME.cpp
+++ b/src/OMSimulatorLib/ComponentFMUME.cpp
@@ -499,15 +499,16 @@ oms_status_enu_t oms::ComponentFMUME::instantiate()
 
 /*
  * function which returns validCrefs
- * (e.g). add.P => P
- * inline parameters should be returned as default value (e.g.) P => P
+ * (e.g) add.P => P
+ * (e.g) chassis.C.mChassis => C.mChassis
+ * inline parameters should be returned as default value (e.g.) P => P or C.mChassis => C.mChassis
  */
 oms::ComRef oms::ComponentFMUME::getValidCref(ComRef cref)
 {
   oms::ComRef tail(cref);
   oms::ComRef head = tail.pop_front();
 
-  if (tail.isEmpty()) // check for inline parameter crefs, (e.g.) P => P
+  if (tail.isEmpty() || head != getCref()) // check for inline parameter crefs, (e.g.) P => P or C.mChassis => C.mChassis
     tail = cref;
   return tail;
 }

--- a/src/OMSimulatorLib/Parameters.cpp
+++ b/src/OMSimulatorLib/Parameters.cpp
@@ -138,6 +138,10 @@ oms_status_enu_t oms::Parameters::importFromSSD(const pugi::xml_node& node, cons
     else
     {
       // inline ParameterBindings
+      if (parameterBindingNode.child(oms::ssp::Version1_0::ssv::parameter_set))
+      {
+        logWarning("Wrong/deprecated content detected but successfully loaded. Please re-export the SSP file to avoid this message.");
+      }
       pugi::xml_node parameterValues = parameterBindingNode.child(oms::ssp::Version1_0::ssd::parameter_values);
       pugi::xml_node parameterSet = parameterValues.child(oms::ssp::Version1_0::ssv::parameter_set);
       std::string paramsetVersion = parameterSet.attribute("version").as_string();

--- a/src/OMSimulatorLib/System.cpp
+++ b/src/OMSimulatorLib/System.cpp
@@ -1814,7 +1814,7 @@ oms_status_enu_t oms::System::getReal(const ComRef& cref, double& value)
 
 /*
  * function which returns valid cref for which are needed to set StartValues
- * if ExportParametersInline is set return the defaule cref
+ * if ExportParametersInline is set return the default cref
  * else when importing from ssv , check for cref belongs to toplevel System or SubSystem
  */
 oms::ComRef oms::System::getValidCref(const ComRef& cref)


### PR DESCRIPTION
### Related Issues

https://github.com/OpenModelica/OMSimulator/issues/773
### Purpose

This PR fixes the crefs in startValues. Consider the below example

```
add.P => P  // correct
chassis.C.mChassis => C.mChassis  // correct
chassis.C.mChassis => mChassis  // wrong
```


