### PR TITLE
Make error in broken dependencies from modelDescription.xml fatal

### DIFF
--- a/src/OMSimulatorLib/ComponentFMUCS.cpp
+++ b/src/OMSimulatorLib/ComponentFMUCS.cpp
@@ -237,8 +237,18 @@ oms::Component* oms::ComponentFMUCS::NewComponent(const oms::ComRef& cref, oms::
   component->connectors.push_back(NULL);
   component->element.setConnectors(&component->connectors[0]);
 
-  component->initializeDependencyGraph_initialUnknowns();
-  component->initializeDependencyGraph_outputs();
+  if (oms_status_ok != component->initializeDependencyGraph_initialUnknowns())
+  {
+    logError(std::string(cref) + ": Couldn't initialize dependency graph for initial unknowns.");
+    delete component;
+    return NULL;
+  }
+  if (oms_status_ok != component->initializeDependencyGraph_outputs())
+  {
+    logError(std::string(cref) + ": Couldn't initialize dependency graph for simulation unknowns.");
+    delete component;
+    return NULL;
+  }
 
   // parse modelDescription.xml to get start values before instantiating fmu's
   component->values.parseModelDescription((tempDir / "modelDescription.xml").string().c_str());
@@ -379,6 +389,13 @@ oms_status_enu_t oms::ComponentFMUCS::initializeDependencyGraph_initialUnknowns(
     {
       for (size_t j = startIndex[i]; j < startIndex[i + 1]; j++)
       {
+        if (dependency[j] <= 0 || allVariables.size() < dependency[j])
+        {
+          logError(std::string(getCref()) + ": Dependecies from modelDescription.xml erroneous.");
+          logDebug("Can't find variable for dependency with index " + std::to_string(dependency[j]) + " for  initial unknown " + std::string(initialUnknownsGraph.getNodes()[i]) + "." );
+          logInfo("Use flag --ignoreInitialUnknowns=true to ignore dependencies, but this can cause inflated loop size.");
+          return oms_status_fatal;
+        }
         logDebug(std::string(getCref()) + ": " + getPath() + " initial unknown " + std::string(initialUnknownsGraph.getNodes()[i]) + " depends on " + std::string(allVariables[dependency[j] - 1]));
         initialUnknownsGraph.addEdge(allVariables[dependency[j] - 1].makeConnector(), initialUnknownsGraph.getNodes()[i]);
       }
@@ -423,6 +440,13 @@ oms_status_enu_t oms::ComponentFMUCS::initializeDependencyGraph_outputs()
     {
       for (size_t j = startIndex[i]; j < startIndex[i + 1]; j++)
       {
+        if (dependency[j] <= 0 || allVariables.size() < dependency[j])
+        {
+          logError(std::string(getCref()) + ": Dependecies from modelDescription.xml erroneous.");
+          logDebug("Can't find variable for dependency with index " + std::to_string(dependency[j]) + " for output " + std::string(outputs[i]) + "." );
+          logInfo("Use flag --ignoreInitialUnknowns=true to ignore dependencies, but this can cause inflated loop size.");
+          return oms_status_fatal;
+        }
         logDebug(std::string(getCref()) + ": " + getPath() + " output " + std::string(outputs[i]) + " depends on " + std::string(allVariables[dependency[j] - 1]));
         outputsGraph.addEdge(allVariables[dependency[j] - 1].makeConnector(), outputs[i].makeConnector());
       }

--- a/src/OMSimulatorLua/OMSimulatorLua.c
+++ b/src/OMSimulatorLua/OMSimulatorLua.c
@@ -890,6 +890,11 @@ static int OMSimulatorLua_oms_addSubModel(lua_State *L)
   const char* fmuPath = lua_tostring(L, 2);
   oms_status_enu_t status = oms_addSubModel(cref, fmuPath);
 
+  if (status!=oms_status_ok)
+  {
+    return luaL_error(L, "oms_addSubModel(%s,%s) failed", cref, fmuPath);
+  }
+
   lua_pushinteger(L, status);
 
   return 1;


### PR DESCRIPTION
### Related Issues

<!-- Link to the issues that are solved with this PR. -->

### Purpose

Give meaningful error messages and advise instead of having some Segmentation Fault.

### Approach

Check if `dependency[j]-1` is in range of `allVariables` before evaluating `allVariables[dependency[j] - 1])`.
