### PR TITLE
Fix the snapshot functionality

### DIFF
--- a/src/OMSimulatorLib/Component.cpp
+++ b/src/OMSimulatorLib/Component.cpp
@@ -113,23 +113,6 @@ oms::Component::~Component()
     if (tlmbusconnector)
       delete tlmbusconnector;
 #endif
-
-  // delete temp directory
-  if (Flags::DeleteTempFiles())
-  {
-    if (!tempDir.empty() && filesystem::is_directory(tempDir))
-    {
-      try
-      {
-        filesystem::remove_all(tempDir);
-        logDebug("removed temp directory: \"" + tempDir + "\"");
-      }
-      catch (const std::exception& e)
-      {
-        logWarning("temp directory \"" + tempDir + "\" couldn't be removed\n" + e.what());
-      }
-    }
-  }
 }
 
 oms::ComRef oms::Component::getFullCref() const


### PR DESCRIPTION
### Related Issues

#749 

### Purpose

This is fixing the snapshot functionality for models with FMUs. The problem is that the temp directory for the FMUs get deleted if a snapshot could be loaded successfully.

### Approach

Just don't delete the temp directories 😄 They get now only removed if the entire model gets unloaded.
