### PR TITLE
export top level connectors to result file when importing

### DIFF
--- a/src/OMSimulatorLib/System.cpp
+++ b/src/OMSimulatorLib/System.cpp
@@ -569,7 +569,8 @@ oms_status_enu_t oms::System::importFromSSD(const pugi::xml_node& node, const st
         connectors.back() = oms::Connector::NewConnector(*itConnectors, sspVersion);
         if (connectors.back())
         {
-          exportConnectors[connectors.back()->getName()] = true;
+          //save the connectors with full cref
+          exportConnectors[getFullCref() + connectors.back()->getName()] = true;
           connectors.push_back(NULL);
         }
         else


### PR DESCRIPTION
### Purpose

This PR fixes bug in exporting top level connectors to result file when importing from ssp file or memory.

### changed files:

System.cpp - save the connectors with full cref