### PR TITLE
Fix check if on master or PR in jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -632,7 +632,7 @@ void submoduleNoChange(path) {
 }
 
 def getExperimentalPath() {
-  if (env.CHANGE_ID ? true : false) {
+  if (env.CHANGE_ID) {
     return "experimental/pr-${env.CHANGE_ID}/"
   }
   else {


### PR DESCRIPTION
### Related Issues

Build artifacts of master are uploaded to `https://build.openmodelica.org/omsimulator/experimental/pr-null/`.

### Approach

`env.CHANGE_ID` will be `null` not `false` when on a branch.
