### PR TITLE
Adding user flag to set maximum number of loop iterations

### DIFF
--- a/src/OMSimulatorLib/Flags.cpp
+++ b/src/OMSimulatorLib/Flags.cpp
@@ -71,6 +71,7 @@ void oms::Flags::setDefaults()
   intervals = 100;
   masterAlgorithm = oms_solver_wc_ma;
   maxEventIteration = 100;
+  maxLoopIteration = 10;
   numProcs = 1;
   progressBar = false;
   realTime = false;
@@ -309,6 +310,12 @@ oms_status_enu_t oms::Flags::LogLevel(const std::string& value)
 oms_status_enu_t oms::Flags::MaxEventIteration(const std::string& value)
 {
   GetInstance().maxEventIteration = atoi(value.c_str());
+  return oms_status_ok;
+}
+
+oms_status_enu_t oms::Flags::MaxLoopIteration(const std::string& value)
+{
+  GetInstance().maxLoopIteration = atoi(value.c_str());
   return oms_status_ok;
 }
 

--- a/src/OMSimulatorLib/Flags.h
+++ b/src/OMSimulatorLib/Flags.h
@@ -78,6 +78,7 @@ namespace oms
     static std::string ResultFile() {return GetInstance().resultFile;}
     static unsigned int Intervals() {return GetInstance().intervals;}
     static unsigned int MaxEventIteration() {return GetInstance().maxEventIteration;}
+    static unsigned int MaxLoopIteration() {return GetInstance().maxLoopIteration;}
     static unsigned int NumProcs() {return GetInstance().numProcs;}
 
   private:
@@ -104,6 +105,7 @@ namespace oms
     std::string resultFile;
     unsigned int intervals;
     unsigned int maxEventIteration;
+    unsigned int maxLoopIteration;
     unsigned int numProcs;
 
   private:
@@ -143,6 +145,7 @@ namespace oms
       {"--logFile", "-l", "Specifies the logfile (stdout is used if no log file is specified)", re_default, Flags::LogFile, false},
       {"--logLevel", "", "0 default, 1 debug, 2 debug+trace", re_number, Flags::LogLevel, false},
       {"--maxEventIteration", "", "Specifies the max. number of iterations for handling a single event", re_number, Flags::MaxEventIteration, false},
+      {"--maxLoopIteration", "", "Specifies the max. number of iterations for solving algebraic loops between system-level components. Internal algebraic loops of components are not affected.", re_number, Flags::MaxLoopIteration, false},
       {"--mode", "-m", "Forces a certain FMI mode iff the FMU provides cs and me (cs, [me])", re_mode, Flags::Mode, false},
       {"--numProcs", "-n", "Specifies the max. number of processors to use (0=auto, 1=default)", re_number, Flags::NumProcs, false},
       {"--progressBar", "", "Shows a progress bar for the simulation progress in the terminal (true, [false])", re_bool, Flags::ProgressBar, false},
@@ -178,6 +181,7 @@ namespace oms
     static oms_status_enu_t LogFile(const std::string& value);
     static oms_status_enu_t LogLevel(const std::string& value);
     static oms_status_enu_t MaxEventIteration(const std::string& value);
+    static oms_status_enu_t MaxLoopIteration(const std::string& value);
     static oms_status_enu_t Mode(const std::string& value);
     static oms_status_enu_t NumProcs(const std::string& value);
     static oms_status_enu_t ProgressBar(const std::string& value);

--- a/src/OMSimulatorLib/SystemSC.cpp
+++ b/src/OMSimulatorLib/SystemSC.cpp
@@ -708,7 +708,7 @@ oms_status_enu_t oms::SystemSC::solveAlgLoop(DirectedGraph& graph, const std::ve
   CallClock callClock(clock);
 
   const int size = SCC.size();
-  const int maxIterations = 10;
+  const int maxIterations = Flags::MaxLoopIteration();
   double maxRes;
   double *res = new double[size]();
 

--- a/src/OMSimulatorLib/SystemWC.cpp
+++ b/src/OMSimulatorLib/SystemWC.cpp
@@ -1069,7 +1069,7 @@ oms_status_enu_t oms::SystemWC::solveAlgLoop(DirectedGraph& graph, const std::ve
   CallClock callClock(clock);
 
   const int size = SCC.size();
-  const int maxIterations = 10;
+  const int maxIterations = Flags::MaxLoopIteration();
   double maxRes;
   double *res = new double[size]();
 


### PR DESCRIPTION
  - Affects iterative solver used for solving algebraic loops over multiple FMUs

### Related Issues

https://github.com/OpenModelica/OMSimulator/issues/809

### Purpose

Give users the option to choose the maximum number of iterations.

### Approach

Added a flag for it.
