### PR TITLE
Add flag -notlm to runtests.pl

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -520,7 +520,7 @@ void partest(cache=true, extraArgs='') {
   ${env.ASAN ? "" : "ulimit -v 6291456" /* Max 6GB per process */}
 
   cd testsuite/partest
-  ./runtests.pl ${env.ASAN ? "-asan": ""} -j${numPhysicalCPU()} -nocolour -with-xml ${params.RUNTESTS_FLAG} ${extraArgs}
+  ./runtests.pl ${env.ASAN ? "-asan": ""} -j${numPhysicalCPU()} -nocolour ${env.BRANCH_NAME == "master" ? "-notlm" : ""} -with-xml ${params.RUNTESTS_FLAG} ${extraArgs}
   CODE=\$?
   test \$CODE = 0 -o \$CODE = 7 || exit 1
   """

--- a/testsuite/partest/runtests.pl
+++ b/testsuite/partest/runtests.pl
@@ -37,8 +37,8 @@ $ENV{GC_MARKERS}="1";
 my $use_db = 1;
 my $save_db = 1;
 my $asan = 0;
+my $notlm = 0;
 my $nocolour = '';
-my $fast = 0;
 my $count_tests = 0;
 my $run_failing = 0;
 my $file;
@@ -79,12 +79,12 @@ for(@ARGV){
     print("  -b            Rebase tests in parallel. Use in conjuction with -file=/path/to/file.\n");
     print("  -counttests   Don't run the test; only count them.\n");
     print("  -failing      Run failing tests instead of working.\n");
-    print("  -fast         Only run fast tests.\n");
     print("  -file         Reads testcases from the given file instead of from a makefile.\n");
     print("  -jN           Use N threads.\n");
     print("  -nocolour     Don't use colours in output.\n");
     print("  -nodb         Don't store timing data.\n");
     print("  -nosavedb     Don't overwrite stored timing data.\n");
+    print("  -notlm        Skip all tlm tests.\n");
     print("  -platform     Force to use a specific platform, e.g. win or linux32.\n");
     print("  -with-txt     Output TXT log.\n");
     print("  -with-xml     Output XML log.\n");
@@ -102,9 +102,6 @@ for(@ARGV){
   elsif(/^-failing$/) {
     $run_failing = 1;
   }
-  elsif(/^-fast$/) {
-    $fast = 1;
-  }
   elsif(/^-file=(.*)$/) {
     $file = $1;
   }
@@ -120,6 +117,9 @@ for(@ARGV){
   }
   elsif(/^-nosavedb$/) {
     $save_db = 0;
+  }
+  elsif(/^-notlm$/) {
+    $notlm = 1;
   }
   elsif(/^-platform(.*)$/) {
     $platform = $_;
@@ -172,7 +172,7 @@ sub read_makefile {
   my $dir = shift;
   my $header = shift;
 
-  return if($fast == 1 and $dir =~ m"/tlm"); # Skip tlm if -fast is given.
+  return if($notlm == 1 and $dir =~ m"/tlm"); # Skip tlm if -notlm is given.
 
   open(my $in, "<", "$dir/Makefile") or die "Couldn't open $dir/Makefile: $!";
 
@@ -418,4 +418,3 @@ if (@dirs) {
 if(@failed_tests) {
   exit 7;
 }
-


### PR DESCRIPTION
### Purpose

TLM tests fail randomly which is especially annoying on the master branch as we just successfully tested all the tests.

### Approach

Skip tlm tests for master, but keep them for the pull requests so that we can be sure to not break any tlm related functionality.

This introduces a new flag `-notlm` which skips all tlm tests. This PR also removes `-fast` since I couldn't find any references to it.
