### PR TITLE
set and get values and startValues

### DIFF
--- a/src/OMSimulatorLib/ComponentFMUME.cpp
+++ b/src/OMSimulatorLib/ComponentFMUME.cpp
@@ -458,22 +458,22 @@ oms_status_enu_t oms::ComponentFMUME::instantiate()
     return logError_FMUCall("fmi2_import_instantiate", this);
 
   // set start values
-  for (const auto& v : startValues.booleanStartValues)
+  for (const auto& v : startValues.booleanValues)
   {
     oms::ComRef cref = getValidCref(v.first);
-    if (oms_status_ok != setBoolean(cref, v.second))
+    if (oms_status_ok != setBoolean(cref, std::get<1>(v.second).getValue()))
       return logError("Failed to set start value for " + std::string(v.first));
   }
-  for (const auto& v : startValues.integerStartValues)
+  for (const auto& v : startValues.integerValues)
   {
     oms::ComRef cref = getValidCref(v.first);
-    if (oms_status_ok != setInteger(cref, v.second))
+    if (oms_status_ok != setInteger(cref, std::get<1>(v.second).getValue()))
       return logError("Failed to set start value for " + std::string(v.first));
   }
-  for (const auto& v : startValues.realStartValues)
+  for (const auto& v : startValues.realValues)
   {
     oms::ComRef cref = getValidCref(v.first);
-    if (oms_status_ok != setReal(cref, v.second))
+    if (oms_status_ok != setReal(cref, std::get<1>(v.second).getValue()))
       return logError("Failed to set start value for " + std::string(v.first));
   }
 
@@ -606,6 +606,20 @@ oms_status_enu_t oms::ComponentFMUME::getBoolean(const fmi2_value_reference_t& v
 oms_status_enu_t oms::ComponentFMUME::getBoolean(const ComRef& cref, bool& value)
 {
   CallClock callClock(clock);
+
+  // check for start suffix
+  if (cref.hasSuffixStart())
+  {
+    auto booleanValue = startValues.booleanValues.find(cref.popSuffix());
+    if (booleanValue != startValues.booleanValues.end())
+    {
+      value = std::get<1>(booleanValue->second).getValue();
+      return oms_status_ok;
+    }
+    // should we return a default start value if did not exist value = 0 or return error ?
+    return oms_status_error;
+  }
+
   int j=-1;
   for (size_t i = 0; i < allVariables.size(); i++)
   {
@@ -636,6 +650,20 @@ oms_status_enu_t oms::ComponentFMUME::getInteger(const fmi2_value_reference_t& v
 oms_status_enu_t oms::ComponentFMUME::getInteger(const ComRef& cref, int& value)
 {
   CallClock callClock(clock);
+
+  // check for start suffix
+  if (cref.hasSuffixStart())
+  {
+    auto integerValue = startValues.integerValues.find(cref.popSuffix());
+    if (integerValue != startValues.integerValues.end())
+    {
+      value = std::get<1>(integerValue->second).getValue();
+      return oms_status_ok;
+    }
+    // should we return a default start value if did not exist value = 0 or return error ?
+    return oms_status_error;
+  }
+
   int j=-1;
   for (size_t i = 0; i < allVariables.size(); i++)
   {
@@ -705,6 +733,21 @@ oms_status_enu_t oms::ComponentFMUME::getReal(const fmi2_value_reference_t& vr, 
 oms_status_enu_t oms::ComponentFMUME::getReal(const ComRef& cref, double& value)
 {
   CallClock callClock(clock);
+
+  // check for start suffix
+  if (cref.hasSuffixStart())
+  {
+    double rvalue;
+    auto realValue = startValues.realValues.find(cref.popSuffix());
+    if (realValue != startValues.realValues.end())
+    {
+      value = std::get<1>(realValue->second).getValue();
+      return oms_status_ok;
+    }
+    // should we return a default start value if did not exist value = 0 or return error ?
+    return oms_status_error;
+  }
+
   int j=-1;
   for (size_t i = 0; i < allVariables.size(); i++)
   {
@@ -738,16 +781,16 @@ oms_status_enu_t oms::ComponentFMUME::setBoolean(const ComRef& cref, bool value)
   if (!fmu || j < 0)
     return logError_UnknownSignal(getFullCref() + cref);
 
-  if (oms_modelState_virgin == getModel()->getModelState())
+  if (cref.hasSuffixStart() && oms_modelState_virgin == getModel()->getModelState())
   {
     if (Flags::ExportParametersInline())
     {
-      startValues.setBoolean(allVariables[j].getCref(), value);
+      startValues.setBoolean(cref, value);
     }
     else
     {
       // append startValues with prefix (e.g) addP.K1
-      startValues.setBoolean(getCref()+allVariables[j].getCref(), value);
+      startValues.setBoolean(getCref()+cref, value);
     }
   }
   else
@@ -777,16 +820,16 @@ oms_status_enu_t oms::ComponentFMUME::setInteger(const ComRef& cref, int value)
   if (!fmu || j < 0)
     return logError_UnknownSignal(getFullCref() + cref);
 
-  if (oms_modelState_virgin == getModel()->getModelState())
+  if (cref.hasSuffixStart() && oms_modelState_virgin == getModel()->getModelState())
   {
     if (Flags::ExportParametersInline())
     {
-      startValues.setInteger(allVariables[j].getCref(), value);
+      startValues.setInteger(cref, value);
     }
     else
     {
       // append startValues with prefix (e.g) addP.K1
-      startValues.setInteger(getCref()+allVariables[j].getCref(), value);
+      startValues.setInteger(getCref()+cref, value);
     }
   }
   else
@@ -824,16 +867,16 @@ oms_status_enu_t oms::ComponentFMUME::setReal(const ComRef& cref, double value)
     if (allVariables[j].isCalculated() || allVariables[j].isIndependent())
       return logWarning("It is not allowed to provide a start value if initial=\"calculated\" or causality=\"independent\".");
 
-  if (oms_modelState_virgin == getModel()->getModelState())
+  if (cref.hasSuffixStart() && oms_modelState_virgin == getModel()->getModelState())
   {
     if (Flags::ExportParametersInline())
     {
-      startValues.setReal(allVariables[j].getCref(), value);
+      startValues.setReal(cref, value);
     }
     else
     {
       // append startValues with prefix (e.g) addP.K1
-      startValues.setReal(getCref()+allVariables[j].getCref(), value);
+      startValues.setReal(getCref()+cref, value);
     }
   }
   else

--- a/src/OMSimulatorLib/Parameters.h
+++ b/src/OMSimulatorLib/Parameters.h
@@ -34,6 +34,7 @@
 
 #include "ComRef.h"
 #include "Types.h"
+#include "Option.h"
 #include <pugixml.hpp>
 #include <map>
 
@@ -57,9 +58,11 @@ namespace oms
     oms_status_enu_t exportStartValuesHelper(pugi::xml_node& node) const;
     oms_status_enu_t importStartValuesHelper(pugi::xml_node& parameters);
 
-    std::map<ComRef, double> realStartValues;  ///< parameters and start values defined before instantiating the FMU
-    std::map<ComRef, int> integerStartValues;  ///< parameters and start values defined before instantiating the FMU
-    std::map<ComRef, bool> booleanStartValues; ///< parameters and start values defined before instantiating the FMU
+    bool isStartValuesEmpty() const;
+
+    std::map<ComRef, std::pair<double, oms::Option<double>>> realValues;  ///< real values defined after initialization and optional start values defined before instantiating the FMU
+    std::map<ComRef, std::pair<int, oms::Option<int>>> integerValues;  ///< integer values defined after initialization and optional start values defined before instantiating the FMU
+    std::map<ComRef, std::pair<bool, oms::Option<bool>>> booleanValues; ///< boolean values defined after initialization and optional start values defined before instantiating the FMU
   };
 }
 

--- a/testsuite/OMSimulator/Makefile
+++ b/testsuite/OMSimulator/Makefile
@@ -11,6 +11,7 @@ import_export.lua \
 import_export.py \
 PI_Controller.lua \
 QuarterCarModel.DisplacementDisplacement.lua \
+setAndGetStartValues.lua \
 simulation.lua \
 simulation.py \
 table.lua \

--- a/testsuite/OMSimulator/setAndGetStartValues.lua
+++ b/testsuite/OMSimulator/setAndGetStartValues.lua
@@ -1,0 +1,153 @@
+-- status: correct
+-- linux: yes
+-- mingw: yes
+-- win: yes
+-- mac: yes
+
+oms_setCommandLineOption("--suppressPath=true")
+oms_setTempDirectory("./setAndGetStartValues_lua/")
+
+oms_newModel("setAndGetStartValues")
+
+oms_addSystem("setAndGetStartValues.Root", oms_system_wc)
+oms_addConnector("setAndGetStartValues.Root.C1", oms_causality_input, oms_signal_type_real)
+oms_addConnector("setAndGetStartValues.Root.C2", oms_causality_output, oms_signal_type_real)
+oms_addConnector("setAndGetStartValues.Root.C3", oms_causality_parameter, oms_signal_type_real)
+
+-- set start values
+oms_setReal("setAndGetStartValues.Root.C1:start", 20.0)
+
+oms_addSubModel("setAndGetStartValues.Root.Gain", "../resources/Modelica.Blocks.Math.Gain.fmu")
+oms_setReal("setAndGetStartValues.Root.Gain.u:start", -40)
+
+-- not allowed without:start suffix before intitialization or instantiation
+oms_setReal("setAndGetStartValues.Root.Gain.u", -60)
+
+oms_instantiate("setAndGetStartValues")
+print("info:      Parameter settings")
+print("info:      setAndGetStartValues.Root.C1:start         : " .. oms_getReal("setAndGetStartValues.Root.C1:start"))
+print("info:      setAndGetStartValues.Root.Gain.u:start     : " .. oms_getReal("setAndGetStartValues.Root.Gain.u:start"))
+print("info:      setAndGetStartValues.Root.Gain.u           : " .. oms_getReal("setAndGetStartValues.Root.Gain.u"))
+
+oms_initialize("setAndGetStartValues")
+print("info:    Initialization")
+print("info:      setAndGetStartValues.Root.C1:start         : " .. oms_getReal("setAndGetStartValues.Root.C1:start"))
+print("info:      setAndGetStartValues.Root.C1               : " .. oms_getReal("setAndGetStartValues.Root.C1"))
+print("info:      setAndGetStartValues.Root.Gain.u:start     : " .. oms_getReal("setAndGetStartValues.Root.Gain.u:start"))
+print("info:      setAndGetStartValues.Root.Gain.u           : " .. oms_getReal("setAndGetStartValues.Root.Gain.u"))
+
+-- not allowed to provide start value after initialization
+oms_setReal("setAndGetStartValues.Root.C1:start", -20)
+
+-- set inputs after initialization
+oms_setReal("setAndGetStartValues.Root.Gain.u", -35)
+oms_setReal("setAndGetStartValues.Root.C1", 50.0)
+
+
+oms_simulate("setAndGetStartValues")
+print("info:    Simulation")
+print("info:      setAndGetStartValues.Root.C1:start         : " .. oms_getReal("setAndGetStartValues.Root.C1:start"))
+print("info:      setAndGetStartValues.Root.C1               : " .. oms_getReal("setAndGetStartValues.Root.C1"))
+print("info:      setAndGetStartValues.Root.Gain.u:start     : " .. oms_getReal("setAndGetStartValues.Root.Gain.u:start"))
+print("info:      setAndGetStartValues.Root.Gain.u           : " .. oms_getReal("setAndGetStartValues.Root.Gain.u"))
+
+src = oms_list("setAndGetStartValues")
+print(src)
+
+
+-- Result:
+-- error:   [setReal] wrong model state, cannot set value or start value for signal "setAndGetStartValues.Root.Gain.u"
+-- info:      Parameter settings
+-- info:      setAndGetStartValues.Root.C1:start         : 20.0
+-- info:      setAndGetStartValues.Root.Gain.u:start     : -40.0
+-- info:      setAndGetStartValues.Root.Gain.u           : -40.0
+-- info:    Result file: setAndGetStartValues_res.mat (bufferSize=10)
+-- info:    Initialization
+-- info:      setAndGetStartValues.Root.C1:start         : 20.0
+-- info:      setAndGetStartValues.Root.C1               : 0.0
+-- info:      setAndGetStartValues.Root.Gain.u:start     : -40.0
+-- info:      setAndGetStartValues.Root.Gain.u           : -40.0
+-- error:   [setReal] wrong model state, cannot set value or start value for signal "setAndGetStartValues.Root.C1:start"
+-- info:    Simulation
+-- info:      setAndGetStartValues.Root.C1:start         : 20.0
+-- info:      setAndGetStartValues.Root.C1               : 50.0
+-- info:      setAndGetStartValues.Root.Gain.u:start     : -40.0
+-- info:      setAndGetStartValues.Root.Gain.u           : -35.0
+-- <?xml version="1.0"?>
+-- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="setAndGetStartValues" version="1.0">
+-- 	<ssd:System name="Root">
+-- 		<ssd:Annotations>
+-- 			<ssc:Annotation type="org.openmodelica">
+-- 				<oms:SimulationInformation>
+-- 					<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+-- 				</oms:SimulationInformation>
+-- 			</ssc:Annotation>
+-- 		</ssd:Annotations>
+-- 		<ssd:Connectors>
+-- 			<ssd:Connector name="C1" kind="input">
+-- 				<ssc:Real />
+-- 			</ssd:Connector>
+-- 			<ssd:Connector name="C2" kind="output">
+-- 				<ssc:Real />
+-- 			</ssd:Connector>
+-- 			<ssd:Connector name="C3" kind="parameter">
+-- 				<ssc:Real />
+-- 			</ssd:Connector>
+-- 		</ssd:Connectors>
+-- 		<ssd:ParameterBindings>
+-- 			<ssd:ParameterBinding>
+-- 				<ssd:ParameterValues>
+-- 					<ssv:ParameterSet version="1.0" name="parameters">
+-- 						<ssv:Parameters>
+-- 							<ssv:Parameter name="C1">
+-- 								<ssv:Real value="20" />
+-- 							</ssv:Parameter>
+-- 						</ssv:Parameters>
+-- 					</ssv:ParameterSet>
+-- 				</ssd:ParameterValues>
+-- 			</ssd:ParameterBinding>
+-- 		</ssd:ParameterBindings>
+-- 		<ssd:Elements>
+-- 			<ssd:Component name="Gain" type="application/x-fmu-sharedlibrary" source="resources/0001_Gain.fmu">
+-- 				<ssd:Connectors>
+-- 					<ssd:Connector name="u" kind="input">
+-- 						<ssc:Real />
+-- 						<ssd:ConnectorGeometry x="0.000000" y="0.500000" />
+-- 					</ssd:Connector>
+-- 					<ssd:Connector name="y" kind="output">
+-- 						<ssc:Real />
+-- 						<ssd:ConnectorGeometry x="1.000000" y="0.500000" />
+-- 					</ssd:Connector>
+-- 					<ssd:Connector name="k" kind="parameter">
+-- 						<ssc:Real />
+-- 					</ssd:Connector>
+-- 				</ssd:Connectors>
+-- 				<ssd:ParameterBindings>
+-- 					<ssd:ParameterBinding>
+-- 						<ssd:ParameterValues>
+-- 							<ssv:ParameterSet version="1.0" name="parameters">
+-- 								<ssv:Parameters>
+-- 									<ssv:Parameter name="u">
+-- 										<ssv:Real value="-40" />
+-- 									</ssv:Parameter>
+-- 								</ssv:Parameters>
+-- 							</ssv:ParameterSet>
+-- 						</ssd:ParameterValues>
+-- 					</ssd:ParameterBinding>
+-- 				</ssd:ParameterBindings>
+-- 			</ssd:Component>
+-- 		</ssd:Elements>
+-- 		<ssd:Connections />
+-- 	</ssd:System>
+-- 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
+-- 		<ssd:Annotations>
+-- 			<ssc:Annotation type="org.openmodelica">
+-- 				<oms:SimulationInformation resultFile="setAndGetStartValues_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter="" />
+-- 			</ssc:Annotation>
+-- 		</ssd:Annotations>
+-- 	</ssd:DefaultExperiment>
+-- </ssd:SystemStructureDescription>
+-- 
+-- info:    0 warnings
+-- info:    2 errors
+-- endResult


### PR DESCRIPTION
### Related Issues

https://github.com/OpenModelica/OMSimulator/issues/768 and also for OMEdit 

### Purpose

This PR allows to set and get values and start values.

### Approach
use  suffix `:start ` to set start Values before instantiatiaon and  without suffix to set values after initialization
 
Example
```
oms_setReal("setAndGetStartValues.Root.C1:start", 20.0) //  with suffix :start , allowed before instantiation 
oms_instantiate("setAndGetStartValues")
oms_initialize("setAndGetStartValues")
oms_setReal("setAndGetStartValues.Root.C1", 50.0) // without suffix :start allowed only after initialization

```

