### PR TITLE
attempt to fix CVODE and KINSOL detection on Xenial

### DIFF
--- a/config.cmake/FindCVODELibrary.cmake
+++ b/config.cmake/FindCVODELibrary.cmake
@@ -2,7 +2,7 @@
 
 find_library(CVODELibrary_LIBRARY
   NAMES sundials_cvode
-  HINTS ${CVODELibrary_ROOT}/lib
+  HINTS ${CVODELibrary_ROOT}/lib ${CVODELibrary_ROOT}/lib/x86_64-linux-gnu ${CVODELibrary_ROOT}/lib/i386-linux-gnu
 )
 
 if(CVODELibrary_LIBRARY)

--- a/config.cmake/FindKINSOLLibrary.cmake
+++ b/config.cmake/FindKINSOLLibrary.cmake
@@ -2,7 +2,7 @@
 
 find_library(KINSOLLibrary_LIBRARY
   NAMES sundials_kinsol
-  HINTS ${KINSOLLibrary_ROOT}/lib
+  HINTS ${KINSOLLibrary_ROOT}/lib ${KINSOLLibrary_ROOT}/lib/x86_64-linux-gnu ${KINSOLLibrary_ROOT}/lib/i386-linux-gnu
 )
 
 if(KINSOLLibrary_LIBRARY)


### PR DESCRIPTION
### Purpose

Build on Xenial fails due to libs being installed in lib/{x86_64|i368}-linux-gnu/ instead of just lib/

### Approach

add these directories to find_package hints
