### PR TITLE
Update Jenkinsfile for UPLOAD_BUILD_OPENMODELICA 

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -633,7 +633,7 @@ void submoduleNoChange(path) {
 
 def getExperimentalPath() {
   if (changeRequest()) {
-    return "experimental/pr-${env.CHANGE_ID}/$BUILD_NUMBER/"
+    return "experimental/pr-${env.CHANGE_ID}/"
   }
   else {
     return ""


### PR DESCRIPTION
  - mingw32 will be build if `MINGW32 || UPLOAD_BUILD_OPENMODELICA || buildTag()` is true
  - Build artifacts will be uploaded if `UPLOAD_BUILD_OPENMODELICA || buildTag()` is true

Now we don't have to manually activate MINGW32 if we wan't to upload artifacts to build.openmodelica.org.
Also on all new tagged commits we should upload artifacts automatically.