### PR TITLE
use ctypes.CDLL to load the libraries

### DIFF
--- a/src/OMSimulatorPython/OMSimulator.py.in
+++ b/src/OMSimulatorPython/OMSimulator.py.in
@@ -1,13 +1,21 @@
-from ctypes import cdll
-import ctypes, sys, os
+from ctypes import CDLL
+import ctypes, sys, os, platform
 
 class OMSimulator:
   def __init__(self, omslib=None, temp_directory=None):
     if omslib is None:
       dirname = os.path.dirname(__file__)
-      self.obj=cdll.LoadLibrary(os.path.join(dirname, "@OMSIMULATORLIB_DIR_STRING@", "@OMSIMULATORLIB_STRING@"))
+      ## use CDLL instances for proper loading in Python versions > 3.8 as winmode=0 parameter is needed for proper loading in windows
+      if platform.python_version() >= "3.8":
+        self.obj=CDLL(os.path.join(dirname, "@OMSIMULATORLIB_DIR_STRING@", "@OMSIMULATORLIB_STRING@"), winmode=0)
+      else:
+        self.obj=CDLL(os.path.join(dirname, "@OMSIMULATORLIB_DIR_STRING@", "@OMSIMULATORLIB_STRING@"))
+      self.obj=CDLL(os.path.join(dirname, "@OMSIMULATORLIB_DIR_STRING@", "@OMSIMULATORLIB_STRING@"), winmode=0)
     else:
-      self.obj=cdll.LoadLibrary(omslib)
+      if platform.python_version() >= "3.8":
+        self.obj=CDLL(omslib, winmode=0)
+      else:
+        self.obj=CDLL(omslib)
 
     ## oms_status_enu_t
     self.status_ok = 0

--- a/src/OMSimulatorPython/OMSimulator.py.in
+++ b/src/OMSimulatorPython/OMSimulator.py.in
@@ -10,7 +10,6 @@ class OMSimulator:
         self.obj=CDLL(os.path.join(dirname, "@OMSIMULATORLIB_DIR_STRING@", "@OMSIMULATORLIB_STRING@"), winmode=0)
       else:
         self.obj=CDLL(os.path.join(dirname, "@OMSIMULATORLIB_DIR_STRING@", "@OMSIMULATORLIB_STRING@"))
-      self.obj=CDLL(os.path.join(dirname, "@OMSIMULATORLIB_DIR_STRING@", "@OMSIMULATORLIB_STRING@"), winmode=0)
     else:
       if platform.python_version() >= "3.8":
         self.obj=CDLL(omslib, winmode=0)


### PR DESCRIPTION
### Purpose

This PR fixes loading the dlls in python using ctypes.CDLL instances, as from python3.8 the loading of CDLL fails in windows  without the use of `winmode` parameter

### Reference

https://docs.python.org/3.8/library/ctypes.html?highlight=cdll#ctypes.CDLL