### PR TITLE
add python support for oms_exportSSVTemplate

### DIFF
--- a/doc/UsersGuide/source/api/exportSSVTemplate.rst
+++ b/doc/UsersGuide/source/api/exportSSVTemplate.rst
@@ -1,0 +1,38 @@
+#CAPTION#
+exportSSVTemplate
+--------------
+
+export start values read from modeldescription.xml to a .ssv file
+
+#END#
+
+#LUA#
+.. code-block:: lua
+
+  status = oms_exportSSVTemplate(cref, filename)
+
+#END#
+
+#PYTHON#
+.. code-block:: python
+
+  status = oms.exportSSVTemplate(cref, filename)
+
+#END#
+
+#CAPI#
+.. code-block:: c
+
+  oms_status_enu_t oms_exportSSVTemplate(const char* cref, const char* filename)
+
+#END#
+
+#OMC#
+.. code-block:: Modelica
+
+  # not available
+
+#END#
+
+#DESCRIPTION#
+#END#

--- a/doc/UsersGuide/source/api/exportSSVTemplate.rst
+++ b/doc/UsersGuide/source/api/exportSSVTemplate.rst
@@ -1,6 +1,6 @@
 #CAPTION#
 exportSSVTemplate
---------------
+-----------------
 
 export start values read from modeldescription.xml to a .ssv file
 

--- a/doc/UsersGuide/source/api/exportSSVTemplate.rst
+++ b/doc/UsersGuide/source/api/exportSSVTemplate.rst
@@ -2,8 +2,7 @@
 exportSSVTemplate
 -----------------
 
-export start values read from modeldescription.xml to a .ssv file
-
+Export start values of a FMU read from modeldescription.xml to a .ssv file. It can be called on a given model or components.
 #END#
 
 #LUA#

--- a/doc/UsersGuide/source/api/exportSSVTemplate.rst
+++ b/doc/UsersGuide/source/api/exportSSVTemplate.rst
@@ -2,7 +2,8 @@
 exportSSVTemplate
 -----------------
 
-Export start values of a FMU read from modeldescription.xml to a .ssv file. It can be called on a given model or components.
+Exports all signals that have start values of one or multiple FMUs to a SSV file that are read from modelDescription.xml. The function can be called for a top level model or a certain FMU component.
+If called for a top level model, start values of all FMUs are exported to the SSV file. If called for a component, start values of just this FMU are exported to the SSV file.
 #END#
 
 #LUA#

--- a/doc/UsersGuide/source/api/exportSnapshot.rst
+++ b/doc/UsersGuide/source/api/exportSnapshot.rst
@@ -19,7 +19,7 @@ doesn't need to call free.
 #PYTHON#
 .. code-block:: python
 
-  contents, status = oms_exportSnapshot(cref)
+  contents, status = oms.exportSnapshot(cref)
 
 #END#
 

--- a/doc/UsersGuide/source/api/importSnapshot.rst
+++ b/doc/UsersGuide/source/api/importSnapshot.rst
@@ -15,7 +15,7 @@ Loads a snapshot to restore a previous model state. The model must be in virgin 
 #PYTHON#
 .. code-block:: python
 
-  status = oms_importSnapshot(cref, snapshot)
+  status = oms.importSnapshot(cref, snapshot)
 
 #END#
 

--- a/doc/UsersGuide/source/api/loadSnapshot.rst
+++ b/doc/UsersGuide/source/api/loadSnapshot.rst
@@ -15,7 +15,7 @@ Loads a snapshot to restore a previous model state. The model must be in virgin 
 #PYTHON#
 .. code-block:: python
 
-  status = oms_loadSnapshot(cref, snapshot)
+  status = oms.loadSnapshot(cref, snapshot)
 
 #END#
 

--- a/src/OMSimulatorPython/OMSimulator.py
+++ b/src/OMSimulatorPython/OMSimulator.py
@@ -282,8 +282,7 @@ class OMSimulator:
     status = self.obj.oms_exportSnapshot(self.checkstring(ident), ctypes.byref(contents))
     return [self.checkstring(contents.value), status]
   def exportSSVTemplate(self, ident, filename):
-    status = self.obj.oms_exportSSVTemplate(self.checkstring(ident), self.checkstring(filename))
-    return status
+    return self.obj.oms_exportSSVTemplate(self.checkstring(ident), self.checkstring(filename))
   def listUnconnectedConnectors(self, ident):
     contents = ctypes.c_char_p()
     status = self.obj.oms_listUnconnectedConnectors(self.checkstring(ident), ctypes.byref(contents))

--- a/src/OMSimulatorPython/OMSimulator.py
+++ b/src/OMSimulatorPython/OMSimulator.py
@@ -108,6 +108,8 @@ class OMSimulator:
     self.obj.oms_exportDependencyGraphs.restype = ctypes.c_int
     self.obj.oms_exportSnapshot.argtypes = [ctypes.c_char_p]
     self.obj.oms_exportSnapshot.restype = ctypes.c_int
+    self.obj.oms_exportSSVTemplate.argtypes = [ctypes.c_char_p, ctypes.c_char_p]
+    self.obj.oms_exportSSVTemplate.restype = ctypes.c_int
     self.obj.oms_faultInjection.argtypes = [ctypes.c_char_p, ctypes.c_int, ctypes.c_double]
     self.obj.oms_faultInjection.restype = ctypes.c_int
     self.obj.oms_getBoolean.argtypes = [ctypes.c_char_p, ctypes.POINTER(ctypes.c_bool)]
@@ -279,6 +281,9 @@ class OMSimulator:
     contents = ctypes.c_char_p()
     status = self.obj.oms_exportSnapshot(self.checkstring(ident), ctypes.byref(contents))
     return [self.checkstring(contents.value), status]
+  def exportSSVTemplate(self, ident, filename):
+    status = self.obj.oms_exportSSVTemplate(self.checkstring(ident), self.checkstring(filename))
+    return status
   def listUnconnectedConnectors(self, ident):
     contents = ctypes.c_char_p()
     status = self.obj.oms_listUnconnectedConnectors(self.checkstring(ident), ctypes.byref(contents))

--- a/testsuite/OMSimulator/exportSSVTemplate.py
+++ b/testsuite/OMSimulator/exportSSVTemplate.py
@@ -1,0 +1,94 @@
+## status: correct
+## linux: yes
+## mingw: yes
+## win: no
+## mac: no
+
+from OMSimulator import OMSimulator
+oms = OMSimulator()
+
+oms.setCommandLineOption("--suppressPath=true")
+oms.setTempDirectory("./exportssvtemplate_py/")
+
+
+def readFile(filename):
+  f = open(filename, "r")
+  content = f.read()
+  print(content)
+  f:close()
+
+
+
+oms.newModel("test")
+
+oms.addSystem("test.Root", oms.system_wc)
+
+oms.addSubModel("test.Root.Gain", "../resources/Modelica.Blocks.Math.Gain.fmu")
+oms.addSubModel("test.Root.add", "../resources/Modelica.Blocks.Math.Add.fmu")
+
+oms.exportSSVTemplate("test", "template.ssv")
+readFile("template.ssv")
+
+oms.exportSSVTemplate("test.Root.add", "add.ssv")
+readFile("add.ssv")
+
+oms.exportSSVTemplate("test.Root.Gain", "gain.ssv")
+readFile("gain.ssv")
+
+
+## Result:
+## <?xml version="1.0" encoding="UTF-8"?>
+## <ssv:ParameterSet xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" version="1.0" name="modelDescriptionStartValues">
+## 	<ssv:Parameters>
+## 		<ssv:Parameter name="add.u2">
+## 			<ssv:Real value="0" />
+## 		</ssv:Parameter>
+## 		<ssv:Parameter name="add.u1">
+## 			<ssv:Real value="0" />
+## 		</ssv:Parameter>
+## 		<ssv:Parameter name="add.k2">
+## 			<ssv:Real value="1" />
+## 		</ssv:Parameter>
+## 		<ssv:Parameter name="add.k1">
+## 			<ssv:Real value="1" />
+## 		</ssv:Parameter>
+## 		<ssv:Parameter name="Gain.u">
+## 			<ssv:Real value="0" />
+## 		</ssv:Parameter>
+## 		<ssv:Parameter name="Gain.k">
+## 			<ssv:Real value="1" />
+## 		</ssv:Parameter>
+## 	</ssv:Parameters>
+## </ssv:ParameterSet>
+## 
+## <?xml version="1.0" encoding="UTF-8"?>
+## <ssv:ParameterSet xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" version="1.0" name="modelDescriptionStartValues">
+## 	<ssv:Parameters>
+## 		<ssv:Parameter name="add.u2">
+## 			<ssv:Real value="0" />
+## 		</ssv:Parameter>
+## 		<ssv:Parameter name="add.u1">
+## 			<ssv:Real value="0" />
+## 		</ssv:Parameter>
+## 		<ssv:Parameter name="add.k2">
+## 			<ssv:Real value="1" />
+## 		</ssv:Parameter>
+## 		<ssv:Parameter name="add.k1">
+## 			<ssv:Real value="1" />
+## 		</ssv:Parameter>
+## 	</ssv:Parameters>
+## </ssv:ParameterSet>
+## 
+## <?xml version="1.0" encoding="UTF-8"?>
+## <ssv:ParameterSet xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" version="1.0" name="modelDescriptionStartValues">
+## 	<ssv:Parameters>
+## 		<ssv:Parameter name="Gain.u">
+## 			<ssv:Real value="0" />
+## 		</ssv:Parameter>
+## 		<ssv:Parameter name="Gain.k">
+## 			<ssv:Real value="1" />
+## 		</ssv:Parameter>
+## 	</ssv:Parameters>
+## </ssv:ParameterSet>
+## 
+## endResult


### PR DESCRIPTION
### Related Issues

https://github.com/OpenModelica/OMSimulator/issues/824

### Purpose

This PR implements python support to  `oms_exportSSVTemplate`  API 

