### PR TITLE
Trying to fix MINGW build with new OMDev

### DIFF
--- a/src/OMSimulator/CMakeLists.txt
+++ b/src/OMSimulator/CMakeLists.txt
@@ -32,10 +32,6 @@ IF (APPLE)
     $<TARGET_FILE:OMSimulator>)
 ENDIF ()
 
-IF (WIN32 AND MINGW)
-  set(CMAKE_EXE_LINKER_FLAGS "-static -static-libgcc -static-libstdc++")
-ENDIF ()
-
 add_definitions(-DOMS_STATIC)
 target_link_libraries(OMSimulator OMSimulatorLib_static)
 


### PR DESCRIPTION
This is now compiling on my machine with mingw. But we don't test the mingw build on Jenkins, but cross-compile for windows.