### PR TITLE
Archive build from linux64 and not centos6

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -60,6 +60,12 @@ pipeline {
 
             // Temporary debugging
             // archiveArtifacts artifacts: 'testsuite/**/*.log', fingerprint: true
+            sh '''
+            # No so-files should ever exist in a bin/ folder
+            ! ls install/linux/bin/*.so 1> /dev/null 2>&1
+            (cd install/linux && tar czf "../../OMSimulator-linux-amd64-`git describe --tags --abbrev=7 --match=v*.* --exclude=*-dev`.tar.gz" *)
+            '''
+            archiveArtifacts "OMSimulator-linux-amd64-*.tar.gz"
 
             sh 'make doc doc-html doc-doxygen'
             sh '(cd install/linux/doc && zip -r "../../../OMSimulator-doc-`git describe --tags --abbrev=7 --match=v*.* --exclude=*-dev`.zip" *)'
@@ -133,12 +139,6 @@ pipeline {
           }
           steps {
             buildOMS()
-            sh '''
-            # No so-files should ever exist in a bin/ folder
-            ! ls install/linux/bin/*.so 1> /dev/null 2>&1
-            (cd install/linux && tar czf "../../OMSimulator-linux-amd64-`git describe --tags --abbrev=7 --match=v*.* --exclude=*-dev`.tar.gz" *)
-            '''
-            archiveArtifacts "OMSimulator-linux-amd64-*.tar.gz"
           }
         }
         stage('centos7') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -60,16 +60,11 @@ pipeline {
 
             // Temporary debugging
             // archiveArtifacts artifacts: 'testsuite/**/*.log', fingerprint: true
-            sh '''
-            # No so-files should ever exist in a bin/ folder
-            ! ls install/linux/bin/*.so 1> /dev/null 2>&1
-            (cd install/linux && tar czf "../../OMSimulator-linux-amd64-`git describe --tags --abbrev=7 --match=v*.* --exclude=*-dev`.tar.gz" *)
-            '''
-            archiveArtifacts "OMSimulator-linux-amd64-*.tar.gz"
+            sh '(cd install/linux && tar czf "../../OMSimulator-linux-amd64-`git describe --tags --abbrev=7 --match=v*.* --exclude=*-dev`.tar.gz" *)'
 
             sh 'make doc doc-html doc-doxygen'
             sh '(cd install/linux/doc && zip -r "../../../OMSimulator-doc-`git describe --tags --abbrev=7 --match=v*.* --exclude=*-dev`.zip" *)'
-            archiveArtifacts artifacts: 'OMSimulator-doc*.zip', fingerprint: true
+            archiveArtifacts artifacts: 'OMSimulator-doc*.zip', 'OMSimulator-linux-amd64-*.tar.gz', fingerprint: true
             stash name: 'docs', includes: "install/linux/doc/**"
           }
         }


### PR DESCRIPTION
### Related Issues

Linux64 bit version string in archived artifacts are missing.

### Approach

Move archiving arivact to `linux64` stage.
