### PR TITLE
add oms_exportSnapshot API

### DIFF
--- a/doc/UsersGuide/source/api/exportSnapshot.rst
+++ b/doc/UsersGuide/source/api/exportSnapshot.rst
@@ -1,5 +1,5 @@
 #CAPTION#
-list
+exportSnapshot
 ----
 
 Lists the SSD representation of a given model, system, or component.

--- a/doc/UsersGuide/source/api/exportSnapshot.rst
+++ b/doc/UsersGuide/source/api/exportSnapshot.rst
@@ -1,6 +1,6 @@
 #CAPTION#
 exportSnapshot
-----
+--------------
 
 Lists the SSD representation of a given model, system, or component.
 

--- a/doc/UsersGuide/source/api/exportSnapshot.rst
+++ b/doc/UsersGuide/source/api/exportSnapshot.rst
@@ -1,0 +1,41 @@
+#CAPTION#
+list
+----
+
+Lists the SSD representation of a given model, system, or component.
+
+Memory is allocated for `contents`. The caller is responsible to free it using
+the C-API. The Lua and Python bindings take care of the memory and the caller
+doesn't need to call free.
+#END#
+
+#LUA#
+.. code-block:: lua
+
+  contents, status = oms_exportSnapshot(cref)
+
+#END#
+
+#PYTHON#
+.. code-block:: python
+
+  contents, status = oms_exportSnapshot(cref)
+
+#END#
+
+#CAPI#
+.. code-block:: c
+
+  oms_status_enu_t oms_exportSnapshot(const char* cref, char** contents);
+
+#END#
+
+#OMC#
+.. code-block:: Modelica
+
+  (contents, status) := oms_exportSnapshot(cref);
+
+#END#
+
+#DESCRIPTION#
+#END#

--- a/doc/UsersGuide/source/api/importSnapshot.rst
+++ b/doc/UsersGuide/source/api/importSnapshot.rst
@@ -1,6 +1,6 @@
 #CAPTION#
 importSnapshot
-------------
+--------------
 
 Loads a snapshot to restore a previous model state. The model must be in virgin model state, which means it must not be instantiated.
 #END#

--- a/doc/UsersGuide/source/api/importSnapshot.rst
+++ b/doc/UsersGuide/source/api/importSnapshot.rst
@@ -1,5 +1,5 @@
 #CAPTION#
-loadSnapshot
+importSnapshot
 ------------
 
 Loads a snapshot to restore a previous model state. The model must be in virgin model state, which means it must not be instantiated.
@@ -8,28 +8,28 @@ Loads a snapshot to restore a previous model state. The model must be in virgin 
 #LUA#
 .. code-block:: lua
 
-  status = oms_loadSnapshot(cref, snapshot)
+  status = oms_importSnapshot(cref, snapshot)
 
 #END#
 
 #PYTHON#
 .. code-block:: python
 
-  status = oms_loadSnapshot(cref, snapshot)
+  status = oms_importSnapshot(cref, snapshot)
 
 #END#
 
 #CAPI#
 .. code-block:: c
 
-  oms_status_enu_t oms_loadSnapshot(const char* cref, const char* snapshot);
+  oms_status_enu_t oms_importSnapshot(const char* cref, const char* snapshot);
 
 #END#
 
 #OMC#
 .. code-block:: Modelica
 
-  status := oms_loadSnapshot(cref, snapshot);
+  status := oms_importSnapshot(cref, snapshot);
 
 #END#
 

--- a/src/OMSimulatorLib/Model.cpp
+++ b/src/OMSimulatorLib/Model.cpp
@@ -316,6 +316,8 @@ oms_status_enu_t oms::Model::exportSnapshot(const oms::ComRef& cref, char** cont
   ssvDeclarationNode.append_attribute("encoding") = "UTF-8";
 
   pugi::xml_node node_parameterset = ssvdoc.append_child(oms::ssp::Version1_0::ssv::parameter_set);
+  node_parameterset.append_attribute("xmlns:ssc") = "http://ssp-standard.org/SSP1/SystemStructureCommon";
+  node_parameterset.append_attribute("xmlns:ssv") = "http://ssp-standard.org/SSP1/SystemStructureParameterValues";
   node_parameterset.append_attribute("version") = "1.0";
   node_parameterset.append_attribute("name") = "parameters";
   pugi::xml_node node_parameters = node_parameterset.append_child(oms::ssp::Version1_0::ssv::parameters);
@@ -340,6 +342,8 @@ oms_status_enu_t oms::Model::exportSnapshot(const oms::ComRef& cref, char** cont
     pugi::xml_node ssvfilenode  = last.append_child(oms::ssp::Version1_0::ssv_file);
     std::string ssvFilePath = "resources/" + std::string(this->getCref()) + ".ssv";
     ssvfilenode.append_attribute("name") = ssvFilePath.c_str();
+    // dump all the ssv file contents
+    ssvfilenode.append_copy(node_parameterset);
     // TODO ssm file
   }
 

--- a/src/OMSimulatorLib/Model.cpp
+++ b/src/OMSimulatorLib/Model.cpp
@@ -175,10 +175,10 @@ oms_status_enu_t oms::Model::importSnapshot(const char* snapshot)
   if (!result)
     return logError("loading snapshot failed (" + std::string(result.description()) + ")");
 
-  const pugi::xml_node node = doc.document_element(); // oms:snapshot
+  snapShot = doc.document_element(); // oms:snapshot
 
   // get ssd:SystemStructureDescription
-  pugi::xml_node ssdNode = node.child(oms::ssp::Version1_0::ssd_file).child(oms::ssp::Draft20180219::ssd::system_structure_description);
+  pugi::xml_node ssdNode = snapShot.child(oms::ssp::Version1_0::ssd_file).child(oms::ssp::Draft20180219::ssd::system_structure_description);
 
   ComRef new_cref = ComRef(ssdNode.attribute("name").as_string());
   std::string ssdVersion = ssdNode.attribute("version").as_string();

--- a/src/OMSimulatorLib/Model.h
+++ b/src/OMSimulatorLib/Model.h
@@ -73,6 +73,7 @@ namespace oms
     oms_status_enu_t exportToSSD(pugi::xml_node& node, pugi::xml_node& ssvNode) const;
     oms_status_enu_t exportSnapshot(const ComRef& cref, char** contents);
     oms_status_enu_t importFromSSD(const pugi::xml_node& node);
+    oms_status_enu_t importSnapshot(const char* snapshot);
     oms_status_enu_t exportToFile(const std::string& filename) const;
     oms_system_enu_t getSystemType(const pugi::xml_node& node, const std::string& sspVersion);
     oms_system_enu_t getSystemTypeHelper(const pugi::xml_node& node, const std::string& sspVersion);

--- a/src/OMSimulatorLib/Model.h
+++ b/src/OMSimulatorLib/Model.h
@@ -71,6 +71,7 @@ namespace oms
     oms_status_enu_t list(const ComRef& cref, char** contents);
     oms_status_enu_t addSystem(const ComRef& cref, oms_system_enu_t type);
     oms_status_enu_t exportToSSD(pugi::xml_node& node, pugi::xml_node& ssvNode) const;
+    oms_status_enu_t exportSnapshot(const ComRef& cref, char** contents);
     oms_status_enu_t importFromSSD(const pugi::xml_node& node);
     oms_status_enu_t exportToFile(const std::string& filename) const;
     oms_system_enu_t getSystemType(const pugi::xml_node& node, const std::string& sspVersion);

--- a/src/OMSimulatorLib/Model.h
+++ b/src/OMSimulatorLib/Model.h
@@ -122,6 +122,8 @@ namespace oms
 
     oms_status_enu_t loadSnapshot(const char* snapshot);
 
+    pugi::xml_node getSnapshot() {return snapShot;}
+
   private:
     Model(const ComRef& cref, const std::string& tempDir);
 
@@ -152,7 +154,9 @@ namespace oms
     std::string resultFilename;             ///< default <name>_res.mat
     Clock clock;
 
-    std::string signalFilter = "";  // default set to empty
+    std::string signalFilter = "";  ///< default set to empty
+
+    pugi::xml_node snapShot; ///< top level snapshot node which contains ssd, ssv and ssm as child nodes
 
     bool cancelSim;
     bool isolatedFMU = false;

--- a/src/OMSimulatorLib/OMSimulator.cpp
+++ b/src/OMSimulatorLib/OMSimulator.cpp
@@ -214,6 +214,17 @@ oms_status_enu_t oms_list(const char* cref_, char** contents)
   return model->list(tail, contents);
 }
 
+oms_status_enu_t oms_exportSnapshot(const char* cref_, char** contents)
+{
+  oms::ComRef tail(cref_);
+  oms::ComRef front = tail.pop_front();
+  oms::Model* model = oms::Scope::GetInstance().getModel(front);
+  if (!model)
+    return logError_ModelNotInScope(front);
+
+  return model->exportSnapshot(tail, contents);
+}
+
 oms_status_enu_t oms_listUnconnectedConnectors(const char* cref_, char** contents)
 {
   oms::ComRef tail(cref_);

--- a/src/OMSimulatorLib/OMSimulator.cpp
+++ b/src/OMSimulatorLib/OMSimulator.cpp
@@ -251,6 +251,17 @@ oms_status_enu_t oms_loadSnapshot(const char* cref_, const char* snapshot)
   return model->loadSnapshot(snapshot);
 }
 
+oms_status_enu_t oms_importSnapshot(const char* cref_, const char* snapshot)
+{
+  oms::ComRef cref(cref_);
+
+  oms::Model* model = oms::Scope::GetInstance().getModel(cref);
+  if (!model)
+    return logError_ModelNotInScope(cref);
+
+  return model->importSnapshot(snapshot);
+}
+
 oms_status_enu_t oms_parseModelName(const char* contents, char** cref)
 {
   return logError_NotImplemented;

--- a/src/OMSimulatorLib/OMSimulator.h
+++ b/src/OMSimulatorLib/OMSimulator.h
@@ -113,6 +113,7 @@ OMSAPI oms_status_enu_t OMSCALL oms_getVariableStepSize(const char* cref, double
 OMSAPI const char* OMSCALL oms_getVersion();
 OMSAPI oms_status_enu_t OMSCALL oms_faultInjection(const char* signal, oms_fault_type_enu_t faultType, double faultValue);
 OMSAPI oms_status_enu_t OMSCALL oms_importFile(const char* filename, char** cref);
+OMSAPI oms_status_enu_t OMSCALL oms_importSnapshot(const char* cref, const char* snapshot);
 OMSAPI oms_status_enu_t OMSCALL oms_initialize(const char* cref);
 OMSAPI oms_status_enu_t OMSCALL oms_instantiate(const char* cref);
 OMSAPI oms_status_enu_t OMSCALL oms_list(const char* cref, char** contents);

--- a/src/OMSimulatorLib/OMSimulator.h
+++ b/src/OMSimulatorLib/OMSimulator.h
@@ -82,6 +82,7 @@ OMSAPI oms_status_enu_t OMSCALL oms_deleteConnectorFromBus(const char* busCref, 
 OMSAPI oms_status_enu_t OMSCALL oms_deleteConnectorFromTLMBus(const char* busCref, const char* connectorCref);
 OMSAPI oms_status_enu_t OMSCALL oms_export(const char* cref, const char* filename);
 OMSAPI oms_status_enu_t OMSCALL oms_exportDependencyGraphs(const char* cref, const char* initialization, const char* simulation);
+OMSAPI oms_status_enu_t OMSCALL oms_exportSnapshot(const char* cref, char** contents);
 OMSAPI oms_status_enu_t OMSCALL oms_extractFMIKind(const char* filename, oms_fmi_kind_enu_t* kind);
 OMSAPI oms_status_enu_t OMSCALL oms_fetchExternalModelInterfaces(const char* cref, char*** names, char*** domains, int** dimensions);
 OMSAPI void OMSCALL oms_freeMemory(void* obj);

--- a/src/OMSimulatorLib/System.cpp
+++ b/src/OMSimulatorLib/System.cpp
@@ -483,69 +483,80 @@ oms_status_enu_t oms::System::importFromSSD(const pugi::xml_node& node, const st
     }
     else if(name == oms::ssp::Version1_0::ssd::parameter_bindings)
     {
-      pugi::xml_node parameterBindingNode = it->child(oms::ssp::Version1_0::ssd::parameter_binding);
-      ssvFileSource = parameterBindingNode.attribute("source").as_string() ;
-      // set parameter bindings associated with the system
-      if (ssvFileSource.empty()) // inline parameterBinding
+      // check for multiple ssv files or parameter bindings
+      for (pugi::xml_node parameterBindingNode = it->child(oms::ssp::Version1_0::ssd::parameter_binding); parameterBindingNode; parameterBindingNode = parameterBindingNode.next_sibling(oms::ssp::Version1_0::ssd::parameter_binding))
       {
-        //std::cout << "\n System ssvFileSource  inline :" << ssvFileSource;
-        std::string tempdir = getModel()->getTempDirectory();
-        if (oms_status_ok !=  values.importFromSSD(*it, sspVersion, tempdir))
-          return logError("Failed to import " + std::string(oms::ssp::Version1_0::ssd::parameter_bindings));
+        std::string ssvFileSource = parameterBindingNode.attribute("source").as_string();
+        // set parameter bindings associated with the system
+        if (ssvFileSource.empty()) // inline parameterBinding
+        {
+          //std::cout << "\n System ssvFileSource  inline :" << ssvFileSource;
+          std::string tempdir = getModel()->getTempDirectory();
+          if (oms_status_ok !=  values.importFromSSD(*it, sspVersion, tempdir))
+            return logError("Failed to import " + std::string(oms::ssp::Version1_0::ssd::parameter_bindings));
+        }
+        else
+        {
+          // store the ssv files and process it later while handling the connection, so all the components are loaded
+          ssvFileSources.push_back(ssvFileSource);
+        }
       }
     }
     else if (name == oms::ssp::Draft20180219::ssd::connections)
     {
       // check for ssvFileSource exist and set the values before the connections
-      if (!ssvFileSource.empty())
+      if (!ssvFileSources.empty())
       {
-        std::string tempdir = getModel()->getTempDirectory();
-        filesystem::path temp_root(tempdir);
-        pugi::xml_document ssvdoc;
-        pugi::xml_parse_result result = ssvdoc.load_file((temp_root / ssvFileSource).string().c_str());
-        pugi::xml_node parameterSet, parameters;
+        for (const auto& ssvFileSource : ssvFileSources)
+        {
+          std::string tempdir = getModel()->getTempDirectory();
+          filesystem::path temp_root(tempdir);
+          pugi::xml_document ssvdoc;
+          pugi::xml_parse_result result = ssvdoc.load_file((temp_root / ssvFileSource).string().c_str());
+          pugi::xml_node parameterSet, parameters;
 
-        if (result) // check from ssv file
-        {
-          parameterSet = ssvdoc.document_element(); // ssv:ParameterSet
-          parameters = parameterSet.child(oms::ssp::Version1_0::ssv::parameters);
-        }
-        else if (getModel()->getSnapshot().child(oms::ssp::Version1_0::ssv_file)) // check in memory oms:ssv_file
-        {
-          parameterSet = getModel()->getSnapshot().child(oms::ssp::Version1_0::ssv_file).child(oms::ssp::Version1_0::ssv::parameter_set); // ssv:ParameterSet
-          parameters = parameterSet.child(oms::ssp::Version1_0::ssv::parameters);
-        }
-        else
-        {
-          return logError("loading \"" + std::string(ssvFileSource) + "\" failed (" + std::string(result.description()) + ")");
-        }
-
-        if (parameters)
-        {
-          for(pugi::xml_node_iterator itparameters = parameters.begin(); itparameters != parameters.end(); ++itparameters)
+          if (result) // check from ssv file
           {
-            std::string name = itparameters->name();
-            if (name == oms::ssp::Version1_0::ssv::parameter)
+            parameterSet = ssvdoc.document_element(); // ssv:ParameterSet
+            parameters = parameterSet.child(oms::ssp::Version1_0::ssv::parameters);
+          }
+          else if (getModel()->getSnapshot().child(oms::ssp::Version1_0::ssv_file)) // check in memory oms:ssv_file
+          {
+            parameterSet = getModel()->getSnapshot().child(oms::ssp::Version1_0::ssv_file).child(oms::ssp::Version1_0::ssv::parameter_set); // ssv:ParameterSet
+            parameters = parameterSet.child(oms::ssp::Version1_0::ssv::parameters);
+          }
+          else
+          {
+            return logError("loading \"" + std::string(ssvFileSource) + "\" failed (" + std::string(result.description()) + ")");
+          }
+
+          if (parameters)
+          {
+            for(pugi::xml_node_iterator itparameters = parameters.begin(); itparameters != parameters.end(); ++itparameters)
             {
-              ComRef cref = ComRef(itparameters->attribute("name").as_string());
-              if (itparameters->child(oms::ssp::Version1_0::ssv::real_type))
+              std::string name = itparameters->name();
+              if (name == oms::ssp::Version1_0::ssv::parameter)
               {
-                double value = itparameters->child(oms::ssp::Version1_0::ssv::real_type).attribute("value").as_double();
-                setReal(cref, value);
-              }
-              else if(itparameters->child(oms::ssp::Version1_0::ssv::integer_type))
-              {
-                int value = itparameters->child(oms::ssp::Version1_0::ssv::integer_type).attribute("value").as_int();
-                setInteger(cref, value);
-              }
-              else if(itparameters->child(oms::ssp::Version1_0::ssv::boolean_type))
-              {
-                bool value = itparameters->child(oms::ssp::Version1_0::ssv::boolean_type).attribute("value").as_bool();
-                setBoolean(cref, value);
-              }
-              else
-              {
-                logError("Failed to import " + std::string(oms::ssp::Version1_0::ssv::parameter) + ":Unknown ParameterBinding-type");
+                ComRef cref = ComRef(itparameters->attribute("name").as_string());
+                if (itparameters->child(oms::ssp::Version1_0::ssv::real_type))
+                {
+                  double value = itparameters->child(oms::ssp::Version1_0::ssv::real_type).attribute("value").as_double();
+                  setReal(cref, value);
+                }
+                else if(itparameters->child(oms::ssp::Version1_0::ssv::integer_type))
+                {
+                  int value = itparameters->child(oms::ssp::Version1_0::ssv::integer_type).attribute("value").as_int();
+                  setInteger(cref, value);
+                }
+                else if(itparameters->child(oms::ssp::Version1_0::ssv::boolean_type))
+                {
+                  bool value = itparameters->child(oms::ssp::Version1_0::ssv::boolean_type).attribute("value").as_bool();
+                  setBoolean(cref, value);
+                }
+                else
+                {
+                  logError("Failed to import " + std::string(oms::ssp::Version1_0::ssv::parameter) + ":Unknown ParameterBinding-type");
+                }
               }
             }
           }

--- a/src/OMSimulatorLib/System.cpp
+++ b/src/OMSimulatorLib/System.cpp
@@ -503,16 +503,16 @@ oms_status_enu_t oms::System::importFromSSD(const pugi::xml_node& node, const st
         filesystem::path temp_root(tempdir);
         pugi::xml_document ssvdoc;
         pugi::xml_parse_result result = ssvdoc.load_file((temp_root / ssvFileSource).string().c_str());
-        pugi::xml_node parameterSet, parameters, ssvNode;
+        pugi::xml_node parameterSet, parameters;
 
         if (result) // check from ssv file
         {
           parameterSet = ssvdoc.document_element(); // ssv:ParameterSet
           parameters = parameterSet.child(oms::ssp::Version1_0::ssv::parameters);
         }
-        else if((ssvNode = getModel()->getSnapshot().child(oms::ssp::Version1_0::ssv_file))) // check in memory oms:ssv_file
+        else if (getModel()->getSnapshot().child(oms::ssp::Version1_0::ssv_file)) // check in memory oms:ssv_file
         {
-          parameterSet = ssvNode.child(oms::ssp::Version1_0::ssv::parameter_set); // ssv:ParameterSet
+          parameterSet = getModel()->getSnapshot().child(oms::ssp::Version1_0::ssv_file).child(oms::ssp::Version1_0::ssv::parameter_set); // ssv:ParameterSet
           parameters = parameterSet.child(oms::ssp::Version1_0::ssv::parameters);
         }
         else

--- a/src/OMSimulatorLib/System.h
+++ b/src/OMSimulatorLib/System.h
@@ -164,7 +164,7 @@ namespace oms
     ctpl::thread_pool& getThreadPool();
 
     std::string getUniqueID() const;
-    std::string ssvFileSource = "";
+    std::vector<std::string> ssvFileSources;
   protected:
     System(const ComRef& cref, oms_system_enu_t type, Model* parentModel, System* parentSystem, oms_solver_enu_t solverMethod);
 

--- a/src/OMSimulatorLib/ssd/Tags.cpp
+++ b/src/OMSimulatorLib/ssd/Tags.cpp
@@ -63,6 +63,11 @@ const char* oms::ssp::Version1_0::simulation_information               = "oms:Si
 const char* oms::ssp::Version1_0::FixedStepMaster                      = "oms:FixedStepMaster"; // WC-System
 const char* oms::ssp::Version1_0::VariableStepSolver                   = "oms:VariableStepSolver"; // SC-System
 
+const char* oms::ssp::Version1_0::snap_shot                             = "oms:snapshot";
+const char* oms::ssp::Version1_0::ssd_file                              = "oms:ssd_file";
+const char* oms::ssp::Version1_0::ssv_file                              = "oms:ssv_file";
+const char* oms::ssp::Version1_0::ssm_file                              = "oms:ssm_file";
+
 const char* oms::ssp::Version1_0::ssd::parameter_bindings              = "ssd:ParameterBindings";
 const char* oms::ssp::Version1_0::ssd::parameter_binding               = "ssd:ParameterBinding";
 const char* oms::ssp::Version1_0::ssd::parameter_values                = "ssd:ParameterValues";

--- a/src/OMSimulatorLib/ssd/Tags.h
+++ b/src/OMSimulatorLib/ssd/Tags.h
@@ -41,6 +41,10 @@ namespace oms
       extern const char* simulation_information;
       extern const char* FixedStepMaster;
       extern const char* VariableStepSolver;
+      extern const char* snap_shot;
+      extern const char* ssd_file;
+      extern const char* ssv_file;
+      extern const char* ssm_file;
 
       namespace ssd
       {

--- a/src/OMSimulatorLua/OMSimulatorLua.c
+++ b/src/OMSimulatorLua/OMSimulatorLua.c
@@ -258,6 +258,26 @@ static int OMSimulatorLua_oms_list(lua_State *L)
   return 2;
 }
 
+//oms_status_enu_t oms_exportSnapshot(const char* cref, char** contents);
+static int OMSimulatorLua_oms_exportSnapshot(lua_State *L)
+{
+  if (lua_gettop(L) != 1)
+    return luaL_error(L, "expecting exactly 1 argument");
+  luaL_checktype(L, 1, LUA_TSTRING);
+
+  const char* cref = lua_tostring(L, 1);
+  char* contents = NULL;
+  oms_status_enu_t status = oms_exportSnapshot(cref, &contents);
+
+  lua_pushstring(L, contents ? contents : "");
+  lua_pushinteger(L, status);
+
+  if (contents)
+    oms_freeMemory(contents);
+
+  return 2;
+}
+
 //oms_status_enu_t oms_listUnconnectedConnectors(const char* cref, char** contents);
 static int OMSimulatorLua_oms_listUnconnectedConnectors(lua_State *L)
 {
@@ -1230,6 +1250,7 @@ DLLEXPORT int luaopen_OMSimulatorLua(lua_State *L)
   REGISTER_LUA_CALL(oms_deleteConnectorFromTLMBus);
   REGISTER_LUA_CALL(oms_export);
   REGISTER_LUA_CALL(oms_exportDependencyGraphs);
+  REGISTER_LUA_CALL(oms_exportSnapshot);
   REGISTER_LUA_CALL(oms_faultInjection);
   REGISTER_LUA_CALL(oms_getBoolean);
   REGISTER_LUA_CALL(oms_getFixedStepSize);

--- a/src/OMSimulatorLua/OMSimulatorLua.c
+++ b/src/OMSimulatorLua/OMSimulatorLua.c
@@ -314,6 +314,22 @@ static int OMSimulatorLua_oms_loadSnapshot(lua_State *L)
   return 1;
 }
 
+//oms_status_enu_t oms_importSnapshot(const char* cref, const char* snapshot);
+static int OMSimulatorLua_oms_importSnapshot(lua_State *L)
+{
+  if (lua_gettop(L) != 2)
+    return luaL_error(L, "expecting exactly 2 arguments\n<integer> = oms_loadSnapshot(<string>, <string>)");
+  luaL_checktype(L, 1, LUA_TSTRING);
+  luaL_checktype(L, 2, LUA_TSTRING);
+
+  const char* cref = lua_tostring(L, 1);
+  const char* snapshot = lua_tostring(L, 2);
+  oms_status_enu_t status = oms_importSnapshot(cref, snapshot);
+
+  lua_pushinteger(L, status);
+  return 1;
+}
+
 //oms_status_enu_t oms_exportDependencyGraphs(const char* cref, const char* initialization, const char* simulation);
 static int OMSimulatorLua_oms_exportDependencyGraphs(lua_State *L)
 {
@@ -1264,6 +1280,7 @@ DLLEXPORT int luaopen_OMSimulatorLua(lua_State *L)
   REGISTER_LUA_CALL(oms_getVariableStepSize);
   REGISTER_LUA_CALL(oms_getVersion);
   REGISTER_LUA_CALL(oms_importFile);
+  REGISTER_LUA_CALL(oms_importSnapshot);
   REGISTER_LUA_CALL(oms_initialize);
   REGISTER_LUA_CALL(oms_instantiate);
   REGISTER_LUA_CALL(oms_list);

--- a/src/OMSimulatorPython/OMSimulator.py.in
+++ b/src/OMSimulatorPython/OMSimulator.py.in
@@ -103,6 +103,8 @@ class OMSimulator:
     self.obj.oms_export.restype = ctypes.c_int
     self.obj.oms_exportDependencyGraphs.argtypes = [ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p]
     self.obj.oms_exportDependencyGraphs.restype = ctypes.c_int
+    self.obj.oms_exportSnapshot.argtypes = [ctypes.c_char_p]
+    self.obj.oms_exportSnapshot.restype = ctypes.c_int
     self.obj.oms_faultInjection.argtypes = [ctypes.c_char_p, ctypes.c_int, ctypes.c_double]
     self.obj.oms_faultInjection.restype = ctypes.c_int
     self.obj.oms_getBoolean.argtypes = [ctypes.c_char_p, ctypes.POINTER(ctypes.c_bool)]
@@ -127,6 +129,8 @@ class OMSimulator:
     self.obj.oms_getVersion.restype = ctypes.c_char_p
     self.obj.oms_importFile.argtypes = [ctypes.c_char_p]
     self.obj.oms_importFile.restype = ctypes.c_int
+    self.obj.oms_importSnapshot.argtypes = [ctypes.c_char_p, ctypes.c_char_p]
+    self.obj.oms_importSnapshot.restype = ctypes.c_int
     self.obj.oms_initialize.argtypes = [ctypes.c_char_p]
     self.obj.oms_initialize.restype = ctypes.c_int
     self.obj.oms_instantiate.argtypes = [ctypes.c_char_p]
@@ -135,6 +139,8 @@ class OMSimulator:
     self.obj.oms_list.restype = ctypes.c_int
     self.obj.oms_listUnconnectedConnectors.argtypes = [ctypes.c_char_p]
     self.obj.oms_listUnconnectedConnectors.restype = ctypes.c_int
+    self.obj.oms_loadSnapshot.argtypes = [ctypes.c_char_p, ctypes.c_char_p]
+    self.obj.oms_loadSnapshot.restype = ctypes.c_int
     self.obj.oms_newModel.argtypes = [ctypes.c_char_p]
     self.obj.oms_newModel.restype = ctypes.c_int
     self.obj.oms_parseModelName.argtypes = [ctypes.c_char_p]
@@ -259,14 +265,24 @@ class OMSimulator:
     contents = ctypes.c_char_p()
     status = self.obj.oms_importFile(self.checkstring(filename), ctypes.byref(contents))
     return [self.checkstring(contents.value), status]
+  def importSnapshot(self, ident, snapshot):
+    status = self.obj.oms_importSnapshot(self.checkstring(ident), self.checkstring(snapshot))
+    return status
   def list(self, ident):
     contents = ctypes.c_char_p()
     status = self.obj.oms_list(self.checkstring(ident), ctypes.byref(contents))
+    return [self.checkstring(contents.value), status]
+  def exportSnapshot(self, ident):
+    contents = ctypes.c_char_p()
+    status = self.obj.oms_exportSnapshot(self.checkstring(ident), ctypes.byref(contents))
     return [self.checkstring(contents.value), status]
   def listUnconnectedConnectors(self, ident):
     contents = ctypes.c_char_p()
     status = self.obj.oms_listUnconnectedConnectors(self.checkstring(ident), ctypes.byref(contents))
     return [self.checkstring(contents.value), status]
+  def loadSnapshot(self, ident, snapshot):
+    status = self.obj.oms_loadSnapshot(self.checkstring(ident), self.checkstring(snapshot))
+    return status
   def parseModelName(self, ident):
     contents = ctypes.c_char_p()
     status = self.obj.oms_parseModelName(self.checkstring(ident), ctypes.byref(contents))

--- a/testsuite/OMSimulator/Makefile
+++ b/testsuite/OMSimulator/Makefile
@@ -8,14 +8,15 @@ DualMassOscillator.lua \
 exportConnectorsToResultFile.lua \
 import_export_parameters_inline.lua \
 import_export_parameters_to_ssv.lua \
+import_export_snapshot.lua \
 import_export.lua \
 import_export.py \
-import_export_snapshot.lua \
 PI_Controller.lua \
 QuarterCarModel.DisplacementDisplacement.lua \
+setExternalInputs.lua \
 simulation.lua \
 simulation.py \
-setExternalInputs.lua \
+snapshot.lua \
 table.lua \
 
 # Run make failingtest

--- a/testsuite/OMSimulator/Makefile
+++ b/testsuite/OMSimulator/Makefile
@@ -11,6 +11,7 @@ import_export_parameters_to_ssv.lua \
 import_export_snapshot.lua \
 import_export.lua \
 import_export.py \
+importStartValues.lua \
 PI_Controller.lua \
 QuarterCarModel.DisplacementDisplacement.lua \
 setExternalInputs.lua \

--- a/testsuite/OMSimulator/Makefile
+++ b/testsuite/OMSimulator/Makefile
@@ -18,6 +18,7 @@ setExternalInputs.lua \
 simulation.lua \
 simulation.py \
 snapshot.lua \
+snapshot.py \
 table.lua \
 
 # Run make failingtest

--- a/testsuite/OMSimulator/Makefile
+++ b/testsuite/OMSimulator/Makefile
@@ -6,6 +6,7 @@ deleteStartValues.lua \
 deleteStartValuesInSSV.lua \
 DualMassOscillator.lua \
 exportConnectorsToResultFile.lua \
+exportSnapshot.lua \
 import_export_parameters_inline.lua \
 import_export_parameters_to_ssv.lua \
 import_export.lua \

--- a/testsuite/OMSimulator/Makefile
+++ b/testsuite/OMSimulator/Makefile
@@ -6,11 +6,11 @@ deleteStartValues.lua \
 deleteStartValuesInSSV.lua \
 DualMassOscillator.lua \
 exportConnectorsToResultFile.lua \
-exportSnapshot.lua \
 import_export_parameters_inline.lua \
 import_export_parameters_to_ssv.lua \
 import_export.lua \
 import_export.py \
+import_export_snapshot.lua \
 PI_Controller.lua \
 QuarterCarModel.DisplacementDisplacement.lua \
 simulation.lua \

--- a/testsuite/OMSimulator/exportSnapshot.lua
+++ b/testsuite/OMSimulator/exportSnapshot.lua
@@ -10,10 +10,13 @@ status = oms_setTempDirectory("./exportSnapshot/")
 
 oms_newModel("exportSnapshot")
 oms_addSystem("exportSnapshot.root", oms_system_wc)
+oms_addConnector("exportSnapshot.root.C1", oms_causality_input, oms_signal_type_real)
+oms_setReal("exportSnapshot.root.C1", -10)
 
 oms_addSubModel("exportSnapshot.root.add", "../resources/Modelica.Blocks.Math.Add.fmu")
 
 oms_setReal("exportSnapshot.root.add.u1", 10)
+oms_setReal("exportSnapshot.root.add.k1", 30)
 
 -- src1 = oms_list("exportSnapshot") 
 -- print(src1)
@@ -54,7 +57,11 @@ oms_delete("exportSnapshot")
 -- 				</oms:SimulationInformation>
 -- 			</ssc:Annotation>
 -- 		</ssd:Annotations>
--- 		<ssd:Connectors />
+-- 		<ssd:Connectors>
+-- 			<ssd:Connector name="C1" kind="input">
+-- 				<ssc:Real />
+-- 			</ssd:Connector>
+-- 		</ssd:Connectors>
 -- 		<ssd:ParameterBindings>
 -- 			<ssd:ParameterBinding source="resources/exportSnapshot.ssv" />
 -- 		</ssd:ParameterBindings>
@@ -105,7 +112,11 @@ oms_delete("exportSnapshot")
 -- 						</oms:SimulationInformation>
 -- 					</ssc:Annotation>
 -- 				</ssd:Annotations>
--- 				<ssd:Connectors />
+-- 				<ssd:Connectors>
+-- 					<ssd:Connector name="C1" kind="input">
+-- 						<ssc:Real />
+-- 					</ssd:Connector>
+-- 				</ssd:Connectors>
 -- 				<ssd:ParameterBindings>
 -- 					<ssd:ParameterBinding source="resources/exportSnapshot.ssv" />
 -- 				</ssd:ParameterBindings>
@@ -144,7 +155,21 @@ oms_delete("exportSnapshot")
 -- 			</ssd:DefaultExperiment>
 -- 		</ssd:SystemStructureDescription>
 -- 	</oms:ssd_file>
--- 	<oms:ssv_file name="resources/exportSnapshot.ssv" />
+-- 	<oms:ssv_file name="resources/exportSnapshot.ssv">
+-- 		<ssv:ParameterSet xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" version="1.0" name="parameters">
+-- 			<ssv:Parameters>
+-- 				<ssv:Parameter name="C1">
+-- 					<ssv:Real value="-10" />
+-- 				</ssv:Parameter>
+-- 				<ssv:Parameter name="add.u1">
+-- 					<ssv:Real value="10" />
+-- 				</ssv:Parameter>
+-- 				<ssv:Parameter name="add.k1">
+-- 					<ssv:Real value="30" />
+-- 				</ssv:Parameter>
+-- 			</ssv:Parameters>
+-- 		</ssv:ParameterSet>
+-- 	</oms:ssv_file>
 -- </oms:snapshot>
 -- 
 -- error:   [exportSnapshot] "exportSnapshot.root.add" is not a top level model

--- a/testsuite/OMSimulator/exportSnapshot.lua
+++ b/testsuite/OMSimulator/exportSnapshot.lua
@@ -1,0 +1,155 @@
+-- status: correct
+-- linux: yes
+-- mingw: yes
+-- win: no
+-- mac: no
+
+
+oms_setCommandLineOption("--suppressPath=true --exportParametersInline=false")
+status = oms_setTempDirectory("./exportSnapshot/")
+
+oms_newModel("exportSnapshot")
+oms_addSystem("exportSnapshot.root", oms_system_wc)
+
+oms_addSubModel("exportSnapshot.root.add", "../resources/Modelica.Blocks.Math.Add.fmu")
+
+oms_setReal("exportSnapshot.root.add.u1", 10)
+
+-- src1 = oms_list("exportSnapshot") 
+-- print(src1)
+
+oms_export("exportSnapshot", "exportSnapshot.ssp");
+oms_delete("exportSnapshot")
+
+oms_importFile("exportSnapshot.ssp");
+
+src1 = oms_list("exportSnapshot") 
+print(src1)
+
+oms_loadSnapshot("exportSnapshot", src1)
+
+src1 = oms_exportSnapshot("exportSnapshot")  
+print(src1)
+
+src1 = oms_exportSnapshot("exportSnapshot.root.add")  
+print(src1)
+
+oms_setStopTime("exportSnapshot", 2)
+ 
+oms_instantiate("exportSnapshot")
+
+oms_initialize("exportSnapshot")
+oms_terminate("exportSnapshot")
+oms_delete("exportSnapshot")
+
+
+-- Result:
+-- <?xml version="1.0"?>
+-- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="exportSnapshot" version="1.0">
+-- 	<ssd:System name="root">
+-- 		<ssd:Annotations>
+-- 			<ssc:Annotation type="org.openmodelica">
+-- 				<oms:SimulationInformation>
+-- 					<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+-- 				</oms:SimulationInformation>
+-- 			</ssc:Annotation>
+-- 		</ssd:Annotations>
+-- 		<ssd:Connectors />
+-- 		<ssd:ParameterBindings>
+-- 			<ssd:ParameterBinding source="resources/exportSnapshot.ssv" />
+-- 		</ssd:ParameterBindings>
+-- 		<ssd:Elements>
+-- 			<ssd:Component name="add" type="application/x-fmu-sharedlibrary" source="resources/0001_add.fmu">
+-- 				<ssd:Connectors>
+-- 					<ssd:Connector name="u1" kind="input">
+-- 						<ssc:Real />
+-- 						<ssd:ConnectorGeometry x="0.000000" y="0.333333" />
+-- 					</ssd:Connector>
+-- 					<ssd:Connector name="u2" kind="input">
+-- 						<ssc:Real />
+-- 						<ssd:ConnectorGeometry x="0.000000" y="0.666667" />
+-- 					</ssd:Connector>
+-- 					<ssd:Connector name="y" kind="output">
+-- 						<ssc:Real />
+-- 						<ssd:ConnectorGeometry x="1.000000" y="0.500000" />
+-- 					</ssd:Connector>
+-- 					<ssd:Connector name="k1" kind="parameter">
+-- 						<ssc:Real />
+-- 					</ssd:Connector>
+-- 					<ssd:Connector name="k2" kind="parameter">
+-- 						<ssc:Real />
+-- 					</ssd:Connector>
+-- 				</ssd:Connectors>
+-- 			</ssd:Component>
+-- 		</ssd:Elements>
+-- 		<ssd:Connections />
+-- 	</ssd:System>
+-- 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
+-- 		<ssd:Annotations>
+-- 			<ssc:Annotation type="org.openmodelica">
+-- 				<oms:SimulationInformation resultFile="exportSnapshot_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter="" />
+-- 			</ssc:Annotation>
+-- 		</ssd:Annotations>
+-- 	</ssd:DefaultExperiment>
+-- </ssd:SystemStructureDescription>
+-- 
+-- <?xml version="1.0"?>
+-- <oms:snapshot>
+-- 	<oms:ssd_file name="SystemStructure.ssd">
+-- 		<ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="exportSnapshot" version="1.0">
+-- 			<ssd:System name="root">
+-- 				<ssd:Annotations>
+-- 					<ssc:Annotation type="org.openmodelica">
+-- 						<oms:SimulationInformation>
+-- 							<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+-- 						</oms:SimulationInformation>
+-- 					</ssc:Annotation>
+-- 				</ssd:Annotations>
+-- 				<ssd:Connectors />
+-- 				<ssd:ParameterBindings>
+-- 					<ssd:ParameterBinding source="resources/exportSnapshot.ssv" />
+-- 				</ssd:ParameterBindings>
+-- 				<ssd:Elements>
+-- 					<ssd:Component name="add" type="application/x-fmu-sharedlibrary" source="resources/0001_add.fmu">
+-- 						<ssd:Connectors>
+-- 							<ssd:Connector name="u1" kind="input">
+-- 								<ssc:Real />
+-- 								<ssd:ConnectorGeometry x="0.000000" y="0.333333" />
+-- 							</ssd:Connector>
+-- 							<ssd:Connector name="u2" kind="input">
+-- 								<ssc:Real />
+-- 								<ssd:ConnectorGeometry x="0.000000" y="0.666667" />
+-- 							</ssd:Connector>
+-- 							<ssd:Connector name="y" kind="output">
+-- 								<ssc:Real />
+-- 								<ssd:ConnectorGeometry x="1.000000" y="0.500000" />
+-- 							</ssd:Connector>
+-- 							<ssd:Connector name="k1" kind="parameter">
+-- 								<ssc:Real />
+-- 							</ssd:Connector>
+-- 							<ssd:Connector name="k2" kind="parameter">
+-- 								<ssc:Real />
+-- 							</ssd:Connector>
+-- 						</ssd:Connectors>
+-- 					</ssd:Component>
+-- 				</ssd:Elements>
+-- 				<ssd:Connections />
+-- 			</ssd:System>
+-- 			<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
+-- 				<ssd:Annotations>
+-- 					<ssc:Annotation type="org.openmodelica">
+-- 						<oms:SimulationInformation resultFile="exportSnapshot_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter="" />
+-- 					</ssc:Annotation>
+-- 				</ssd:Annotations>
+-- 			</ssd:DefaultExperiment>
+-- 		</ssd:SystemStructureDescription>
+-- 	</oms:ssd_file>
+-- 	<oms:ssv_file name="resources/exportSnapshot.ssv" />
+-- </oms:snapshot>
+-- 
+-- error:   [exportSnapshot] "exportSnapshot.root.add" is not a top level model
+-- 
+-- info:    Result file: exportSnapshot_res.mat (bufferSize=10)
+-- info:    0 warnings
+-- info:    1 errors
+-- endResult

--- a/testsuite/OMSimulator/importStartValues.lua
+++ b/testsuite/OMSimulator/importStartValues.lua
@@ -1,0 +1,103 @@
+-- status: correct
+-- linux: yes
+-- mingw: yes
+-- win: yes
+-- mac: no
+
+oms_setCommandLineOption("--suppressPath=true --exportParametersInline=false")
+
+status = oms_setTempDirectory("./importStartValues/")
+
+oms_importFile("../resources/importStartValues.ssp");
+
+src1 = oms_exportSnapshot("importStartValues")  
+print(src1)
+
+oms_setStopTime("importStartValues", 2)
+ 
+oms_instantiate("importStartValues")
+
+oms_initialize("importStartValues")
+oms_simulate("importStartValues")
+
+oms_terminate("importStartValues")
+
+oms_delete("importStartValues")
+
+
+-- Result:
+-- <?xml version="1.0"?>
+-- <oms:snapshot>
+-- 	<oms:ssd_file name="SystemStructure.ssd">
+-- 		<ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="importStartValues" version="1.0">
+-- 			<ssd:System name="root">
+-- 				<ssd:Annotations>
+-- 					<ssc:Annotation type="org.openmodelica">
+-- 						<oms:SimulationInformation>
+-- 							<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+-- 						</oms:SimulationInformation>
+-- 					</ssc:Annotation>
+-- 				</ssd:Annotations>
+-- 				<ssd:Connectors>
+-- 					<ssd:Connector name="C1" kind="input">
+-- 						<ssc:Real />
+-- 					</ssd:Connector>
+-- 				</ssd:Connectors>
+-- 				<ssd:ParameterBindings>
+-- 					<ssd:ParameterBinding source="resources/importStartValues.ssv" />
+-- 				</ssd:ParameterBindings>
+-- 				<ssd:Elements>
+-- 					<ssd:System name="System1">
+-- 						<ssd:Annotations>
+-- 							<ssc:Annotation type="org.openmodelica">
+-- 								<oms:SimulationInformation>
+-- 									<oms:VariableStepSolver description="euler" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+-- 								</oms:SimulationInformation>
+-- 							</ssc:Annotation>
+-- 						</ssd:Annotations>
+-- 						<ssd:Connectors>
+-- 							<ssd:Connector name="C1" kind="input">
+-- 								<ssc:Real />
+-- 							</ssd:Connector>
+-- 							<ssd:Connector name="C2" kind="parameter">
+-- 								<ssc:Real />
+-- 							</ssd:Connector>
+-- 							<ssd:Connector name="C3" kind="output">
+-- 								<ssc:Real />
+-- 							</ssd:Connector>
+-- 						</ssd:Connectors>
+-- 						<ssd:Elements />
+-- 						<ssd:Connections />
+-- 					</ssd:System>
+-- 				</ssd:Elements>
+-- 				<ssd:Connections />
+-- 			</ssd:System>
+-- 			<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
+-- 				<ssd:Annotations>
+-- 					<ssc:Annotation type="org.openmodelica">
+-- 						<oms:SimulationInformation resultFile="importStartValues_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter="" />
+-- 					</ssc:Annotation>
+-- 				</ssd:Annotations>
+-- 			</ssd:DefaultExperiment>
+-- 		</ssd:SystemStructureDescription>
+-- 	</oms:ssd_file>
+-- 	<oms:ssv_file name="resources/importStartValues.ssv">
+-- 		<ssv:ParameterSet xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" version="1.0" name="parameters">
+-- 			<ssv:Parameters>
+-- 				<ssv:Parameter name="C1">
+-- 					<ssv:Real value="-10.5" />
+-- 				</ssv:Parameter>
+-- 				<ssv:Parameter name="System1.C2">
+-- 					<ssv:Real value="3.5" />
+-- 				</ssv:Parameter>
+-- 				<ssv:Parameter name="System1.C1">
+-- 					<ssv:Real value="-13.5" />
+-- 				</ssv:Parameter>
+-- 			</ssv:Parameters>
+-- 		</ssv:ParameterSet>
+-- 	</oms:ssv_file>
+-- </oms:snapshot>
+-- 
+-- info:    model doesn't contain any continuous state
+-- info:    Result file: importStartValues_res.mat (bufferSize=10)
+-- endResult

--- a/testsuite/OMSimulator/import_export_snapshot.lua
+++ b/testsuite/OMSimulator/import_export_snapshot.lua
@@ -6,49 +6,50 @@
 
 
 oms_setCommandLineOption("--suppressPath=true --exportParametersInline=false")
-status = oms_setTempDirectory("./exportSnapshot/")
+status = oms_setTempDirectory("./import_export_snapshot/")
 
-oms_newModel("exportSnapshot")
-oms_addSystem("exportSnapshot.root", oms_system_wc)
-oms_addConnector("exportSnapshot.root.C1", oms_causality_input, oms_signal_type_real)
-oms_setReal("exportSnapshot.root.C1", -10)
+oms_newModel("import_export_snapshot")
+oms_addSystem("import_export_snapshot.root", oms_system_wc)
+oms_addConnector("import_export_snapshot.root.C1", oms_causality_input, oms_signal_type_real)
+oms_setReal("import_export_snapshot.root.C1", -10)
 
-oms_addSubModel("exportSnapshot.root.add", "../resources/Modelica.Blocks.Math.Add.fmu")
+oms_addSubModel("import_export_snapshot.root.add", "../resources/Modelica.Blocks.Math.Add.fmu")
 
-oms_setReal("exportSnapshot.root.add.u1", 10)
-oms_setReal("exportSnapshot.root.add.k1", 30)
+oms_setReal("import_export_snapshot.root.add.u1", 10)
+oms_setReal("import_export_snapshot.root.add.k1", 30)
 
--- src1 = oms_list("exportSnapshot") 
+-- src1 = oms_list("import_export_snapshot") 
 -- print(src1)
 
-oms_export("exportSnapshot", "exportSnapshot.ssp");
-oms_delete("exportSnapshot")
+oms_export("import_export_snapshot", "import_export_snapshot.ssp");
+oms_delete("import_export_snapshot")
 
-oms_importFile("exportSnapshot.ssp");
+oms_importFile("import_export_snapshot.ssp");
 
-src1 = oms_list("exportSnapshot") 
+src1 = oms_list("import_export_snapshot") 
 print(src1)
 
-oms_loadSnapshot("exportSnapshot", src1)
+src2 = oms_exportSnapshot("import_export_snapshot")  
+print(src2)
 
-src1 = oms_exportSnapshot("exportSnapshot")  
-print(src1)
+oms_importSnapshot("import_export_snapshot", src2)
 
-src1 = oms_exportSnapshot("exportSnapshot.root.add")  
-print(src1)
+-- check of error msg 
+oms_exportSnapshot("import_export_snapshot.root.add")  
 
-oms_setStopTime("exportSnapshot", 2)
+oms_setStopTime("import_export_snapshot", 2)
  
-oms_instantiate("exportSnapshot")
+oms_instantiate("import_export_snapshot")
 
-oms_initialize("exportSnapshot")
-oms_terminate("exportSnapshot")
-oms_delete("exportSnapshot")
+oms_initialize("import_export_snapshot")
+oms_simulate("import_export_snapshot")
+oms_terminate("import_export_snapshot")
+oms_delete("import_export_snapshot")
 
 
 -- Result:
 -- <?xml version="1.0"?>
--- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="exportSnapshot" version="1.0">
+-- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="import_export_snapshot" version="1.0">
 -- 	<ssd:System name="root">
 -- 		<ssd:Annotations>
 -- 			<ssc:Annotation type="org.openmodelica">
@@ -63,7 +64,7 @@ oms_delete("exportSnapshot")
 -- 			</ssd:Connector>
 -- 		</ssd:Connectors>
 -- 		<ssd:ParameterBindings>
--- 			<ssd:ParameterBinding source="resources/exportSnapshot.ssv" />
+-- 			<ssd:ParameterBinding source="resources/import_export_snapshot.ssv" />
 -- 		</ssd:ParameterBindings>
 -- 		<ssd:Elements>
 -- 			<ssd:Component name="add" type="application/x-fmu-sharedlibrary" source="resources/0001_add.fmu">
@@ -94,7 +95,7 @@ oms_delete("exportSnapshot")
 -- 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
 -- 		<ssd:Annotations>
 -- 			<ssc:Annotation type="org.openmodelica">
--- 				<oms:SimulationInformation resultFile="exportSnapshot_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter="" />
+-- 				<oms:SimulationInformation resultFile="import_export_snapshot_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter="" />
 -- 			</ssc:Annotation>
 -- 		</ssd:Annotations>
 -- 	</ssd:DefaultExperiment>
@@ -103,7 +104,7 @@ oms_delete("exportSnapshot")
 -- <?xml version="1.0"?>
 -- <oms:snapshot>
 -- 	<oms:ssd_file name="SystemStructure.ssd">
--- 		<ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="exportSnapshot" version="1.0">
+-- 		<ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="import_export_snapshot" version="1.0">
 -- 			<ssd:System name="root">
 -- 				<ssd:Annotations>
 -- 					<ssc:Annotation type="org.openmodelica">
@@ -118,7 +119,7 @@ oms_delete("exportSnapshot")
 -- 					</ssd:Connector>
 -- 				</ssd:Connectors>
 -- 				<ssd:ParameterBindings>
--- 					<ssd:ParameterBinding source="resources/exportSnapshot.ssv" />
+-- 					<ssd:ParameterBinding source="resources/import_export_snapshot.ssv" />
 -- 				</ssd:ParameterBindings>
 -- 				<ssd:Elements>
 -- 					<ssd:Component name="add" type="application/x-fmu-sharedlibrary" source="resources/0001_add.fmu">
@@ -149,13 +150,13 @@ oms_delete("exportSnapshot")
 -- 			<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
 -- 				<ssd:Annotations>
 -- 					<ssc:Annotation type="org.openmodelica">
--- 						<oms:SimulationInformation resultFile="exportSnapshot_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter="" />
+-- 						<oms:SimulationInformation resultFile="import_export_snapshot_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter="" />
 -- 					</ssc:Annotation>
 -- 				</ssd:Annotations>
 -- 			</ssd:DefaultExperiment>
 -- 		</ssd:SystemStructureDescription>
 -- 	</oms:ssd_file>
--- 	<oms:ssv_file name="resources/exportSnapshot.ssv">
+-- 	<oms:ssv_file name="resources/import_export_snapshot.ssv">
 -- 		<ssv:ParameterSet xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" version="1.0" name="parameters">
 -- 			<ssv:Parameters>
 -- 				<ssv:Parameter name="C1">
@@ -172,9 +173,8 @@ oms_delete("exportSnapshot")
 -- 	</oms:ssv_file>
 -- </oms:snapshot>
 -- 
--- error:   [exportSnapshot] "exportSnapshot.root.add" is not a top level model
--- 
--- info:    Result file: exportSnapshot_res.mat (bufferSize=10)
+-- error:   [exportSnapshot] "import_export_snapshot.root.add" is not a top level model
+-- info:    Result file: import_export_snapshot_res.mat (bufferSize=10)
 -- info:    0 warnings
 -- info:    1 errors
 -- endResult

--- a/testsuite/OMSimulator/snapshot.lua
+++ b/testsuite/OMSimulator/snapshot.lua
@@ -1,0 +1,108 @@
+-- status: correct
+-- linux: yes
+-- mingw: yes
+-- win: no
+-- mac: no
+
+oms_setCommandLineOption("--suppressPath=true --exportParametersInline=false")
+oms_setTempDirectory("./snapshot/")
+
+oms_newModel("snapshot")
+oms_addSystem("snapshot.root", oms_system_wc)
+
+oms_addConnector("snapshot.root.C1", oms_causality_input, oms_signal_type_real)
+oms_setReal("snapshot.root.C1", -10)
+
+oms_addSubModel("snapshot.root.add", "../resources/Modelica.Blocks.Math.Add.fmu")
+oms_setReal("snapshot.root.add.u1", 10)
+oms_setReal("snapshot.root.add.k1", 30)
+
+snapshot = oms_exportSnapshot("snapshot")
+--print(snapshot)
+oms_setReal("snapshot.root.add.u1", 3.5)
+
+oms_importSnapshot("snapshot", snapshot)
+
+snapshot = oms_exportSnapshot("snapshot")
+print(snapshot)
+
+oms_delete("snapshot")
+
+-- Result:
+-- error:   [importFromSSD] loading "resources/snapshot.ssv" failed (File was not found)
+-- error:   [importSnapshot] loading snapshot failed
+-- <?xml version="1.0"?>
+-- <oms:snapshot>
+-- 	<oms:ssd_file name="SystemStructure.ssd">
+-- 		<ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="snapshot" version="1.0">
+-- 			<ssd:System name="root">
+-- 				<ssd:Annotations>
+-- 					<ssc:Annotation type="org.openmodelica">
+-- 						<oms:SimulationInformation>
+-- 							<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+-- 						</oms:SimulationInformation>
+-- 					</ssc:Annotation>
+-- 				</ssd:Annotations>
+-- 				<ssd:Connectors>
+-- 					<ssd:Connector name="C1" kind="input">
+-- 						<ssc:Real />
+-- 					</ssd:Connector>
+-- 				</ssd:Connectors>
+-- 				<ssd:ParameterBindings>
+-- 					<ssd:ParameterBinding source="resources/snapshot.ssv" />
+-- 				</ssd:ParameterBindings>
+-- 				<ssd:Elements>
+-- 					<ssd:Component name="add" type="application/x-fmu-sharedlibrary" source="resources/0001_add.fmu">
+-- 						<ssd:Connectors>
+-- 							<ssd:Connector name="u1" kind="input">
+-- 								<ssc:Real />
+-- 								<ssd:ConnectorGeometry x="0.000000" y="0.333333" />
+-- 							</ssd:Connector>
+-- 							<ssd:Connector name="u2" kind="input">
+-- 								<ssc:Real />
+-- 								<ssd:ConnectorGeometry x="0.000000" y="0.666667" />
+-- 							</ssd:Connector>
+-- 							<ssd:Connector name="y" kind="output">
+-- 								<ssc:Real />
+-- 								<ssd:ConnectorGeometry x="1.000000" y="0.500000" />
+-- 							</ssd:Connector>
+-- 							<ssd:Connector name="k1" kind="parameter">
+-- 								<ssc:Real />
+-- 							</ssd:Connector>
+-- 							<ssd:Connector name="k2" kind="parameter">
+-- 								<ssc:Real />
+-- 							</ssd:Connector>
+-- 						</ssd:Connectors>
+-- 					</ssd:Component>
+-- 				</ssd:Elements>
+-- 				<ssd:Connections />
+-- 			</ssd:System>
+-- 			<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
+-- 				<ssd:Annotations>
+-- 					<ssc:Annotation type="org.openmodelica">
+-- 						<oms:SimulationInformation resultFile="snapshot_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter="" />
+-- 					</ssc:Annotation>
+-- 				</ssd:Annotations>
+-- 			</ssd:DefaultExperiment>
+-- 		</ssd:SystemStructureDescription>
+-- 	</oms:ssd_file>
+-- 	<oms:ssv_file name="resources/snapshot.ssv">
+-- 		<ssv:ParameterSet xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" version="1.0" name="parameters">
+-- 			<ssv:Parameters>
+-- 				<ssv:Parameter name="C1">
+-- 					<ssv:Real value="-10" />
+-- 				</ssv:Parameter>
+-- 				<ssv:Parameter name="add.u1">
+-- 					<ssv:Real value="3.5" />
+-- 				</ssv:Parameter>
+-- 				<ssv:Parameter name="add.k1">
+-- 					<ssv:Real value="30" />
+-- 				</ssv:Parameter>
+-- 			</ssv:Parameters>
+-- 		</ssv:ParameterSet>
+-- 	</oms:ssv_file>
+-- </oms:snapshot>
+--
+-- info:    0 warnings
+-- info:    2 errors
+-- endResult

--- a/testsuite/OMSimulator/snapshot.lua
+++ b/testsuite/OMSimulator/snapshot.lua
@@ -29,8 +29,6 @@ print(snapshot)
 oms_delete("snapshot")
 
 -- Result:
--- error:   [importFromSSD] loading "resources/snapshot.ssv" failed (File was not found)
--- error:   [importSnapshot] loading snapshot failed
 -- <?xml version="1.0"?>
 -- <oms:snapshot>
 -- 	<oms:ssd_file name="SystemStructure.ssd">
@@ -93,7 +91,7 @@ oms_delete("snapshot")
 -- 					<ssv:Real value="-10" />
 -- 				</ssv:Parameter>
 -- 				<ssv:Parameter name="add.u1">
--- 					<ssv:Real value="3.5" />
+-- 					<ssv:Real value="10" />
 -- 				</ssv:Parameter>
 -- 				<ssv:Parameter name="add.k1">
 -- 					<ssv:Real value="30" />
@@ -102,7 +100,5 @@ oms_delete("snapshot")
 -- 		</ssv:ParameterSet>
 -- 	</oms:ssv_file>
 -- </oms:snapshot>
---
--- info:    0 warnings
--- info:    2 errors
+-- 
 -- endResult

--- a/testsuite/OMSimulator/snapshot.py
+++ b/testsuite/OMSimulator/snapshot.py
@@ -1,0 +1,108 @@
+## status: correct
+## linux: yes
+## mingw: yes
+## win: no
+## mac: no
+
+
+from OMSimulator import OMSimulator
+oms = OMSimulator()
+
+oms.setCommandLineOption("--suppressPath=true --exportParametersInline=false")
+oms.setTempDirectory("./snapshot-py/")
+
+oms.newModel("snapshot")
+oms.addSystem("snapshot.root", oms.system_wc)
+
+oms.addConnector("snapshot.root.C1", oms.input, oms.signal_type_real)
+oms.setReal("snapshot.root.C1", -10)
+
+oms.addSubModel("snapshot.root.add", "../resources/Modelica.Blocks.Math.Add.fmu")
+oms.setReal("snapshot.root.add.u1", 10)
+oms.setReal("snapshot.root.add.k1", 30)
+
+snapshot, status = oms.exportSnapshot("snapshot")
+##print(snapshot, flush=True)
+oms.setReal("snapshot.root.add.u1", 3.5)
+
+oms.importSnapshot("snapshot", snapshot)
+
+snapshot, status = oms.exportSnapshot("snapshot")
+print(snapshot, flush=True)
+
+oms.delete("snapshot")
+
+## Result:
+## <?xml version="1.0"?>
+## <oms:snapshot>
+## 	<oms:ssd_file name="SystemStructure.ssd">
+## 		<ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="snapshot" version="1.0">
+## 			<ssd:System name="root">
+## 				<ssd:Annotations>
+## 					<ssc:Annotation type="org.openmodelica">
+## 						<oms:SimulationInformation>
+## 							<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+## 						</oms:SimulationInformation>
+## 					</ssc:Annotation>
+## 				</ssd:Annotations>
+## 				<ssd:Connectors>
+## 					<ssd:Connector name="C1" kind="input">
+## 						<ssc:Real />
+## 					</ssd:Connector>
+## 				</ssd:Connectors>
+## 				<ssd:ParameterBindings>
+## 					<ssd:ParameterBinding source="resources/snapshot.ssv" />
+## 				</ssd:ParameterBindings>
+## 				<ssd:Elements>
+## 					<ssd:Component name="add" type="application/x-fmu-sharedlibrary" source="resources/0001_add.fmu">
+## 						<ssd:Connectors>
+## 							<ssd:Connector name="u1" kind="input">
+## 								<ssc:Real />
+## 								<ssd:ConnectorGeometry x="0.000000" y="0.333333" />
+## 							</ssd:Connector>
+## 							<ssd:Connector name="u2" kind="input">
+## 								<ssc:Real />
+## 								<ssd:ConnectorGeometry x="0.000000" y="0.666667" />
+## 							</ssd:Connector>
+## 							<ssd:Connector name="y" kind="output">
+## 								<ssc:Real />
+## 								<ssd:ConnectorGeometry x="1.000000" y="0.500000" />
+## 							</ssd:Connector>
+## 							<ssd:Connector name="k1" kind="parameter">
+## 								<ssc:Real />
+## 							</ssd:Connector>
+## 							<ssd:Connector name="k2" kind="parameter">
+## 								<ssc:Real />
+## 							</ssd:Connector>
+## 						</ssd:Connectors>
+## 					</ssd:Component>
+## 				</ssd:Elements>
+## 				<ssd:Connections />
+## 			</ssd:System>
+## 			<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
+## 				<ssd:Annotations>
+## 					<ssc:Annotation type="org.openmodelica">
+## 						<oms:SimulationInformation resultFile="snapshot_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter="" />
+## 					</ssc:Annotation>
+## 				</ssd:Annotations>
+## 			</ssd:DefaultExperiment>
+## 		</ssd:SystemStructureDescription>
+## 	</oms:ssd_file>
+## 	<oms:ssv_file name="resources/snapshot.ssv">
+## 		<ssv:ParameterSet xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" version="1.0" name="parameters">
+## 			<ssv:Parameters>
+## 				<ssv:Parameter name="C1">
+## 					<ssv:Real value="-10" />
+## 				</ssv:Parameter>
+## 				<ssv:Parameter name="add.u1">
+## 					<ssv:Real value="10" />
+## 				</ssv:Parameter>
+## 				<ssv:Parameter name="add.k1">
+## 					<ssv:Real value="30" />
+## 				</ssv:Parameter>
+## 			</ssv:Parameters>
+## 		</ssv:ParameterSet>
+## 	</oms:ssv_file>
+## </oms:snapshot>
+## 
+## endResult

--- a/testsuite/api/Makefile
+++ b/testsuite/api/Makefile
@@ -12,6 +12,7 @@ test01.py \
 test02.lua \
 test02.py \
 test03.lua \
+test03.py \
 
 # Run make failingtest
 FAILINGTESTFILES = \

--- a/testsuite/api/test03.py
+++ b/testsuite/api/test03.py
@@ -1,0 +1,158 @@
+## status: correct
+## teardown_command: rm -rf test03-py/ test_res.mat
+## linux: yes
+## mingw: yes
+## win: no
+## mac: no
+
+
+from OMSimulator import OMSimulator
+oms = OMSimulator()
+
+oms.setCommandLineOption("--suppressPath=true")
+oms.setTempDirectory("./test03-py/")
+
+def printStatus(status, expected):
+  cmp = ""
+  if status == expected:
+    cmp = "correct"
+  else:
+    cmp = "wrong"
+
+  if 0 == status:
+    status = "ok"
+  elif 1 == status:
+    status = "warning"
+  elif 3 == status:
+    status = "error"
+  print("status:  [%s] %s" % (cmp, status), flush=True)
+
+
+
+oms.newModel("test")
+oms.addSystem("test.eoo", oms.system_wc)
+oms.addSubModel("test.eoo.source", "../resources/Modelica.Blocks.Sources.Sine.fmu")
+
+## save snapshot
+src, status = oms.list("test")
+print(src, flush=True)
+
+## change model
+oms.addSystem("test.eoo.goo", oms.system_sc)
+oms.delete("test.eoo.source")
+oms.addSubModel("test.eoo.source", "../resources/Modelica.Blocks.Sources.Constant.fmu")
+
+## restore model from snapshot
+status = oms.loadSnapshot("test", src)
+printStatus(status, 0)
+
+src, status = oms.list("test")
+print(src, flush=True)
+
+oms.instantiate("test")
+oms.initialize("test")
+oms.simulate("test")
+oms.terminate("test")
+
+oms.delete("test")
+
+
+## Result:
+## <?xml version="1.0"?>
+## <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="test" version="1.0">
+## 	<ssd:System name="eoo">
+## 		<ssd:Annotations>
+## 			<ssc:Annotation type="org.openmodelica">
+## 				<oms:SimulationInformation>
+## 					<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+## 				</oms:SimulationInformation>
+## 			</ssc:Annotation>
+## 		</ssd:Annotations>
+## 		<ssd:Connectors />
+## 		<ssd:Elements>
+## 			<ssd:Component name="source" type="application/x-fmu-sharedlibrary" source="resources/0001_source.fmu">
+## 				<ssd:Connectors>
+## 					<ssd:Connector name="y" kind="output">
+## 						<ssc:Real />
+## 						<ssd:ConnectorGeometry x="1.000000" y="0.500000" />
+## 					</ssd:Connector>
+## 					<ssd:Connector name="amplitude" kind="parameter">
+## 						<ssc:Real />
+## 					</ssd:Connector>
+## 					<ssd:Connector name="freqHz" kind="parameter">
+## 						<ssc:Real />
+## 					</ssd:Connector>
+## 					<ssd:Connector name="offset" kind="parameter">
+## 						<ssc:Real />
+## 					</ssd:Connector>
+## 					<ssd:Connector name="phase" kind="parameter">
+## 						<ssc:Real />
+## 					</ssd:Connector>
+## 					<ssd:Connector name="startTime" kind="parameter">
+## 						<ssc:Real />
+## 					</ssd:Connector>
+## 				</ssd:Connectors>
+## 			</ssd:Component>
+## 		</ssd:Elements>
+## 		<ssd:Connections />
+## 	</ssd:System>
+## 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
+## 		<ssd:Annotations>
+## 			<ssc:Annotation type="org.openmodelica">
+## 				<oms:SimulationInformation resultFile="test_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter="" />
+## 			</ssc:Annotation>
+## 		</ssd:Annotations>
+## 	</ssd:DefaultExperiment>
+## </ssd:SystemStructureDescription>
+## 
+## info:    Delete source
+## status:  [correct] ok
+## <?xml version="1.0"?>
+## <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="test" version="1.0">
+## 	<ssd:System name="eoo">
+## 		<ssd:Annotations>
+## 			<ssc:Annotation type="org.openmodelica">
+## 				<oms:SimulationInformation>
+## 					<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+## 				</oms:SimulationInformation>
+## 			</ssc:Annotation>
+## 		</ssd:Annotations>
+## 		<ssd:Connectors />
+## 		<ssd:Elements>
+## 			<ssd:Component name="source" type="application/x-fmu-sharedlibrary" source="resources/0001_source.fmu">
+## 				<ssd:Connectors>
+## 					<ssd:Connector name="y" kind="output">
+## 						<ssc:Real />
+## 						<ssd:ConnectorGeometry x="1.000000" y="0.500000" />
+## 					</ssd:Connector>
+## 					<ssd:Connector name="amplitude" kind="parameter">
+## 						<ssc:Real />
+## 					</ssd:Connector>
+## 					<ssd:Connector name="freqHz" kind="parameter">
+## 						<ssc:Real />
+## 					</ssd:Connector>
+## 					<ssd:Connector name="offset" kind="parameter">
+## 						<ssc:Real />
+## 					</ssd:Connector>
+## 					<ssd:Connector name="phase" kind="parameter">
+## 						<ssc:Real />
+## 					</ssd:Connector>
+## 					<ssd:Connector name="startTime" kind="parameter">
+## 						<ssc:Real />
+## 					</ssd:Connector>
+## 				</ssd:Connectors>
+## 			</ssd:Component>
+## 		</ssd:Elements>
+## 		<ssd:Connections />
+## 	</ssd:System>
+## 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
+## 		<ssd:Annotations>
+## 			<ssc:Annotation type="org.openmodelica">
+## 				<oms:SimulationInformation resultFile="test_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter="" />
+## 			</ssc:Annotation>
+## 		</ssd:Annotations>
+## 	</ssd:DefaultExperiment>
+## </ssd:SystemStructureDescription>
+## 
+## info:    Result file: test_res.mat (bufferSize=10)
+## endResult

--- a/testsuite/resources/Makefile
+++ b/testsuite/resources/Makefile
@@ -59,17 +59,12 @@ HelloWorld.mos \
 Lin2DimODE.mos \
 MassSpring.mos \
 
-.PHONY: all generateFMUs generateSSPs
+.PHONY: all generateFMUs 
 
 all:
 	@echo
 	@echo preparing FMUs...
 	@for fmu in $(FMUs) ; do cd $$fmu && zip -r ../$$fmu.fmu * && cd .. ; done
-
-
-generateSSPs:
-	@echo
-	@echo preparing SSPs...
 	@for ssp in $(SSPs) ; do cd $$ssp && zip -r ../$$ssp.ssp * && cd .. ; done
 
 

--- a/testsuite/resources/Makefile
+++ b/testsuite/resources/Makefile
@@ -44,6 +44,10 @@ tlm.UpperPendulum \
 tlm.UpperPendulumFG \
 tlm.UpperPendulumFG \
 
+SSPs = \
+importStartValues \
+
+
 MOSs = \
 ASSCExample.mos \
 DualMassOscillator.mos \
@@ -55,12 +59,19 @@ HelloWorld.mos \
 Lin2DimODE.mos \
 MassSpring.mos \
 
-.PHONY: all generateFMUs
+.PHONY: all generateFMUs generateSSPs
 
 all:
 	@echo
 	@echo preparing FMUs...
 	@for fmu in $(FMUs) ; do cd $$fmu && zip -r ../$$fmu.fmu * && cd .. ; done
+
+
+generateSSPs:
+	@echo
+	@echo preparing SSPs...
+	@for ssp in $(SSPs) ; do cd $$ssp && zip -r ../$$ssp.ssp * && cd .. ; done
+
 
 generateFMUs:
 	@echo

--- a/testsuite/resources/importStartValues/SystemStructure.ssd
+++ b/testsuite/resources/importStartValues/SystemStructure.ssd
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="importStartValues" version="1.0">
+    <ssd:System name="root">
+        <ssd:Annotations>
+            <ssc:Annotation type="org.openmodelica">
+                <oms:SimulationInformation>
+                    <oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+                </oms:SimulationInformation>
+            </ssc:Annotation>
+        </ssd:Annotations>
+        <ssd:Connectors>
+            <ssd:Connector name="C1" kind="input">
+                <ssc:Real />
+            </ssd:Connector>
+        </ssd:Connectors>
+        <ssd:ParameterBindings>
+            <ssd:ParameterBinding source="resources/Root.ssv" />
+            <ssd:ParameterBinding source="resources/System1.ssv" />
+        </ssd:ParameterBindings>
+        <ssd:Elements>
+            <ssd:System name="System1">
+                <ssd:Annotations>
+                    <ssc:Annotation type="org.openmodelica">
+                        <oms:SimulationInformation>
+                            <oms:VariableStepSolver description="euler" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+                        </oms:SimulationInformation>
+                    </ssc:Annotation>
+                </ssd:Annotations>
+                <ssd:Connectors>
+                    <ssd:Connector name="C1" kind="input">
+                        <ssc:Real />
+                    </ssd:Connector>
+                    <ssd:Connector name="C2" kind="parameter">
+                        <ssc:Real />
+                    </ssd:Connector>
+                    <ssd:Connector name="C3" kind="output">
+                        <ssc:Real />
+                    </ssd:Connector>
+                </ssd:Connectors>
+                <ssd:Elements />
+                <ssd:Connections />
+            </ssd:System>
+        </ssd:Elements>
+        <ssd:Connections />
+    </ssd:System>
+    <ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
+        <ssd:Annotations>
+            <ssc:Annotation type="org.openmodelica">
+                <oms:SimulationInformation resultFile="importStartValues_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter="" />
+            </ssc:Annotation>
+        </ssd:Annotations>
+    </ssd:DefaultExperiment>
+</ssd:SystemStructureDescription>

--- a/testsuite/resources/importStartValues/resources/Root.ssv
+++ b/testsuite/resources/importStartValues/resources/Root.ssv
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ssv:ParameterSet xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" version="1.0" name="parameters">
+	<ssv:Parameters>
+		<ssv:Parameter name="C1">
+			<ssv:Real value="-10.5" />
+		</ssv:Parameter>
+	</ssv:Parameters>
+</ssv:ParameterSet>

--- a/testsuite/resources/importStartValues/resources/System1.ssv
+++ b/testsuite/resources/importStartValues/resources/System1.ssv
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ssv:ParameterSet xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" version="1.0" name="parameters">
+	<ssv:Parameters>
+		<ssv:Parameter name="System1.C2">
+			<ssv:Real value="3.5" />
+		</ssv:Parameter>
+		<ssv:Parameter name="System1.C1">
+			<ssv:Real value="-13.5" />
+		</ssv:Parameter>
+	</ssv:Parameters>
+</ssv:ParameterSet>


### PR DESCRIPTION
### Purpose

This PR adds new API `oms_exportSnapshot` which adds layering to xml file for identifyfing different kind of ssp files like
 
1. .ssd
2.  .ssv
3.  .ssm

### Approach
We use a new tagging 
```
<oms:snapshot>   
<oms:ssd_file>      
<oms:ssv_file>     
<oms:ssm_file>   
```

### Example

```
<?xml version="1.0"?>
<oms:snapshot>
 <oms:ssd_file name="SystemStructure.ssd">
   <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="exportSnapshot" version="1.0">
     <ssd:System name="root">
       <ssd:Annotations>
         <ssc:Annotation type="org.openmodelica">
           <oms:SimulationInformation>
             <oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
           </oms:SimulationInformation>
         </ssc:Annotation>
       </ssd:Annotations>
       <ssd:Connectors>
         <ssd:Connector name="C1" kind="input">
           <ssc:Real />
         </ssd:Connector>
       </ssd:Connectors>
       <ssd:ParameterBindings>
         <ssd:ParameterBinding source="resources/exportSnapshot.ssv" />
       </ssd:ParameterBindings>
       <ssd:Elements>
         <ssd:Component name="add" type="application/x-fmu-sharedlibrary" source="resources/0001_add.fmu">
           <ssd:Connectors>
             <ssd:Connector name="u1" kind="input">
               <ssc:Real />
               <ssd:ConnectorGeometry x="0.000000" y="0.333333" />
             </ssd:Connector>
             <ssd:Connector name="u2" kind="input">
               <ssc:Real />
               <ssd:ConnectorGeometry x="0.000000" y="0.666667" />
             </ssd:Connector>
             <ssd:Connector name="y" kind="output">
               <ssc:Real />
               <ssd:ConnectorGeometry x="1.000000" y="0.500000" />
             </ssd:Connector>
             <ssd:Connector name="k1" kind="parameter">
               <ssc:Real />
             </ssd:Connector>
             <ssd:Connector name="k2" kind="parameter">
               <ssc:Real />
             </ssd:Connector>
           </ssd:Connectors>
         </ssd:Component>
       </ssd:Elements>
       <ssd:Connections />
     </ssd:System>
     <ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
       <ssd:Annotations>
         <ssc:Annotation type="org.openmodelica">
           <oms:SimulationInformation resultFile="exportSnapshot_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter="" />
         </ssc:Annotation>
       </ssd:Annotations>
     </ssd:DefaultExperiment>
   </ssd:SystemStructureDescription>
 </oms:ssd_file>
 <oms:ssv_file name="resources/exportSnapshot.ssv">
   <ssv:ParameterSet xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" version="1.0" name="parameters">
     <ssv:Parameters>
       <ssv:Parameter name="C1">
         <ssv:Real value="-10" />
       </ssv:Parameter>
       <ssv:Parameter name="add.u1">
         <ssv:Real value="10" />
       </ssv:Parameter>
       <ssv:Parameter name="add.k1">
         <ssv:Real value="30" />
       </ssv:Parameter>
     </ssv:Parameters>
   </ssv:ParameterSet>
 </oms:ssv_file>
</oms:snapshot>
```
