### PR TITLE
support older solver tags in ssp

### DIFF
--- a/src/OMSimulatorLib/Model.cpp
+++ b/src/OMSimulatorLib/Model.cpp
@@ -495,38 +495,23 @@ oms_system_enu_t oms::Model::getSystemType(const pugi::xml_node& node, const std
 
 oms_system_enu_t oms::Model::getSystemTypeHelper(const pugi::xml_node& node, const std::string& sspVersion)
 {
-  const char* VariableStepSolver = "";
-  const char* FixedStepSolver = "";
-  const char* VariableStepMaster = "";
-  const char* FixedStepMaster = "";
-
-  if (sspVersion == "1.0")
-  {
-    VariableStepSolver = oms::ssp::Version1_0::VariableStepSolver;
-    FixedStepMaster = oms::ssp::Version1_0::FixedStepMaster;
-    // TODO check whether below two option exists
-    VariableStepMaster = "oms:VariableStepMaster";
-    FixedStepSolver = "oms:FixedStepSolver";
-  }
-  else
-  {
-
-    VariableStepSolver = "VariableStepSolver";
-    FixedStepMaster = "FixedStepMaster";
-    // TODO check whether below two option exists
-    VariableStepMaster = "VariableStepMaster";
-    FixedStepSolver = "FixedStepSolver";
-  }
-
   oms_system_enu_t systemType = oms_system_tlm;
-  if (std::string(node.child(VariableStepSolver).attribute("description").as_string()) != "")
+  if (node.child(oms::ssp::Version1_0::VariableStepSolver).attribute("description").as_string() != "" || node.child("VariableStepSolver").attribute("description").as_string() !="")
+  {
     systemType = oms_system_sc;
-  if (std::string(node.child(FixedStepSolver).attribute("description").as_string()) != "")
+  }
+  else if (node.child("oms:FixedStepSolver").attribute("description").as_string() != "" || node.child("FixedStepSolver").attribute("description").as_string() != "")
+  {
     systemType = oms_system_sc;
-  if (std::string(node.child(VariableStepMaster).attribute("description").as_string()) != "")
+  }
+  else if (node.child("oms:VariableStepMaster").attribute("description").as_string() != "" || node.child("VariableStepMaster").attribute("description").as_string() != "")
+  {
     systemType = oms_system_wc;
-  if (std::string(node.child(FixedStepMaster).attribute("description").as_string()) != "")
+  }
+  else if (node.child(oms::ssp::Version1_0::FixedStepMaster).attribute("description").as_string() != "" || node.child("FixedStepMaster").attribute("description").as_string() != "")
+  {
     systemType = oms_system_wc;
+  }
 
   return systemType;
 }

--- a/src/OMSimulatorLib/SystemSC.cpp
+++ b/src/OMSimulatorLib/SystemSC.cpp
@@ -162,9 +162,10 @@ oms_status_enu_t oms::SystemSC::importFromSSD_SimulationInformation(const pugi::
   std::string solverName = "";
   const char* VariableStepSolver = "";
 
-  if (sspVersion == "1.0")
+  pugi::xml_node variableStepSolver = node.child(oms::ssp::Version1_0::VariableStepSolver);
+  if (variableStepSolver)
   {
-    solverName = node.child(oms::ssp::Version1_0::VariableStepSolver).attribute("description").as_string();
+    solverName = variableStepSolver.attribute("description").as_string();
     VariableStepSolver = oms::ssp::Version1_0::VariableStepSolver;
   }
   else

--- a/src/OMSimulatorLib/SystemWC.cpp
+++ b/src/OMSimulatorLib/SystemWC.cpp
@@ -125,9 +125,11 @@ oms_status_enu_t oms::SystemWC::importFromSSD_SimulationInformation(const pugi::
 {
   std::string solverName = "";
   const char* FixedStepMaster = "";
-  if (sspVersion == "1.0")
+
+  pugi::xml_node fixedStepMaster = node.child(oms::ssp::Version1_0::FixedStepMaster);
+  if (fixedStepMaster)
   {
-    solverName = node.child(oms::ssp::Version1_0::FixedStepMaster).attribute("description").as_string();
+    solverName = fixedStepMaster.attribute("description").as_string();
     FixedStepMaster = oms::ssp::Version1_0::FixedStepMaster;
   }
   else


### PR DESCRIPTION
### Reference 

The example provided with issue https://github.com/OpenModelica/OMSimulator/issues/749 "Test.zip" are having older tags in ssp file

### Purpose

This PR fixes the older ssp files to be successfully loaded with warnings to the user. 

### Example

older ssp files:
```
<oms:SimulationInformation>
   <FixedStepMaster description="oms-ma" stepSize="0.100000" />
</oms:SimulationInformation>

```
new ssp files

```
<oms:SimulationInformation>
   <oms:FixedStepMaster description="oms-ma" stepSize="0.100000" />
</oms:SimulationInformation>

```

   