### PR TITLE
delete startvalues with suffix :start

### DIFF
--- a/src/OMSimulatorLib/ComRef.cpp
+++ b/src/OMSimulatorLib/ComRef.cpp
@@ -133,7 +133,7 @@ oms::ComRef oms::ComRef::popSuffix() const
     return front;
   }
 
-  return oms::ComRef(cref);
+  return *this;
 }
 
 bool oms::ComRef::isRootOf(ComRef child) const
@@ -160,7 +160,7 @@ oms::ComRef oms::ComRef::front() const
     }
   }
 
-  return oms::ComRef(cref);
+  return *this;
 }
 
 oms::ComRef oms::ComRef::pop_front()
@@ -178,7 +178,7 @@ oms::ComRef oms::ComRef::pop_front()
   }
 
   oms::ComRef front(cref);
-  *this = oms::ComRef("");
+  *this = oms::ComRef();
   return front;
 }
 

--- a/src/OMSimulatorLib/ComRef.cpp
+++ b/src/OMSimulatorLib/ComRef.cpp
@@ -98,6 +98,44 @@ bool oms::ComRef::isEmpty() const
   return (cref[0] == '\0');
 }
 
+bool oms::ComRef::hasSuffixStart() const
+{
+  int i=0;
+  while (cref[i])
+    ++i;
+
+  if (i < 7)
+    return false;
+
+  if (cref[i-6] == ':' &&
+      cref[i-5] == 's' &&
+      cref[i-4] == 't' &&
+      cref[i-3] == 'a' &&
+      cref[i-2] == 'r' &&
+      cref[i-1] == 't')
+    return true;
+
+  return false;
+}
+
+oms::ComRef oms::ComRef::popSuffix() const
+{
+  int index=0;
+  for (int i=0; cref[i]; ++i)
+    if (cref[i] == ':')
+      index = i;
+
+  if (index > 0)
+  {
+    cref[index] = '\0';
+    oms::ComRef front(cref);
+    cref[index] = ':';
+    return front;
+  }
+
+  return oms::ComRef(cref);
+}
+
 bool oms::ComRef::isRootOf(ComRef child) const
 {
   ComRef root(*this);

--- a/src/OMSimulatorLib/ComRef.h
+++ b/src/OMSimulatorLib/ComRef.h
@@ -61,6 +61,9 @@ namespace oms
     ComRef front() const;
     ComRef pop_front();
 
+    bool hasSuffixStart() const;
+    ComRef popSuffix() const;
+
     const char* c_str() const {return cref;}
     size_t size() {return strlen(cref);}
     operator std::string() const {return std::string(cref);}

--- a/src/OMSimulatorLib/Component.cpp
+++ b/src/OMSimulatorLib/Component.cpp
@@ -205,7 +205,6 @@ oms_status_enu_t oms::Component::deleteConnector(const ComRef& cref)
   {
     if (connectors[i] && connectors[i]->getName() == cref)
     {
-
       // delete startValues associated with components connector
       Component * component = parentSystem->getComponent(getCref());
       if (Flags::ExportParametersInline())

--- a/src/OMSimulatorLib/ComponentFMUCS.cpp
+++ b/src/OMSimulatorLib/ComponentFMUCS.cpp
@@ -884,8 +884,7 @@ oms_status_enu_t oms::ComponentFMUCS::setReal(const ComRef& cref, double value)
 
 oms_status_enu_t oms::ComponentFMUCS::deleteStartValue(const ComRef& cref)
 {
-  startValues.deleteStartValue(cref);
-  return oms_status_ok;
+  return startValues.deleteStartValue(cref);
 }
 
 oms_status_enu_t oms::ComponentFMUCS::registerSignalsForResultFile(ResultWriter& resultFile)

--- a/src/OMSimulatorLib/ComponentFMUME.cpp
+++ b/src/OMSimulatorLib/ComponentFMUME.cpp
@@ -801,8 +801,7 @@ oms_status_enu_t oms::ComponentFMUME::setInteger(const ComRef& cref, int value)
 
 oms_status_enu_t oms::ComponentFMUME::deleteStartValue(const ComRef& cref)
 {
-  startValues.deleteStartValue(cref);
-  return oms_status_ok;
+  return startValues.deleteStartValue(cref);
 }
 
 oms_status_enu_t oms::ComponentFMUME::setReal(const ComRef& cref, double value)

--- a/src/OMSimulatorLib/Parameters.cpp
+++ b/src/OMSimulatorLib/Parameters.cpp
@@ -94,7 +94,7 @@ oms_status_enu_t oms::Parameters::deleteStartValue(const ComRef& cref)
     return oms_status_ok;
   }
 
-  return oms_status_ok;
+  return oms_status_error;
 }
 
 oms_status_enu_t oms::Parameters::exportToSSD(pugi::xml_node& node) const

--- a/src/OMSimulatorLib/Parameters.cpp
+++ b/src/OMSimulatorLib/Parameters.cpp
@@ -72,22 +72,28 @@ oms_status_enu_t oms::Parameters::setBoolean(const ComRef& cref, bool value)
 
 oms_status_enu_t oms::Parameters::deleteStartValue(const ComRef& cref)
 {
-  // realstartValues
-  auto realValue = realStartValues.find(cref);
+  oms::ComRef signal(cref);
+  if (signal.hasSuffixStart())
+    signal = cref.popSuffix();
+
+  // reals
+  auto realValue = realStartValues.find(signal);
   if (realValue != realStartValues.end())
   {
     realStartValues.erase(realValue);
     return oms_status_ok;
   }
-  // integerstartValues
-  auto integerValue = integerStartValues.find(cref);
+
+  // integers
+  auto integerValue = integerStartValues.find(signal);
   if (integerValue != integerStartValues.end())
   {
     integerStartValues.erase(integerValue);
     return oms_status_ok;
   }
-  // booleanstartValues
-  auto boolValue = booleanStartValues.find(cref);
+
+  // booleans
+  auto boolValue = booleanStartValues.find(signal);
   if (boolValue != booleanStartValues.end())
   {
     booleanStartValues.erase(boolValue);

--- a/src/OMSimulatorLib/System.cpp
+++ b/src/OMSimulatorLib/System.cpp
@@ -1566,13 +1566,8 @@ oms_status_enu_t oms::System::delete_(const oms::ComRef& cref)
     // check cref has ":start" suffix at the end to delete only start values
     if (front.hasSuffixStart())
     {
-      // add prefix to cref start values if ssv file is used (e.g) f:start -> foo.f:start
-      if(!Flags::ExportParametersInline())
-      {
-        front = getCref()+front;
-      }
-      if (oms_status_ok != startValues.deleteStartValue(front))
-        return logWarning("failed to delete start value \"" + std::string(getFullCref()+front) + "\"" + " because the identifier couldn't be resolved to any system");
+      if (oms_status_ok != startValues.deleteStartValue(getValidCref(front)))
+        return logWarning("failed to delete start value \"" + std::string(getFullCref()+front) + "\"" + " because the identifier couldn't be resolved to any system signal");
       return oms_status_ok;
     }
 
@@ -1598,16 +1593,8 @@ oms_status_enu_t oms::System::delete_(const oms::ComRef& cref)
     for (int i=0; i<connectors.size()-1; ++i)
       if (connectors[i]->getName() == front)
       {
-        if (Flags::ExportParametersInline())
-        {
-          // delete startValues associated with the Connector
-          startValues.deleteStartValue(front);
-        }
-        else
-        {
-          // delete startValues associated with the Connector from ssv file
-          startValues.deleteStartValue(getCref()+front);
-        }
+        // delete startValues associated with the Connector
+        startValues.deleteStartValue(getValidCref(front));
         deleteAllConectionsTo(front);
         exportConnectors.erase(front);
         delete connectors[i];
@@ -1620,16 +1607,8 @@ oms_status_enu_t oms::System::delete_(const oms::ComRef& cref)
     for (int i=0; i<busconnectors.size()-1; ++i)
       if (busconnectors[i]->getName() == front)
       {
-        if (Flags::ExportParametersInline())
-        {
-          // delete startValues associated with the Connector
-          startValues.deleteStartValue(front);
-        }
-        else
-        {
-          // delete startValues associated with the Connector from ssv file
-          startValues.deleteStartValue(getCref()+front);
-        }
+        // delete startValues associated with the Connector
+        startValues.deleteStartValue(getValidCref(front));
         deleteAllConectionsTo(front);
         exportConnectors.erase(front);
         delete busconnectors[i];
@@ -1642,16 +1621,8 @@ oms_status_enu_t oms::System::delete_(const oms::ComRef& cref)
     for (int i=0; i<tlmbusconnectors.size()-1; ++i)
       if (tlmbusconnectors[i]->getName() == front)
       {
-        if (Flags::ExportParametersInline())
-        {
-          // delete startValues associated with the Connector
-          startValues.deleteStartValue(front);
-        }
-        else
-        {
-          // delete startValues associated with the Connector from ssv file
-          startValues.deleteStartValue(getCref()+front);
-        }
+        // delete startValues associated with the Connector
+        startValues.deleteStartValue(getValidCref(front));
         deleteAllConectionsTo(front);
         exportConnectors.erase(front);
         delete tlmbusconnectors[i];
@@ -1683,7 +1654,7 @@ oms_status_enu_t oms::System::delete_(const oms::ComRef& cref)
           tail = cref;
         }
         if (oms_status_ok != component->second->deleteStartValue(tail))
-          return logWarning("failed to delete start value \"" + std::string(getFullCref()+cref) + "\"" + " because the identifier couldn't be resolved to any signal");
+          return logWarning("failed to delete start value \"" + std::string(getFullCref()+cref) + "\"" + " because the identifier couldn't be resolved to any component signal");
         return oms_status_ok;
       }
 

--- a/src/OMSimulatorLib/System.cpp
+++ b/src/OMSimulatorLib/System.cpp
@@ -1566,6 +1566,11 @@ oms_status_enu_t oms::System::delete_(const oms::ComRef& cref)
     // check cref has ":start" suffix at the end to delete only start values
     if (front.hasSuffixStart())
     {
+      // add prefix to cref start values if ssv file is used (e.g) f:start -> foo.f:start
+      if(!Flags::ExportParametersInline())
+      {
+        front = getCref()+front;
+      }
       if (oms_status_ok != startValues.deleteStartValue(front))
         return logWarning("failed to delete start value \"" + std::string(getFullCref()+front) + "\"" + " because the identifier couldn't be resolved to any system");
       return oms_status_ok;
@@ -1672,6 +1677,11 @@ oms_status_enu_t oms::System::delete_(const oms::ComRef& cref)
       // check cref has ":start" suffix at the end to delete only start values
       if (tail.hasSuffixStart())
       {
+        // add prefix to cref start values if ssv file is used (e.g) k1:start -> addP.k1:start
+        if(!Flags::ExportParametersInline())
+        {
+          tail = cref;
+        }
         if (oms_status_ok != component->second->deleteStartValue(tail))
           return logWarning("failed to delete start value \"" + std::string(getFullCref()+cref) + "\"" + " because the identifier couldn't be resolved to any signal");
         return oms_status_ok;

--- a/src/OMSimulatorLib/System.cpp
+++ b/src/OMSimulatorLib/System.cpp
@@ -1562,8 +1562,7 @@ oms_status_enu_t oms::System::delete_(const oms::ComRef& cref)
   if (cref.hasSuffixStart())
   {
     oms::ComRef signal = cref.popSuffix();
-    deleteStartValue(signal);
-    return oms_status_ok;
+    return deleteStartValue(signal);
   }
 
   oms::ComRef tail(cref);
@@ -1685,9 +1684,7 @@ oms_status_enu_t oms::System::deleteStartValue(const ComRef& cref)
   if (tail.isEmpty())
   {
     if (oms_status_ok != startValues.deleteStartValue(front))
-    {
-      logWarning("failed to delete start value \"" + std::string(getFullCref()+cref)+":start" + "\"" + " because the identifier couldn't be resolved to any System");
-    }
+      return logWarning("failed to delete start value \"" + std::string(getFullCref()+cref)+":start" + "\"" + " because the identifier couldn't be resolved to any system");
     return oms_status_ok;
   }
 
@@ -1701,14 +1698,11 @@ oms_status_enu_t oms::System::deleteStartValue(const ComRef& cref)
   if (component != components.end())
   {
     if (oms_status_ok != component->second->deleteStartValue(tail))
-    {
-      logWarning("failed to delete start value \"" + std::string(getFullCref()+cref)+":start" + "\"" + " because the identifier couldn't be resolved to any component");
-    }
+      return logWarning("failed to delete start value \"" + std::string(getFullCref()+cref)+":start" + "\"" + " because the identifier couldn't be resolved to any component");
     return oms_status_ok;
   }
 
-  logWarning("failed to delete start value \"" + std::string(getFullCref()+cref)+":start" + "\"" + " because the identifier couldn't be resolved to any connector, component, system, or model");
-  return oms_status_ok;
+  return logWarning("failed to delete start value \"" + std::string(getFullCref()+cref)+":start" + "\"" + " because the identifier couldn't be resolved to any connector, component, system, or model");
 }
 
 bool oms::System::copyResources()

--- a/src/OMSimulatorLib/System.h
+++ b/src/OMSimulatorLib/System.h
@@ -113,7 +113,6 @@ namespace oms
     oms_status_enu_t addExternalModel(const ComRef &cref, std::string path, std::string startscript);
     oms_status_enu_t delete_(const ComRef& cref);
     oms_status_enu_t deleteAllConectionsTo(const ComRef& cref);
-    oms_status_enu_t deleteStartValue(const ComRef& cref);
     bool isConnected(const ComRef& cref) const;
     Model* getModel();
     System* getParentSystem() const {return parentSystem;}

--- a/src/OMSimulatorLib/System.h
+++ b/src/OMSimulatorLib/System.h
@@ -113,6 +113,7 @@ namespace oms
     oms_status_enu_t addExternalModel(const ComRef &cref, std::string path, std::string startscript);
     oms_status_enu_t delete_(const ComRef& cref);
     oms_status_enu_t deleteAllConectionsTo(const ComRef& cref);
+    oms_status_enu_t deleteStartValue(const ComRef& cref);
     bool isConnected(const ComRef& cref) const;
     Model* getModel();
     System* getParentSystem() const {return parentSystem;}

--- a/testsuite/OMSimulator/Makefile
+++ b/testsuite/OMSimulator/Makefile
@@ -12,6 +12,7 @@ simulation.lua \
 simulation.py \
 table.lua \
 deleteConnector.lua \
+deleteStartValues.lua \
 
 # Run make failingtest
 FAILINGTESTFILES = \

--- a/testsuite/OMSimulator/Makefile
+++ b/testsuite/OMSimulator/Makefile
@@ -3,6 +3,7 @@ TEST = ../rtest -v
 TESTFILES = \
 deleteConnector.lua \
 deleteStartValues.lua \
+deleteStartValuesInSSV.lua \
 DualMassOscillator.lua \
 import_export_parameters_inline.lua \
 import_export_parameters_to_ssv.lua \

--- a/testsuite/OMSimulator/Makefile
+++ b/testsuite/OMSimulator/Makefile
@@ -1,9 +1,11 @@
 TEST = ../rtest -v
 
 TESTFILES = \
+deleteConnector.lua \
+deleteStartValues.lua \
 DualMassOscillator.lua \
-import_export_parameters_to_ssv.lua \
 import_export_parameters_inline.lua \
+import_export_parameters_to_ssv.lua \
 import_export.lua \
 import_export.py \
 PI_Controller.lua \
@@ -11,8 +13,6 @@ QuarterCarModel.DisplacementDisplacement.lua \
 simulation.lua \
 simulation.py \
 table.lua \
-deleteConnector.lua \
-deleteStartValues.lua \
 
 # Run make failingtest
 FAILINGTESTFILES = \

--- a/testsuite/OMSimulator/deleteConnector.lua
+++ b/testsuite/OMSimulator/deleteConnector.lua
@@ -170,7 +170,7 @@ print(src)
 -- 		</ssd:Annotations>
 -- 	</ssd:DefaultExperiment>
 -- </ssd:SystemStructureDescription>
--- 
+--
 -- warning: failed to delete object "deleteConnector.Root.System2.C6" because the identifier couldn't be resolved to any connector, component, system, or model
 -- warning: failed to delete object "deleteConnector.Root.System3" because the identifier couldn't be resolved to any connector, component, system, or model
 -- <?xml version="1.0"?>
@@ -263,7 +263,7 @@ print(src)
 -- 		</ssd:Annotations>
 -- 	</ssd:DefaultExperiment>
 -- </ssd:SystemStructureDescription>
--- 
+--
 -- info:    2 warnings
 -- info:    0 errors
 -- endResult

--- a/testsuite/OMSimulator/deleteStartValues.lua
+++ b/testsuite/OMSimulator/deleteStartValues.lua
@@ -30,7 +30,7 @@ oms_setReal("deleteStartValues.Root.System2.C4", 30.0)
 
 oms_addSubModel("deleteStartValues.Root.System1.Gain", "../resources/Modelica.Blocks.Math.Gain.fmu")
 
---oms_setReal("deleteStartValues.Root.System1.Gain.k:start", 30.0) // this is allowed before initialization 
+--oms_setReal("deleteStartValues.Root.System1.Gain.k:start", 30.0) // this is allowed before initialization
 --oms_setReal("deleteStartValues.Root.System1.Gain.k", 20.0) // allowed only if model is initialized, we are allowed to provide different value after initialization
 
 src = oms_list("deleteStartValues")
@@ -185,7 +185,7 @@ print(src)
 -- 		</ssd:Annotations>
 -- 	</ssd:DefaultExperiment>
 -- </ssd:SystemStructureDescription>
--- 
+--
 -- warning: failed to delete start value "deleteStartValues.Root.System3.C4:start" because the identifier couldn't be resolved to any connector, component, system, or model
 -- warning: failed to delete start value "deleteStartValues.Root.System1.Gain.k:start" because the identifier couldn't be resolved to any component
 -- <?xml version="1.0"?>
@@ -275,7 +275,7 @@ print(src)
 -- 		</ssd:Annotations>
 -- 	</ssd:DefaultExperiment>
 -- </ssd:SystemStructureDescription>
--- 
+--
 -- info:    2 warnings
 -- info:    0 errors
 -- endResult

--- a/testsuite/OMSimulator/deleteStartValues.lua
+++ b/testsuite/OMSimulator/deleteStartValues.lua
@@ -51,7 +51,6 @@ oms_delete("deleteStartValues.Root.System1.Gain.k:start")
 src = oms_list("deleteStartValues")
 print(src)
 
-
 -- Result:
 -- <?xml version="1.0"?>
 -- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="deleteStartValues" version="1.0">
@@ -186,8 +185,8 @@ print(src)
 -- 	</ssd:DefaultExperiment>
 -- </ssd:SystemStructureDescription>
 --
--- warning: failed to delete start value "deleteStartValues.Root.System3.C4:start" because the identifier couldn't be resolved to any connector, component, system, or model
--- warning: failed to delete start value "deleteStartValues.Root.System1.Gain.k:start" because the identifier couldn't be resolved to any component
+-- warning: failed to delete object "deleteStartValues.Root.System3.C4:start" because the identifier couldn't be resolved to any connector, component, system, or model
+-- warning: failed to delete start value "deleteStartValues.Root.System1.Gain.k:start" because the identifier couldn't be resolved to any signal
 -- <?xml version="1.0"?>
 -- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="deleteStartValues" version="1.0">
 -- 	<ssd:System name="Root">

--- a/testsuite/OMSimulator/deleteStartValues.lua
+++ b/testsuite/OMSimulator/deleteStartValues.lua
@@ -186,7 +186,7 @@ print(src)
 -- </ssd:SystemStructureDescription>
 --
 -- warning: failed to delete object "deleteStartValues.Root.System3.C4:start" because the identifier couldn't be resolved to any connector, component, system, or model
--- warning: failed to delete start value "deleteStartValues.Root.System1.Gain.k:start" because the identifier couldn't be resolved to any signal
+-- warning: failed to delete start value "deleteStartValues.Root.System1.Gain.k:start" because the identifier couldn't be resolved to any component signal
 -- <?xml version="1.0"?>
 -- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="deleteStartValues" version="1.0">
 -- 	<ssd:System name="Root">

--- a/testsuite/OMSimulator/deleteStartValues.lua
+++ b/testsuite/OMSimulator/deleteStartValues.lua
@@ -1,0 +1,281 @@
+-- status: correct
+-- linux: yes
+-- mingw: yes
+-- win: yes
+-- mac: yes
+
+oms_setCommandLineOption("--suppressPath=true")
+oms_setTempDirectory("./deleteStartValues_lua/")
+
+oms_newModel("deleteStartValues")
+
+oms_addSystem("deleteStartValues.Root", oms_system_wc)
+oms_addConnector("deleteStartValues.Root.C1", oms_causality_input, oms_signal_type_real)
+oms_addConnector("deleteStartValues.Root.C2", oms_causality_output, oms_signal_type_real)
+oms_addConnector("deleteStartValues.Root.C3", oms_causality_parameter, oms_signal_type_real)
+oms_setReal("deleteStartValues.Root.C3", 10.0)
+
+oms_addSystem("deleteStartValues.Root.System1", oms_system_sc)
+oms_addConnector("deleteStartValues.Root.System1.C1", oms_causality_input, oms_signal_type_real)
+oms_addConnector("deleteStartValues.Root.System1.C2", oms_causality_input, oms_signal_type_real)
+
+oms_setReal("deleteStartValues.Root.System1.C1", -10.0)
+oms_setReal("deleteStartValues.Root.System1.C2", -30.0)
+
+oms_addSystem("deleteStartValues.Root.System2", oms_system_sc)
+oms_addConnector("deleteStartValues.Root.System2.C3", oms_causality_output, oms_signal_type_real)
+oms_addConnector("deleteStartValues.Root.System2.C4", oms_causality_output, oms_signal_type_real)
+oms_setReal("deleteStartValues.Root.System2.C3", 20.0)
+oms_setReal("deleteStartValues.Root.System2.C4", 30.0)
+
+oms_addSubModel("deleteStartValues.Root.System1.Gain", "../resources/Modelica.Blocks.Math.Gain.fmu")
+
+--oms_setReal("deleteStartValues.Root.System1.Gain.k:start", 30.0) // this is allowed before initialization 
+--oms_setReal("deleteStartValues.Root.System1.Gain.k", 20.0) // allowed only if model is initialized, we are allowed to provide different value after initialization
+
+src = oms_list("deleteStartValues")
+print(src)
+
+oms_delete("deleteStartValues.Root.C3:start")
+oms_delete("deleteStartValues.Root.System1.C1:start")
+oms_delete("deleteStartValues.Root.System1.C2:start")
+oms_delete("deleteStartValues.Root.System2.C3:start")
+oms_delete("deleteStartValues.Root.System2.C4:start")
+
+-- delete unknown system startValue for warning
+oms_delete("deleteStartValues.Root.System3.C4:start")
+
+-- delete components startValue which was not set
+oms_delete("deleteStartValues.Root.System1.Gain.k:start")
+
+src = oms_list("deleteStartValues")
+print(src)
+
+
+-- Result:
+-- <?xml version="1.0"?>
+-- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="deleteStartValues" version="1.0">
+-- 	<ssd:System name="Root">
+-- 		<ssd:Annotations>
+-- 			<ssc:Annotation type="org.openmodelica">
+-- 				<oms:SimulationInformation>
+-- 					<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+-- 				</oms:SimulationInformation>
+-- 			</ssc:Annotation>
+-- 		</ssd:Annotations>
+-- 		<ssd:Connectors>
+-- 			<ssd:Connector name="C1" kind="input">
+-- 				<ssc:Real />
+-- 			</ssd:Connector>
+-- 			<ssd:Connector name="C2" kind="output">
+-- 				<ssc:Real />
+-- 			</ssd:Connector>
+-- 			<ssd:Connector name="C3" kind="parameter">
+-- 				<ssc:Real />
+-- 			</ssd:Connector>
+-- 		</ssd:Connectors>
+-- 		<ssd:ParameterBindings>
+-- 			<ssd:ParameterBinding>
+-- 				<ssd:ParameterValues>
+-- 					<ssv:ParameterSet version="1.0" name="parameters">
+-- 						<ssv:Parameters>
+-- 							<ssv:Parameter name="C3">
+-- 								<ssv:Real value="10" />
+-- 							</ssv:Parameter>
+-- 						</ssv:Parameters>
+-- 					</ssv:ParameterSet>
+-- 				</ssd:ParameterValues>
+-- 			</ssd:ParameterBinding>
+-- 		</ssd:ParameterBindings>
+-- 		<ssd:Elements>
+-- 			<ssd:System name="System2">
+-- 				<ssd:Annotations>
+-- 					<ssc:Annotation type="org.openmodelica">
+-- 						<oms:SimulationInformation>
+-- 							<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+-- 						</oms:SimulationInformation>
+-- 					</ssc:Annotation>
+-- 				</ssd:Annotations>
+-- 				<ssd:Connectors>
+-- 					<ssd:Connector name="C3" kind="output">
+-- 						<ssc:Real />
+-- 					</ssd:Connector>
+-- 					<ssd:Connector name="C4" kind="output">
+-- 						<ssc:Real />
+-- 					</ssd:Connector>
+-- 				</ssd:Connectors>
+-- 				<ssd:ParameterBindings>
+-- 					<ssd:ParameterBinding>
+-- 						<ssd:ParameterValues>
+-- 							<ssv:ParameterSet version="1.0" name="parameters">
+-- 								<ssv:Parameters>
+-- 									<ssv:Parameter name="C4">
+-- 										<ssv:Real value="30" />
+-- 									</ssv:Parameter>
+-- 									<ssv:Parameter name="C3">
+-- 										<ssv:Real value="20" />
+-- 									</ssv:Parameter>
+-- 								</ssv:Parameters>
+-- 							</ssv:ParameterSet>
+-- 						</ssd:ParameterValues>
+-- 					</ssd:ParameterBinding>
+-- 				</ssd:ParameterBindings>
+-- 				<ssd:Elements />
+-- 				<ssd:Connections />
+-- 			</ssd:System>
+-- 			<ssd:System name="System1">
+-- 				<ssd:Annotations>
+-- 					<ssc:Annotation type="org.openmodelica">
+-- 						<oms:SimulationInformation>
+-- 							<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+-- 						</oms:SimulationInformation>
+-- 					</ssc:Annotation>
+-- 				</ssd:Annotations>
+-- 				<ssd:Connectors>
+-- 					<ssd:Connector name="C1" kind="input">
+-- 						<ssc:Real />
+-- 					</ssd:Connector>
+-- 					<ssd:Connector name="C2" kind="input">
+-- 						<ssc:Real />
+-- 					</ssd:Connector>
+-- 				</ssd:Connectors>
+-- 				<ssd:ParameterBindings>
+-- 					<ssd:ParameterBinding>
+-- 						<ssd:ParameterValues>
+-- 							<ssv:ParameterSet version="1.0" name="parameters">
+-- 								<ssv:Parameters>
+-- 									<ssv:Parameter name="C2">
+-- 										<ssv:Real value="-30" />
+-- 									</ssv:Parameter>
+-- 									<ssv:Parameter name="C1">
+-- 										<ssv:Real value="-10" />
+-- 									</ssv:Parameter>
+-- 								</ssv:Parameters>
+-- 							</ssv:ParameterSet>
+-- 						</ssd:ParameterValues>
+-- 					</ssd:ParameterBinding>
+-- 				</ssd:ParameterBindings>
+-- 				<ssd:Elements>
+-- 					<ssd:Component name="Gain" type="application/x-fmu-sharedlibrary" source="resources/0001_Gain.fmu">
+-- 						<ssd:Connectors>
+-- 							<ssd:Connector name="u" kind="input">
+-- 								<ssc:Real />
+-- 								<ssd:ConnectorGeometry x="0.000000" y="0.500000" />
+-- 							</ssd:Connector>
+-- 							<ssd:Connector name="y" kind="output">
+-- 								<ssc:Real />
+-- 								<ssd:ConnectorGeometry x="1.000000" y="0.500000" />
+-- 							</ssd:Connector>
+-- 							<ssd:Connector name="k" kind="parameter">
+-- 								<ssc:Real />
+-- 							</ssd:Connector>
+-- 						</ssd:Connectors>
+-- 					</ssd:Component>
+-- 				</ssd:Elements>
+-- 				<ssd:Connections />
+-- 			</ssd:System>
+-- 		</ssd:Elements>
+-- 		<ssd:Connections />
+-- 	</ssd:System>
+-- 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
+-- 		<ssd:Annotations>
+-- 			<ssc:Annotation type="org.openmodelica">
+-- 				<oms:SimulationInformation resultFile="deleteStartValues_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter="" />
+-- 			</ssc:Annotation>
+-- 		</ssd:Annotations>
+-- 	</ssd:DefaultExperiment>
+-- </ssd:SystemStructureDescription>
+-- 
+-- warning: failed to delete start value "deleteStartValues.Root.System3.C4:start" because the identifier couldn't be resolved to any connector, component, system, or model
+-- warning: failed to delete start value "deleteStartValues.Root.System1.Gain.k:start" because the identifier couldn't be resolved to any component
+-- <?xml version="1.0"?>
+-- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="deleteStartValues" version="1.0">
+-- 	<ssd:System name="Root">
+-- 		<ssd:Annotations>
+-- 			<ssc:Annotation type="org.openmodelica">
+-- 				<oms:SimulationInformation>
+-- 					<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+-- 				</oms:SimulationInformation>
+-- 			</ssc:Annotation>
+-- 		</ssd:Annotations>
+-- 		<ssd:Connectors>
+-- 			<ssd:Connector name="C1" kind="input">
+-- 				<ssc:Real />
+-- 			</ssd:Connector>
+-- 			<ssd:Connector name="C2" kind="output">
+-- 				<ssc:Real />
+-- 			</ssd:Connector>
+-- 			<ssd:Connector name="C3" kind="parameter">
+-- 				<ssc:Real />
+-- 			</ssd:Connector>
+-- 		</ssd:Connectors>
+-- 		<ssd:Elements>
+-- 			<ssd:System name="System2">
+-- 				<ssd:Annotations>
+-- 					<ssc:Annotation type="org.openmodelica">
+-- 						<oms:SimulationInformation>
+-- 							<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+-- 						</oms:SimulationInformation>
+-- 					</ssc:Annotation>
+-- 				</ssd:Annotations>
+-- 				<ssd:Connectors>
+-- 					<ssd:Connector name="C3" kind="output">
+-- 						<ssc:Real />
+-- 					</ssd:Connector>
+-- 					<ssd:Connector name="C4" kind="output">
+-- 						<ssc:Real />
+-- 					</ssd:Connector>
+-- 				</ssd:Connectors>
+-- 				<ssd:Elements />
+-- 				<ssd:Connections />
+-- 			</ssd:System>
+-- 			<ssd:System name="System1">
+-- 				<ssd:Annotations>
+-- 					<ssc:Annotation type="org.openmodelica">
+-- 						<oms:SimulationInformation>
+-- 							<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+-- 						</oms:SimulationInformation>
+-- 					</ssc:Annotation>
+-- 				</ssd:Annotations>
+-- 				<ssd:Connectors>
+-- 					<ssd:Connector name="C1" kind="input">
+-- 						<ssc:Real />
+-- 					</ssd:Connector>
+-- 					<ssd:Connector name="C2" kind="input">
+-- 						<ssc:Real />
+-- 					</ssd:Connector>
+-- 				</ssd:Connectors>
+-- 				<ssd:Elements>
+-- 					<ssd:Component name="Gain" type="application/x-fmu-sharedlibrary" source="resources/0001_Gain.fmu">
+-- 						<ssd:Connectors>
+-- 							<ssd:Connector name="u" kind="input">
+-- 								<ssc:Real />
+-- 								<ssd:ConnectorGeometry x="0.000000" y="0.500000" />
+-- 							</ssd:Connector>
+-- 							<ssd:Connector name="y" kind="output">
+-- 								<ssc:Real />
+-- 								<ssd:ConnectorGeometry x="1.000000" y="0.500000" />
+-- 							</ssd:Connector>
+-- 							<ssd:Connector name="k" kind="parameter">
+-- 								<ssc:Real />
+-- 							</ssd:Connector>
+-- 						</ssd:Connectors>
+-- 					</ssd:Component>
+-- 				</ssd:Elements>
+-- 				<ssd:Connections />
+-- 			</ssd:System>
+-- 		</ssd:Elements>
+-- 		<ssd:Connections />
+-- 	</ssd:System>
+-- 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
+-- 		<ssd:Annotations>
+-- 			<ssc:Annotation type="org.openmodelica">
+-- 				<oms:SimulationInformation resultFile="deleteStartValues_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter="" />
+-- 			</ssc:Annotation>
+-- 		</ssd:Annotations>
+-- 	</ssd:DefaultExperiment>
+-- </ssd:SystemStructureDescription>
+-- 
+-- info:    2 warnings
+-- info:    0 errors
+-- endResult

--- a/testsuite/OMSimulator/deleteStartValuesInSSV.lua
+++ b/testsuite/OMSimulator/deleteStartValuesInSSV.lua
@@ -1,0 +1,132 @@
+-- status: correct
+-- linux: yes
+-- mingw: yes
+-- win: yes
+-- mac: yes
+
+oms_setCommandLineOption("--suppressPath=true --exportParametersInline=false")
+oms_setCommandLineOption("--suppressPath=true")
+
+oms_setTempDirectory("./deleteStartValuesInSSV_lua/")
+
+oms_newModel("deleteStartValuesInSSV")
+
+oms_addSystem("deleteStartValuesInSSV.Root", oms_system_wc)
+
+oms_addConnector("deleteStartValuesInSSV.Root.C1", oms_causality_input, oms_signal_type_real)
+oms_addConnector("deleteStartValuesInSSV.Root.C2", oms_causality_output, oms_signal_type_real)
+oms_setReal("deleteStartValuesInSSV.Root.C1", 10.0)
+oms_setReal("deleteStartValuesInSSV.Root.C2", 15.0)
+
+-- add subSystem
+oms_addSystem("deleteStartValuesInSSV.Root.System1", oms_system_sc)
+oms_addConnector("deleteStartValuesInSSV.Root.System1.C1", oms_causality_input, oms_signal_type_real)
+oms_addConnector("deleteStartValuesInSSV.Root.System1.C2", oms_causality_input, oms_signal_type_real)
+
+oms_setReal("deleteStartValuesInSSV.Root.System1.C1", 20.0)
+oms_setReal("deleteStartValuesInSSV.Root.System1.C2", 30.0)
+
+-- add submodel
+oms_addSubModel("deleteStartValuesInSSV.Root.System1.Gain", "../resources/Modelica.Blocks.Math.Gain.fmu")
+oms_setReal("deleteStartValuesInSSV.Root.System1.Gain.k", 40.0)
+
+src = oms_list("deleteStartValuesInSSV")
+print(src)
+
+-- delete top level system start value
+oms_delete("deleteStartValuesInSSV.Root.C1:start")
+
+-- delete subsystem start value
+oms_delete("deleteStartValuesInSSV.Root.System1.C1:start")
+
+-- delete unknown top level start value for warning
+oms_delete("deleteStartValuesInSSV.Root.C3:start")
+
+-- delete unknown subsystem start value for warning
+oms_delete("deleteStartValuesInSSV.Root.System1.C4:start")
+
+-- delete unknown component start values for warning
+oms_delete("deleteStartValuesInSSV.Root.System1.Gain.j:start")
+
+oms_export("deleteStartValuesInSSV", "deleteStartValuesInSSV.ssp");
+
+oms_delete("deleteStartValuesInSSV")
+
+
+
+-- Result:
+-- <?xml version="1.0"?>
+-- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="deleteStartValuesInSSV" version="1.0">
+-- 	<ssd:System name="Root">
+-- 		<ssd:Annotations>
+-- 			<ssc:Annotation type="org.openmodelica">
+-- 				<oms:SimulationInformation>
+-- 					<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+-- 				</oms:SimulationInformation>
+-- 			</ssc:Annotation>
+-- 		</ssd:Annotations>
+-- 		<ssd:Connectors>
+-- 			<ssd:Connector name="C1" kind="input">
+-- 				<ssc:Real />
+-- 			</ssd:Connector>
+-- 			<ssd:Connector name="C2" kind="output">
+-- 				<ssc:Real />
+-- 			</ssd:Connector>
+-- 		</ssd:Connectors>
+-- 		<ssd:ParameterBindings>
+-- 			<ssd:ParameterBinding source="resources/deleteStartValuesInSSV.ssv" />
+-- 		</ssd:ParameterBindings>
+-- 		<ssd:Elements>
+-- 			<ssd:System name="System1">
+-- 				<ssd:Annotations>
+-- 					<ssc:Annotation type="org.openmodelica">
+-- 						<oms:SimulationInformation>
+-- 							<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+-- 						</oms:SimulationInformation>
+-- 					</ssc:Annotation>
+-- 				</ssd:Annotations>
+-- 				<ssd:Connectors>
+-- 					<ssd:Connector name="C1" kind="input">
+-- 						<ssc:Real />
+-- 					</ssd:Connector>
+-- 					<ssd:Connector name="C2" kind="input">
+-- 						<ssc:Real />
+-- 					</ssd:Connector>
+-- 				</ssd:Connectors>
+-- 				<ssd:Elements>
+-- 					<ssd:Component name="Gain" type="application/x-fmu-sharedlibrary" source="resources/0001_Gain.fmu">
+-- 						<ssd:Connectors>
+-- 							<ssd:Connector name="u" kind="input">
+-- 								<ssc:Real />
+-- 								<ssd:ConnectorGeometry x="0.000000" y="0.500000" />
+-- 							</ssd:Connector>
+-- 							<ssd:Connector name="y" kind="output">
+-- 								<ssc:Real />
+-- 								<ssd:ConnectorGeometry x="1.000000" y="0.500000" />
+-- 							</ssd:Connector>
+-- 							<ssd:Connector name="k" kind="parameter">
+-- 								<ssc:Real />
+-- 							</ssd:Connector>
+-- 						</ssd:Connectors>
+-- 					</ssd:Component>
+-- 				</ssd:Elements>
+-- 				<ssd:Connections />
+-- 			</ssd:System>
+-- 		</ssd:Elements>
+-- 		<ssd:Connections />
+-- 	</ssd:System>
+-- 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
+-- 		<ssd:Annotations>
+-- 			<ssc:Annotation type="org.openmodelica">
+-- 				<oms:SimulationInformation resultFile="deleteStartValuesInSSV_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter="" />
+-- 			</ssc:Annotation>
+-- 		</ssd:Annotations>
+-- 	</ssd:DefaultExperiment>
+-- </ssd:SystemStructureDescription>
+-- 
+-- warning: failed to delete start value "deleteStartValuesInSSV.Root.C3:start" because the identifier couldn't be resolved to any system signal
+-- warning: failed to delete start value "deleteStartValuesInSSV.Root.System1.C4:start" because the identifier couldn't be resolved to any system signal
+-- warning: failed to delete start value "deleteStartValuesInSSV.Root.System1.Gain.j:start" because the identifier couldn't be resolved to any component signal
+-- info:    3 warnings
+-- info:    0 errors
+-- endResult

--- a/testsuite/OMSimulator/import_export.lua
+++ b/testsuite/OMSimulator/import_export.lua
@@ -356,7 +356,7 @@ printStatus(status, 0)
 --         </ssd:Annotations>
 --     </ssd:DefaultExperiment>
 -- </ssd:SystemStructureDescription>
--- 
+--
 -- status:  [correct] ok
 -- status:  [correct] ok
 -- status:  [correct] ok
@@ -524,6 +524,6 @@ printStatus(status, 0)
 --         </ssd:Annotations>
 --     </ssd:DefaultExperiment>
 -- </ssd:SystemStructureDescription>
--- 
+--
 -- status:  [correct] ok
 -- endResult

--- a/testsuite/OMSimulator/import_export_parameters_inline.lua
+++ b/testsuite/OMSimulator/import_export_parameters_inline.lua
@@ -302,7 +302,7 @@ oms_delete("import_export_parameters")
 -- 		</ssd:Annotations>
 -- 	</ssd:DefaultExperiment>
 -- </ssd:SystemStructureDescription>
--- 
+--
 -- info:    model doesn't contain any continuous state
 -- info:      Parameter settings
 -- info:      import_export_parameters.co_sim.addP.k1     : 10.0

--- a/testsuite/OMSimulator/import_export_parameters_to_ssv.lua
+++ b/testsuite/OMSimulator/import_export_parameters_to_ssv.lua
@@ -244,7 +244,7 @@ oms_delete("import_export_parameters")
 -- 		</ssd:Annotations>
 -- 	</ssd:DefaultExperiment>
 -- </ssd:SystemStructureDescription>
--- 
+--
 -- info:    model doesn't contain any continuous state
 -- info:      Parameter settings
 -- info:      import_export_parameters.co_sim.addP.k1     : 10.0


### PR DESCRIPTION
### Related Issues

https://github.com/OpenModelica/OMSimulator/issues/771
### Purpose

This PR deletes the startvalue alone when using `oms_delete` with suffix `:start`

### Example
`oms_delete("deleteStartValues.Root.C3:start")`