### PR TITLE
Use Origin/master to test if we are on the master branch

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -740,7 +740,7 @@ def shouldWeUploadArtifacts() {
     }
     return params.UPLOAD_BUILD_OPENMODELICA
   }
-  if (env.GIT_BRANCH == "master") {
+  if (env.GIT_BRANCH == "origin/master") {
     return true
   }
   return false


### PR DESCRIPTION
### Related Issues

Uploading of Artifacts on master branch broken again.

Test `env.GIT_BRANCH == "origin/master"`
