### PR TITLE
Rename the 3rdParty repository

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "3rdParty"]
 	path = 3rdParty
-	url = https://github.com/OpenModelica/OMFMISimulator-3rdParty.git
+	url = https://github.com/OpenModelica/OMSimulator-3rdParty.git
 [submodule "OMTLMSimulator"]
 	path = OMTLMSimulator
 	url = https://github.com/OpenModelica/OMTLMSimulator.git

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The latest documentation is avilable as [pdf](https://openmodelica.org/doc/OMSim
 - [cmake](http://www.cmake.org)
 - [Sphinx](http://www.sphinx-doc.org/en/stable/)
 - [readline (if using Lua)](http://git.savannah.gnu.org/cgit/readline.git)
-- [3rdParty subproject](https://github.com/OpenModelica/OMFMISimulator-3rdParty)
+- [3rdParty subproject](https://github.com/OpenModelica/OMSimulator-3rdParty)
   - FMILibrary
   - Lua
   - PugiXML


### PR DESCRIPTION
The old name of the 3rdParty repository was a bit confusing and is now shortened to `OMSimulator-3rdParty`.