### PR TITLE
Fix path to find the omsimulator lib

### DIFF
--- a/src/OMSimulatorPython/OMSimulator.py.in
+++ b/src/OMSimulatorPython/OMSimulator.py.in
@@ -5,10 +5,7 @@ class OMSimulator:
   def __init__(self, omslib=None, temp_directory=None):
     if omslib is None:
       dirname = os.path.dirname(__file__)
-      if "@OMSIMULATORLIB_DIR_STRING@":
-        omslib = os.path.join(dirname, "@OMSIMULATORLIB_DIR_STRING@", "@OMSIMULATORLIB_STRING@")
-      else:
-        omslib = os.path.join(dirname, "..", "@OMSIMULATORLIB_STRING@")
+      omslib = os.path.join(dirname, "..", "@OMSIMULATORLIB_DIR_STRING@", "@OMSIMULATORLIB_STRING@")
 
     # Use CDLL instances with winmode=0 for proper loading in Python
     # versions > 3.8 as needed on Windows


### PR DESCRIPTION
### Related Issues

OMSimulatorPython3 doesn't find the lib when running from the OM superproject.