### PR TITLE
use absolute path to CSV Reader

### DIFF
--- a/src/OMSimulatorLib/ComponentTable.cpp
+++ b/src/OMSimulatorLib/ComponentTable.cpp
@@ -82,7 +82,7 @@ oms::Component* oms::ComponentTable::NewComponent(const oms::ComRef& cref, oms::
   if (parentSystem->copyResources())
     oms_copy_file(filesystem::path(path), absPath);
 
-  component->resultReader = ResultReader::newReader(path.c_str());
+  component->resultReader = ResultReader::newReader(absPath.string().c_str());
   if (!component->resultReader)
   {
     logError("Could not load lookup table: " + path);


### PR DESCRIPTION
### Related Issues

https://github.com/OpenModelica/OMSimulator/issues/749

### Purpose

This PR should fix  oms_loadSnapshot called before instantiation.










<!--- How does this change address the problem? -->
