### PR TITLE
add oms_exportSSVTemplate API to export start values read from modeldescription.xml

### DIFF
--- a/src/OMSimulatorLib/Component.h
+++ b/src/OMSimulatorLib/Component.h
@@ -85,6 +85,7 @@ namespace oms
     oms_status_enu_t deleteConnectorFromTLMBus(const ComRef& busCref, const ComRef& connectorCref);
 
     virtual oms_status_enu_t exportToSSD(pugi::xml_node& node, pugi::xml_node& ssvNode) const = 0;
+    virtual oms_status_enu_t exportToSSVTemplate(pugi::xml_node& ssvNode) {return oms_status_ok;}
     virtual oms_status_enu_t instantiate() = 0;
     virtual oms_status_enu_t initialize() = 0;
     virtual oms_status_enu_t terminate() = 0;

--- a/src/OMSimulatorLib/Component.h
+++ b/src/OMSimulatorLib/Component.h
@@ -85,7 +85,7 @@ namespace oms
     oms_status_enu_t deleteConnectorFromTLMBus(const ComRef& busCref, const ComRef& connectorCref);
 
     virtual oms_status_enu_t exportToSSD(pugi::xml_node& node, pugi::xml_node& ssvNode) const = 0;
-    virtual oms_status_enu_t exportToSSVTemplate(pugi::xml_node& ssvNode) {return oms_status_ok;}
+    virtual oms_status_enu_t exportToSSVTemplate(pugi::xml_node& ssvNode) {return logError_NotImplemented;}
     virtual oms_status_enu_t instantiate() = 0;
     virtual oms_status_enu_t initialize() = 0;
     virtual oms_status_enu_t terminate() = 0;

--- a/src/OMSimulatorLib/ComponentFMUCS.cpp
+++ b/src/OMSimulatorLib/ComponentFMUCS.cpp
@@ -353,6 +353,12 @@ oms_status_enu_t oms::ComponentFMUCS::exportToSSD(pugi::xml_node& node, pugi::xm
   return oms_status_ok;
 }
 
+oms_status_enu_t oms::ComponentFMUCS::exportToSSVTemplate(pugi::xml_node& ssvNode)
+{
+  values.exportToSSVTemplate(ssvNode, getCref());
+  return oms_status_ok;
+}
+
 oms_status_enu_t oms::ComponentFMUCS::initializeDependencyGraph_initialUnknowns()
 {
   if (initialUnknownsGraph.getEdges().size() > 0)

--- a/src/OMSimulatorLib/ComponentFMUCS.h
+++ b/src/OMSimulatorLib/ComponentFMUCS.h
@@ -59,6 +59,7 @@ namespace oms
     const FMUInfo* getFMUInfo() const {return &(this->fmuInfo);}
 
     oms_status_enu_t exportToSSD(pugi::xml_node& node, pugi::xml_node& ssvNode) const;
+    oms_status_enu_t exportToSSVTemplate(pugi::xml_node& ssvNode);
     oms_status_enu_t instantiate();
     oms_status_enu_t initialize();
     oms_status_enu_t terminate();

--- a/src/OMSimulatorLib/ComponentFMUME.cpp
+++ b/src/OMSimulatorLib/ComponentFMUME.cpp
@@ -355,6 +355,12 @@ oms_status_enu_t oms::ComponentFMUME::exportToSSD(pugi::xml_node& node, pugi::xm
   return oms_status_ok;
 }
 
+oms_status_enu_t oms::ComponentFMUME::exportToSSVTemplate(pugi::xml_node& ssvNode)
+{
+  values.exportToSSVTemplate(ssvNode, getCref());
+  return oms_status_ok;
+}
+
 oms_status_enu_t oms::ComponentFMUME::initializeDependencyGraph_initialUnknowns()
 {
   if (initialUnknownsGraph.getEdges().size() > 0)

--- a/src/OMSimulatorLib/ComponentFMUME.h
+++ b/src/OMSimulatorLib/ComponentFMUME.h
@@ -57,6 +57,7 @@ namespace oms
     const FMUInfo* getFMUInfo() const {return &(this->fmuInfo);}
 
     oms_status_enu_t exportToSSD(pugi::xml_node& node, pugi::xml_node& ssvNode) const;
+    oms_status_enu_t exportToSSVTemplate(pugi::xml_node& ssvNode);
     oms_status_enu_t instantiate();
     oms_status_enu_t initialize();
     oms_status_enu_t terminate();

--- a/src/OMSimulatorLib/ComponentTable.h
+++ b/src/OMSimulatorLib/ComponentTable.h
@@ -55,7 +55,7 @@ namespace oms
     static Component* NewComponent(const pugi::xml_node& node, System* parentSystem, const std::string& sspVersion);
 
     oms_status_enu_t exportToSSD(pugi::xml_node& node, pugi::xml_node& ssvNode) const;
-    oms_status_enu_t exportToSSVTemplate(pugi::xml_node& ssvNode) {return logError_NotImplemented;}
+    oms_status_enu_t exportToSSVTemplate(pugi::xml_node& ssvNode) {return oms_status_ok;}
     oms_status_enu_t instantiate();
     oms_status_enu_t initialize() {return oms_status_ok;}
     oms_status_enu_t terminate() {return oms_status_ok;}

--- a/src/OMSimulatorLib/ComponentTable.h
+++ b/src/OMSimulatorLib/ComponentTable.h
@@ -55,6 +55,7 @@ namespace oms
     static Component* NewComponent(const pugi::xml_node& node, System* parentSystem, const std::string& sspVersion);
 
     oms_status_enu_t exportToSSD(pugi::xml_node& node, pugi::xml_node& ssvNode) const;
+    oms_status_enu_t exportToSSVTemplate(pugi::xml_node& ssvNode) {return oms_status_ok;}
     oms_status_enu_t instantiate();
     oms_status_enu_t initialize() {return oms_status_ok;}
     oms_status_enu_t terminate() {return oms_status_ok;}

--- a/src/OMSimulatorLib/ComponentTable.h
+++ b/src/OMSimulatorLib/ComponentTable.h
@@ -55,7 +55,7 @@ namespace oms
     static Component* NewComponent(const pugi::xml_node& node, System* parentSystem, const std::string& sspVersion);
 
     oms_status_enu_t exportToSSD(pugi::xml_node& node, pugi::xml_node& ssvNode) const;
-    oms_status_enu_t exportToSSVTemplate(pugi::xml_node& ssvNode) {return oms_status_ok;}
+    oms_status_enu_t exportToSSVTemplate(pugi::xml_node& ssvNode) {return logError_NotImplemented;}
     oms_status_enu_t instantiate();
     oms_status_enu_t initialize() {return oms_status_ok;}
     oms_status_enu_t terminate() {return oms_status_ok;}

--- a/src/OMSimulatorLib/Model.cpp
+++ b/src/OMSimulatorLib/Model.cpp
@@ -403,11 +403,8 @@ oms_status_enu_t oms::Model::exportSnapshot(const oms::ComRef& cref, char** cont
 
 oms_status_enu_t oms::Model::exportSSVTemplate(const oms::ComRef& cref, const std::string& filename)
 {
-  // only top level model is allowed
-  if (!cref.isEmpty())
-  {
-    return logError("\"" + std::string(getCref()+std::string(cref)) + "\" is not a top level model");
-  }
+  oms::ComRef tail(cref);
+  oms::ComRef front = tail.pop_front();
 
   pugi::xml_document ssvdoc;
 
@@ -433,9 +430,12 @@ oms_status_enu_t oms::Model::exportSSVTemplate(const oms::ComRef& cref, const st
 
   for (const auto& component : system->getComponents())
   {
-    if (oms_status_ok != component.second->exportToSSVTemplate(node_parameters))
+    if(tail == component.first || cref.isEmpty()) // allow querying single component or whole model
     {
-      return logError("export of ssv template failed for component " + std::string(system->getFullCref()+std::string(component.first)));
+      if (oms_status_ok != component.second->exportToSSVTemplate(node_parameters))
+      {
+        return logError("export of ssv template failed for component " + std::string(system->getFullCref()+std::string(component.first)));
+      }
     }
   }
 

--- a/src/OMSimulatorLib/Model.h
+++ b/src/OMSimulatorLib/Model.h
@@ -72,6 +72,7 @@ namespace oms
     oms_status_enu_t addSystem(const ComRef& cref, oms_system_enu_t type);
     oms_status_enu_t exportToSSD(pugi::xml_node& node, pugi::xml_node& ssvNode) const;
     oms_status_enu_t exportSnapshot(const ComRef& cref, char** contents);
+    oms_status_enu_t exportSSVTemplate(const ComRef& cref, const std::string& filename);
     oms_status_enu_t importFromSSD(const pugi::xml_node& node);
     oms_status_enu_t importSnapshot(const char* snapshot);
     oms_status_enu_t exportToFile(const std::string& filename) const;

--- a/src/OMSimulatorLib/OMSimulator.cpp
+++ b/src/OMSimulatorLib/OMSimulator.cpp
@@ -225,6 +225,17 @@ oms_status_enu_t oms_exportSnapshot(const char* cref_, char** contents)
   return model->exportSnapshot(tail, contents);
 }
 
+oms_status_enu_t oms_exportSSVTemplate(const char* cref_, const char* filename)
+{
+  oms::ComRef tail(cref_);
+  oms::ComRef front = tail.pop_front();
+  oms::Model* model = oms::Scope::GetInstance().getModel(front);
+  if (!model)
+    return logError_ModelNotInScope(front);
+
+  return model->exportSSVTemplate(tail, std::string(filename));
+}
+
 oms_status_enu_t oms_listUnconnectedConnectors(const char* cref_, char** contents)
 {
   oms::ComRef tail(cref_);

--- a/src/OMSimulatorLib/OMSimulator.h
+++ b/src/OMSimulatorLib/OMSimulator.h
@@ -83,6 +83,7 @@ OMSAPI oms_status_enu_t OMSCALL oms_deleteConnectorFromTLMBus(const char* busCre
 OMSAPI oms_status_enu_t OMSCALL oms_export(const char* cref, const char* filename);
 OMSAPI oms_status_enu_t OMSCALL oms_exportDependencyGraphs(const char* cref, const char* initialization, const char* event, const char* simulation);
 OMSAPI oms_status_enu_t OMSCALL oms_exportSnapshot(const char* cref, char** contents);
+OMSAPI oms_status_enu_t OMSCALL oms_exportSSVTemplate(const char* cref, const char* filename);
 OMSAPI oms_status_enu_t OMSCALL oms_extractFMIKind(const char* filename, oms_fmi_kind_enu_t* kind);
 OMSAPI oms_status_enu_t OMSCALL oms_fetchExternalModelInterfaces(const char* cref, char*** names, char*** domains, int** dimensions);
 OMSAPI void OMSCALL oms_freeMemory(void* obj);

--- a/src/OMSimulatorLib/Values.cpp
+++ b/src/OMSimulatorLib/Values.cpp
@@ -204,6 +204,46 @@ oms_status_enu_t oms::Values::exportStartValuesHelper(pugi::xml_node& node) cons
   return oms_status_ok;
 }
 
+/*
+ * exports the start values read from modeldescription.xml to ssv template
+ */
+oms_status_enu_t oms::Values::exportToSSVTemplate(pugi::xml_node& node, const ComRef& cref)
+{
+  // skip this if there is nothing to export
+  if (modelDescriptionRealStartValues.empty() && modelDescriptionIntegerStartValues.empty() && modelDescriptionBooleanStartValues.empty())
+    return oms_status_ok;
+
+  // realStartValues
+  for (const auto& r : modelDescriptionRealStartValues)
+  {
+    //std::cout << "\n Start Values : " << std::string(r.first) << " = " << r.second ;
+    pugi::xml_node node_parameter = node.append_child(oms::ssp::Version1_0::ssv::parameter);
+    node_parameter.append_attribute("name") = std::string(cref + r.first).c_str();
+    pugi::xml_node node_parameter_type = node_parameter.append_child(oms::ssp::Version1_0::ssv::real_type);
+    node_parameter_type.append_attribute("value") = r.second;
+  }
+
+  // integerStartValues
+  for (const auto& i : modelDescriptionIntegerStartValues)
+  {
+    pugi::xml_node node_parameter = node.append_child(oms::ssp::Version1_0::ssv::parameter);
+    node_parameter.append_attribute("name") = std::string(cref + i.first).c_str();
+    pugi::xml_node node_parameter_type = node_parameter.append_child(oms::ssp::Version1_0::ssv::integer_type);
+    node_parameter_type.append_attribute("value") = i.second;
+  }
+
+  // boolStartValues
+  for (const auto& b : modelDescriptionBooleanStartValues)
+  {
+    pugi::xml_node node_parameter = node.append_child(oms::ssp::Version1_0::ssv::parameter);
+    node_parameter.append_attribute("name") = std::string(cref + b.first).c_str();
+    pugi::xml_node node_parameter_type = node_parameter.append_child(oms::ssp::Version1_0::ssv::boolean_type);
+    node_parameter_type.append_attribute("value") = b.second;
+  }
+
+  return oms_status_ok;
+}
+
 oms_status_enu_t oms::Values::importStartValuesHelper(pugi::xml_node& parameters)
 {
   if (parameters)

--- a/src/OMSimulatorLib/Values.h
+++ b/src/OMSimulatorLib/Values.h
@@ -54,6 +54,7 @@ namespace oms
     oms_status_enu_t deleteStartValue(const ComRef& cref);
 
     oms_status_enu_t exportToSSV(pugi::xml_node& ssvNode) const;
+    oms_status_enu_t exportToSSVTemplate(pugi::xml_node& ssvNode, const ComRef& cref);  ///< start values read from modelDescription.xml
     oms_status_enu_t exportStartValuesHelper(pugi::xml_node& node) const;
     oms_status_enu_t importStartValuesHelper(pugi::xml_node& parameters);
     oms_status_enu_t parseModelDescription(const char *filename);

--- a/src/OMSimulatorLua/OMSimulatorLua.c
+++ b/src/OMSimulatorLua/OMSimulatorLua.c
@@ -278,6 +278,22 @@ static int OMSimulatorLua_oms_exportSnapshot(lua_State *L)
   return 2;
 }
 
+//oms_status_enu_t oms_exportSSVTemplate(const char* cref, const char* filename);
+static int OMSimulatorLua_oms_exportSSVTemplate(lua_State *L)
+{
+  if (lua_gettop(L) != 2)
+    return luaL_error(L, "expecting exactly 2 arguments");
+  luaL_checktype(L, 1, LUA_TSTRING);
+  luaL_checktype(L, 2, LUA_TSTRING);
+
+  const char* cref = lua_tostring(L, 1);
+  const char* filename = lua_tostring(L, 2);
+  oms_status_enu_t status = oms_exportSSVTemplate(cref, filename);
+
+  lua_pushinteger(L, status);
+  return 1;
+}
+
 //oms_status_enu_t oms_listUnconnectedConnectors(const char* cref, char** contents);
 static int OMSimulatorLua_oms_listUnconnectedConnectors(lua_State *L)
 {
@@ -1269,6 +1285,7 @@ DLLEXPORT int luaopen_OMSimulatorLua(lua_State *L)
   REGISTER_LUA_CALL(oms_export);
   REGISTER_LUA_CALL(oms_exportDependencyGraphs);
   REGISTER_LUA_CALL(oms_exportSnapshot);
+  REGISTER_LUA_CALL(oms_exportSSVTemplate);
   REGISTER_LUA_CALL(oms_faultInjection);
   REGISTER_LUA_CALL(oms_getBoolean);
   REGISTER_LUA_CALL(oms_getFixedStepSize);

--- a/testsuite/OMSimulator/Makefile
+++ b/testsuite/OMSimulator/Makefile
@@ -6,6 +6,7 @@ deleteStartValues.lua \
 deleteStartValuesInSSV.lua \
 DualMassOscillator.lua \
 exportConnectorsToResultFile.lua \
+exportSSVTemplate.lua \
 Enumeration.lua \
 import_export_parameters_inline.lua \
 import_export_parameters_to_ssv.lua \

--- a/testsuite/OMSimulator/exportSSVTemplate.lua
+++ b/testsuite/OMSimulator/exportSSVTemplate.lua
@@ -14,72 +14,37 @@ oms_addSystem("test.Root", oms_system_wc)
 oms_addSubModel("test.Root.Gain", "../resources/Modelica.Blocks.Math.Gain.fmu")
 oms_addSubModel("test.Root.add", "../resources/Modelica.Blocks.Math.Add.fmu")
 
-src = oms_list("test")
-print(src)
-
 oms_exportSSVTemplate("test", "template.ssv")
+
+local f = assert(io.open("template.ssv", "r"))
+local content = f:read("*all")
+print(content)
+f:close()
 
 
 -- Result:
--- <?xml version="1.0"?>
--- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="test" version="1.0">
--- 	<ssd:System name="Root">
--- 		<ssd:Annotations>
--- 			<ssc:Annotation type="org.openmodelica">
--- 				<oms:SimulationInformation>
--- 					<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
--- 				</oms:SimulationInformation>
--- 			</ssc:Annotation>
--- 		</ssd:Annotations>
--- 		<ssd:Connectors />
--- 		<ssd:Elements>
--- 			<ssd:Component name="add" type="application/x-fmu-sharedlibrary" source="resources/0002_add.fmu">
--- 				<ssd:Connectors>
--- 					<ssd:Connector name="u1" kind="input">
--- 						<ssc:Real />
--- 						<ssd:ConnectorGeometry x="0.000000" y="0.333333" />
--- 					</ssd:Connector>
--- 					<ssd:Connector name="u2" kind="input">
--- 						<ssc:Real />
--- 						<ssd:ConnectorGeometry x="0.000000" y="0.666667" />
--- 					</ssd:Connector>
--- 					<ssd:Connector name="y" kind="output">
--- 						<ssc:Real />
--- 						<ssd:ConnectorGeometry x="1.000000" y="0.500000" />
--- 					</ssd:Connector>
--- 					<ssd:Connector name="k1" kind="parameter">
--- 						<ssc:Real />
--- 					</ssd:Connector>
--- 					<ssd:Connector name="k2" kind="parameter">
--- 						<ssc:Real />
--- 					</ssd:Connector>
--- 				</ssd:Connectors>
--- 			</ssd:Component>
--- 			<ssd:Component name="Gain" type="application/x-fmu-sharedlibrary" source="resources/0001_Gain.fmu">
--- 				<ssd:Connectors>
--- 					<ssd:Connector name="u" kind="input">
--- 						<ssc:Real />
--- 						<ssd:ConnectorGeometry x="0.000000" y="0.500000" />
--- 					</ssd:Connector>
--- 					<ssd:Connector name="y" kind="output">
--- 						<ssc:Real />
--- 						<ssd:ConnectorGeometry x="1.000000" y="0.500000" />
--- 					</ssd:Connector>
--- 					<ssd:Connector name="k" kind="parameter">
--- 						<ssc:Real />
--- 					</ssd:Connector>
--- 				</ssd:Connectors>
--- 			</ssd:Component>
--- 		</ssd:Elements>
--- 		<ssd:Connections />
--- 	</ssd:System>
--- 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
--- 		<ssd:Annotations>
--- 			<ssc:Annotation type="org.openmodelica">
--- 				<oms:SimulationInformation resultFile="test_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter="" />
--- 			</ssc:Annotation>
--- 		</ssd:Annotations>
--- 	</ssd:DefaultExperiment>
--- </ssd:SystemStructureDescription>
+-- <?xml version="1.0" encoding="UTF-8"?>
+-- <ssv:ParameterSet xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" version="1.0" name="modelDescriptionStartValues">
+-- 	<ssv:Parameters>
+-- 		<ssv:Parameter name="add.u2">
+-- 			<ssv:Real value="0" />
+-- 		</ssv:Parameter>
+-- 		<ssv:Parameter name="add.u1">
+-- 			<ssv:Real value="0" />
+-- 		</ssv:Parameter>
+-- 		<ssv:Parameter name="add.k2">
+-- 			<ssv:Real value="1" />
+-- 		</ssv:Parameter>
+-- 		<ssv:Parameter name="add.k1">
+-- 			<ssv:Real value="1" />
+-- 		</ssv:Parameter>
+-- 		<ssv:Parameter name="Gain.u">
+-- 			<ssv:Real value="0" />
+-- 		</ssv:Parameter>
+-- 		<ssv:Parameter name="Gain.k">
+-- 			<ssv:Real value="1" />
+-- 		</ssv:Parameter>
+-- 	</ssv:Parameters>
+-- </ssv:ParameterSet>
 -- 
 -- endResult

--- a/testsuite/OMSimulator/exportSSVTemplate.lua
+++ b/testsuite/OMSimulator/exportSSVTemplate.lua
@@ -1,0 +1,85 @@
+-- status: correct
+-- linux: yes
+-- mingw: yes
+-- win: no
+-- mac: no
+
+oms_setCommandLineOption("--suppressPath=true")
+oms_setTempDirectory("./exportssvtemplate_lua/")
+
+oms_newModel("test")
+
+oms_addSystem("test.Root", oms_system_wc)
+
+oms_addSubModel("test.Root.Gain", "../resources/Modelica.Blocks.Math.Gain.fmu")
+oms_addSubModel("test.Root.add", "../resources/Modelica.Blocks.Math.Add.fmu")
+
+src = oms_list("test")
+print(src)
+
+oms_exportSSVTemplate("test", "template.ssv")
+
+
+-- Result:
+-- <?xml version="1.0"?>
+-- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="test" version="1.0">
+-- 	<ssd:System name="Root">
+-- 		<ssd:Annotations>
+-- 			<ssc:Annotation type="org.openmodelica">
+-- 				<oms:SimulationInformation>
+-- 					<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+-- 				</oms:SimulationInformation>
+-- 			</ssc:Annotation>
+-- 		</ssd:Annotations>
+-- 		<ssd:Connectors />
+-- 		<ssd:Elements>
+-- 			<ssd:Component name="add" type="application/x-fmu-sharedlibrary" source="resources/0002_add.fmu">
+-- 				<ssd:Connectors>
+-- 					<ssd:Connector name="u1" kind="input">
+-- 						<ssc:Real />
+-- 						<ssd:ConnectorGeometry x="0.000000" y="0.333333" />
+-- 					</ssd:Connector>
+-- 					<ssd:Connector name="u2" kind="input">
+-- 						<ssc:Real />
+-- 						<ssd:ConnectorGeometry x="0.000000" y="0.666667" />
+-- 					</ssd:Connector>
+-- 					<ssd:Connector name="y" kind="output">
+-- 						<ssc:Real />
+-- 						<ssd:ConnectorGeometry x="1.000000" y="0.500000" />
+-- 					</ssd:Connector>
+-- 					<ssd:Connector name="k1" kind="parameter">
+-- 						<ssc:Real />
+-- 					</ssd:Connector>
+-- 					<ssd:Connector name="k2" kind="parameter">
+-- 						<ssc:Real />
+-- 					</ssd:Connector>
+-- 				</ssd:Connectors>
+-- 			</ssd:Component>
+-- 			<ssd:Component name="Gain" type="application/x-fmu-sharedlibrary" source="resources/0001_Gain.fmu">
+-- 				<ssd:Connectors>
+-- 					<ssd:Connector name="u" kind="input">
+-- 						<ssc:Real />
+-- 						<ssd:ConnectorGeometry x="0.000000" y="0.500000" />
+-- 					</ssd:Connector>
+-- 					<ssd:Connector name="y" kind="output">
+-- 						<ssc:Real />
+-- 						<ssd:ConnectorGeometry x="1.000000" y="0.500000" />
+-- 					</ssd:Connector>
+-- 					<ssd:Connector name="k" kind="parameter">
+-- 						<ssc:Real />
+-- 					</ssd:Connector>
+-- 				</ssd:Connectors>
+-- 			</ssd:Component>
+-- 		</ssd:Elements>
+-- 		<ssd:Connections />
+-- 	</ssd:System>
+-- 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
+-- 		<ssd:Annotations>
+-- 			<ssc:Annotation type="org.openmodelica">
+-- 				<oms:SimulationInformation resultFile="test_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter="" />
+-- 			</ssc:Annotation>
+-- 		</ssd:Annotations>
+-- 	</ssd:DefaultExperiment>
+-- </ssd:SystemStructureDescription>
+-- 
+-- endResult

--- a/testsuite/OMSimulator/exportSSVTemplate.lua
+++ b/testsuite/OMSimulator/exportSSVTemplate.lua
@@ -7,6 +7,15 @@
 oms_setCommandLineOption("--suppressPath=true")
 oms_setTempDirectory("./exportssvtemplate_lua/")
 
+
+function readFile(filename)
+  local f = assert(io.open(filename, "r"))
+  local content = f:read("*all")
+  print(content)
+  f:close()
+end
+
+
 oms_newModel("test")
 
 oms_addSystem("test.Root", oms_system_wc)
@@ -15,11 +24,13 @@ oms_addSubModel("test.Root.Gain", "../resources/Modelica.Blocks.Math.Gain.fmu")
 oms_addSubModel("test.Root.add", "../resources/Modelica.Blocks.Math.Add.fmu")
 
 oms_exportSSVTemplate("test", "template.ssv")
+readFile("template.ssv")
 
-local f = assert(io.open("template.ssv", "r"))
-local content = f:read("*all")
-print(content)
-f:close()
+oms_exportSSVTemplate("test.Root.add", "add.ssv")
+readFile("add.ssv")
+
+oms_exportSSVTemplate("test.Root.Gain", "gain.ssv")
+readFile("gain.ssv")
 
 
 -- Result:
@@ -38,6 +49,36 @@ f:close()
 -- 		<ssv:Parameter name="add.k1">
 -- 			<ssv:Real value="1" />
 -- 		</ssv:Parameter>
+-- 		<ssv:Parameter name="Gain.u">
+-- 			<ssv:Real value="0" />
+-- 		</ssv:Parameter>
+-- 		<ssv:Parameter name="Gain.k">
+-- 			<ssv:Real value="1" />
+-- 		</ssv:Parameter>
+-- 	</ssv:Parameters>
+-- </ssv:ParameterSet>
+-- 
+-- <?xml version="1.0" encoding="UTF-8"?>
+-- <ssv:ParameterSet xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" version="1.0" name="modelDescriptionStartValues">
+-- 	<ssv:Parameters>
+-- 		<ssv:Parameter name="add.u2">
+-- 			<ssv:Real value="0" />
+-- 		</ssv:Parameter>
+-- 		<ssv:Parameter name="add.u1">
+-- 			<ssv:Real value="0" />
+-- 		</ssv:Parameter>
+-- 		<ssv:Parameter name="add.k2">
+-- 			<ssv:Real value="1" />
+-- 		</ssv:Parameter>
+-- 		<ssv:Parameter name="add.k1">
+-- 			<ssv:Real value="1" />
+-- 		</ssv:Parameter>
+-- 	</ssv:Parameters>
+-- </ssv:ParameterSet>
+-- 
+-- <?xml version="1.0" encoding="UTF-8"?>
+-- <ssv:ParameterSet xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" version="1.0" name="modelDescriptionStartValues">
+-- 	<ssv:Parameters>
 -- 		<ssv:Parameter name="Gain.u">
 -- 			<ssv:Real value="0" />
 -- 		</ssv:Parameter>


### PR DESCRIPTION

### Related Issues

https://github.com/OpenModelica/OMSimulator/issues/824

### Purpose

This PR implements a new API `oms_exportSSVTemplate` which exports start values read from `modeldescription.xml` to 
a `.ssv file`

### example
```
oms_newModel("test")
oms_addSystem("test.Root", oms_system_wc)
oms_addSubModel("test.Root.Gain", "../resources/Modelica.Blocks.Math.Gain.fmu")
oms_addSubModel("test.Root.add", "../resources/Modelica.Blocks.Math.Add.fmu")
oms_exportSSVTemplate("test", "template.ssv")
```

