### PR TITLE
Add ignoreInitialUnknowns for CS FMUs

### DIFF
--- a/src/OMSimulatorLib/ComponentFMUCS.cpp
+++ b/src/OMSimulatorLib/ComponentFMUCS.cpp
@@ -361,6 +361,18 @@ oms_status_enu_t oms::ComponentFMUCS::initializeDependencyGraph_initialUnknowns(
     return oms_status_error;
   }
 
+  if (Flags::IgnoreInitialUnknowns())
+  {
+    int N=initialUnknownsGraph.getNodes().size();
+    for (int i = 0; i < N; i++)
+    {
+      logDebug(std::string(getCref()) + ": " + getPath() + " initial unknown " + std::string(initialUnknownsGraph.getNodes()[i]) + " depends on all");
+      for (int j = 0; j < inputs.size(); j++)
+        initialUnknownsGraph.addEdge(inputs[j].makeConnector(), initialUnknownsGraph.getNodes()[i]);
+    }
+    return oms_status_ok;
+  }
+
   size_t *startIndex=NULL, *dependency=NULL;
   char* factorKind;
 
@@ -391,7 +403,7 @@ oms_status_enu_t oms::ComponentFMUCS::initializeDependencyGraph_initialUnknowns(
       {
         if (dependency[j] <= 0 || allVariables.size() < dependency[j])
         {
-          logError(std::string(getCref()) + ": Dependecies from modelDescription.xml erroneous.");
+          logError(std::string(getCref()) + ": Dependencies from modelDescription.xml erroneous.");
           logDebug("Can't find variable for dependency with index " + std::to_string(dependency[j]) + " for  initial unknown " + std::string(initialUnknownsGraph.getNodes()[i]) + "." );
           logInfo("Use flag --ignoreInitialUnknowns=true to ignore dependencies, but this can cause inflated loop size.");
           return oms_status_fatal;
@@ -442,7 +454,7 @@ oms_status_enu_t oms::ComponentFMUCS::initializeDependencyGraph_outputs()
       {
         if (dependency[j] <= 0 || allVariables.size() < dependency[j])
         {
-          logError(std::string(getCref()) + ": Dependecies from modelDescription.xml erroneous.");
+          logError(std::string(getCref()) + ": Dependnecies from modelDescription.xml erroneous.");
           logDebug("Can't find variable for dependency with index " + std::to_string(dependency[j]) + " for output " + std::string(outputs[i]) + "." );
           logInfo("Use flag --ignoreInitialUnknowns=true to ignore dependencies, but this can cause inflated loop size.");
           return oms_status_fatal;

--- a/src/OMSimulatorLib/ComponentFMUME.cpp
+++ b/src/OMSimulatorLib/ComponentFMUME.cpp
@@ -405,7 +405,7 @@ oms_status_enu_t oms::ComponentFMUME::initializeDependencyGraph_initialUnknowns(
       {
         if (dependency[j] <= 0 || allVariables.size() < dependency[j])
         {
-          logError(std::string(getCref()) + ": Dependecies from modelDescription.xml erroneous.");
+          logError(std::string(getCref()) + ": Dependencies from modelDescription.xml erroneous.");
           logDebug("Can't find variable for dependency with index " + std::to_string(dependency[j]) + " for initial unknown " + std::string(initialUnknownsGraph.getNodes()[i]) + "." );
           logInfo("Use flag --ignoreInitialUnknowns=true to ignore dependencies, but this can cause inflated loop size.");
           return oms_status_fatal;
@@ -456,7 +456,7 @@ oms_status_enu_t oms::ComponentFMUME::initializeDependencyGraph_outputs()
       {
         if (dependency[j] <= 0 || allVariables.size() < dependency[j])
         {
-          logError(std::string(getCref()) + ": Dependecies from modelDescription.xml erroneous.");
+          logError(std::string(getCref()) + ": Dependencies from modelDescription.xml erroneous.");
           logDebug("Can't find variable for dependency with index " + std::to_string(dependency[j]) + " for output " + std::string(outputs[i]) + "." );
           logInfo("Use flag --ignoreInitialUnknowns=true to ignore dependencies, but this can cause inflated loop size.");
           return oms_status_fatal;


### PR DESCRIPTION
### Related Issues

Broken dependencies in CS FMUs will lead to reporting a fatal error and the hint to try `--ignoreInitialUnknowns=true`.
But ignoreInitialUnknowns was not implemented for CS.

### Purpose

Give users the option to ignore initial unknowns for CS FMUs. Should only be used if the dependencies are broken for whatever reason.

### Approach

Copy-Paste for the win.
Also fixing ~~embarings~~ ~~embarrasnigs~~ embarrassing typo.
