### PR TITLE
Add Doxygen documentation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,10 @@ The OMSimulator project is a FMI-based co-simulation environment that supports o
 
 Pre-compiled binaries are available for [Windows, Linux, and Mac](https://test.openmodelica.org/jenkins/job/OMSimulator/job/master/lastSuccessfulBuild/artifact/).
 
+## Documentation
+
 The latest documentation is avilable as [pdf](https://openmodelica.org/doc/OMSimulator/master/OMSimulator.pdf) and [html](https://openmodelica.org/doc/OMSimulator/master/html/).
+For OMSimulatorLib a [Doxygen source code documentation](https://openmodelica.org/doc/OMSimulator/master/OMSimulatorLib/) is available as well.
 
 ## Dependencies
 


### PR DESCRIPTION
### Related Issues

I added some Doxygen documentation for #815, but it is hard to find the generated documentation.

### Purpose

Make it possible for users and developers to find generated Doxygen documentation.

### Approach

Added link to README.md
