### PR TITLE
export <ssd:annotation> to end, inorder to be valid with easy-ssp

### DIFF
--- a/src/OMSimulatorLib/System.cpp
+++ b/src/OMSimulatorLib/System.cpp
@@ -390,10 +390,6 @@ oms_status_enu_t oms::System::exportToSSD(pugi::xml_node& node, pugi::xml_node& 
 {
   node.append_attribute("name") = this->getCref().c_str();
 
-  // export ssd:SimulationInformation
-  if (oms_status_ok != this->exportToSSD_SimulationInformation(node))
-    return logError("export of system SimulationInformation failed");
-
   if (oms_status_ok != element.getGeometry()->exportToSSD(node))
     return logError("export of system ElementGeometry failed");
 
@@ -478,6 +474,10 @@ oms_status_enu_t oms::System::exportToSSD(pugi::xml_node& node, pugi::xml_node& 
         busconnection->exportToSSD(busconnections_node);
     }
   }
+
+  //export ssd:SimulationInformation to end, in order to make it valid with easy-ssp
+  if (oms_status_ok != this->exportToSSD_SimulationInformation(node))
+    return logError("export of system SimulationInformation failed");
 
   return oms_status_ok;
 }

--- a/testsuite/OMSimulator/deleteConnector.lua
+++ b/testsuite/OMSimulator/deleteConnector.lua
@@ -56,13 +56,6 @@ print(src)
 -- <?xml version="1.0"?>
 -- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="deleteConnector" version="1.0">
 -- 	<ssd:System name="Root">
--- 		<ssd:Annotations>
--- 			<ssc:Annotation type="org.openmodelica">
--- 				<oms:SimulationInformation>
--- 					<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
--- 				</oms:SimulationInformation>
--- 			</ssc:Annotation>
--- 		</ssd:Annotations>
 -- 		<ssd:Connectors>
 -- 			<ssd:Connector name="C1" kind="input">
 -- 				<ssc:Real />
@@ -73,13 +66,6 @@ print(src)
 -- 		</ssd:Connectors>
 -- 		<ssd:Elements>
 -- 			<ssd:System name="System2">
--- 				<ssd:Annotations>
--- 					<ssc:Annotation type="org.openmodelica">
--- 						<oms:SimulationInformation>
--- 							<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
--- 						</oms:SimulationInformation>
--- 					</ssc:Annotation>
--- 				</ssd:Annotations>
 -- 				<ssd:Connectors>
 -- 					<ssd:Connector name="C3" kind="output">
 -- 						<ssc:Real />
@@ -104,8 +90,6 @@ print(src)
 -- 						</ssd:ParameterValues>
 -- 					</ssd:ParameterBinding>
 -- 				</ssd:ParameterBindings>
--- 			</ssd:System>
--- 			<ssd:System name="System1">
 -- 				<ssd:Annotations>
 -- 					<ssc:Annotation type="org.openmodelica">
 -- 						<oms:SimulationInformation>
@@ -113,6 +97,8 @@ print(src)
 -- 						</oms:SimulationInformation>
 -- 					</ssc:Annotation>
 -- 				</ssd:Annotations>
+-- 			</ssd:System>
+-- 			<ssd:System name="System1">
 -- 				<ssd:Connectors>
 -- 					<ssd:Connector name="C1" kind="input">
 -- 						<ssc:Real />
@@ -151,6 +137,13 @@ print(src)
 -- 						</ssd:ParameterBindings>
 -- 					</ssd:Component>
 -- 				</ssd:Elements>
+-- 				<ssd:Annotations>
+-- 					<ssc:Annotation type="org.openmodelica">
+-- 						<oms:SimulationInformation>
+-- 							<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+-- 						</oms:SimulationInformation>
+-- 					</ssc:Annotation>
+-- 				</ssd:Annotations>
 -- 			</ssd:System>
 -- 		</ssd:Elements>
 -- 		<ssd:Connections>
@@ -158,6 +151,13 @@ print(src)
 -- 			<ssd:Connection startElement="System2" startConnector="C3" endElement="System1" endConnector="C1" />
 -- 			<ssd:Connection startElement="System2" startConnector="C4" endElement="System1" endConnector="C2" />
 -- 		</ssd:Connections>
+-- 		<ssd:Annotations>
+-- 			<ssc:Annotation type="org.openmodelica">
+-- 				<oms:SimulationInformation>
+-- 					<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+-- 				</oms:SimulationInformation>
+-- 			</ssc:Annotation>
+-- 		</ssd:Annotations>
 -- 	</ssd:System>
 -- 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
 -- 		<ssd:Annotations>
@@ -173,13 +173,6 @@ print(src)
 -- <?xml version="1.0"?>
 -- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="deleteConnector" version="1.0">
 -- 	<ssd:System name="Root">
--- 		<ssd:Annotations>
--- 			<ssc:Annotation type="org.openmodelica">
--- 				<oms:SimulationInformation>
--- 					<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
--- 				</oms:SimulationInformation>
--- 			</ssc:Annotation>
--- 		</ssd:Annotations>
 -- 		<ssd:Connectors>
 -- 			<ssd:Connector name="C2" kind="output">
 -- 				<ssc:Real />
@@ -187,13 +180,6 @@ print(src)
 -- 		</ssd:Connectors>
 -- 		<ssd:Elements>
 -- 			<ssd:System name="System2">
--- 				<ssd:Annotations>
--- 					<ssc:Annotation type="org.openmodelica">
--- 						<oms:SimulationInformation>
--- 							<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
--- 						</oms:SimulationInformation>
--- 					</ssc:Annotation>
--- 				</ssd:Annotations>
 -- 				<ssd:Connectors>
 -- 					<ssd:Connector name="C4" kind="output">
 -- 						<ssc:Real />
@@ -212,8 +198,6 @@ print(src)
 -- 						</ssd:ParameterValues>
 -- 					</ssd:ParameterBinding>
 -- 				</ssd:ParameterBindings>
--- 			</ssd:System>
--- 			<ssd:System name="System1">
 -- 				<ssd:Annotations>
 -- 					<ssc:Annotation type="org.openmodelica">
 -- 						<oms:SimulationInformation>
@@ -221,6 +205,8 @@ print(src)
 -- 						</oms:SimulationInformation>
 -- 					</ssc:Annotation>
 -- 				</ssd:Annotations>
+-- 			</ssd:System>
+-- 			<ssd:System name="System1">
 -- 				<ssd:Connectors>
 -- 					<ssd:Connector name="C1" kind="input">
 -- 						<ssc:Real />
@@ -243,11 +229,25 @@ print(src)
 -- 						</ssd:Connectors>
 -- 					</ssd:Component>
 -- 				</ssd:Elements>
+-- 				<ssd:Annotations>
+-- 					<ssc:Annotation type="org.openmodelica">
+-- 						<oms:SimulationInformation>
+-- 							<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+-- 						</oms:SimulationInformation>
+-- 					</ssc:Annotation>
+-- 				</ssd:Annotations>
 -- 			</ssd:System>
 -- 		</ssd:Elements>
 -- 		<ssd:Connections>
 -- 			<ssd:Connection startElement="System2" startConnector="C4" endElement="System1" endConnector="C2" />
 -- 		</ssd:Connections>
+-- 		<ssd:Annotations>
+-- 			<ssc:Annotation type="org.openmodelica">
+-- 				<oms:SimulationInformation>
+-- 					<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+-- 				</oms:SimulationInformation>
+-- 			</ssc:Annotation>
+-- 		</ssd:Annotations>
 -- 	</ssd:System>
 -- 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
 -- 		<ssd:Annotations>

--- a/testsuite/OMSimulator/deleteStartValues.lua
+++ b/testsuite/OMSimulator/deleteStartValues.lua
@@ -55,13 +55,6 @@ print(src)
 -- <?xml version="1.0"?>
 -- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="deleteStartValues" version="1.0">
 -- 	<ssd:System name="Root">
--- 		<ssd:Annotations>
--- 			<ssc:Annotation type="org.openmodelica">
--- 				<oms:SimulationInformation>
--- 					<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
--- 				</oms:SimulationInformation>
--- 			</ssc:Annotation>
--- 		</ssd:Annotations>
 -- 		<ssd:Connectors>
 -- 			<ssd:Connector name="C1" kind="input">
 -- 				<ssc:Real />
@@ -88,13 +81,6 @@ print(src)
 -- 		</ssd:ParameterBindings>
 -- 		<ssd:Elements>
 -- 			<ssd:System name="System2">
--- 				<ssd:Annotations>
--- 					<ssc:Annotation type="org.openmodelica">
--- 						<oms:SimulationInformation>
--- 							<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
--- 						</oms:SimulationInformation>
--- 					</ssc:Annotation>
--- 				</ssd:Annotations>
 -- 				<ssd:Connectors>
 -- 					<ssd:Connector name="C3" kind="output">
 -- 						<ssc:Real />
@@ -119,8 +105,6 @@ print(src)
 -- 						</ssd:ParameterValues>
 -- 					</ssd:ParameterBinding>
 -- 				</ssd:ParameterBindings>
--- 			</ssd:System>
--- 			<ssd:System name="System1">
 -- 				<ssd:Annotations>
 -- 					<ssc:Annotation type="org.openmodelica">
 -- 						<oms:SimulationInformation>
@@ -128,6 +112,8 @@ print(src)
 -- 						</oms:SimulationInformation>
 -- 					</ssc:Annotation>
 -- 				</ssd:Annotations>
+-- 			</ssd:System>
+-- 			<ssd:System name="System1">
 -- 				<ssd:Connectors>
 -- 					<ssd:Connector name="C1" kind="input">
 -- 						<ssc:Real />
@@ -169,8 +155,22 @@ print(src)
 -- 						</ssd:Connectors>
 -- 					</ssd:Component>
 -- 				</ssd:Elements>
+-- 				<ssd:Annotations>
+-- 					<ssc:Annotation type="org.openmodelica">
+-- 						<oms:SimulationInformation>
+-- 							<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+-- 						</oms:SimulationInformation>
+-- 					</ssc:Annotation>
+-- 				</ssd:Annotations>
 -- 			</ssd:System>
 -- 		</ssd:Elements>
+-- 		<ssd:Annotations>
+-- 			<ssc:Annotation type="org.openmodelica">
+-- 				<oms:SimulationInformation>
+-- 					<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+-- 				</oms:SimulationInformation>
+-- 			</ssc:Annotation>
+-- 		</ssd:Annotations>
 -- 	</ssd:System>
 -- 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
 -- 		<ssd:Annotations>
@@ -186,13 +186,6 @@ print(src)
 -- <?xml version="1.0"?>
 -- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="deleteStartValues" version="1.0">
 -- 	<ssd:System name="Root">
--- 		<ssd:Annotations>
--- 			<ssc:Annotation type="org.openmodelica">
--- 				<oms:SimulationInformation>
--- 					<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
--- 				</oms:SimulationInformation>
--- 			</ssc:Annotation>
--- 		</ssd:Annotations>
 -- 		<ssd:Connectors>
 -- 			<ssd:Connector name="C1" kind="input">
 -- 				<ssc:Real />
@@ -206,13 +199,6 @@ print(src)
 -- 		</ssd:Connectors>
 -- 		<ssd:Elements>
 -- 			<ssd:System name="System2">
--- 				<ssd:Annotations>
--- 					<ssc:Annotation type="org.openmodelica">
--- 						<oms:SimulationInformation>
--- 							<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
--- 						</oms:SimulationInformation>
--- 					</ssc:Annotation>
--- 				</ssd:Annotations>
 -- 				<ssd:Connectors>
 -- 					<ssd:Connector name="C3" kind="output">
 -- 						<ssc:Real />
@@ -221,8 +207,6 @@ print(src)
 -- 						<ssc:Real />
 -- 					</ssd:Connector>
 -- 				</ssd:Connectors>
--- 			</ssd:System>
--- 			<ssd:System name="System1">
 -- 				<ssd:Annotations>
 -- 					<ssc:Annotation type="org.openmodelica">
 -- 						<oms:SimulationInformation>
@@ -230,6 +214,8 @@ print(src)
 -- 						</oms:SimulationInformation>
 -- 					</ssc:Annotation>
 -- 				</ssd:Annotations>
+-- 			</ssd:System>
+-- 			<ssd:System name="System1">
 -- 				<ssd:Connectors>
 -- 					<ssd:Connector name="C1" kind="input">
 -- 						<ssc:Real />
@@ -255,8 +241,22 @@ print(src)
 -- 						</ssd:Connectors>
 -- 					</ssd:Component>
 -- 				</ssd:Elements>
+-- 				<ssd:Annotations>
+-- 					<ssc:Annotation type="org.openmodelica">
+-- 						<oms:SimulationInformation>
+-- 							<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+-- 						</oms:SimulationInformation>
+-- 					</ssc:Annotation>
+-- 				</ssd:Annotations>
 -- 			</ssd:System>
 -- 		</ssd:Elements>
+-- 		<ssd:Annotations>
+-- 			<ssc:Annotation type="org.openmodelica">
+-- 				<oms:SimulationInformation>
+-- 					<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+-- 				</oms:SimulationInformation>
+-- 			</ssc:Annotation>
+-- 		</ssd:Annotations>
 -- 	</ssd:System>
 -- 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
 -- 		<ssd:Annotations>

--- a/testsuite/OMSimulator/deleteStartValuesInSSV.lua
+++ b/testsuite/OMSimulator/deleteStartValuesInSSV.lua
@@ -58,13 +58,6 @@ oms_delete("deleteStartValuesInSSV")
 -- <?xml version="1.0"?>
 -- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="deleteStartValuesInSSV" version="1.0">
 -- 	<ssd:System name="Root">
--- 		<ssd:Annotations>
--- 			<ssc:Annotation type="org.openmodelica">
--- 				<oms:SimulationInformation>
--- 					<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
--- 				</oms:SimulationInformation>
--- 			</ssc:Annotation>
--- 		</ssd:Annotations>
 -- 		<ssd:Connectors>
 -- 			<ssd:Connector name="C1" kind="input">
 -- 				<ssc:Real />
@@ -78,13 +71,6 @@ oms_delete("deleteStartValuesInSSV")
 -- 		</ssd:ParameterBindings>
 -- 		<ssd:Elements>
 -- 			<ssd:System name="System1">
--- 				<ssd:Annotations>
--- 					<ssc:Annotation type="org.openmodelica">
--- 						<oms:SimulationInformation>
--- 							<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
--- 						</oms:SimulationInformation>
--- 					</ssc:Annotation>
--- 				</ssd:Annotations>
 -- 				<ssd:Connectors>
 -- 					<ssd:Connector name="C1" kind="input">
 -- 						<ssc:Real />
@@ -110,8 +96,22 @@ oms_delete("deleteStartValuesInSSV")
 -- 						</ssd:Connectors>
 -- 					</ssd:Component>
 -- 				</ssd:Elements>
+-- 				<ssd:Annotations>
+-- 					<ssc:Annotation type="org.openmodelica">
+-- 						<oms:SimulationInformation>
+-- 							<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+-- 						</oms:SimulationInformation>
+-- 					</ssc:Annotation>
+-- 				</ssd:Annotations>
 -- 			</ssd:System>
 -- 		</ssd:Elements>
+-- 		<ssd:Annotations>
+-- 			<ssc:Annotation type="org.openmodelica">
+-- 				<oms:SimulationInformation>
+-- 					<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+-- 				</oms:SimulationInformation>
+-- 			</ssc:Annotation>
+-- 		</ssd:Annotations>
 -- 	</ssd:System>
 -- 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
 -- 		<ssd:Annotations>

--- a/testsuite/OMSimulator/exportConnectorsToResultFile.lua
+++ b/testsuite/OMSimulator/exportConnectorsToResultFile.lua
@@ -90,13 +90,6 @@ oms_delete("exportConnectors")
 -- <?xml version="1.0"?>
 -- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="exportConnectors" version="1.0">
 -- 	<ssd:System name="Root">
--- 		<ssd:Annotations>
--- 			<ssc:Annotation type="org.openmodelica">
--- 				<oms:SimulationInformation>
--- 					<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
--- 				</oms:SimulationInformation>
--- 			</ssc:Annotation>
--- 		</ssd:Annotations>
 -- 		<ssd:Connectors>
 -- 			<ssd:Connector name="C1" kind="input">
 -- 				<ssc:Real />
@@ -154,6 +147,13 @@ oms_delete("exportConnectors")
 -- 				</ssd:ParameterBindings>
 -- 			</ssd:Component>
 -- 		</ssd:Elements>
+-- 		<ssd:Annotations>
+-- 			<ssc:Annotation type="org.openmodelica">
+-- 				<oms:SimulationInformation>
+-- 					<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+-- 				</oms:SimulationInformation>
+-- 			</ssc:Annotation>
+-- 		</ssd:Annotations>
 -- 	</ssd:System>
 -- 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
 -- 		<ssd:Annotations>

--- a/testsuite/OMSimulator/importStartValues.lua
+++ b/testsuite/OMSimulator/importStartValues.lua
@@ -31,13 +31,6 @@ oms_delete("importStartValues")
 -- 	<oms:ssd_file name="SystemStructure.ssd">
 -- 		<ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="importStartValues" version="1.0">
 -- 			<ssd:System name="root">
--- 				<ssd:Annotations>
--- 					<ssc:Annotation type="org.openmodelica">
--- 						<oms:SimulationInformation>
--- 							<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
--- 						</oms:SimulationInformation>
--- 					</ssc:Annotation>
--- 				</ssd:Annotations>
 -- 				<ssd:Connectors>
 -- 					<ssd:Connector name="C1" kind="input">
 -- 						<ssc:Real />
@@ -48,13 +41,6 @@ oms_delete("importStartValues")
 -- 				</ssd:ParameterBindings>
 -- 				<ssd:Elements>
 -- 					<ssd:System name="System1">
--- 						<ssd:Annotations>
--- 							<ssc:Annotation type="org.openmodelica">
--- 								<oms:SimulationInformation>
--- 									<oms:VariableStepSolver description="euler" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
--- 								</oms:SimulationInformation>
--- 							</ssc:Annotation>
--- 						</ssd:Annotations>
 -- 						<ssd:Connectors>
 -- 							<ssd:Connector name="C1" kind="input">
 -- 								<ssc:Real />
@@ -66,8 +52,22 @@ oms_delete("importStartValues")
 -- 								<ssc:Real />
 -- 							</ssd:Connector>
 -- 						</ssd:Connectors>
+-- 						<ssd:Annotations>
+-- 							<ssc:Annotation type="org.openmodelica">
+-- 								<oms:SimulationInformation>
+-- 									<oms:VariableStepSolver description="euler" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+-- 								</oms:SimulationInformation>
+-- 							</ssc:Annotation>
+-- 						</ssd:Annotations>
 -- 					</ssd:System>
 -- 				</ssd:Elements>
+-- 				<ssd:Annotations>
+-- 					<ssc:Annotation type="org.openmodelica">
+-- 						<oms:SimulationInformation>
+-- 							<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+-- 						</oms:SimulationInformation>
+-- 					</ssc:Annotation>
+-- 				</ssd:Annotations>
 -- 			</ssd:System>
 -- 			<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
 -- 				<ssd:Annotations>

--- a/testsuite/OMSimulator/import_export.lua
+++ b/testsuite/OMSimulator/import_export.lua
@@ -196,22 +196,8 @@ printStatus(status, 0)
 -- <?xml version="1.0"?>
 -- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="test" version="1.0">
 --     <ssd:System name="eoo">
---         <ssd:Annotations>
---             <ssc:Annotation type="org.openmodelica">
---                 <oms:SimulationInformation>
---                     <oms:TlmMaster ip="127.0.1.1" managerport="11111" monitorport="11121" />
---                 </oms:SimulationInformation>
---             </ssc:Annotation>
---         </ssd:Annotations>
 --         <ssd:Elements>
 --             <ssd:System name="foo2">
---                 <ssd:Annotations>
---                     <ssc:Annotation type="org.openmodelica">
---                         <oms:SimulationInformation>
---                             <oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
---                         </oms:SimulationInformation>
---                     </ssc:Annotation>
---                 </ssd:Annotations>
 --                 <ssd:Connectors>
 --                     <ssd:Connector name="f" kind="input">
 --                         <ssc:Real />
@@ -246,8 +232,6 @@ printStatus(status, 0)
 --                         </oms:Bus>
 --                     </ssc:Annotation>
 --                 </ssd:Annotations>
---             </ssd:System>
---             <ssd:System name="foo">
 --                 <ssd:Annotations>
 --                     <ssc:Annotation type="org.openmodelica">
 --                         <oms:SimulationInformation>
@@ -255,6 +239,8 @@ printStatus(status, 0)
 --                         </oms:SimulationInformation>
 --                     </ssc:Annotation>
 --                 </ssd:Annotations>
+--             </ssd:System>
+--             <ssd:System name="foo">
 --                 <ssd:Connectors>
 --                     <ssd:Connector name="f" kind="input">
 --                         <ssc:Real />
@@ -326,6 +312,13 @@ printStatus(status, 0)
 --                         </oms:Bus>
 --                     </ssc:Annotation>
 --                 </ssd:Annotations>
+--                 <ssd:Annotations>
+--                     <ssc:Annotation type="org.openmodelica">
+--                         <oms:SimulationInformation>
+--                             <oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+--                         </oms:SimulationInformation>
+--                     </ssc:Annotation>
+--                 </ssd:Annotations>
 --             </ssd:System>
 --         </ssd:Elements>
 --         <ssd:Connections>
@@ -338,6 +331,13 @@ printStatus(status, 0)
 --                     <oms:Connection startElement="foo" startConnector="tlm" endElement="foo2" endConnector="tlm" delay="0.001000" alpha="0.300000" linearimpedance="100.000000" angularimpedance="0.000000" />
 --                     <oms:Connection startElement="foo" startConnector="bus" endElement="foo2" endConnector="bus" />
 --                 </oms:Connections>
+--             </ssc:Annotation>
+--         </ssd:Annotations>
+--         <ssd:Annotations>
+--             <ssc:Annotation type="org.openmodelica">
+--                 <oms:SimulationInformation>
+--                     <oms:TlmMaster ip="127.0.1.1" managerport="11111" monitorport="11121" />
+--                 </oms:SimulationInformation>
 --             </ssc:Annotation>
 --         </ssd:Annotations>
 --     </ssd:System>
@@ -357,22 +357,8 @@ printStatus(status, 0)
 -- <?xml version="1.0"?>
 -- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="test" version="1.0">
 --     <ssd:System name="eoo">
---         <ssd:Annotations>
---             <ssc:Annotation type="org.openmodelica">
---                 <oms:SimulationInformation>
---                     <oms:TlmMaster ip="" managerport="0" monitorport="0" />
---                 </oms:SimulationInformation>
---             </ssc:Annotation>
---         </ssd:Annotations>
 --         <ssd:Elements>
 --             <ssd:System name="foo2">
---                 <ssd:Annotations>
---                     <ssc:Annotation type="org.openmodelica">
---                         <oms:SimulationInformation>
---                             <oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
---                         </oms:SimulationInformation>
---                     </ssc:Annotation>
---                 </ssd:Annotations>
 --                 <ssd:Connectors>
 --                     <ssd:Connector name="f" kind="input">
 --                         <ssc:Real />
@@ -407,8 +393,6 @@ printStatus(status, 0)
 --                         </oms:Bus>
 --                     </ssc:Annotation>
 --                 </ssd:Annotations>
---             </ssd:System>
---             <ssd:System name="foo">
 --                 <ssd:Annotations>
 --                     <ssc:Annotation type="org.openmodelica">
 --                         <oms:SimulationInformation>
@@ -416,6 +400,8 @@ printStatus(status, 0)
 --                         </oms:SimulationInformation>
 --                     </ssc:Annotation>
 --                 </ssd:Annotations>
+--             </ssd:System>
+--             <ssd:System name="foo">
 --                 <ssd:Connectors>
 --                     <ssd:Connector name="f" kind="input">
 --                         <ssc:Real />
@@ -487,6 +473,13 @@ printStatus(status, 0)
 --                         </oms:Bus>
 --                     </ssc:Annotation>
 --                 </ssd:Annotations>
+--                 <ssd:Annotations>
+--                     <ssc:Annotation type="org.openmodelica">
+--                         <oms:SimulationInformation>
+--                             <oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+--                         </oms:SimulationInformation>
+--                     </ssc:Annotation>
+--                 </ssd:Annotations>
 --             </ssd:System>
 --         </ssd:Elements>
 --         <ssd:Connections>
@@ -499,6 +492,13 @@ printStatus(status, 0)
 --                     <oms:Connection startElement="foo" startConnector="tlm" endElement="foo2" endConnector="tlm" delay="0.001000" alpha="0.300000" linearimpedance="100.000000" angularimpedance="0.000000" />
 --                     <oms:Connection startElement="foo" startConnector="bus" endElement="foo2" endConnector="bus" />
 --                 </oms:Connections>
+--             </ssc:Annotation>
+--         </ssd:Annotations>
+--         <ssd:Annotations>
+--             <ssc:Annotation type="org.openmodelica">
+--                 <oms:SimulationInformation>
+--                     <oms:TlmMaster ip="" managerport="0" monitorport="0" />
+--                 </oms:SimulationInformation>
 --             </ssc:Annotation>
 --         </ssd:Annotations>
 --     </ssd:System>

--- a/testsuite/OMSimulator/import_export.py
+++ b/testsuite/OMSimulator/import_export.py
@@ -195,22 +195,8 @@ printStatus(status, 0)
 ## <?xml version="1.0"?>
 ## <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="test" version="1.0">
 ##     <ssd:System name="eoo">
-##         <ssd:Annotations>
-##             <ssc:Annotation type="org.openmodelica">
-##                 <oms:SimulationInformation>
-##                     <oms:TlmMaster ip="127.0.1.1" managerport="11111" monitorport="11121" />
-##                 </oms:SimulationInformation>
-##             </ssc:Annotation>
-##         </ssd:Annotations>
 ##         <ssd:Elements>
 ##             <ssd:System name="foo2">
-##                 <ssd:Annotations>
-##                     <ssc:Annotation type="org.openmodelica">
-##                         <oms:SimulationInformation>
-##                             <oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
-##                         </oms:SimulationInformation>
-##                     </ssc:Annotation>
-##                 </ssd:Annotations>
 ##                 <ssd:Connectors>
 ##                     <ssd:Connector name="f" kind="input">
 ##                         <ssc:Real />
@@ -245,8 +231,6 @@ printStatus(status, 0)
 ##                         </oms:Bus>
 ##                     </ssc:Annotation>
 ##                 </ssd:Annotations>
-##             </ssd:System>
-##             <ssd:System name="foo">
 ##                 <ssd:Annotations>
 ##                     <ssc:Annotation type="org.openmodelica">
 ##                         <oms:SimulationInformation>
@@ -254,6 +238,8 @@ printStatus(status, 0)
 ##                         </oms:SimulationInformation>
 ##                     </ssc:Annotation>
 ##                 </ssd:Annotations>
+##             </ssd:System>
+##             <ssd:System name="foo">
 ##                 <ssd:Connectors>
 ##                     <ssd:Connector name="f" kind="input">
 ##                         <ssc:Real />
@@ -325,6 +311,13 @@ printStatus(status, 0)
 ##                         </oms:Bus>
 ##                     </ssc:Annotation>
 ##                 </ssd:Annotations>
+##                 <ssd:Annotations>
+##                     <ssc:Annotation type="org.openmodelica">
+##                         <oms:SimulationInformation>
+##                             <oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+##                         </oms:SimulationInformation>
+##                     </ssc:Annotation>
+##                 </ssd:Annotations>
 ##             </ssd:System>
 ##         </ssd:Elements>
 ##         <ssd:Connections>
@@ -337,6 +330,13 @@ printStatus(status, 0)
 ##                     <oms:Connection startElement="foo" startConnector="tlm" endElement="foo2" endConnector="tlm" delay="0.001000" alpha="0.300000" linearimpedance="100.000000" angularimpedance="0.000000" />
 ##                     <oms:Connection startElement="foo" startConnector="bus" endElement="foo2" endConnector="bus" />
 ##                 </oms:Connections>
+##             </ssc:Annotation>
+##         </ssd:Annotations>
+##         <ssd:Annotations>
+##             <ssc:Annotation type="org.openmodelica">
+##                 <oms:SimulationInformation>
+##                     <oms:TlmMaster ip="127.0.1.1" managerport="11111" monitorport="11121" />
+##                 </oms:SimulationInformation>
 ##             </ssc:Annotation>
 ##         </ssd:Annotations>
 ##     </ssd:System>
@@ -356,22 +356,8 @@ printStatus(status, 0)
 ## <?xml version="1.0"?>
 ## <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="test" version="1.0">
 ##     <ssd:System name="eoo">
-##         <ssd:Annotations>
-##             <ssc:Annotation type="org.openmodelica">
-##                 <oms:SimulationInformation>
-##                     <oms:TlmMaster ip="" managerport="0" monitorport="0" />
-##                 </oms:SimulationInformation>
-##             </ssc:Annotation>
-##         </ssd:Annotations>
 ##         <ssd:Elements>
 ##             <ssd:System name="foo2">
-##                 <ssd:Annotations>
-##                     <ssc:Annotation type="org.openmodelica">
-##                         <oms:SimulationInformation>
-##                             <oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
-##                         </oms:SimulationInformation>
-##                     </ssc:Annotation>
-##                 </ssd:Annotations>
 ##                 <ssd:Connectors>
 ##                     <ssd:Connector name="f" kind="input">
 ##                         <ssc:Real />
@@ -406,8 +392,6 @@ printStatus(status, 0)
 ##                         </oms:Bus>
 ##                     </ssc:Annotation>
 ##                 </ssd:Annotations>
-##             </ssd:System>
-##             <ssd:System name="foo">
 ##                 <ssd:Annotations>
 ##                     <ssc:Annotation type="org.openmodelica">
 ##                         <oms:SimulationInformation>
@@ -415,6 +399,8 @@ printStatus(status, 0)
 ##                         </oms:SimulationInformation>
 ##                     </ssc:Annotation>
 ##                 </ssd:Annotations>
+##             </ssd:System>
+##             <ssd:System name="foo">
 ##                 <ssd:Connectors>
 ##                     <ssd:Connector name="f" kind="input">
 ##                         <ssc:Real />
@@ -486,6 +472,13 @@ printStatus(status, 0)
 ##                         </oms:Bus>
 ##                     </ssc:Annotation>
 ##                 </ssd:Annotations>
+##                 <ssd:Annotations>
+##                     <ssc:Annotation type="org.openmodelica">
+##                         <oms:SimulationInformation>
+##                             <oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+##                         </oms:SimulationInformation>
+##                     </ssc:Annotation>
+##                 </ssd:Annotations>
 ##             </ssd:System>
 ##         </ssd:Elements>
 ##         <ssd:Connections>
@@ -498,6 +491,13 @@ printStatus(status, 0)
 ##                     <oms:Connection startElement="foo" startConnector="tlm" endElement="foo2" endConnector="tlm" delay="0.001000" alpha="0.300000" linearimpedance="100.000000" angularimpedance="0.000000" />
 ##                     <oms:Connection startElement="foo" startConnector="bus" endElement="foo2" endConnector="bus" />
 ##                 </oms:Connections>
+##             </ssc:Annotation>
+##         </ssd:Annotations>
+##         <ssd:Annotations>
+##             <ssc:Annotation type="org.openmodelica">
+##                 <oms:SimulationInformation>
+##                     <oms:TlmMaster ip="" managerport="0" monitorport="0" />
+##                 </oms:SimulationInformation>
 ##             </ssc:Annotation>
 ##         </ssd:Annotations>
 ##     </ssd:System>

--- a/testsuite/OMSimulator/import_export_parameters_inline.lua
+++ b/testsuite/OMSimulator/import_export_parameters_inline.lua
@@ -121,13 +121,6 @@ oms_delete("import_export_parameters")
 -- <?xml version="1.0"?>
 -- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="import_export_parameters" version="1.0">
 -- 	<ssd:System name="co_sim">
--- 		<ssd:Annotations>
--- 			<ssc:Annotation type="org.openmodelica">
--- 				<oms:SimulationInformation>
--- 					<oms:FixedStepMaster description="oms-ma" stepSize="0.001000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
--- 				</oms:SimulationInformation>
--- 			</ssc:Annotation>
--- 		</ssd:Annotations>
 -- 		<ssd:Connectors>
 -- 			<ssd:Connector name="Input_cref" kind="input">
 -- 				<ssc:Real />
@@ -163,13 +156,6 @@ oms_delete("import_export_parameters")
 -- 		</ssd:ParameterBindings>
 -- 		<ssd:Elements>
 -- 			<ssd:System name="foo">
--- 				<ssd:Annotations>
--- 					<ssc:Annotation type="org.openmodelica">
--- 						<oms:SimulationInformation>
--- 							<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
--- 						</oms:SimulationInformation>
--- 					</ssc:Annotation>
--- 				</ssd:Annotations>
 -- 				<ssd:Connectors>
 -- 					<ssd:Connector name="F_cref" kind="parameter">
 -- 						<ssc:Real />
@@ -188,6 +174,13 @@ oms_delete("import_export_parameters")
 -- 						</ssd:ParameterValues>
 -- 					</ssd:ParameterBinding>
 -- 				</ssd:ParameterBindings>
+-- 				<ssd:Annotations>
+-- 					<ssc:Annotation type="org.openmodelica">
+-- 						<oms:SimulationInformation>
+-- 							<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+-- 						</oms:SimulationInformation>
+-- 					</ssc:Annotation>
+-- 				</ssd:Annotations>
 -- 			</ssd:System>
 -- 			<ssd:Component name="addP" type="application/x-fmu-sharedlibrary" source="resources/0001_addP.fmu">
 -- 				<ssd:Connectors>
@@ -291,6 +284,13 @@ oms_delete("import_export_parameters")
 -- 			<ssd:Connection startElement="" startConnector="Input_cref" endElement="addP" endConnector="u1" />
 -- 			<ssd:Connection startElement="addP" startConnector="y" endElement="" endConnector="Output_cref" />
 -- 		</ssd:Connections>
+-- 		<ssd:Annotations>
+-- 			<ssc:Annotation type="org.openmodelica">
+-- 				<oms:SimulationInformation>
+-- 					<oms:FixedStepMaster description="oms-ma" stepSize="0.001000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+-- 				</oms:SimulationInformation>
+-- 			</ssc:Annotation>
+-- 		</ssd:Annotations>
 -- 	</ssd:System>
 -- 	<ssd:DefaultExperiment startTime="0.000000" stopTime="4.000000">
 -- 		<ssd:Annotations>

--- a/testsuite/OMSimulator/import_export_parameters_to_ssv.lua
+++ b/testsuite/OMSimulator/import_export_parameters_to_ssv.lua
@@ -121,13 +121,6 @@ oms_delete("import_export_parameters")
 -- <?xml version="1.0"?>
 -- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="import_export_parameters" version="1.0">
 -- 	<ssd:System name="co_sim">
--- 		<ssd:Annotations>
--- 			<ssc:Annotation type="org.openmodelica">
--- 				<oms:SimulationInformation>
--- 					<oms:FixedStepMaster description="oms-ma" stepSize="0.001000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
--- 				</oms:SimulationInformation>
--- 			</ssc:Annotation>
--- 		</ssd:Annotations>
 -- 		<ssd:Connectors>
 -- 			<ssd:Connector name="Input_cref" kind="input">
 -- 				<ssc:Real />
@@ -147,6 +140,11 @@ oms_delete("import_export_parameters")
 -- 		</ssd:ParameterBindings>
 -- 		<ssd:Elements>
 -- 			<ssd:System name="foo">
+-- 				<ssd:Connectors>
+-- 					<ssd:Connector name="F_cref" kind="parameter">
+-- 						<ssc:Real />
+-- 					</ssd:Connector>
+-- 				</ssd:Connectors>
 -- 				<ssd:Annotations>
 -- 					<ssc:Annotation type="org.openmodelica">
 -- 						<oms:SimulationInformation>
@@ -154,11 +152,6 @@ oms_delete("import_export_parameters")
 -- 						</oms:SimulationInformation>
 -- 					</ssc:Annotation>
 -- 				</ssd:Annotations>
--- 				<ssd:Connectors>
--- 					<ssd:Connector name="F_cref" kind="parameter">
--- 						<ssc:Real />
--- 					</ssd:Connector>
--- 				</ssd:Connectors>
 -- 			</ssd:System>
 -- 			<ssd:Component name="addP" type="application/x-fmu-sharedlibrary" source="resources/0001_addP.fmu">
 -- 				<ssd:Connectors>
@@ -233,6 +226,13 @@ oms_delete("import_export_parameters")
 -- 			<ssd:Connection startElement="" startConnector="Input_cref" endElement="addP" endConnector="u1" />
 -- 			<ssd:Connection startElement="addP" startConnector="y" endElement="" endConnector="Output_cref" />
 -- 		</ssd:Connections>
+-- 		<ssd:Annotations>
+-- 			<ssc:Annotation type="org.openmodelica">
+-- 				<oms:SimulationInformation>
+-- 					<oms:FixedStepMaster description="oms-ma" stepSize="0.001000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+-- 				</oms:SimulationInformation>
+-- 			</ssc:Annotation>
+-- 		</ssd:Annotations>
 -- 	</ssd:System>
 -- 	<ssd:DefaultExperiment startTime="0.000000" stopTime="4.000000">
 -- 		<ssd:Annotations>

--- a/testsuite/OMSimulator/import_export_snapshot.lua
+++ b/testsuite/OMSimulator/import_export_snapshot.lua
@@ -51,13 +51,6 @@ oms_delete("import_export_snapshot")
 -- <?xml version="1.0"?>
 -- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="import_export_snapshot" version="1.0">
 -- 	<ssd:System name="root">
--- 		<ssd:Annotations>
--- 			<ssc:Annotation type="org.openmodelica">
--- 				<oms:SimulationInformation>
--- 					<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
--- 				</oms:SimulationInformation>
--- 			</ssc:Annotation>
--- 		</ssd:Annotations>
 -- 		<ssd:Connectors>
 -- 			<ssd:Connector name="C1" kind="input">
 -- 				<ssc:Real />
@@ -90,6 +83,13 @@ oms_delete("import_export_snapshot")
 -- 				</ssd:Connectors>
 -- 			</ssd:Component>
 -- 		</ssd:Elements>
+-- 		<ssd:Annotations>
+-- 			<ssc:Annotation type="org.openmodelica">
+-- 				<oms:SimulationInformation>
+-- 					<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+-- 				</oms:SimulationInformation>
+-- 			</ssc:Annotation>
+-- 		</ssd:Annotations>
 -- 	</ssd:System>
 -- 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
 -- 		<ssd:Annotations>
@@ -105,13 +105,6 @@ oms_delete("import_export_snapshot")
 -- 	<oms:ssd_file name="SystemStructure.ssd">
 -- 		<ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="import_export_snapshot" version="1.0">
 -- 			<ssd:System name="root">
--- 				<ssd:Annotations>
--- 					<ssc:Annotation type="org.openmodelica">
--- 						<oms:SimulationInformation>
--- 							<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
--- 						</oms:SimulationInformation>
--- 					</ssc:Annotation>
--- 				</ssd:Annotations>
 -- 				<ssd:Connectors>
 -- 					<ssd:Connector name="C1" kind="input">
 -- 						<ssc:Real />
@@ -144,6 +137,13 @@ oms_delete("import_export_snapshot")
 -- 						</ssd:Connectors>
 -- 					</ssd:Component>
 -- 				</ssd:Elements>
+-- 				<ssd:Annotations>
+-- 					<ssc:Annotation type="org.openmodelica">
+-- 						<oms:SimulationInformation>
+-- 							<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+-- 						</oms:SimulationInformation>
+-- 					</ssc:Annotation>
+-- 				</ssd:Annotations>
 -- 			</ssd:System>
 -- 			<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
 -- 				<ssd:Annotations>

--- a/testsuite/OMSimulator/setExternalInputs.lua
+++ b/testsuite/OMSimulator/setExternalInputs.lua
@@ -47,13 +47,6 @@ oms_delete("setExternalInputs")
 -- <?xml version="1.0"?>
 -- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="setExternalInputs" version="1.0">
 -- 	<ssd:System name="Root">
--- 		<ssd:Annotations>
--- 			<ssc:Annotation type="org.openmodelica">
--- 				<oms:SimulationInformation>
--- 					<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
--- 				</oms:SimulationInformation>
--- 			</ssc:Annotation>
--- 		</ssd:Annotations>
 -- 		<ssd:Elements>
 -- 			<ssd:Component name="Gain" type="application/x-fmu-sharedlibrary" source="resources/0001_Gain.fmu">
 -- 				<ssd:Connectors>
@@ -71,6 +64,13 @@ oms_delete("setExternalInputs")
 -- 				</ssd:Connectors>
 -- 			</ssd:Component>
 -- 		</ssd:Elements>
+-- 		<ssd:Annotations>
+-- 			<ssc:Annotation type="org.openmodelica">
+-- 				<oms:SimulationInformation>
+-- 					<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+-- 				</oms:SimulationInformation>
+-- 			</ssc:Annotation>
+-- 		</ssd:Annotations>
 -- 	</ssd:System>
 -- 	<ssd:DefaultExperiment startTime="0.000000" stopTime="5.000000">
 -- 		<ssd:Annotations>

--- a/testsuite/OMSimulator/snapshot.lua
+++ b/testsuite/OMSimulator/snapshot.lua
@@ -34,13 +34,6 @@ oms_delete("snapshot")
 -- 	<oms:ssd_file name="SystemStructure.ssd">
 -- 		<ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="snapshot" version="1.0">
 -- 			<ssd:System name="root">
--- 				<ssd:Annotations>
--- 					<ssc:Annotation type="org.openmodelica">
--- 						<oms:SimulationInformation>
--- 							<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
--- 						</oms:SimulationInformation>
--- 					</ssc:Annotation>
--- 				</ssd:Annotations>
 -- 				<ssd:Connectors>
 -- 					<ssd:Connector name="C1" kind="input">
 -- 						<ssc:Real />
@@ -73,6 +66,13 @@ oms_delete("snapshot")
 -- 						</ssd:Connectors>
 -- 					</ssd:Component>
 -- 				</ssd:Elements>
+-- 				<ssd:Annotations>
+-- 					<ssc:Annotation type="org.openmodelica">
+-- 						<oms:SimulationInformation>
+-- 							<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+-- 						</oms:SimulationInformation>
+-- 					</ssc:Annotation>
+-- 				</ssd:Annotations>
 -- 			</ssd:System>
 -- 			<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
 -- 				<ssd:Annotations>

--- a/testsuite/OMSimulator/snapshot.py
+++ b/testsuite/OMSimulator/snapshot.py
@@ -38,13 +38,6 @@ oms.delete("snapshot")
 ## 	<oms:ssd_file name="SystemStructure.ssd">
 ## 		<ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="snapshot" version="1.0">
 ## 			<ssd:System name="root">
-## 				<ssd:Annotations>
-## 					<ssc:Annotation type="org.openmodelica">
-## 						<oms:SimulationInformation>
-## 							<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
-## 						</oms:SimulationInformation>
-## 					</ssc:Annotation>
-## 				</ssd:Annotations>
 ## 				<ssd:Connectors>
 ## 					<ssd:Connector name="C1" kind="input">
 ## 						<ssc:Real />
@@ -77,6 +70,13 @@ oms.delete("snapshot")
 ## 						</ssd:Connectors>
 ## 					</ssd:Component>
 ## 				</ssd:Elements>
+## 				<ssd:Annotations>
+## 					<ssc:Annotation type="org.openmodelica">
+## 						<oms:SimulationInformation>
+## 							<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+## 						</oms:SimulationInformation>
+## 					</ssc:Annotation>
+## 				</ssd:Annotations>
 ## 			</ssd:System>
 ## 			<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
 ## 				<ssd:Annotations>

--- a/testsuite/api/buses.lua
+++ b/testsuite/api/buses.lua
@@ -105,22 +105,8 @@ printStatus(status, 0)
 -- status:  [correct] error
 -- <?xml version="1.0"?>
 -- <ssd:System name="tlm">
--- 	<ssd:Annotations>
--- 		<ssc:Annotation type="org.openmodelica">
--- 			<oms:SimulationInformation>
--- 				<oms:TlmMaster ip="" managerport="0" monitorport="0" />
--- 			</oms:SimulationInformation>
--- 		</ssc:Annotation>
--- 	</ssd:Annotations>
 -- 	<ssd:Elements>
 -- 		<ssd:System name="wc2">
--- 			<ssd:Annotations>
--- 				<ssc:Annotation type="org.openmodelica">
--- 					<oms:SimulationInformation>
--- 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
--- 					</oms:SimulationInformation>
--- 				</ssc:Annotation>
--- 			</ssd:Annotations>
 -- 			<ssd:Connectors>
 -- 				<ssd:Connector name="y1" kind="output">
 -- 					<ssc:Real />
@@ -142,8 +128,6 @@ printStatus(status, 0)
 -- 					</oms:Bus>
 -- 				</ssc:Annotation>
 -- 			</ssd:Annotations>
--- 		</ssd:System>
--- 		<ssd:System name="wc1">
 -- 			<ssd:Annotations>
 -- 				<ssc:Annotation type="org.openmodelica">
 -- 					<oms:SimulationInformation>
@@ -151,6 +135,8 @@ printStatus(status, 0)
 -- 					</oms:SimulationInformation>
 -- 				</ssc:Annotation>
 -- 			</ssd:Annotations>
+-- 		</ssd:System>
+-- 		<ssd:System name="wc1">
 -- 			<ssd:Connectors>
 -- 				<ssd:Connector name="u1" kind="input">
 -- 					<ssc:Real />
@@ -173,6 +159,13 @@ printStatus(status, 0)
 -- 					</oms:Bus>
 -- 				</ssc:Annotation>
 -- 			</ssd:Annotations>
+-- 			<ssd:Annotations>
+-- 				<ssc:Annotation type="org.openmodelica">
+-- 					<oms:SimulationInformation>
+-- 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+-- 					</oms:SimulationInformation>
+-- 				</ssc:Annotation>
+-- 			</ssd:Annotations>
 -- 		</ssd:System>
 -- 	</ssd:Elements>
 -- 	<ssd:Connections>
@@ -186,11 +179,6 @@ printStatus(status, 0)
 -- 			</oms:Connections>
 -- 		</ssc:Annotation>
 -- 	</ssd:Annotations>
--- </ssd:System>
---
--- status:  [correct] ok
--- <?xml version="1.0"?>
--- <ssd:System name="tlm">
 -- 	<ssd:Annotations>
 -- 		<ssc:Annotation type="org.openmodelica">
 -- 			<oms:SimulationInformation>
@@ -198,15 +186,13 @@ printStatus(status, 0)
 -- 			</oms:SimulationInformation>
 -- 		</ssc:Annotation>
 -- 	</ssd:Annotations>
+-- </ssd:System>
+--
+-- status:  [correct] ok
+-- <?xml version="1.0"?>
+-- <ssd:System name="tlm">
 -- 	<ssd:Elements>
 -- 		<ssd:System name="wc2">
--- 			<ssd:Annotations>
--- 				<ssc:Annotation type="org.openmodelica">
--- 					<oms:SimulationInformation>
--- 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
--- 					</oms:SimulationInformation>
--- 				</ssc:Annotation>
--- 			</ssd:Annotations>
 -- 			<ssd:Connectors>
 -- 				<ssd:Connector name="y1" kind="output">
 -- 					<ssc:Real />
@@ -228,8 +214,6 @@ printStatus(status, 0)
 -- 					</oms:Bus>
 -- 				</ssc:Annotation>
 -- 			</ssd:Annotations>
--- 		</ssd:System>
--- 		<ssd:System name="wc1">
 -- 			<ssd:Annotations>
 -- 				<ssc:Annotation type="org.openmodelica">
 -- 					<oms:SimulationInformation>
@@ -237,6 +221,8 @@ printStatus(status, 0)
 -- 					</oms:SimulationInformation>
 -- 				</ssc:Annotation>
 -- 			</ssd:Annotations>
+-- 		</ssd:System>
+-- 		<ssd:System name="wc1">
 -- 			<ssd:Connectors>
 -- 				<ssd:Connector name="u1" kind="input">
 -- 					<ssc:Real />
@@ -258,6 +244,13 @@ printStatus(status, 0)
 -- 					</oms:Bus>
 -- 				</ssc:Annotation>
 -- 			</ssd:Annotations>
+-- 			<ssd:Annotations>
+-- 				<ssc:Annotation type="org.openmodelica">
+-- 					<oms:SimulationInformation>
+-- 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+-- 					</oms:SimulationInformation>
+-- 				</ssc:Annotation>
+-- 			</ssd:Annotations>
 -- 		</ssd:System>
 -- 	</ssd:Elements>
 -- 	<ssd:Connections>
@@ -269,6 +262,13 @@ printStatus(status, 0)
 -- 			<oms:Connections>
 -- 				<oms:Connection startElement="wc1" startConnector="bus1" endElement="wc2" endConnector="bus2" />
 -- 			</oms:Connections>
+-- 		</ssc:Annotation>
+-- 	</ssd:Annotations>
+-- 	<ssd:Annotations>
+-- 		<ssc:Annotation type="org.openmodelica">
+-- 			<oms:SimulationInformation>
+-- 				<oms:TlmMaster ip="" managerport="0" monitorport="0" />
+-- 			</oms:SimulationInformation>
 -- 		</ssc:Annotation>
 -- 	</ssd:Annotations>
 -- </ssd:System>

--- a/testsuite/api/buses.py
+++ b/testsuite/api/buses.py
@@ -104,22 +104,8 @@ printStatus(status, 0)
 ## status:  [correct] error
 ## <?xml version="1.0"?>
 ## <ssd:System name="tlm">
-## 	<ssd:Annotations>
-## 		<ssc:Annotation type="org.openmodelica">
-## 			<oms:SimulationInformation>
-## 				<oms:TlmMaster ip="" managerport="0" monitorport="0" />
-## 			</oms:SimulationInformation>
-## 		</ssc:Annotation>
-## 	</ssd:Annotations>
 ## 	<ssd:Elements>
 ## 		<ssd:System name="wc2">
-## 			<ssd:Annotations>
-## 				<ssc:Annotation type="org.openmodelica">
-## 					<oms:SimulationInformation>
-## 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
-## 					</oms:SimulationInformation>
-## 				</ssc:Annotation>
-## 			</ssd:Annotations>
 ## 			<ssd:Connectors>
 ## 				<ssd:Connector name="y1" kind="output">
 ## 					<ssc:Real />
@@ -141,8 +127,6 @@ printStatus(status, 0)
 ## 					</oms:Bus>
 ## 				</ssc:Annotation>
 ## 			</ssd:Annotations>
-## 		</ssd:System>
-## 		<ssd:System name="wc1">
 ## 			<ssd:Annotations>
 ## 				<ssc:Annotation type="org.openmodelica">
 ## 					<oms:SimulationInformation>
@@ -150,6 +134,8 @@ printStatus(status, 0)
 ## 					</oms:SimulationInformation>
 ## 				</ssc:Annotation>
 ## 			</ssd:Annotations>
+## 		</ssd:System>
+## 		<ssd:System name="wc1">
 ## 			<ssd:Connectors>
 ## 				<ssd:Connector name="u1" kind="input">
 ## 					<ssc:Real />
@@ -172,6 +158,13 @@ printStatus(status, 0)
 ## 					</oms:Bus>
 ## 				</ssc:Annotation>
 ## 			</ssd:Annotations>
+## 			<ssd:Annotations>
+## 				<ssc:Annotation type="org.openmodelica">
+## 					<oms:SimulationInformation>
+## 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+## 					</oms:SimulationInformation>
+## 				</ssc:Annotation>
+## 			</ssd:Annotations>
 ## 		</ssd:System>
 ## 	</ssd:Elements>
 ## 	<ssd:Connections>
@@ -185,11 +178,6 @@ printStatus(status, 0)
 ## 			</oms:Connections>
 ## 		</ssc:Annotation>
 ## 	</ssd:Annotations>
-## </ssd:System>
-##
-## status:  [correct] ok
-## <?xml version="1.0"?>
-## <ssd:System name="tlm">
 ## 	<ssd:Annotations>
 ## 		<ssc:Annotation type="org.openmodelica">
 ## 			<oms:SimulationInformation>
@@ -197,15 +185,13 @@ printStatus(status, 0)
 ## 			</oms:SimulationInformation>
 ## 		</ssc:Annotation>
 ## 	</ssd:Annotations>
+## </ssd:System>
+##
+## status:  [correct] ok
+## <?xml version="1.0"?>
+## <ssd:System name="tlm">
 ## 	<ssd:Elements>
 ## 		<ssd:System name="wc2">
-## 			<ssd:Annotations>
-## 				<ssc:Annotation type="org.openmodelica">
-## 					<oms:SimulationInformation>
-## 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
-## 					</oms:SimulationInformation>
-## 				</ssc:Annotation>
-## 			</ssd:Annotations>
 ## 			<ssd:Connectors>
 ## 				<ssd:Connector name="y1" kind="output">
 ## 					<ssc:Real />
@@ -227,8 +213,6 @@ printStatus(status, 0)
 ## 					</oms:Bus>
 ## 				</ssc:Annotation>
 ## 			</ssd:Annotations>
-## 		</ssd:System>
-## 		<ssd:System name="wc1">
 ## 			<ssd:Annotations>
 ## 				<ssc:Annotation type="org.openmodelica">
 ## 					<oms:SimulationInformation>
@@ -236,6 +220,8 @@ printStatus(status, 0)
 ## 					</oms:SimulationInformation>
 ## 				</ssc:Annotation>
 ## 			</ssd:Annotations>
+## 		</ssd:System>
+## 		<ssd:System name="wc1">
 ## 			<ssd:Connectors>
 ## 				<ssd:Connector name="u1" kind="input">
 ## 					<ssc:Real />
@@ -257,6 +243,13 @@ printStatus(status, 0)
 ## 					</oms:Bus>
 ## 				</ssc:Annotation>
 ## 			</ssd:Annotations>
+## 			<ssd:Annotations>
+## 				<ssc:Annotation type="org.openmodelica">
+## 					<oms:SimulationInformation>
+## 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+## 					</oms:SimulationInformation>
+## 				</ssc:Annotation>
+## 			</ssd:Annotations>
 ## 		</ssd:System>
 ## 	</ssd:Elements>
 ## 	<ssd:Connections>
@@ -268,6 +261,13 @@ printStatus(status, 0)
 ## 			<oms:Connections>
 ## 				<oms:Connection startElement="wc1" startConnector="bus1" endElement="wc2" endConnector="bus2" />
 ## 			</oms:Connections>
+## 		</ssc:Annotation>
+## 	</ssd:Annotations>
+## 	<ssd:Annotations>
+## 		<ssc:Annotation type="org.openmodelica">
+## 			<oms:SimulationInformation>
+## 				<oms:TlmMaster ip="" managerport="0" monitorport="0" />
+## 			</oms:SimulationInformation>
 ## 		</ssc:Annotation>
 ## 	</ssd:Annotations>
 ## </ssd:System>

--- a/testsuite/api/connections.lua
+++ b/testsuite/api/connections.lua
@@ -94,22 +94,8 @@ printStatus(status, 0)
 -- status:  [correct] error
 -- <?xml version="1.0"?>
 -- <ssd:System name="wc">
--- 	<ssd:Annotations>
--- 		<ssc:Annotation type="org.openmodelica">
--- 			<oms:SimulationInformation>
--- 				<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
--- 			</oms:SimulationInformation>
--- 		</ssc:Annotation>
--- 	</ssd:Annotations>
 -- 	<ssd:Elements>
 -- 		<ssd:System name="sc2">
--- 			<ssd:Annotations>
--- 				<ssc:Annotation type="org.openmodelica">
--- 					<oms:SimulationInformation>
--- 						<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
--- 					</oms:SimulationInformation>
--- 				</ssc:Annotation>
--- 			</ssd:Annotations>
 -- 			<ssd:Connectors>
 -- 				<ssd:Connector name="y1" kind="output">
 -- 					<ssc:Real />
@@ -121,8 +107,6 @@ printStatus(status, 0)
 -- 					<ssc:Real />
 -- 				</ssd:Connector>
 -- 			</ssd:Connectors>
--- 		</ssd:System>
--- 		<ssd:System name="sc1">
 -- 			<ssd:Annotations>
 -- 				<ssc:Annotation type="org.openmodelica">
 -- 					<oms:SimulationInformation>
@@ -130,6 +114,8 @@ printStatus(status, 0)
 -- 					</oms:SimulationInformation>
 -- 				</ssc:Annotation>
 -- 			</ssd:Annotations>
+-- 		</ssd:System>
+-- 		<ssd:System name="sc1">
 -- 			<ssd:Connectors>
 -- 				<ssd:Connector name="u1" kind="input">
 -- 					<ssc:Real />
@@ -141,16 +127,18 @@ printStatus(status, 0)
 -- 					<ssc:Real />
 -- 				</ssd:Connector>
 -- 			</ssd:Connectors>
+-- 			<ssd:Annotations>
+-- 				<ssc:Annotation type="org.openmodelica">
+-- 					<oms:SimulationInformation>
+-- 						<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+-- 					</oms:SimulationInformation>
+-- 				</ssc:Annotation>
+-- 			</ssd:Annotations>
 -- 		</ssd:System>
 -- 	</ssd:Elements>
 -- 	<ssd:Connections>
 -- 		<ssd:Connection startElement="sc2" startConnector="y1" endElement="sc1" endConnector="u1" />
 -- 	</ssd:Connections>
--- </ssd:System>
---
--- status:  [correct] ok
--- <?xml version="1.0"?>
--- <ssd:System name="wc">
 -- 	<ssd:Annotations>
 -- 		<ssc:Annotation type="org.openmodelica">
 -- 			<oms:SimulationInformation>
@@ -158,15 +146,13 @@ printStatus(status, 0)
 -- 			</oms:SimulationInformation>
 -- 		</ssc:Annotation>
 -- 	</ssd:Annotations>
+-- </ssd:System>
+--
+-- status:  [correct] ok
+-- <?xml version="1.0"?>
+-- <ssd:System name="wc">
 -- 	<ssd:Elements>
 -- 		<ssd:System name="sc2">
--- 			<ssd:Annotations>
--- 				<ssc:Annotation type="org.openmodelica">
--- 					<oms:SimulationInformation>
--- 						<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
--- 					</oms:SimulationInformation>
--- 				</ssc:Annotation>
--- 			</ssd:Annotations>
 -- 			<ssd:Connectors>
 -- 				<ssd:Connector name="y1" kind="output">
 -- 					<ssc:Real />
@@ -178,8 +164,6 @@ printStatus(status, 0)
 -- 					<ssc:Real />
 -- 				</ssd:Connector>
 -- 			</ssd:Connectors>
--- 		</ssd:System>
--- 		<ssd:System name="sc1">
 -- 			<ssd:Annotations>
 -- 				<ssc:Annotation type="org.openmodelica">
 -- 					<oms:SimulationInformation>
@@ -187,6 +171,8 @@ printStatus(status, 0)
 -- 					</oms:SimulationInformation>
 -- 				</ssc:Annotation>
 -- 			</ssd:Annotations>
+-- 		</ssd:System>
+-- 		<ssd:System name="sc1">
 -- 			<ssd:Connectors>
 -- 				<ssd:Connector name="u1" kind="input">
 -- 					<ssc:Real />
@@ -198,8 +184,22 @@ printStatus(status, 0)
 -- 					<ssc:Real />
 -- 				</ssd:Connector>
 -- 			</ssd:Connectors>
+-- 			<ssd:Annotations>
+-- 				<ssc:Annotation type="org.openmodelica">
+-- 					<oms:SimulationInformation>
+-- 						<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+-- 					</oms:SimulationInformation>
+-- 				</ssc:Annotation>
+-- 			</ssd:Annotations>
 -- 		</ssd:System>
 -- 	</ssd:Elements>
+-- 	<ssd:Annotations>
+-- 		<ssc:Annotation type="org.openmodelica">
+-- 			<oms:SimulationInformation>
+-- 				<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+-- 			</oms:SimulationInformation>
+-- 		</ssc:Annotation>
+-- 	</ssd:Annotations>
 -- </ssd:System>
 --
 -- status:  [correct] ok

--- a/testsuite/api/connections.py
+++ b/testsuite/api/connections.py
@@ -94,22 +94,8 @@ printStatus(status, 0)
 ## status:  [correct] error
 ## <?xml version="1.0"?>
 ## <ssd:System name="wc">
-## 	<ssd:Annotations>
-## 		<ssc:Annotation type="org.openmodelica">
-## 			<oms:SimulationInformation>
-## 				<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
-## 			</oms:SimulationInformation>
-## 		</ssc:Annotation>
-## 	</ssd:Annotations>
 ## 	<ssd:Elements>
 ## 		<ssd:System name="sc2">
-## 			<ssd:Annotations>
-## 				<ssc:Annotation type="org.openmodelica">
-## 					<oms:SimulationInformation>
-## 						<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
-## 					</oms:SimulationInformation>
-## 				</ssc:Annotation>
-## 			</ssd:Annotations>
 ## 			<ssd:Connectors>
 ## 				<ssd:Connector name="y1" kind="output">
 ## 					<ssc:Real />
@@ -121,8 +107,6 @@ printStatus(status, 0)
 ## 					<ssc:Real />
 ## 				</ssd:Connector>
 ## 			</ssd:Connectors>
-## 		</ssd:System>
-## 		<ssd:System name="sc1">
 ## 			<ssd:Annotations>
 ## 				<ssc:Annotation type="org.openmodelica">
 ## 					<oms:SimulationInformation>
@@ -130,6 +114,8 @@ printStatus(status, 0)
 ## 					</oms:SimulationInformation>
 ## 				</ssc:Annotation>
 ## 			</ssd:Annotations>
+## 		</ssd:System>
+## 		<ssd:System name="sc1">
 ## 			<ssd:Connectors>
 ## 				<ssd:Connector name="u1" kind="input">
 ## 					<ssc:Real />
@@ -141,16 +127,18 @@ printStatus(status, 0)
 ## 					<ssc:Real />
 ## 				</ssd:Connector>
 ## 			</ssd:Connectors>
+## 			<ssd:Annotations>
+## 				<ssc:Annotation type="org.openmodelica">
+## 					<oms:SimulationInformation>
+## 						<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+## 					</oms:SimulationInformation>
+## 				</ssc:Annotation>
+## 			</ssd:Annotations>
 ## 		</ssd:System>
 ## 	</ssd:Elements>
 ## 	<ssd:Connections>
 ## 		<ssd:Connection startElement="sc2" startConnector="y1" endElement="sc1" endConnector="u1" />
 ## 	</ssd:Connections>
-## </ssd:System>
-##
-## status:  [correct] ok
-## <?xml version="1.0"?>
-## <ssd:System name="wc">
 ## 	<ssd:Annotations>
 ## 		<ssc:Annotation type="org.openmodelica">
 ## 			<oms:SimulationInformation>
@@ -158,15 +146,13 @@ printStatus(status, 0)
 ## 			</oms:SimulationInformation>
 ## 		</ssc:Annotation>
 ## 	</ssd:Annotations>
+## </ssd:System>
+##
+## status:  [correct] ok
+## <?xml version="1.0"?>
+## <ssd:System name="wc">
 ## 	<ssd:Elements>
 ## 		<ssd:System name="sc2">
-## 			<ssd:Annotations>
-## 				<ssc:Annotation type="org.openmodelica">
-## 					<oms:SimulationInformation>
-## 						<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
-## 					</oms:SimulationInformation>
-## 				</ssc:Annotation>
-## 			</ssd:Annotations>
 ## 			<ssd:Connectors>
 ## 				<ssd:Connector name="y1" kind="output">
 ## 					<ssc:Real />
@@ -178,8 +164,6 @@ printStatus(status, 0)
 ## 					<ssc:Real />
 ## 				</ssd:Connector>
 ## 			</ssd:Connectors>
-## 		</ssd:System>
-## 		<ssd:System name="sc1">
 ## 			<ssd:Annotations>
 ## 				<ssc:Annotation type="org.openmodelica">
 ## 					<oms:SimulationInformation>
@@ -187,6 +171,8 @@ printStatus(status, 0)
 ## 					</oms:SimulationInformation>
 ## 				</ssc:Annotation>
 ## 			</ssd:Annotations>
+## 		</ssd:System>
+## 		<ssd:System name="sc1">
 ## 			<ssd:Connectors>
 ## 				<ssd:Connector name="u1" kind="input">
 ## 					<ssc:Real />
@@ -198,8 +184,22 @@ printStatus(status, 0)
 ## 					<ssc:Real />
 ## 				</ssd:Connector>
 ## 			</ssd:Connectors>
+## 			<ssd:Annotations>
+## 				<ssc:Annotation type="org.openmodelica">
+## 					<oms:SimulationInformation>
+## 						<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+## 					</oms:SimulationInformation>
+## 				</ssc:Annotation>
+## 			</ssd:Annotations>
 ## 		</ssd:System>
 ## 	</ssd:Elements>
+## 	<ssd:Annotations>
+## 		<ssc:Annotation type="org.openmodelica">
+## 			<oms:SimulationInformation>
+## 				<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+## 			</oms:SimulationInformation>
+## 		</ssc:Annotation>
+## 	</ssd:Annotations>
 ## </ssd:System>
 ##
 ## status:  [correct] ok

--- a/testsuite/api/test01.lua
+++ b/testsuite/api/test01.lua
@@ -89,13 +89,6 @@ printStatus(status, 3)
 -- <?xml version="1.0"?>
 -- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="test" version="1.0">
 -- 	<ssd:System name="foo">
--- 		<ssd:Annotations>
--- 			<ssc:Annotation type="org.openmodelica">
--- 				<oms:SimulationInformation>
--- 					<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
--- 				</oms:SimulationInformation>
--- 			</ssc:Annotation>
--- 		</ssd:Annotations>
 -- 		<ssd:Elements>
 -- 			<ssd:System name="goo">
 -- 				<ssd:Annotations>
@@ -107,6 +100,13 @@ printStatus(status, 3)
 -- 				</ssd:Annotations>
 -- 			</ssd:System>
 -- 		</ssd:Elements>
+-- 		<ssd:Annotations>
+-- 			<ssc:Annotation type="org.openmodelica">
+-- 				<oms:SimulationInformation>
+-- 					<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+-- 				</oms:SimulationInformation>
+-- 			</ssc:Annotation>
+-- 		</ssd:Annotations>
 -- 	</ssd:System>
 -- 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
 -- 		<ssd:Annotations>
@@ -119,13 +119,6 @@ printStatus(status, 3)
 --
 -- <?xml version="1.0"?>
 -- <ssd:System name="foo">
--- 	<ssd:Annotations>
--- 		<ssc:Annotation type="org.openmodelica">
--- 			<oms:SimulationInformation>
--- 				<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
--- 			</oms:SimulationInformation>
--- 		</ssc:Annotation>
--- 	</ssd:Annotations>
 -- 	<ssd:Elements>
 -- 		<ssd:System name="goo">
 -- 			<ssd:Annotations>
@@ -137,6 +130,13 @@ printStatus(status, 3)
 -- 			</ssd:Annotations>
 -- 		</ssd:System>
 -- 	</ssd:Elements>
+-- 	<ssd:Annotations>
+-- 		<ssc:Annotation type="org.openmodelica">
+-- 			<oms:SimulationInformation>
+-- 				<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+-- 			</oms:SimulationInformation>
+-- 		</ssc:Annotation>
+-- 	</ssd:Annotations>
 -- </ssd:System>
 --
 -- <?xml version="1.0"?>

--- a/testsuite/api/test01.py
+++ b/testsuite/api/test01.py
@@ -88,13 +88,6 @@ printStatus(status, 3)
 ## <?xml version="1.0"?>
 ## <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="test" version="1.0">
 ## 	<ssd:System name="foo">
-## 		<ssd:Annotations>
-## 			<ssc:Annotation type="org.openmodelica">
-## 				<oms:SimulationInformation>
-## 					<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
-## 				</oms:SimulationInformation>
-## 			</ssc:Annotation>
-## 		</ssd:Annotations>
 ## 		<ssd:Elements>
 ## 			<ssd:System name="goo">
 ## 				<ssd:Annotations>
@@ -106,6 +99,13 @@ printStatus(status, 3)
 ## 				</ssd:Annotations>
 ## 			</ssd:System>
 ## 		</ssd:Elements>
+## 		<ssd:Annotations>
+## 			<ssc:Annotation type="org.openmodelica">
+## 				<oms:SimulationInformation>
+## 					<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+## 				</oms:SimulationInformation>
+## 			</ssc:Annotation>
+## 		</ssd:Annotations>
 ## 	</ssd:System>
 ## 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
 ## 		<ssd:Annotations>
@@ -118,13 +118,6 @@ printStatus(status, 3)
 ##
 ## <?xml version="1.0"?>
 ## <ssd:System name="foo">
-## 	<ssd:Annotations>
-## 		<ssc:Annotation type="org.openmodelica">
-## 			<oms:SimulationInformation>
-## 				<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
-## 			</oms:SimulationInformation>
-## 		</ssc:Annotation>
-## 	</ssd:Annotations>
 ## 	<ssd:Elements>
 ## 		<ssd:System name="goo">
 ## 			<ssd:Annotations>
@@ -136,6 +129,13 @@ printStatus(status, 3)
 ## 			</ssd:Annotations>
 ## 		</ssd:System>
 ## 	</ssd:Elements>
+## 	<ssd:Annotations>
+## 		<ssc:Annotation type="org.openmodelica">
+## 			<oms:SimulationInformation>
+## 				<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+## 			</oms:SimulationInformation>
+## 		</ssc:Annotation>
+## 	</ssd:Annotations>
 ## </ssd:System>
 ##
 ## <?xml version="1.0"?>

--- a/testsuite/api/test03.lua
+++ b/testsuite/api/test03.lua
@@ -69,13 +69,6 @@ oms_delete("test")
 -- <?xml version="1.0"?>
 -- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="test" version="1.0">
 -- 	<ssd:System name="eoo">
--- 		<ssd:Annotations>
--- 			<ssc:Annotation type="org.openmodelica">
--- 				<oms:SimulationInformation>
--- 					<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
--- 				</oms:SimulationInformation>
--- 			</ssc:Annotation>
--- 		</ssd:Annotations>
 -- 		<ssd:Elements>
 -- 			<ssd:Component name="source" type="application/x-fmu-sharedlibrary" source="resources/0001_source.fmu">
 -- 				<ssd:Connectors>
@@ -101,6 +94,13 @@ oms_delete("test")
 -- 				</ssd:Connectors>
 -- 			</ssd:Component>
 -- 		</ssd:Elements>
+-- 		<ssd:Annotations>
+-- 			<ssc:Annotation type="org.openmodelica">
+-- 				<oms:SimulationInformation>
+-- 					<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+-- 				</oms:SimulationInformation>
+-- 			</ssc:Annotation>
+-- 		</ssd:Annotations>
 -- 	</ssd:System>
 -- 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
 -- 		<ssd:Annotations>
@@ -116,13 +116,6 @@ oms_delete("test")
 -- <?xml version="1.0"?>
 -- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="test" version="1.0">
 -- 	<ssd:System name="eoo">
--- 		<ssd:Annotations>
--- 			<ssc:Annotation type="org.openmodelica">
--- 				<oms:SimulationInformation>
--- 					<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
--- 				</oms:SimulationInformation>
--- 			</ssc:Annotation>
--- 		</ssd:Annotations>
 -- 		<ssd:Elements>
 -- 			<ssd:Component name="source" type="application/x-fmu-sharedlibrary" source="resources/0001_source.fmu">
 -- 				<ssd:Connectors>
@@ -148,6 +141,13 @@ oms_delete("test")
 -- 				</ssd:Connectors>
 -- 			</ssd:Component>
 -- 		</ssd:Elements>
+-- 		<ssd:Annotations>
+-- 			<ssc:Annotation type="org.openmodelica">
+-- 				<oms:SimulationInformation>
+-- 					<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+-- 				</oms:SimulationInformation>
+-- 			</ssc:Annotation>
+-- 		</ssd:Annotations>
 -- 	</ssd:System>
 -- 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
 -- 		<ssd:Annotations>

--- a/testsuite/api/test03.py
+++ b/testsuite/api/test03.py
@@ -61,13 +61,6 @@ oms.delete("test")
 ## <?xml version="1.0"?>
 ## <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="test" version="1.0">
 ## 	<ssd:System name="eoo">
-## 		<ssd:Annotations>
-## 			<ssc:Annotation type="org.openmodelica">
-## 				<oms:SimulationInformation>
-## 					<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
-## 				</oms:SimulationInformation>
-## 			</ssc:Annotation>
-## 		</ssd:Annotations>
 ## 		<ssd:Elements>
 ## 			<ssd:Component name="source" type="application/x-fmu-sharedlibrary" source="resources/0001_source.fmu">
 ## 				<ssd:Connectors>
@@ -93,6 +86,13 @@ oms.delete("test")
 ## 				</ssd:Connectors>
 ## 			</ssd:Component>
 ## 		</ssd:Elements>
+## 		<ssd:Annotations>
+## 			<ssc:Annotation type="org.openmodelica">
+## 				<oms:SimulationInformation>
+## 					<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+## 				</oms:SimulationInformation>
+## 			</ssc:Annotation>
+## 		</ssd:Annotations>
 ## 	</ssd:System>
 ## 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
 ## 		<ssd:Annotations>
@@ -108,13 +108,6 @@ oms.delete("test")
 ## <?xml version="1.0"?>
 ## <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="test" version="1.0">
 ## 	<ssd:System name="eoo">
-## 		<ssd:Annotations>
-## 			<ssc:Annotation type="org.openmodelica">
-## 				<oms:SimulationInformation>
-## 					<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
-## 				</oms:SimulationInformation>
-## 			</ssc:Annotation>
-## 		</ssd:Annotations>
 ## 		<ssd:Elements>
 ## 			<ssd:Component name="source" type="application/x-fmu-sharedlibrary" source="resources/0001_source.fmu">
 ## 				<ssd:Connectors>
@@ -140,6 +133,13 @@ oms.delete("test")
 ## 				</ssd:Connectors>
 ## 			</ssd:Component>
 ## 		</ssd:Elements>
+## 		<ssd:Annotations>
+## 			<ssc:Annotation type="org.openmodelica">
+## 				<oms:SimulationInformation>
+## 					<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+## 				</oms:SimulationInformation>
+## 			</ssc:Annotation>
+## 		</ssd:Annotations>
 ## 	</ssd:System>
 ## 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
 ## 		<ssd:Annotations>

--- a/testsuite/tlm/externalmodels.lua
+++ b/testsuite/tlm/externalmodels.lua
@@ -52,13 +52,6 @@ printStatus(status, 0)
 -- status:  [correct] ok
 -- <?xml version="1.0"?>
 -- <ssd:System name="tlm">
--- 	<ssd:Annotations>
--- 		<ssc:Annotation type="org.openmodelica">
--- 			<oms:SimulationInformation>
--- 				<oms:TlmMaster ip="" managerport="0" monitorport="0" />
--- 			</oms:SimulationInformation>
--- 		</ssc:Annotation>
--- 	</ssd:Annotations>
 -- 	<ssd:Elements>
 -- 		<ssd:Component name="external" source="resources/external.mo">
 -- 			<ssd:Annotations>
@@ -73,6 +66,13 @@ printStatus(status, 0)
 -- 			</ssd:Annotations>
 -- 		</ssd:Component>
 -- 	</ssd:Elements>
+-- 	<ssd:Annotations>
+-- 		<ssc:Annotation type="org.openmodelica">
+-- 			<oms:SimulationInformation>
+-- 				<oms:TlmMaster ip="" managerport="0" monitorport="0" />
+-- 			</oms:SimulationInformation>
+-- 		</ssc:Annotation>
+-- 	</ssd:Annotations>
 -- </ssd:System>
 --
 -- status:  [correct] ok

--- a/testsuite/tlm/externalmodels.py
+++ b/testsuite/tlm/externalmodels.py
@@ -52,13 +52,6 @@ printStatus(status, 0)
 ## status:  [correct] ok
 ## <?xml version="1.0"?>
 ## <ssd:System name="tlm">
-## 	<ssd:Annotations>
-## 		<ssc:Annotation type="org.openmodelica">
-## 			<oms:SimulationInformation>
-## 				<oms:TlmMaster ip="" managerport="0" monitorport="0" />
-## 			</oms:SimulationInformation>
-## 		</ssc:Annotation>
-## 	</ssd:Annotations>
 ## 	<ssd:Elements>
 ## 		<ssd:Component name="external" source="resources/external.mo">
 ## 			<ssd:Annotations>
@@ -73,6 +66,13 @@ printStatus(status, 0)
 ## 			</ssd:Annotations>
 ## 		</ssd:Component>
 ## 	</ssd:Elements>
+## 	<ssd:Annotations>
+## 		<ssc:Annotation type="org.openmodelica">
+## 			<oms:SimulationInformation>
+## 				<oms:TlmMaster ip="" managerport="0" monitorport="0" />
+## 			</oms:SimulationInformation>
+## 		</ssc:Annotation>
+## 	</ssd:Annotations>
 ## </ssd:System>
 ##
 ## status:  [correct] ok

--- a/testsuite/tlm/tlmbuses.lua
+++ b/testsuite/tlm/tlmbuses.lua
@@ -110,22 +110,8 @@ printStatus(status, 0)
 -- status:  [correct] ok
 -- <?xml version="1.0"?>
 -- <ssd:System name="tlm">
--- 	<ssd:Annotations>
--- 		<ssc:Annotation type="org.openmodelica">
--- 			<oms:SimulationInformation>
--- 				<oms:TlmMaster ip="127.0.1.1" managerport="11111" monitorport="11121" />
--- 			</oms:SimulationInformation>
--- 		</ssc:Annotation>
--- 	</ssd:Annotations>
 -- 	<ssd:Elements>
 -- 		<ssd:System name="wc2">
--- 			<ssd:Annotations>
--- 				<ssc:Annotation type="org.openmodelica">
--- 					<oms:SimulationInformation>
--- 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
--- 					</oms:SimulationInformation>
--- 				</ssc:Annotation>
--- 			</ssd:Annotations>
 -- 			<ssd:Connectors>
 -- 				<ssd:Connector name="y" kind="input">
 -- 					<ssc:Real />
@@ -149,8 +135,6 @@ printStatus(status, 0)
 -- 					</oms:Bus>
 -- 				</ssc:Annotation>
 -- 			</ssd:Annotations>
--- 		</ssd:System>
--- 		<ssd:System name="wc1">
 -- 			<ssd:Annotations>
 -- 				<ssc:Annotation type="org.openmodelica">
 -- 					<oms:SimulationInformation>
@@ -158,6 +142,8 @@ printStatus(status, 0)
 -- 					</oms:SimulationInformation>
 -- 				</ssc:Annotation>
 -- 			</ssd:Annotations>
+-- 		</ssd:System>
+-- 		<ssd:System name="wc1">
 -- 			<ssd:Connectors>
 -- 				<ssd:Connector name="y" kind="output">
 -- 					<ssc:Real />
@@ -188,6 +174,13 @@ printStatus(status, 0)
 -- 					</oms:Bus>
 -- 				</ssc:Annotation>
 -- 			</ssd:Annotations>
+-- 			<ssd:Annotations>
+-- 				<ssc:Annotation type="org.openmodelica">
+-- 					<oms:SimulationInformation>
+-- 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+-- 					</oms:SimulationInformation>
+-- 				</ssc:Annotation>
+-- 			</ssd:Annotations>
 -- 		</ssd:System>
 -- 	</ssd:Elements>
 -- 	<ssd:Annotations>
@@ -197,11 +190,6 @@ printStatus(status, 0)
 -- 			</oms:Connections>
 -- 		</ssc:Annotation>
 -- 	</ssd:Annotations>
--- </ssd:System>
---
--- status:  [correct] ok
--- <?xml version="1.0"?>
--- <ssd:System name="tlm">
 -- 	<ssd:Annotations>
 -- 		<ssc:Annotation type="org.openmodelica">
 -- 			<oms:SimulationInformation>
@@ -209,15 +197,13 @@ printStatus(status, 0)
 -- 			</oms:SimulationInformation>
 -- 		</ssc:Annotation>
 -- 	</ssd:Annotations>
+-- </ssd:System>
+--
+-- status:  [correct] ok
+-- <?xml version="1.0"?>
+-- <ssd:System name="tlm">
 -- 	<ssd:Elements>
 -- 		<ssd:System name="wc2">
--- 			<ssd:Annotations>
--- 				<ssc:Annotation type="org.openmodelica">
--- 					<oms:SimulationInformation>
--- 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
--- 					</oms:SimulationInformation>
--- 				</ssc:Annotation>
--- 			</ssd:Annotations>
 -- 			<ssd:Connectors>
 -- 				<ssd:Connector name="y" kind="input">
 -- 					<ssc:Real />
@@ -241,8 +227,6 @@ printStatus(status, 0)
 -- 					</oms:Bus>
 -- 				</ssc:Annotation>
 -- 			</ssd:Annotations>
--- 		</ssd:System>
--- 		<ssd:System name="wc1">
 -- 			<ssd:Annotations>
 -- 				<ssc:Annotation type="org.openmodelica">
 -- 					<oms:SimulationInformation>
@@ -250,6 +234,8 @@ printStatus(status, 0)
 -- 					</oms:SimulationInformation>
 -- 				</ssc:Annotation>
 -- 			</ssd:Annotations>
+-- 		</ssd:System>
+-- 		<ssd:System name="wc1">
 -- 			<ssd:Connectors>
 -- 				<ssd:Connector name="y" kind="output">
 -- 					<ssc:Real />
@@ -279,6 +265,13 @@ printStatus(status, 0)
 -- 					</oms:Bus>
 -- 				</ssc:Annotation>
 -- 			</ssd:Annotations>
+-- 			<ssd:Annotations>
+-- 				<ssc:Annotation type="org.openmodelica">
+-- 					<oms:SimulationInformation>
+-- 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+-- 					</oms:SimulationInformation>
+-- 				</ssc:Annotation>
+-- 			</ssd:Annotations>
 -- 		</ssd:System>
 -- 	</ssd:Elements>
 -- 	<ssd:Annotations>
@@ -286,6 +279,13 @@ printStatus(status, 0)
 -- 			<oms:Connections>
 -- 				<oms:Connection startElement="wc1" startConnector="bus1" endElement="wc2" endConnector="bus2" delay="0.001000" alpha="0.300000" linearimpedance="100.000000" angularimpedance="0.000000" />
 -- 			</oms:Connections>
+-- 		</ssc:Annotation>
+-- 	</ssd:Annotations>
+-- 	<ssd:Annotations>
+-- 		<ssc:Annotation type="org.openmodelica">
+-- 			<oms:SimulationInformation>
+-- 				<oms:TlmMaster ip="127.0.1.1" managerport="11111" monitorport="11121" />
+-- 			</oms:SimulationInformation>
 -- 		</ssc:Annotation>
 -- 	</ssd:Annotations>
 -- </ssd:System>

--- a/testsuite/tlm/tlmbuses.py
+++ b/testsuite/tlm/tlmbuses.py
@@ -110,22 +110,8 @@ printStatus(status, 0)
 ## status:  [correct] ok
 ## <?xml version="1.0"?>
 ## <ssd:System name="tlm">
-## 	<ssd:Annotations>
-## 		<ssc:Annotation type="org.openmodelica">
-## 			<oms:SimulationInformation>
-## 				<oms:TlmMaster ip="127.0.1.1" managerport="11111" monitorport="11121" />
-## 			</oms:SimulationInformation>
-## 		</ssc:Annotation>
-## 	</ssd:Annotations>
 ## 	<ssd:Elements>
 ## 		<ssd:System name="wc2">
-## 			<ssd:Annotations>
-## 				<ssc:Annotation type="org.openmodelica">
-## 					<oms:SimulationInformation>
-## 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
-## 					</oms:SimulationInformation>
-## 				</ssc:Annotation>
-## 			</ssd:Annotations>
 ## 			<ssd:Connectors>
 ## 				<ssd:Connector name="y" kind="input">
 ## 					<ssc:Real />
@@ -149,8 +135,6 @@ printStatus(status, 0)
 ## 					</oms:Bus>
 ## 				</ssc:Annotation>
 ## 			</ssd:Annotations>
-## 		</ssd:System>
-## 		<ssd:System name="wc1">
 ## 			<ssd:Annotations>
 ## 				<ssc:Annotation type="org.openmodelica">
 ## 					<oms:SimulationInformation>
@@ -158,6 +142,8 @@ printStatus(status, 0)
 ## 					</oms:SimulationInformation>
 ## 				</ssc:Annotation>
 ## 			</ssd:Annotations>
+## 		</ssd:System>
+## 		<ssd:System name="wc1">
 ## 			<ssd:Connectors>
 ## 				<ssd:Connector name="y" kind="output">
 ## 					<ssc:Real />
@@ -188,6 +174,13 @@ printStatus(status, 0)
 ## 					</oms:Bus>
 ## 				</ssc:Annotation>
 ## 			</ssd:Annotations>
+## 			<ssd:Annotations>
+## 				<ssc:Annotation type="org.openmodelica">
+## 					<oms:SimulationInformation>
+## 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+## 					</oms:SimulationInformation>
+## 				</ssc:Annotation>
+## 			</ssd:Annotations>
 ## 		</ssd:System>
 ## 	</ssd:Elements>
 ## 	<ssd:Annotations>
@@ -197,11 +190,6 @@ printStatus(status, 0)
 ## 			</oms:Connections>
 ## 		</ssc:Annotation>
 ## 	</ssd:Annotations>
-## </ssd:System>
-##
-## status:  [correct] ok
-## <?xml version="1.0"?>
-## <ssd:System name="tlm">
 ## 	<ssd:Annotations>
 ## 		<ssc:Annotation type="org.openmodelica">
 ## 			<oms:SimulationInformation>
@@ -209,15 +197,13 @@ printStatus(status, 0)
 ## 			</oms:SimulationInformation>
 ## 		</ssc:Annotation>
 ## 	</ssd:Annotations>
+## </ssd:System>
+##
+## status:  [correct] ok
+## <?xml version="1.0"?>
+## <ssd:System name="tlm">
 ## 	<ssd:Elements>
 ## 		<ssd:System name="wc2">
-## 			<ssd:Annotations>
-## 				<ssc:Annotation type="org.openmodelica">
-## 					<oms:SimulationInformation>
-## 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
-## 					</oms:SimulationInformation>
-## 				</ssc:Annotation>
-## 			</ssd:Annotations>
 ## 			<ssd:Connectors>
 ## 				<ssd:Connector name="y" kind="input">
 ## 					<ssc:Real />
@@ -241,8 +227,6 @@ printStatus(status, 0)
 ## 					</oms:Bus>
 ## 				</ssc:Annotation>
 ## 			</ssd:Annotations>
-## 		</ssd:System>
-## 		<ssd:System name="wc1">
 ## 			<ssd:Annotations>
 ## 				<ssc:Annotation type="org.openmodelica">
 ## 					<oms:SimulationInformation>
@@ -250,6 +234,8 @@ printStatus(status, 0)
 ## 					</oms:SimulationInformation>
 ## 				</ssc:Annotation>
 ## 			</ssd:Annotations>
+## 		</ssd:System>
+## 		<ssd:System name="wc1">
 ## 			<ssd:Connectors>
 ## 				<ssd:Connector name="y" kind="output">
 ## 					<ssc:Real />
@@ -279,6 +265,13 @@ printStatus(status, 0)
 ## 					</oms:Bus>
 ## 				</ssc:Annotation>
 ## 			</ssd:Annotations>
+## 			<ssd:Annotations>
+## 				<ssc:Annotation type="org.openmodelica">
+## 					<oms:SimulationInformation>
+## 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+## 					</oms:SimulationInformation>
+## 				</ssc:Annotation>
+## 			</ssd:Annotations>
 ## 		</ssd:System>
 ## 	</ssd:Elements>
 ## 	<ssd:Annotations>
@@ -286,6 +279,13 @@ printStatus(status, 0)
 ## 			<oms:Connections>
 ## 				<oms:Connection startElement="wc1" startConnector="bus1" endElement="wc2" endConnector="bus2" delay="0.001000" alpha="0.300000" linearimpedance="100.000000" angularimpedance="0.000000" />
 ## 			</oms:Connections>
+## 		</ssc:Annotation>
+## 	</ssd:Annotations>
+## 	<ssd:Annotations>
+## 		<ssc:Annotation type="org.openmodelica">
+## 			<oms:SimulationInformation>
+## 				<oms:TlmMaster ip="127.0.1.1" managerport="11111" monitorport="11121" />
+## 			</oms:SimulationInformation>
 ## 		</ssc:Annotation>
 ## 	</ssd:Annotations>
 ## </ssd:System>


### PR DESCRIPTION
### Purpose

This PR, fixes the `SSP's` generated by `OMSimulator`  to be valid with [easy-ssp](https://www.easy-ssp.com/app/?lng=en)

### Approach
Move the  `<ssp:annotation>`  to end, inorder to be validated by easy-ssp.