### PR TITLE
add <oms:Annotations> to handle all oms annotations

### DIFF
--- a/src/OMSimulatorLib/Model.cpp
+++ b/src/OMSimulatorLib/Model.cpp
@@ -530,7 +530,8 @@ oms_status_enu_t oms::Model::exportToSSD(pugi::xml_node& node, pugi::xml_node& s
   pugi::xml_node node_annotations = default_experiment.append_child(oms::ssp::Draft20180219::ssd::annotations);
   pugi::xml_node node_annotation = node_annotations.append_child(oms::ssp::Version1_0::ssc::annotation);
   node_annotation.append_attribute("type") =  oms::ssp::Draft20180219::annotation_type;
-  pugi::xml_node oms_simulation_information = node_annotation.append_child(oms::ssp::Version1_0::simulation_information);
+  pugi::xml_node oms_annotation_node = node_annotation.append_child(oms::ssp::Version1_0::oms_annotations);
+  pugi::xml_node oms_simulation_information = oms_annotation_node.append_child(oms::ssp::Version1_0::simulation_information);
   //pugi::xml_node oms_default_experiment = oms_simulation_information.append_child("DefaultExperiment");
 
   oms_simulation_information.append_attribute("resultFile") = resultFilename.c_str();
@@ -589,7 +590,14 @@ oms_status_enu_t oms::Model::importFromSSD(const pugi::xml_node& node)
 
       if (annotation_node && std::string(annotation_node.attribute("type").as_string()) == oms::ssp::Draft20180219::annotation_type)
       {
-        for(pugi::xml_node_iterator itAnnotations = annotation_node.begin(); itAnnotations != annotation_node.end(); ++itAnnotations)
+        pugi::xml_node oms_annotation_node = annotation_node.child(oms::ssp::Version1_0::oms_annotations);
+        // support older <ssc:annotation>
+        if (!oms_annotation_node)
+        {
+          oms_annotation_node = annotation_node;
+          logWarning_deprecated;
+        }
+        for(pugi::xml_node_iterator itAnnotations = oms_annotation_node.begin(); itAnnotations != oms_annotation_node.end(); ++itAnnotations)
         {
           name = itAnnotations->name();
           // check for oms_default_experiment from version 1.0
@@ -637,7 +645,16 @@ oms_system_enu_t oms::Model::getSystemType(const pugi::xml_node& node, const std
 
       if (annotation_node && std::string(annotation_node.attribute("type").as_string()) == oms::ssp::Draft20180219::annotation_type)
       {
-        for(pugi::xml_node_iterator itAnnotations = annotation_node.begin(); itAnnotations != annotation_node.end(); ++itAnnotations)
+        pugi::xml_node oms_annotation_node;
+        oms_annotation_node = annotation_node.child(oms::ssp::Version1_0::oms_annotations);
+        // support older <ssc:annotation>
+        if (!oms_annotation_node)
+        {
+          oms_annotation_node = annotation_node;
+          logWarning_deprecated;
+        }
+
+        for(pugi::xml_node_iterator itAnnotations = oms_annotation_node.begin(); itAnnotations != oms_annotation_node.end(); ++itAnnotations)
         {
           std::string annotationName = itAnnotations->name();
           if (std::string(annotationName) == oms::ssp::Version1_0::simulation_information) // check for oms:simulationInformation from version 1.0

--- a/src/OMSimulatorLib/System.cpp
+++ b/src/OMSimulatorLib/System.cpp
@@ -461,21 +461,24 @@ oms_status_enu_t oms::System::exportToSSD(pugi::xml_node& node, pugi::xml_node& 
   if (busconnectors[0] || !busconnections.empty())
 #endif
   {
-    pugi::xml_node oms_buses_node;
-    if (busconnectors.size() > 1 || tlmbusconnectors.size() > 1)
+    if (busconnectors.size() > 1)
     {
-      oms_buses_node = oms_annotation_node.append_child(oms::ssp::Version1_0::oms_buses);
-    }
-    for (const auto& busconnector : busconnectors)
-    {
-      if (busconnector)
-        busconnector->exportToSSD(oms_buses_node);
+      pugi::xml_node oms_buses_node = oms_annotation_node.append_child(oms::ssp::Version1_0::oms_buses);
+      for (const auto& busconnector : busconnectors)
+      {
+        if (busconnector)
+          busconnector->exportToSSD(oms_buses_node);
+      }
     }
 #if !defined(NO_TLM)
-    for (const auto& tlmbusconnector : tlmbusconnectors)
+    if (tlmbusconnectors.size() > 1)
     {
-      if (tlmbusconnector)
-        tlmbusconnector->exportToSSD(oms_buses_node);
+      pugi::xml_node oms_buses_node = oms_annotation_node.append_child(oms::ssp::Version1_0::oms_buses);
+      for (const auto& tlmbusconnector : tlmbusconnectors)
+      {
+        if (tlmbusconnector)
+          tlmbusconnector->exportToSSD(oms_buses_node);
+      }
     }
 #endif
     if (!busconnections.empty())

--- a/src/OMSimulatorLib/System.cpp
+++ b/src/OMSimulatorLib/System.cpp
@@ -450,33 +450,44 @@ oms_status_enu_t oms::System::exportToSSD(pugi::xml_node& node, pugi::xml_node& 
     }
   }
 
+  pugi::xml_node annotations_node = node.append_child(oms::ssp::Draft20180219::ssd::annotations);
+  pugi::xml_node annotation_node = annotations_node.append_child(oms::ssp::Version1_0::ssc::annotation);
+  annotation_node.append_attribute("type") = oms::ssp::Draft20180219::annotation_type;
+  pugi::xml_node oms_annotation_node = annotation_node.append_child(oms::ssp::Version1_0::oms_annotations);
+
 #if !defined(NO_TLM)
   if (busconnectors[0] || tlmbusconnectors[0] || !busconnections.empty())
 #else
   if (busconnectors[0] || !busconnections.empty())
 #endif
   {
-    pugi::xml_node annotations_node = node.append_child(oms::ssp::Draft20180219::ssd::annotations);
-    pugi::xml_node annotation_node = annotations_node.append_child(oms::ssp::Version1_0::ssc::annotation);
-    annotation_node.append_attribute("type") = oms::ssp::Draft20180219::annotation_type;
+    pugi::xml_node oms_buses_node;
+    if (busconnectors.size() > 1 || tlmbusconnectors.size() > 1)
+    {
+      oms_buses_node = oms_annotation_node.append_child(oms::ssp::Version1_0::oms_buses);
+    }
     for (const auto& busconnector : busconnectors)
+    {
       if (busconnector)
-        busconnector->exportToSSD(annotation_node);
+        busconnector->exportToSSD(oms_buses_node);
+    }
 #if !defined(NO_TLM)
     for (const auto& tlmbusconnector : tlmbusconnectors)
+    {
       if (tlmbusconnector)
-        tlmbusconnector->exportToSSD(annotation_node);
+        tlmbusconnector->exportToSSD(oms_buses_node);
+    }
 #endif
     if (!busconnections.empty())
     {
-      pugi::xml_node busconnections_node = annotation_node.append_child(oms::ssp::Draft20180219::bus_connections);
+      pugi::xml_node busconnections_node = oms_annotation_node.append_child(oms::ssp::Draft20180219::bus_connections);
       for (const auto& busconnection : busconnections)
         busconnection->exportToSSD(busconnections_node);
     }
   }
 
   //export ssd:SimulationInformation to end, in order to make it valid with easy-ssp
-  if (oms_status_ok != this->exportToSSD_SimulationInformation(node))
+  if (oms_status_ok != this->exportToSSD_SimulationInformation(oms_annotation_node))
     return logError("export of system SimulationInformation failed");
 
   return oms_status_ok;
@@ -504,10 +515,10 @@ oms_status_enu_t oms::System::importFromSSD(const pugi::xml_node& node, const st
       for (pugi::xml_node parameterBindingNode = it->child(oms::ssp::Version1_0::ssd::parameter_binding); parameterBindingNode; parameterBindingNode = parameterBindingNode.next_sibling(oms::ssp::Version1_0::ssd::parameter_binding))
       {
         std::string ssvFileSource = parameterBindingNode.attribute("source").as_string();
+
         // set parameter bindings associated with the system
         if (ssvFileSource.empty()) // inline parameterBinding
         {
-          //std::cout << "\n System ssvFileSource  inline :" << ssvFileSource;
           std::string tempdir = getModel()->getTempDirectory();
           if (oms_status_ok !=  values.importFromSSD(*it, sspVersion, tempdir))
             return logError("Failed to import " + std::string(oms::ssp::Version1_0::ssd::parameter_bindings));
@@ -586,7 +597,7 @@ oms_status_enu_t oms::System::importFromSSD(const pugi::xml_node& node, const st
           Component* component = NULL;
           std::string type = itElements->attribute("type").as_string();
           // allow component type to be empty, as type is optional according to SSP-1.0 and default type is application/x-fmu-sharedlibrary
-          if ("application/x-fmu-sharedlibrary" == type || type.empty())
+          if ("application/x-fmu-sharedlibrary" == type || type.empty() && getType() != oms_system_tlm)
           {
             if (getType() == oms_system_wc)
               component = ComponentFMUCS::NewComponent(*itElements, this, sspVersion);
@@ -598,101 +609,96 @@ oms_status_enu_t oms::System::importFromSSD(const pugi::xml_node& node, const st
           else if ("application/table" == type)
             component = ComponentTable::NewComponent(*itElements, this, sspVersion);
 #if !defined(NO_TLM)
-          else if (itElements->attribute("type") == nullptr) {
-              std::string name = itElements->attribute("name").as_string();
-              std::string source = itElements->attribute("source").as_string();
+          else if (itElements->attribute("type") == nullptr && getType() == oms_system_tlm) {
+            std::string name = itElements->attribute("name").as_string();
+            std::string source = itElements->attribute("source").as_string();
 
-              if (sspVersion == "Draft20180219") {
-                pugi::xml_node simulationInformationNode = itElements->child(oms::ssp::Draft20180219::ssd::simulation_information);
-                if(simulationInformationNode && sspVersion == "Draft20180219") {
-                  pugi::xml_node annotationsNode = simulationInformationNode.child(oms::ssp::Draft20180219::ssd::annotations);
-                  if(annotationsNode) {
-                    if (annotationsNode.child(oms::ssp::Draft20180219::ssd::annotation))
+            // parse older <ssd:SimulationInformation> <ssd:annotations> </ssd:annotations> </ssd:SimulationInformation>
+            if (sspVersion == "Draft20180219")
+            {
+              pugi::xml_node simulationInformationNode = itElements->child(oms::ssp::Draft20180219::ssd::simulation_information);
+              if (simulationInformationNode && sspVersion == "Draft20180219")
+              {
+                pugi::xml_node annotationsNode = simulationInformationNode.child(oms::ssp::Draft20180219::ssd::annotations);
+                if (annotationsNode)
+                {
+                  if (annotationsNode.child(oms::ssp::Draft20180219::ssd::annotation))
+                  {
+                    logWarning_deprecated;
+                  }
+                  for (pugi::xml_node annotationNode = annotationsNode.child(oms::ssp::Draft20180219::ssd::annotation); annotationNode; annotationNode = annotationsNode.next_sibling(oms::ssp::Draft20180219::ssd::annotation))
+                  {
+                    std::string type = annotationNode.attribute("type").as_string();
+                    if (oms::ssp::Draft20180219::annotation_type == type)
                     {
-                      logWarning_deprecated;
-                    }
-                    for (pugi::xml_node annotationNode = annotationsNode.child(oms::ssp::Draft20180219::ssd::annotation); annotationNode; annotationNode = annotationsNode.next_sibling(oms::ssp::Draft20180219::ssd::annotation)) {
-                      std::string type = annotationNode.attribute("type").as_string() ;
-                      if(oms::ssp::Draft20180219::annotation_type == type) {
-                        pugi::xml_node externalModelNode = annotationNode.child(oms::ssp::Draft20180219::external_model);
-                        if(externalModelNode) {
-                          std::string startScript = externalModelNode.attribute("startscript").as_string();
-                          component = oms::ExternalModel::NewComponent(name,this,source,startScript);
-                        }
+                      pugi::xml_node externalModelNode = annotationNode.child(oms::ssp::Draft20180219::external_model);
+                      if (externalModelNode)
+                      {
+                        std::string startScript = externalModelNode.attribute("startscript").as_string();
+                        component = oms::ExternalModel::NewComponent(name, this, source, startScript);
                       }
                     }
                   }
                 }
               }
+            }
 
+            // sspVersion-1.0
+            pugi::xml_node annotationsNode = itElements->child(oms::ssp::Draft20180219::ssd::annotations);
+            pugi::xml_node annotation_node = annotationsNode.child(oms::ssp::Version1_0::ssc::annotation);
 
-              pugi::xml_node annotationsNode = itElements->child(oms::ssp::Draft20180219::ssd::annotations);
-              if(annotationsNode) {
-                  const char* annotationNodeString = "";
-                  pugi::xml_node annotationNodeChild;
-                  annotationNodeChild = annotationsNode.child(oms::ssp::Version1_0::ssc::annotation);
-                  if(annotationNodeChild)
-                  {
-                    annotationNodeString = oms::ssp::Version1_0::ssc::annotation;
-                  }
-                  else
-                  {
-                    annotationNodeString = oms::ssp::Draft20180219::ssd::annotation;
-                    logWarning_deprecated;
-                  }
+            // check for ssd:annotation to support older version, which is a bug
+            if(!annotation_node)
+            {
+              annotation_node = annotationsNode.child(oms::ssp::Draft20180219::ssd::annotation);
+              logWarning_deprecated;
+            }
 
-                  for (pugi::xml_node annotationNode = annotationsNode.child(annotationNodeString); annotationNode; annotationNode = annotationsNode.next_sibling(annotationNodeString)) {
-                      std::string type = annotationNode.attribute("type").as_string() ;
-                      if(oms::ssp::Draft20180219::annotation_type == type) {
-
-                          if (sspVersion == "1.0"){
-                            pugi::xml_node omsSimulationInformationNode = annotationNode.child(oms::ssp::Version1_0::simulation_information);
-                            if(omsSimulationInformationNode) {
-                              pugi::xml_node externalModelNode = omsSimulationInformationNode.child(oms::ssp::Draft20180219::external_model);
-                              if(externalModelNode) {
-                                std::string startScript = externalModelNode.attribute("startscript").as_string();
-                                component = oms::ExternalModel::NewComponent(name, this, source, startScript);
-                              }
-                            }
-                          }
-
-                          pugi::xml_node busNode = annotationNode.child(oms::ssp::Draft20180219::bus);
-                          //Load TLM bus connector for external model
-                          std::string busname = busNode.attribute("name").as_string();
-                          std::string domainstr = busNode.attribute("domain").as_string();
-                          int dimensions = busNode.attribute("dimensions").as_int();
-                          std::string interpolationstr = busNode.attribute("interpolation").as_string();
-                          oms_tlm_interpolation_t interpolation;
-                          if (interpolationstr == "none")
-                              interpolation = oms_tlm_no_interpolation;
-                          else if (interpolationstr == "coarsegrained")
-                              interpolation = oms_tlm_coarse_grained;
-                          else if (interpolationstr == "finegrained")
-                              interpolation = oms_tlm_fine_grained;
-                          else
-                              return logError("Unsupported interpolation type: "+interpolationstr);
-
-                          oms_tlm_domain_t domain;
-                          if(domainstr == "input")
-                              domain = oms_tlm_domain_input;
-                          else if(domainstr == "output")
-                              domain = oms_tlm_domain_output;
-                          else if(domainstr == "mechanical")
-                              domain = oms_tlm_domain_mechanical;
-                          else if(domainstr == "rotational")
-                              domain = oms_tlm_domain_rotational;
-                          else if(domainstr == "hydraulic")
-                              domain = oms_tlm_domain_hydraulic;
-                          else if(domainstr == "electric")
-                              domain = oms_tlm_domain_electric;
-                          else
-                              return logError("Unsupported TLM domain: "+domainstr);
-
-                          if (oms_status_ok != component->addTLMBus(busname,domain,dimensions,interpolation))
-                              return oms_status_error;
-                      }
-                  }
+            if (annotation_node && std::string(annotation_node.attribute("type").as_string()) == oms::ssp::Draft20180219::annotation_type)
+            {
+              pugi::xml_node oms_annotation_node = annotation_node.child(oms::ssp::Version1_0::oms_annotations);
+              // support older <ssc:annotation>
+              if (!oms_annotation_node)
+              {
+                oms_annotation_node = annotation_node;
+                logWarning_deprecated;
               }
+
+              if (oms_annotation_node)
+              {
+                pugi::xml_node oms_simulation_information = oms_annotation_node.child(oms::ssp::Version1_0::simulation_information);
+                if (oms_simulation_information)
+                {
+                  pugi::xml_node externalModelNode = oms_simulation_information.child(oms::ssp::Draft20180219::external_model);
+                  if (externalModelNode)
+                  {
+                    std::string startScript = externalModelNode.attribute("startscript").as_string();
+                    component = oms::ExternalModel::NewComponent(name, this, source, startScript);
+                  }
+                }
+                // parse <oms:Buses>
+                for (pugi::xml_node_iterator itAnnotations = oms_annotation_node.begin(); itAnnotations != oms_annotation_node.end(); ++itAnnotations)
+                {
+                  std::string nodeName = itAnnotations->name();
+                  // support older <oms:bus>
+                  if (nodeName == oms::ssp::Draft20180219::bus)
+                  {
+                    importTLMBus(*itAnnotations, component);
+                  }
+                  // <oms:buses>
+                  if (nodeName == oms::ssp::Version1_0::oms_buses)
+                  {
+                    for (pugi::xml_node_iterator itbuses = itAnnotations->begin(); itbuses != itAnnotations->end(); ++itbuses)
+                    {
+                      if (std::string(itbuses->name()) == oms::ssp::Draft20180219::bus)
+                      {
+                        importTLMBus(*itbuses, component);
+                      }
+                    }
+                  }
+                }
+              }
+            }
           }
 #endif
           if (component)
@@ -712,66 +718,12 @@ oms_status_enu_t oms::System::importFromSSD(const pugi::xml_node& node, const st
       // check for ssvFileSource exist and set the values before the connections
       if (!ssvFileSources.empty())
       {
-        for (const auto& ssvFileSource : ssvFileSources)
-        {
-          std::string tempdir = getModel()->getTempDirectory();
-          filesystem::path temp_root(tempdir);
-          pugi::xml_document ssvdoc;
-          pugi::xml_parse_result result = ssvdoc.load_file((temp_root / ssvFileSource).string().c_str());
-          pugi::xml_node parameterSet, parameters;
-
-          if (result) // check from ssv file
-          {
-            parameterSet = ssvdoc.document_element(); // ssv:ParameterSet
-            parameters = parameterSet.child(oms::ssp::Version1_0::ssv::parameters);
-          }
-          else if (getModel()->getSnapshot().child(oms::ssp::Version1_0::ssv_file)) // check in memory oms:ssv_file
-          {
-            parameterSet = getModel()->getSnapshot().child(oms::ssp::Version1_0::ssv_file).child(oms::ssp::Version1_0::ssv::parameter_set); // ssv:ParameterSet
-            parameters = parameterSet.child(oms::ssp::Version1_0::ssv::parameters);
-          }
-          else
-          {
-            return logError("loading \"" + std::string(ssvFileSource) + "\" failed (" + std::string(result.description()) + ")");
-          }
-
-          if (parameters)
-          {
-            for(pugi::xml_node_iterator itparameters = parameters.begin(); itparameters != parameters.end(); ++itparameters)
-            {
-              std::string name = itparameters->name();
-              if (name == oms::ssp::Version1_0::ssv::parameter)
-              {
-                ComRef cref = ComRef(itparameters->attribute("name").as_string());
-                if (itparameters->child(oms::ssp::Version1_0::ssv::real_type))
-                {
-                  double value = itparameters->child(oms::ssp::Version1_0::ssv::real_type).attribute("value").as_double();
-                  setReal(cref, value);
-                }
-                else if(itparameters->child(oms::ssp::Version1_0::ssv::integer_type))
-                {
-                  int value = itparameters->child(oms::ssp::Version1_0::ssv::integer_type).attribute("value").as_int();
-                  setInteger(cref, value);
-                }
-                else if(itparameters->child(oms::ssp::Version1_0::ssv::boolean_type))
-                {
-                  bool value = itparameters->child(oms::ssp::Version1_0::ssv::boolean_type).attribute("value").as_bool();
-                  setBoolean(cref, value);
-                }
-                else
-                {
-                  logError("Failed to import " + std::string(oms::ssp::Version1_0::ssv::parameter) + ":Unknown ParameterBinding-type");
-                }
-              }
-            }
-          }
-        }
+        importStartValuesFromSSV();
       }
     }
     else if (name == oms::ssp::Draft20180219::ssd::annotations)
     {
-      pugi::xml_node annotation_node;
-      annotation_node = it->child(oms::ssp::Version1_0::ssc::annotation);
+      pugi::xml_node annotation_node = it->child(oms::ssp::Version1_0::ssc::annotation);
 
       // check for ssd:annotation to support older version, which is a bug
       if(!annotation_node)
@@ -782,100 +734,71 @@ oms_status_enu_t oms::System::importFromSSD(const pugi::xml_node& node, const st
 
       if (annotation_node && std::string(annotation_node.attribute("type").as_string()) == oms::ssp::Draft20180219::annotation_type)
       {
-        for(pugi::xml_node_iterator itAnnotations = annotation_node.begin(); itAnnotations != annotation_node.end(); ++itAnnotations)
+        pugi::xml_node oms_annotation_node = annotation_node.child(oms::ssp::Version1_0::oms_annotations);
+
+        // support older <ssc:annotation>
+        if (!oms_annotation_node)
+        {
+          oms_annotation_node = annotation_node;
+          logWarning_deprecated;
+        }
+
+        // parse <oms:annotations>
+        for(pugi::xml_node_iterator itAnnotations = oms_annotation_node.begin(); itAnnotations != oms_annotation_node.end(); ++itAnnotations)
         {
           name = itAnnotations->name();
+
           // check for oms:simulationInformation from version 1.0
           if (std::string(name) == oms::ssp::Version1_0::simulation_information && sspVersion == "1.0")
           {
             if (oms_status_ok != importFromSSD_SimulationInformation(*itAnnotations, sspVersion))
               return logError("Failed to import " + std::string(oms::ssp::Version1_0::simulation_information));
           }
+
+          // support older <ssc:annotation> <oms:bus> </oms:bus> </ssc:annotation>
           if (std::string(name) == oms::ssp::Draft20180219::bus)
           {
             //Load bus connector
             std::string busname = itAnnotations->attribute("name").as_string();
             if (std::string(itAnnotations->attribute("type").as_string()) == "tlm")
             {
-              std::string domainstr = itAnnotations->attribute("domain").as_string();
-              int dimensions = itAnnotations->attribute("dimensions").as_int();
-              std::string interpolationstr = itAnnotations->attribute("interpolation").as_string();
-              oms_tlm_interpolation_t interpolation;
-              if (interpolationstr == "none")
-                interpolation = oms_tlm_no_interpolation;
-              else if (interpolationstr == "coarsegrained")
-                interpolation = oms_tlm_coarse_grained;
-              else if (interpolationstr == "finegrained")
-                interpolation = oms_tlm_fine_grained;
-              else
-                return logError("Unsupported interpolation type: "+interpolationstr);
-
-              oms_tlm_domain_t domain;
-              if(domainstr == "input")
-                domain = oms_tlm_domain_input;
-              else if(domainstr == "output")
-                domain = oms_tlm_domain_output;
-              else if(domainstr == "mechanical")
-                domain = oms_tlm_domain_mechanical;
-              else if(domainstr == "rotational")
-                domain = oms_tlm_domain_rotational;
-              else if(domainstr == "hydraulic")
-                domain = oms_tlm_domain_hydraulic;
-              else if(domainstr == "electric")
-                domain = oms_tlm_domain_electric;
-              else
-                return logError("Unsupported TLM domain: "+domainstr);
-
-              if (oms_status_ok != addTLMBus(busname,domain,dimensions,interpolation))
-                return oms_status_error;
+              importTLMBus(*itAnnotations, NULL);
             }
-            else {
+            else
+            {
               if (oms_status_ok != addBus(busname))
                 return oms_status_error;
             }
-
             //Load bus connector signals
-            pugi::xml_node signals_node = itAnnotations->child(oms::ssp::Draft20180219::signals);
-            if (signals_node)
-            {
-              for(pugi::xml_node_iterator itSignals = signals_node.begin(); itSignals != signals_node.end(); ++itSignals)
-              {
-                name = itSignals->name();
-                if (name == oms::ssp::Draft20180219::signal)
-                {
-                  std::string signalname = itSignals->attribute("name").as_string();
-                  if (std::string(itAnnotations->attribute("type").as_string()) == "tlm")
-                  {
-                    std::string signaltype = itSignals->attribute("type").as_string();
-                    addConnectorToTLMBus(busname, signalname, signaltype);
-                  }
-                  else
-                    addConnectorToBus(busname, signalname);
-                }
-              }
-            }
+            importBusConnectorSignals (*itAnnotations);
 
             // Load bus connector geometry
-            pugi::xml_node connectorGeometryNode = itAnnotations->child(oms::ssp::Draft20180219::ssd::connector_geometry);
-            if (connectorGeometryNode)
+            importBusConnectorGeometry(*itAnnotations);
+          }
+
+          // support <ssc:annotation> <oms:buses> <oms:bus> </oms:bus> </oms:buses></ssc:annotation>
+          if (std::string(name) == oms::ssp::Version1_0::oms_buses)
+          {
+            for(pugi::xml_node_iterator itbuses = itAnnotations->begin(); itbuses != itAnnotations->end(); ++itbuses)
             {
-              oms::ssd::ConnectorGeometry geometry(0.0, 0.0);
-              geometry.setPosition(connectorGeometryNode.attribute("x").as_double(), connectorGeometryNode.attribute("y").as_double());
-              if (std::string(itAnnotations->attribute("type").as_string()) == "tlm")
+              if (std::string(itbuses->name()) == oms::ssp::Draft20180219::bus)
               {
-#if !defined(NO_TLM)
-                oms::TLMBusConnector* tlmBusConnector = getTLMBusConnector(busname);
-                if (tlmBusConnector)
-                  tlmBusConnector->setGeometry(&geometry);
-#else
-                return LOG_NO_TLM();
-#endif
-              }
-              else
-              {
-                oms::BusConnector* busConnector = getBusConnector(busname);
-                if (busConnector)
-                  busConnector->setGeometry(&geometry);
+                //Load bus connector
+                std::string busname = itbuses->attribute("name").as_string();
+                if (std::string(itbuses->attribute("type").as_string()) == "tlm")
+                {
+                  importTLMBus(*itbuses, NULL);
+                }
+                else
+                {
+                  if (oms_status_ok != addBus(busname))
+                    return oms_status_error;
+                }
+                //Load bus connector signals
+                importBusConnectorSignals(*itbuses);
+
+                // Load bus connector geometry
+                importBusConnectorGeometry(*itbuses);
               }
             }
           }
@@ -2306,4 +2229,171 @@ oms_status_enu_t oms::System::setFaultInjection(const oms::ComRef& signal, oms_f
     return component->second->setFaultInjection(tail, faultType, faultValue);
 
   return oms_status_error;
+}
+
+oms_status_enu_t oms::System::importTLMBus(const pugi::xml_node& node, Component* component)
+{
+  std::string busname = node.attribute("name").as_string();
+  std::string domainstr = node.attribute("domain").as_string();
+  int dimensions = node.attribute("dimensions").as_int();
+  std::string interpolationstr = node.attribute("interpolation").as_string();
+
+  oms_tlm_interpolation_t interpolation;
+  if (interpolationstr == "none")
+    interpolation = oms_tlm_no_interpolation;
+  else if (interpolationstr == "coarsegrained")
+    interpolation = oms_tlm_coarse_grained;
+  else if (interpolationstr == "finegrained")
+    interpolation = oms_tlm_fine_grained;
+  else
+    return logError("Unsupported interpolation type: " + interpolationstr);
+
+  oms_tlm_domain_t domain;
+  if (domainstr == "input")
+    domain = oms_tlm_domain_input;
+  else if (domainstr == "output")
+    domain = oms_tlm_domain_output;
+  else if (domainstr == "mechanical")
+    domain = oms_tlm_domain_mechanical;
+  else if (domainstr == "rotational")
+    domain = oms_tlm_domain_rotational;
+  else if (domainstr == "hydraulic")
+    domain = oms_tlm_domain_hydraulic;
+  else if (domainstr == "electric")
+    domain = oms_tlm_domain_electric;
+  else
+    return logError("Unsupported TLM domain: " + domainstr);
+
+  if (component)
+  {
+    if (oms_status_ok != component->addTLMBus(busname, domain, dimensions, interpolation))
+      return oms_status_error;
+  }
+  else
+  {
+    if (oms_status_ok != addTLMBus(busname, domain, dimensions, interpolation))
+      return oms_status_error;
+  }
+
+  return oms_status_ok;
+}
+
+
+oms_status_enu_t oms::System::importBusConnectorSignals(const pugi::xml_node& node)
+{
+  std::string busname = node.attribute("name").as_string();
+  //Load bus connector signals
+  pugi::xml_node signals_node = node.child(oms::ssp::Draft20180219::signals);
+
+  if (signals_node)
+  {
+    for(pugi::xml_node_iterator itSignals = signals_node.begin(); itSignals != signals_node.end(); ++itSignals)
+    {
+      std::string name = itSignals->name();
+      if (name == oms::ssp::Draft20180219::signal)
+      {
+        std::string signalname = itSignals->attribute("name").as_string();
+        if (std::string(node.attribute("type").as_string()) == "tlm")
+        {
+          std::string signaltype = itSignals->attribute("type").as_string();
+          addConnectorToTLMBus(busname, signalname, signaltype);
+        }
+        else
+          addConnectorToBus(busname, signalname);
+      }
+    }
+  }
+
+  return oms_status_ok;
+}
+
+oms_status_enu_t oms::System::importBusConnectorGeometry(const pugi::xml_node& node)
+{
+  std::string busname = node.attribute("name").as_string();
+  //Load bus connector signals
+  pugi::xml_node connectorGeometryNode = node.child(oms::ssp::Draft20180219::ssd::connector_geometry);
+
+  if (connectorGeometryNode)
+  {
+    oms::ssd::ConnectorGeometry geometry(0.0, 0.0);
+    geometry.setPosition(connectorGeometryNode.attribute("x").as_double(), connectorGeometryNode.attribute("y").as_double());
+    if (std::string(node.attribute("type").as_string()) == "tlm")
+    {
+#if !defined(NO_TLM)
+      oms::TLMBusConnector* tlmBusConnector = getTLMBusConnector(busname);
+      if (tlmBusConnector)
+        tlmBusConnector->setGeometry(&geometry);
+#else
+      return LOG_NO_TLM();
+#endif
+    }
+    else
+    {
+      oms::BusConnector* busConnector = getBusConnector(busname);
+      if (busConnector)
+        busConnector->setGeometry(&geometry);
+    }
+  }
+
+  return oms_status_ok;
+}
+
+oms_status_enu_t oms::System::importStartValuesFromSSV()
+{
+  for (const auto& ssvFileSource : ssvFileSources)
+  {
+    std::string tempdir = getModel()->getTempDirectory();
+    filesystem::path temp_root(tempdir);
+    pugi::xml_document ssvdoc;
+    pugi::xml_parse_result result = ssvdoc.load_file((temp_root / ssvFileSource).string().c_str());
+    pugi::xml_node parameterSet, parameters;
+
+    if (result) // check from ssv file
+    {
+      parameterSet = ssvdoc.document_element(); // ssv:ParameterSet
+      parameters = parameterSet.child(oms::ssp::Version1_0::ssv::parameters);
+    }
+    else if (getModel()->getSnapshot().child(oms::ssp::Version1_0::ssv_file)) // check in memory oms:ssv_file
+    {
+      parameterSet = getModel()->getSnapshot().child(oms::ssp::Version1_0::ssv_file).child(oms::ssp::Version1_0::ssv::parameter_set); // ssv:ParameterSet
+      parameters = parameterSet.child(oms::ssp::Version1_0::ssv::parameters);
+    }
+    else
+    {
+      return logError("loading \"" + std::string(ssvFileSource) + "\" failed (" + std::string(result.description()) + ")");
+    }
+
+    if (parameters)
+    {
+      for(pugi::xml_node_iterator itparameters = parameters.begin(); itparameters != parameters.end(); ++itparameters)
+      {
+        std::string name = itparameters->name();
+        if (name == oms::ssp::Version1_0::ssv::parameter)
+        {
+          ComRef cref = ComRef(itparameters->attribute("name").as_string());
+          if (itparameters->child(oms::ssp::Version1_0::ssv::real_type))
+          {
+            double value = itparameters->child(oms::ssp::Version1_0::ssv::real_type).attribute("value").as_double();
+            setReal(cref, value);
+          }
+          else if(itparameters->child(oms::ssp::Version1_0::ssv::integer_type))
+          {
+            int value = itparameters->child(oms::ssp::Version1_0::ssv::integer_type).attribute("value").as_int();
+            setInteger(cref, value);
+          }
+          else if(itparameters->child(oms::ssp::Version1_0::ssv::boolean_type))
+          {
+            bool value = itparameters->child(oms::ssp::Version1_0::ssv::boolean_type).attribute("value").as_bool();
+            setBoolean(cref, value);
+          }
+          else
+          {
+            logError("Failed to import " + std::string(oms::ssp::Version1_0::ssv::parameter) + ":Unknown ParameterBinding-type");
+          }
+        }
+      }
+    }
+  }
+
+  return oms_status_ok;
 }

--- a/src/OMSimulatorLib/System.h
+++ b/src/OMSimulatorLib/System.h
@@ -211,6 +211,10 @@ namespace oms
 
     oms_status_enu_t importFromSSD_ConnectionGeometry(const pugi::xml_node& node, const ComRef& crefA, const ComRef& crefB);
     oms::ComRef getValidCref(const ComRef& cref);
+    oms_status_enu_t importTLMBus(const pugi::xml_node& node, Component* component);
+    oms_status_enu_t importBusConnectorSignals(const pugi::xml_node& node);
+    oms_status_enu_t importBusConnectorGeometry(const pugi::xml_node& node);
+    oms_status_enu_t importStartValuesFromSSV();
   };
 }
 

--- a/src/OMSimulatorLib/SystemSC.cpp
+++ b/src/OMSimulatorLib/SystemSC.cpp
@@ -137,12 +137,8 @@ oms_status_enu_t oms::SystemSC::setSolverMethod(std::string solver)
 
 oms_status_enu_t oms::SystemSC::exportToSSD_SimulationInformation(pugi::xml_node& node) const
 {
-  pugi::xml_node node_annotations = node.append_child(oms::ssp::Draft20180219::ssd::annotations);
-  pugi::xml_node node_annotation = node_annotations.append_child(oms::ssp::Version1_0::ssc::annotation);
-  node_annotation.append_attribute("type") = oms::ssp::Draft20180219::annotation_type;
-
   /* ssd:SimulationInformation should be added as vendor specific annotations from Version 1.0 */
-  pugi::xml_node node_simulation_information = node_annotation.append_child(oms::ssp::Version1_0::simulation_information);
+  pugi::xml_node node_simulation_information = node.append_child(oms::ssp::Version1_0::simulation_information);
 
   pugi::xml_node node_solver = node_simulation_information.append_child(oms::ssp::Version1_0::VariableStepSolver);
   node_solver.append_attribute("description") = getSolverName().c_str();

--- a/src/OMSimulatorLib/SystemWC.cpp
+++ b/src/OMSimulatorLib/SystemWC.cpp
@@ -105,12 +105,8 @@ oms_status_enu_t oms::SystemWC::setSolverMethod(std::string solver)
 
 oms_status_enu_t oms::SystemWC::exportToSSD_SimulationInformation(pugi::xml_node& node) const
 {
-  pugi::xml_node node_annotations = node.append_child(oms::ssp::Draft20180219::ssd::annotations);
-  pugi::xml_node node_annotation = node_annotations.append_child(oms::ssp::Version1_0::ssc::annotation);
-  node_annotation.append_attribute("type") =  oms::ssp::Draft20180219::annotation_type;
-
   /* ssd:SimulationInformation should be added as vendor specific annotations from Version 1.0 */
-  pugi::xml_node node_simulation_information = node_annotation.append_child(oms::ssp::Version1_0::simulation_information);
+  pugi::xml_node node_simulation_information = node.append_child(oms::ssp::Version1_0::simulation_information);
 
   pugi::xml_node node_solver = node_simulation_information.append_child(oms::ssp::Version1_0::FixedStepMaster);
   node_solver.append_attribute("description") = getSolverName().c_str();

--- a/src/OMSimulatorLib/TLM/ExternalModel.cpp
+++ b/src/OMSimulatorLib/TLM/ExternalModel.cpp
@@ -92,18 +92,20 @@ oms_status_enu_t oms::ExternalModel::exportToSSD(pugi::xml_node& node, pugi::xml
   pugi::xml_node annotations_node = node.append_child(oms::ssp::Draft20180219::ssd::annotations);
   pugi::xml_node annotation_node = annotations_node.append_child(oms::ssp::Version1_0::ssc::annotation);
   annotation_node.append_attribute("type") = oms::ssp::Draft20180219::annotation_type;
+  pugi::xml_node oms_annotation_node = annotation_node.append_child(oms::ssp::Version1_0::oms_annotations);
 
   if (tlmbusconnectors[0])
   {
+    pugi::xml_node oms_buses_node = oms_annotation_node.append_child(oms::ssp::Version1_0::oms_buses);
     for (const auto& tlmbusconnector : tlmbusconnectors)
       if (tlmbusconnector)
-        tlmbusconnector->exportToSSD(annotation_node);
+        tlmbusconnector->exportToSSD(oms_buses_node);
   }
 
   node.append_attribute("name") = this->getCref().c_str();
   node.append_attribute("source") = this->getPath().c_str();
   /* ssd:SimulationInformation should be added as vendor specific annotations from Version 1.0 */
-  pugi::xml_node siminfo_node = annotation_node.append_child(oms::ssp::Version1_0::simulation_information);
+  pugi::xml_node siminfo_node = oms_annotation_node.append_child(oms::ssp::Version1_0::simulation_information);
 
   pugi::xml_node externalmodel_node = siminfo_node.append_child(oms::ssp::Draft20180219::external_model);
   externalmodel_node.append_attribute("startscript") = externalModelInfo.getStartScript().c_str();

--- a/src/OMSimulatorLib/TLM/SystemTLM.cpp
+++ b/src/OMSimulatorLib/TLM/SystemTLM.cpp
@@ -80,12 +80,8 @@ oms::System* oms::SystemTLM::NewSystem(const oms::ComRef& cref, oms::Model* pare
 
 oms_status_enu_t oms::SystemTLM::exportToSSD_SimulationInformation(pugi::xml_node& node) const
 {
-  pugi::xml_node node_annotations = node.append_child(oms::ssp::Draft20180219::ssd::annotations);
-  pugi::xml_node node_annotation = node_annotations.append_child(oms::ssp::Version1_0::ssc::annotation);
-  node_annotation.append_attribute("type") = oms::ssp::Draft20180219::annotation_type;
-
   /* ssd:SimulationInformation should be added as vendor specific annotations from Version 1.0 */
-  pugi::xml_node node_simulation_information = node_annotation.append_child(oms::ssp::Version1_0::simulation_information);
+  pugi::xml_node node_simulation_information = node.append_child(oms::ssp::Version1_0::simulation_information);
 
   pugi::xml_node node_tlm = node_simulation_information.append_child(oms::ssp::Draft20180219::tlm_master);
 

--- a/src/OMSimulatorLib/ssd/Tags.cpp
+++ b/src/OMSimulatorLib/ssd/Tags.cpp
@@ -62,11 +62,13 @@ const char* oms::ssp::Draft20180219::ssd::units                        = "ssd:Un
 const char* oms::ssp::Version1_0::simulation_information               = "oms:SimulationInformation"; // simulation information must be handled in a vendor specific annotation
 const char* oms::ssp::Version1_0::FixedStepMaster                      = "oms:FixedStepMaster"; // WC-System
 const char* oms::ssp::Version1_0::VariableStepSolver                   = "oms:VariableStepSolver"; // SC-System
+const char* oms::ssp::Version1_0::oms_annotations                      = "oms:Annotations"; // root node for all oms_annotations
+const char* oms::ssp::Version1_0::oms_buses                            = "oms:Buses";
 
-const char* oms::ssp::Version1_0::snap_shot                             = "oms:snapshot";
-const char* oms::ssp::Version1_0::ssd_file                              = "oms:ssd_file";
-const char* oms::ssp::Version1_0::ssv_file                              = "oms:ssv_file";
-const char* oms::ssp::Version1_0::ssm_file                              = "oms:ssm_file";
+const char* oms::ssp::Version1_0::snap_shot                            = "oms:snapshot";
+const char* oms::ssp::Version1_0::ssd_file                             = "oms:ssd_file";
+const char* oms::ssp::Version1_0::ssv_file                             = "oms:ssv_file";
+const char* oms::ssp::Version1_0::ssm_file                             = "oms:ssm_file";
 
 const char* oms::ssp::Version1_0::ssd::parameter_bindings              = "ssd:ParameterBindings";
 const char* oms::ssp::Version1_0::ssd::parameter_binding               = "ssd:ParameterBinding";

--- a/src/OMSimulatorLib/ssd/Tags.h
+++ b/src/OMSimulatorLib/ssd/Tags.h
@@ -45,6 +45,8 @@ namespace oms
       extern const char* ssd_file;
       extern const char* ssv_file;
       extern const char* ssm_file;
+      extern const char* oms_annotations;
+      extern const char* oms_buses;
 
       namespace ssd
       {

--- a/testsuite/OMSimulator/deleteConnector.lua
+++ b/testsuite/OMSimulator/deleteConnector.lua
@@ -92,9 +92,11 @@ print(src)
 -- 				</ssd:ParameterBindings>
 -- 				<ssd:Annotations>
 -- 					<ssc:Annotation type="org.openmodelica">
--- 						<oms:SimulationInformation>
--- 							<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
--- 						</oms:SimulationInformation>
+-- 						<oms:Annotations>
+-- 							<oms:SimulationInformation>
+-- 								<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+-- 							</oms:SimulationInformation>
+-- 						</oms:Annotations>
 -- 					</ssc:Annotation>
 -- 				</ssd:Annotations>
 -- 			</ssd:System>
@@ -139,9 +141,11 @@ print(src)
 -- 				</ssd:Elements>
 -- 				<ssd:Annotations>
 -- 					<ssc:Annotation type="org.openmodelica">
--- 						<oms:SimulationInformation>
--- 							<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
--- 						</oms:SimulationInformation>
+-- 						<oms:Annotations>
+-- 							<oms:SimulationInformation>
+-- 								<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+-- 							</oms:SimulationInformation>
+-- 						</oms:Annotations>
 -- 					</ssc:Annotation>
 -- 				</ssd:Annotations>
 -- 			</ssd:System>
@@ -153,16 +157,20 @@ print(src)
 -- 		</ssd:Connections>
 -- 		<ssd:Annotations>
 -- 			<ssc:Annotation type="org.openmodelica">
--- 				<oms:SimulationInformation>
--- 					<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
--- 				</oms:SimulationInformation>
+-- 				<oms:Annotations>
+-- 					<oms:SimulationInformation>
+-- 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+-- 					</oms:SimulationInformation>
+-- 				</oms:Annotations>
 -- 			</ssc:Annotation>
 -- 		</ssd:Annotations>
 -- 	</ssd:System>
 -- 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
 -- 		<ssd:Annotations>
 -- 			<ssc:Annotation type="org.openmodelica">
--- 				<oms:SimulationInformation resultFile="deleteConnector_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter=".*" />
+-- 				<oms:Annotations>
+-- 					<oms:SimulationInformation resultFile="deleteConnector_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter=".*" />
+-- 				</oms:Annotations>
 -- 			</ssc:Annotation>
 -- 		</ssd:Annotations>
 -- 	</ssd:DefaultExperiment>
@@ -200,9 +208,11 @@ print(src)
 -- 				</ssd:ParameterBindings>
 -- 				<ssd:Annotations>
 -- 					<ssc:Annotation type="org.openmodelica">
--- 						<oms:SimulationInformation>
--- 							<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
--- 						</oms:SimulationInformation>
+-- 						<oms:Annotations>
+-- 							<oms:SimulationInformation>
+-- 								<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+-- 							</oms:SimulationInformation>
+-- 						</oms:Annotations>
 -- 					</ssc:Annotation>
 -- 				</ssd:Annotations>
 -- 			</ssd:System>
@@ -231,9 +241,11 @@ print(src)
 -- 				</ssd:Elements>
 -- 				<ssd:Annotations>
 -- 					<ssc:Annotation type="org.openmodelica">
--- 						<oms:SimulationInformation>
--- 							<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
--- 						</oms:SimulationInformation>
+-- 						<oms:Annotations>
+-- 							<oms:SimulationInformation>
+-- 								<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+-- 							</oms:SimulationInformation>
+-- 						</oms:Annotations>
 -- 					</ssc:Annotation>
 -- 				</ssd:Annotations>
 -- 			</ssd:System>
@@ -243,16 +255,20 @@ print(src)
 -- 		</ssd:Connections>
 -- 		<ssd:Annotations>
 -- 			<ssc:Annotation type="org.openmodelica">
--- 				<oms:SimulationInformation>
--- 					<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
--- 				</oms:SimulationInformation>
+-- 				<oms:Annotations>
+-- 					<oms:SimulationInformation>
+-- 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+-- 					</oms:SimulationInformation>
+-- 				</oms:Annotations>
 -- 			</ssc:Annotation>
 -- 		</ssd:Annotations>
 -- 	</ssd:System>
 -- 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
 -- 		<ssd:Annotations>
 -- 			<ssc:Annotation type="org.openmodelica">
--- 				<oms:SimulationInformation resultFile="deleteConnector_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter=".*" />
+-- 				<oms:Annotations>
+-- 					<oms:SimulationInformation resultFile="deleteConnector_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter=".*" />
+-- 				</oms:Annotations>
 -- 			</ssc:Annotation>
 -- 		</ssd:Annotations>
 -- 	</ssd:DefaultExperiment>

--- a/testsuite/OMSimulator/deleteStartValues.lua
+++ b/testsuite/OMSimulator/deleteStartValues.lua
@@ -107,9 +107,11 @@ print(src)
 -- 				</ssd:ParameterBindings>
 -- 				<ssd:Annotations>
 -- 					<ssc:Annotation type="org.openmodelica">
--- 						<oms:SimulationInformation>
--- 							<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
--- 						</oms:SimulationInformation>
+-- 						<oms:Annotations>
+-- 							<oms:SimulationInformation>
+-- 								<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+-- 							</oms:SimulationInformation>
+-- 						</oms:Annotations>
 -- 					</ssc:Annotation>
 -- 				</ssd:Annotations>
 -- 			</ssd:System>
@@ -157,25 +159,31 @@ print(src)
 -- 				</ssd:Elements>
 -- 				<ssd:Annotations>
 -- 					<ssc:Annotation type="org.openmodelica">
--- 						<oms:SimulationInformation>
--- 							<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
--- 						</oms:SimulationInformation>
+-- 						<oms:Annotations>
+-- 							<oms:SimulationInformation>
+-- 								<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+-- 							</oms:SimulationInformation>
+-- 						</oms:Annotations>
 -- 					</ssc:Annotation>
 -- 				</ssd:Annotations>
 -- 			</ssd:System>
 -- 		</ssd:Elements>
 -- 		<ssd:Annotations>
 -- 			<ssc:Annotation type="org.openmodelica">
--- 				<oms:SimulationInformation>
--- 					<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
--- 				</oms:SimulationInformation>
+-- 				<oms:Annotations>
+-- 					<oms:SimulationInformation>
+-- 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+-- 					</oms:SimulationInformation>
+-- 				</oms:Annotations>
 -- 			</ssc:Annotation>
 -- 		</ssd:Annotations>
 -- 	</ssd:System>
 -- 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
 -- 		<ssd:Annotations>
 -- 			<ssc:Annotation type="org.openmodelica">
--- 				<oms:SimulationInformation resultFile="deleteStartValues_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter=".*" />
+-- 				<oms:Annotations>
+-- 					<oms:SimulationInformation resultFile="deleteStartValues_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter=".*" />
+-- 				</oms:Annotations>
 -- 			</ssc:Annotation>
 -- 		</ssd:Annotations>
 -- 	</ssd:DefaultExperiment>
@@ -209,9 +217,11 @@ print(src)
 -- 				</ssd:Connectors>
 -- 				<ssd:Annotations>
 -- 					<ssc:Annotation type="org.openmodelica">
--- 						<oms:SimulationInformation>
--- 							<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
--- 						</oms:SimulationInformation>
+-- 						<oms:Annotations>
+-- 							<oms:SimulationInformation>
+-- 								<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+-- 							</oms:SimulationInformation>
+-- 						</oms:Annotations>
 -- 					</ssc:Annotation>
 -- 				</ssd:Annotations>
 -- 			</ssd:System>
@@ -243,25 +253,31 @@ print(src)
 -- 				</ssd:Elements>
 -- 				<ssd:Annotations>
 -- 					<ssc:Annotation type="org.openmodelica">
--- 						<oms:SimulationInformation>
--- 							<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
--- 						</oms:SimulationInformation>
+-- 						<oms:Annotations>
+-- 							<oms:SimulationInformation>
+-- 								<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+-- 							</oms:SimulationInformation>
+-- 						</oms:Annotations>
 -- 					</ssc:Annotation>
 -- 				</ssd:Annotations>
 -- 			</ssd:System>
 -- 		</ssd:Elements>
 -- 		<ssd:Annotations>
 -- 			<ssc:Annotation type="org.openmodelica">
--- 				<oms:SimulationInformation>
--- 					<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
--- 				</oms:SimulationInformation>
+-- 				<oms:Annotations>
+-- 					<oms:SimulationInformation>
+-- 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+-- 					</oms:SimulationInformation>
+-- 				</oms:Annotations>
 -- 			</ssc:Annotation>
 -- 		</ssd:Annotations>
 -- 	</ssd:System>
 -- 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
 -- 		<ssd:Annotations>
 -- 			<ssc:Annotation type="org.openmodelica">
--- 				<oms:SimulationInformation resultFile="deleteStartValues_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter=".*" />
+-- 				<oms:Annotations>
+-- 					<oms:SimulationInformation resultFile="deleteStartValues_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter=".*" />
+-- 				</oms:Annotations>
 -- 			</ssc:Annotation>
 -- 		</ssd:Annotations>
 -- 	</ssd:DefaultExperiment>

--- a/testsuite/OMSimulator/deleteStartValuesInSSV.lua
+++ b/testsuite/OMSimulator/deleteStartValuesInSSV.lua
@@ -98,25 +98,31 @@ oms_delete("deleteStartValuesInSSV")
 -- 				</ssd:Elements>
 -- 				<ssd:Annotations>
 -- 					<ssc:Annotation type="org.openmodelica">
--- 						<oms:SimulationInformation>
--- 							<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
--- 						</oms:SimulationInformation>
+-- 						<oms:Annotations>
+-- 							<oms:SimulationInformation>
+-- 								<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+-- 							</oms:SimulationInformation>
+-- 						</oms:Annotations>
 -- 					</ssc:Annotation>
 -- 				</ssd:Annotations>
 -- 			</ssd:System>
 -- 		</ssd:Elements>
 -- 		<ssd:Annotations>
 -- 			<ssc:Annotation type="org.openmodelica">
--- 				<oms:SimulationInformation>
--- 					<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
--- 				</oms:SimulationInformation>
+-- 				<oms:Annotations>
+-- 					<oms:SimulationInformation>
+-- 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+-- 					</oms:SimulationInformation>
+-- 				</oms:Annotations>
 -- 			</ssc:Annotation>
 -- 		</ssd:Annotations>
 -- 	</ssd:System>
 -- 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
 -- 		<ssd:Annotations>
 -- 			<ssc:Annotation type="org.openmodelica">
--- 				<oms:SimulationInformation resultFile="deleteStartValuesInSSV_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter=".*" />
+-- 				<oms:Annotations>
+-- 					<oms:SimulationInformation resultFile="deleteStartValuesInSSV_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter=".*" />
+-- 				</oms:Annotations>
 -- 			</ssc:Annotation>
 -- 		</ssd:Annotations>
 -- 	</ssd:DefaultExperiment>

--- a/testsuite/OMSimulator/exportConnectorsToResultFile.lua
+++ b/testsuite/OMSimulator/exportConnectorsToResultFile.lua
@@ -149,16 +149,20 @@ oms_delete("exportConnectors")
 -- 		</ssd:Elements>
 -- 		<ssd:Annotations>
 -- 			<ssc:Annotation type="org.openmodelica">
--- 				<oms:SimulationInformation>
--- 					<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
--- 				</oms:SimulationInformation>
+-- 				<oms:Annotations>
+-- 					<oms:SimulationInformation>
+-- 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+-- 					</oms:SimulationInformation>
+-- 				</oms:Annotations>
 -- 			</ssc:Annotation>
 -- 		</ssd:Annotations>
 -- 	</ssd:System>
 -- 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
 -- 		<ssd:Annotations>
 -- 			<ssc:Annotation type="org.openmodelica">
--- 				<oms:SimulationInformation resultFile="exportConnectors_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter=".*" />
+-- 				<oms:Annotations>
+-- 					<oms:SimulationInformation resultFile="exportConnectors_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter=".*" />
+-- 				</oms:Annotations>
 -- 			</ssc:Annotation>
 -- 		</ssd:Annotations>
 -- 	</ssd:DefaultExperiment>

--- a/testsuite/OMSimulator/importStartValues.lua
+++ b/testsuite/OMSimulator/importStartValues.lua
@@ -26,6 +26,11 @@ oms_delete("importStartValues")
 
 
 -- Result:
+-- warning: Wrong/deprecated content detected but successfully loaded. Please re-export the SSP file to avoid this message.
+-- warning: Wrong/deprecated content detected but successfully loaded. Please re-export the SSP file to avoid this message.
+-- warning: Wrong/deprecated content detected but successfully loaded. Please re-export the SSP file to avoid this message.
+-- warning: Wrong/deprecated content detected but successfully loaded. Please re-export the SSP file to avoid this message.
+-- warning: Wrong/deprecated content detected but successfully loaded. Please re-export the SSP file to avoid this message.
 -- <?xml version="1.0"?>
 -- <oms:snapshot>
 -- 	<oms:ssd_file name="SystemStructure.ssd">
@@ -54,25 +59,31 @@ oms_delete("importStartValues")
 -- 						</ssd:Connectors>
 -- 						<ssd:Annotations>
 -- 							<ssc:Annotation type="org.openmodelica">
--- 								<oms:SimulationInformation>
--- 									<oms:VariableStepSolver description="euler" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
--- 								</oms:SimulationInformation>
+-- 								<oms:Annotations>
+-- 									<oms:SimulationInformation>
+-- 										<oms:VariableStepSolver description="euler" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+-- 									</oms:SimulationInformation>
+-- 								</oms:Annotations>
 -- 							</ssc:Annotation>
 -- 						</ssd:Annotations>
 -- 					</ssd:System>
 -- 				</ssd:Elements>
 -- 				<ssd:Annotations>
 -- 					<ssc:Annotation type="org.openmodelica">
--- 						<oms:SimulationInformation>
--- 							<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
--- 						</oms:SimulationInformation>
+-- 						<oms:Annotations>
+-- 							<oms:SimulationInformation>
+-- 								<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+-- 							</oms:SimulationInformation>
+-- 						</oms:Annotations>
 -- 					</ssc:Annotation>
 -- 				</ssd:Annotations>
 -- 			</ssd:System>
 -- 			<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
 -- 				<ssd:Annotations>
 -- 					<ssc:Annotation type="org.openmodelica">
--- 						<oms:SimulationInformation resultFile="importStartValues_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter=".*" />
+-- 						<oms:Annotations>
+-- 							<oms:SimulationInformation resultFile="importStartValues_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter=".*" />
+-- 						</oms:Annotations>
 -- 					</ssc:Annotation>
 -- 				</ssd:Annotations>
 -- 			</ssd:DefaultExperiment>
@@ -97,4 +108,6 @@ oms_delete("importStartValues")
 --
 -- info:    model doesn't contain any continuous state
 -- info:    Result file: importStartValues_res.mat (bufferSize=10)
+-- info:    5 warnings
+-- info:    0 errors
 -- endResult

--- a/testsuite/OMSimulator/import_export.lua
+++ b/testsuite/OMSimulator/import_export.lua
@@ -195,159 +195,165 @@ printStatus(status, 0)
 -- status:  [correct] ok
 -- <?xml version="1.0"?>
 -- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="test" version="1.0">
---     <ssd:System name="eoo">
---         <ssd:Elements>
---             <ssd:System name="foo2">
---                 <ssd:Connectors>
---                     <ssd:Connector name="f" kind="input">
---                         <ssc:Real />
---                     </ssd:Connector>
---                     <ssd:Connector name="x" kind="output">
---                         <ssc:Real />
---                     </ssd:Connector>
---                     <ssd:Connector name="v" kind="output">
---                         <ssc:Real />
---                     </ssd:Connector>
---                     <ssd:Connector name="u1" kind="input">
---                         <ssc:Real />
---                     </ssd:Connector>
---                     <ssd:Connector name="u2" kind="input">
---                         <ssc:Real />
---                     </ssd:Connector>
---                 </ssd:Connectors>
---                 <ssd:Annotations>
---                     <ssc:Annotation type="org.openmodelica">
---                         <oms:Bus name="bus">
---                             <oms:Signals>
---                                 <oms:Signal name="u1" />
---                                 <oms:Signal name="u2" />
---                             </oms:Signals>
---                         </oms:Bus>
---                         <oms:Bus name="tlm" type="tlm" domain="mechanical" dimensions="1" interpolation="none">
---                             <oms:Signals>
---                                 <oms:Signal name="f" type="effort" />
---                                 <oms:Signal name="v" type="flow" />
---                                 <oms:Signal name="x" type="state" />
---                             </oms:Signals>
---                         </oms:Bus>
---                     </ssc:Annotation>
---                 </ssd:Annotations>
---                 <ssd:Annotations>
---                     <ssc:Annotation type="org.openmodelica">
---                         <oms:SimulationInformation>
---                             <oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
---                         </oms:SimulationInformation>
---                     </ssc:Annotation>
---                 </ssd:Annotations>
---             </ssd:System>
---             <ssd:System name="foo">
---                 <ssd:Connectors>
---                     <ssd:Connector name="f" kind="input">
---                         <ssc:Real />
---                     </ssd:Connector>
---                     <ssd:Connector name="x" kind="output">
---                         <ssc:Real />
---                     </ssd:Connector>
---                     <ssd:Connector name="v" kind="output">
---                         <ssc:Real />
---                     </ssd:Connector>
---                     <ssd:Connector name="y1" kind="output">
---                         <ssc:Real />
---                     </ssd:Connector>
---                     <ssd:Connector name="y2" kind="output">
---                         <ssc:Real />
---                     </ssd:Connector>
---                 </ssd:Connectors>
---                 <ssd:Elements>
---                     <ssd:System name="goo">
---                         <ssd:Annotations>
---                             <ssc:Annotation type="org.openmodelica">
---                                 <oms:SimulationInformation>
---                                     <oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
---                                 </oms:SimulationInformation>
---                             </ssc:Annotation>
---                         </ssd:Annotations>
---                     </ssd:System>
---                     <ssd:Component name="T" type="application/table" source="resources/0002_T.csv">
---                         <ssd:Connectors>
---                             <ssd:Connector name="time" kind="output">
---                                 <ssc:Real />
---                                 <ssd:ConnectorGeometry x="1.000000" y="0.333333" />
---                             </ssd:Connector>
---                             <ssd:Connector name="speed" kind="output">
---                                 <ssc:Real />
---                                 <ssd:ConnectorGeometry x="1.000000" y="0.666667" />
---                             </ssd:Connector>
---                         </ssd:Connectors>
---                     </ssd:Component>
---                     <ssd:Component name="A" type="application/x-fmu-sharedlibrary" source="resources/0001_A.fmu">
---                         <ssd:Connectors>
---                             <ssd:Connector name="y" kind="output">
---                                 <ssc:Real />
---                                 <ssd:ConnectorGeometry x="1.000000" y="0.500000" />
---                             </ssd:Connector>
---                             <ssd:Connector name="A" kind="parameter">
---                                 <ssc:Real />
---                             </ssd:Connector>
---                             <ssd:Connector name="omega" kind="parameter">
---                                 <ssc:Real />
---                             </ssd:Connector>
---                         </ssd:Connectors>
---                     </ssd:Component>
---                 </ssd:Elements>
---                 <ssd:Annotations>
---                     <ssc:Annotation type="org.openmodelica">
---                         <oms:Bus name="bus">
---                             <oms:Signals>
---                                 <oms:Signal name="y1" />
---                                 <oms:Signal name="y2" />
---                             </oms:Signals>
---                         </oms:Bus>
---                         <oms:Bus name="tlm" type="tlm" domain="mechanical" dimensions="1" interpolation="none">
---                             <oms:Signals>
---                                 <oms:Signal name="f" type="effort" />
---                                 <oms:Signal name="v" type="flow" />
---                                 <oms:Signal name="x" type="state" />
---                             </oms:Signals>
---                         </oms:Bus>
---                     </ssc:Annotation>
---                 </ssd:Annotations>
---                 <ssd:Annotations>
---                     <ssc:Annotation type="org.openmodelica">
---                         <oms:SimulationInformation>
---                             <oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
---                         </oms:SimulationInformation>
---                     </ssc:Annotation>
---                 </ssd:Annotations>
---             </ssd:System>
---         </ssd:Elements>
---         <ssd:Connections>
---             <ssd:Connection startElement="foo" startConnector="y1" endElement="foo2" endConnector="u1" />
---             <ssd:Connection startElement="foo" startConnector="y2" endElement="foo2" endConnector="u2" />
---         </ssd:Connections>
---         <ssd:Annotations>
---             <ssc:Annotation type="org.openmodelica">
---                 <oms:Connections>
---                     <oms:Connection startElement="foo" startConnector="tlm" endElement="foo2" endConnector="tlm" delay="0.001000" alpha="0.300000" linearimpedance="100.000000" angularimpedance="0.000000" />
---                     <oms:Connection startElement="foo" startConnector="bus" endElement="foo2" endConnector="bus" />
---                 </oms:Connections>
---             </ssc:Annotation>
---         </ssd:Annotations>
---         <ssd:Annotations>
---             <ssc:Annotation type="org.openmodelica">
---                 <oms:SimulationInformation>
---                     <oms:TlmMaster ip="127.0.1.1" managerport="11111" monitorport="11121" />
---                 </oms:SimulationInformation>
---             </ssc:Annotation>
---         </ssd:Annotations>
---     </ssd:System>
---     <ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
---         <ssd:Annotations>
---             <ssc:Annotation type="org.openmodelica">
---                 <oms:SimulationInformation resultFile="test_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter=".*" />
---             </ssc:Annotation>
---         </ssd:Annotations>
---     </ssd:DefaultExperiment>
+-- 	<ssd:System name="eoo">
+-- 		<ssd:Elements>
+-- 			<ssd:System name="foo2">
+-- 				<ssd:Connectors>
+-- 					<ssd:Connector name="f" kind="input">
+-- 						<ssc:Real />
+-- 					</ssd:Connector>
+-- 					<ssd:Connector name="x" kind="output">
+-- 						<ssc:Real />
+-- 					</ssd:Connector>
+-- 					<ssd:Connector name="v" kind="output">
+-- 						<ssc:Real />
+-- 					</ssd:Connector>
+-- 					<ssd:Connector name="u1" kind="input">
+-- 						<ssc:Real />
+-- 					</ssd:Connector>
+-- 					<ssd:Connector name="u2" kind="input">
+-- 						<ssc:Real />
+-- 					</ssd:Connector>
+-- 				</ssd:Connectors>
+-- 				<ssd:Annotations>
+-- 					<ssc:Annotation type="org.openmodelica">
+-- 						<oms:Annotations>
+-- 							<oms:Buses>
+-- 								<oms:Bus name="bus">
+-- 									<oms:Signals>
+-- 										<oms:Signal name="u1" />
+-- 										<oms:Signal name="u2" />
+-- 									</oms:Signals>
+-- 								</oms:Bus>
+-- 							</oms:Buses>
+-- 							<oms:Buses>
+-- 								<oms:Bus name="tlm" type="tlm" domain="mechanical" dimensions="1" interpolation="none">
+-- 									<oms:Signals>
+-- 										<oms:Signal name="f" type="effort" />
+-- 										<oms:Signal name="v" type="flow" />
+-- 										<oms:Signal name="x" type="state" />
+-- 									</oms:Signals>
+-- 								</oms:Bus>
+-- 							</oms:Buses>
+-- 							<oms:SimulationInformation>
+-- 								<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+-- 							</oms:SimulationInformation>
+-- 						</oms:Annotations>
+-- 					</ssc:Annotation>
+-- 				</ssd:Annotations>
+-- 			</ssd:System>
+-- 			<ssd:System name="foo">
+-- 				<ssd:Connectors>
+-- 					<ssd:Connector name="f" kind="input">
+-- 						<ssc:Real />
+-- 					</ssd:Connector>
+-- 					<ssd:Connector name="x" kind="output">
+-- 						<ssc:Real />
+-- 					</ssd:Connector>
+-- 					<ssd:Connector name="v" kind="output">
+-- 						<ssc:Real />
+-- 					</ssd:Connector>
+-- 					<ssd:Connector name="y1" kind="output">
+-- 						<ssc:Real />
+-- 					</ssd:Connector>
+-- 					<ssd:Connector name="y2" kind="output">
+-- 						<ssc:Real />
+-- 					</ssd:Connector>
+-- 				</ssd:Connectors>
+-- 				<ssd:Elements>
+-- 					<ssd:System name="goo">
+-- 						<ssd:Annotations>
+-- 							<ssc:Annotation type="org.openmodelica">
+-- 								<oms:Annotations>
+-- 									<oms:SimulationInformation>
+-- 										<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+-- 									</oms:SimulationInformation>
+-- 								</oms:Annotations>
+-- 							</ssc:Annotation>
+-- 						</ssd:Annotations>
+-- 					</ssd:System>
+-- 					<ssd:Component name="T" type="application/table" source="resources/0002_T.csv">
+-- 						<ssd:Connectors>
+-- 							<ssd:Connector name="time" kind="output">
+-- 								<ssc:Real />
+-- 								<ssd:ConnectorGeometry x="1.000000" y="0.333333" />
+-- 							</ssd:Connector>
+-- 							<ssd:Connector name="speed" kind="output">
+-- 								<ssc:Real />
+-- 								<ssd:ConnectorGeometry x="1.000000" y="0.666667" />
+-- 							</ssd:Connector>
+-- 						</ssd:Connectors>
+-- 					</ssd:Component>
+-- 					<ssd:Component name="A" type="application/x-fmu-sharedlibrary" source="resources/0001_A.fmu">
+-- 						<ssd:Connectors>
+-- 							<ssd:Connector name="y" kind="output">
+-- 								<ssc:Real />
+-- 								<ssd:ConnectorGeometry x="1.000000" y="0.500000" />
+-- 							</ssd:Connector>
+-- 							<ssd:Connector name="A" kind="parameter">
+-- 								<ssc:Real />
+-- 							</ssd:Connector>
+-- 							<ssd:Connector name="omega" kind="parameter">
+-- 								<ssc:Real />
+-- 							</ssd:Connector>
+-- 						</ssd:Connectors>
+-- 					</ssd:Component>
+-- 				</ssd:Elements>
+-- 				<ssd:Annotations>
+-- 					<ssc:Annotation type="org.openmodelica">
+-- 						<oms:Annotations>
+-- 							<oms:Buses>
+-- 								<oms:Bus name="bus">
+-- 									<oms:Signals>
+-- 										<oms:Signal name="y1" />
+-- 										<oms:Signal name="y2" />
+-- 									</oms:Signals>
+-- 								</oms:Bus>
+-- 							</oms:Buses>
+-- 							<oms:Buses>
+-- 								<oms:Bus name="tlm" type="tlm" domain="mechanical" dimensions="1" interpolation="none">
+-- 									<oms:Signals>
+-- 										<oms:Signal name="f" type="effort" />
+-- 										<oms:Signal name="v" type="flow" />
+-- 										<oms:Signal name="x" type="state" />
+-- 									</oms:Signals>
+-- 								</oms:Bus>
+-- 							</oms:Buses>
+-- 							<oms:SimulationInformation>
+-- 								<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+-- 							</oms:SimulationInformation>
+-- 						</oms:Annotations>
+-- 					</ssc:Annotation>
+-- 				</ssd:Annotations>
+-- 			</ssd:System>
+-- 		</ssd:Elements>
+-- 		<ssd:Connections>
+-- 			<ssd:Connection startElement="foo" startConnector="y1" endElement="foo2" endConnector="u1" />
+-- 			<ssd:Connection startElement="foo" startConnector="y2" endElement="foo2" endConnector="u2" />
+-- 		</ssd:Connections>
+-- 		<ssd:Annotations>
+-- 			<ssc:Annotation type="org.openmodelica">
+-- 				<oms:Annotations>
+-- 					<oms:Connections>
+-- 						<oms:Connection startElement="foo" startConnector="tlm" endElement="foo2" endConnector="tlm" delay="0.001000" alpha="0.300000" linearimpedance="100.000000" angularimpedance="0.000000" />
+-- 						<oms:Connection startElement="foo" startConnector="bus" endElement="foo2" endConnector="bus" />
+-- 					</oms:Connections>
+-- 					<oms:SimulationInformation>
+-- 						<oms:TlmMaster ip="127.0.1.1" managerport="11111" monitorport="11121" />
+-- 					</oms:SimulationInformation>
+-- 				</oms:Annotations>
+-- 			</ssc:Annotation>
+-- 		</ssd:Annotations>
+-- 	</ssd:System>
+-- 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
+-- 		<ssd:Annotations>
+-- 			<ssc:Annotation type="org.openmodelica">
+-- 				<oms:Annotations>
+-- 					<oms:SimulationInformation resultFile="test_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter=".*" />
+-- 				</oms:Annotations>
+-- 			</ssc:Annotation>
+-- 		</ssd:Annotations>
+-- 	</ssd:DefaultExperiment>
 -- </ssd:SystemStructureDescription>
 --
 -- status:  [correct] ok
@@ -356,159 +362,165 @@ printStatus(status, 0)
 -- status:  [correct] ok
 -- <?xml version="1.0"?>
 -- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="test" version="1.0">
---     <ssd:System name="eoo">
---         <ssd:Elements>
---             <ssd:System name="foo2">
---                 <ssd:Connectors>
---                     <ssd:Connector name="f" kind="input">
---                         <ssc:Real />
---                     </ssd:Connector>
---                     <ssd:Connector name="x" kind="output">
---                         <ssc:Real />
---                     </ssd:Connector>
---                     <ssd:Connector name="v" kind="output">
---                         <ssc:Real />
---                     </ssd:Connector>
---                     <ssd:Connector name="u1" kind="input">
---                         <ssc:Real />
---                     </ssd:Connector>
---                     <ssd:Connector name="u2" kind="input">
---                         <ssc:Real />
---                     </ssd:Connector>
---                 </ssd:Connectors>
---                 <ssd:Annotations>
---                     <ssc:Annotation type="org.openmodelica">
---                         <oms:Bus name="bus">
---                             <oms:Signals>
---                                 <oms:Signal name="u1" />
---                                 <oms:Signal name="u2" />
---                             </oms:Signals>
---                         </oms:Bus>
---                         <oms:Bus name="tlm" type="tlm" domain="mechanical" dimensions="1" interpolation="none">
---                             <oms:Signals>
---                                 <oms:Signal name="f" type="effort" />
---                                 <oms:Signal name="v" type="flow" />
---                                 <oms:Signal name="x" type="state" />
---                             </oms:Signals>
---                         </oms:Bus>
---                     </ssc:Annotation>
---                 </ssd:Annotations>
---                 <ssd:Annotations>
---                     <ssc:Annotation type="org.openmodelica">
---                         <oms:SimulationInformation>
---                             <oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
---                         </oms:SimulationInformation>
---                     </ssc:Annotation>
---                 </ssd:Annotations>
---             </ssd:System>
---             <ssd:System name="foo">
---                 <ssd:Connectors>
---                     <ssd:Connector name="f" kind="input">
---                         <ssc:Real />
---                     </ssd:Connector>
---                     <ssd:Connector name="x" kind="output">
---                         <ssc:Real />
---                     </ssd:Connector>
---                     <ssd:Connector name="v" kind="output">
---                         <ssc:Real />
---                     </ssd:Connector>
---                     <ssd:Connector name="y1" kind="output">
---                         <ssc:Real />
---                     </ssd:Connector>
---                     <ssd:Connector name="y2" kind="output">
---                         <ssc:Real />
---                     </ssd:Connector>
---                 </ssd:Connectors>
---                 <ssd:Elements>
---                     <ssd:System name="goo">
---                         <ssd:Annotations>
---                             <ssc:Annotation type="org.openmodelica">
---                                 <oms:SimulationInformation>
---                                     <oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
---                                 </oms:SimulationInformation>
---                             </ssc:Annotation>
---                         </ssd:Annotations>
---                     </ssd:System>
---                     <ssd:Component name="T" type="application/table" source="resources/0002_T.csv">
---                         <ssd:Connectors>
---                             <ssd:Connector name="time" kind="output">
---                                 <ssc:Real />
---                                 <ssd:ConnectorGeometry x="1.000000" y="0.333333" />
---                             </ssd:Connector>
---                             <ssd:Connector name="speed" kind="output">
---                                 <ssc:Real />
---                                 <ssd:ConnectorGeometry x="1.000000" y="0.666667" />
---                             </ssd:Connector>
---                         </ssd:Connectors>
---                     </ssd:Component>
---                     <ssd:Component name="A" type="application/x-fmu-sharedlibrary" source="resources/0001_A.fmu">
---                         <ssd:Connectors>
---                             <ssd:Connector name="y" kind="output">
---                                 <ssc:Real />
---                                 <ssd:ConnectorGeometry x="1.000000" y="0.500000" />
---                             </ssd:Connector>
---                             <ssd:Connector name="A" kind="parameter">
---                                 <ssc:Real />
---                             </ssd:Connector>
---                             <ssd:Connector name="omega" kind="parameter">
---                                 <ssc:Real />
---                             </ssd:Connector>
---                         </ssd:Connectors>
---                     </ssd:Component>
---                 </ssd:Elements>
---                 <ssd:Annotations>
---                     <ssc:Annotation type="org.openmodelica">
---                         <oms:Bus name="bus">
---                             <oms:Signals>
---                                 <oms:Signal name="y1" />
---                                 <oms:Signal name="y2" />
---                             </oms:Signals>
---                         </oms:Bus>
---                         <oms:Bus name="tlm" type="tlm" domain="mechanical" dimensions="1" interpolation="none">
---                             <oms:Signals>
---                                 <oms:Signal name="f" type="effort" />
---                                 <oms:Signal name="v" type="flow" />
---                                 <oms:Signal name="x" type="state" />
---                             </oms:Signals>
---                         </oms:Bus>
---                     </ssc:Annotation>
---                 </ssd:Annotations>
---                 <ssd:Annotations>
---                     <ssc:Annotation type="org.openmodelica">
---                         <oms:SimulationInformation>
---                             <oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
---                         </oms:SimulationInformation>
---                     </ssc:Annotation>
---                 </ssd:Annotations>
---             </ssd:System>
---         </ssd:Elements>
---         <ssd:Connections>
---             <ssd:Connection startElement="foo" startConnector="y1" endElement="foo2" endConnector="u1" />
---             <ssd:Connection startElement="foo" startConnector="y2" endElement="foo2" endConnector="u2" />
---         </ssd:Connections>
---         <ssd:Annotations>
---             <ssc:Annotation type="org.openmodelica">
---                 <oms:Connections>
---                     <oms:Connection startElement="foo" startConnector="tlm" endElement="foo2" endConnector="tlm" delay="0.001000" alpha="0.300000" linearimpedance="100.000000" angularimpedance="0.000000" />
---                     <oms:Connection startElement="foo" startConnector="bus" endElement="foo2" endConnector="bus" />
---                 </oms:Connections>
---             </ssc:Annotation>
---         </ssd:Annotations>
---         <ssd:Annotations>
---             <ssc:Annotation type="org.openmodelica">
---                 <oms:SimulationInformation>
---                     <oms:TlmMaster ip="" managerport="0" monitorport="0" />
---                 </oms:SimulationInformation>
---             </ssc:Annotation>
---         </ssd:Annotations>
---     </ssd:System>
---     <ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
---         <ssd:Annotations>
---             <ssc:Annotation type="org.openmodelica">
---                 <oms:SimulationInformation resultFile="test_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter=".*" />
---             </ssc:Annotation>
---         </ssd:Annotations>
---     </ssd:DefaultExperiment>
+-- 	<ssd:System name="eoo">
+-- 		<ssd:Elements>
+-- 			<ssd:System name="foo2">
+-- 				<ssd:Connectors>
+-- 					<ssd:Connector name="f" kind="input">
+-- 						<ssc:Real />
+-- 					</ssd:Connector>
+-- 					<ssd:Connector name="x" kind="output">
+-- 						<ssc:Real />
+-- 					</ssd:Connector>
+-- 					<ssd:Connector name="v" kind="output">
+-- 						<ssc:Real />
+-- 					</ssd:Connector>
+-- 					<ssd:Connector name="u1" kind="input">
+-- 						<ssc:Real />
+-- 					</ssd:Connector>
+-- 					<ssd:Connector name="u2" kind="input">
+-- 						<ssc:Real />
+-- 					</ssd:Connector>
+-- 				</ssd:Connectors>
+-- 				<ssd:Annotations>
+-- 					<ssc:Annotation type="org.openmodelica">
+-- 						<oms:Annotations>
+-- 							<oms:Buses>
+-- 								<oms:Bus name="bus">
+-- 									<oms:Signals>
+-- 										<oms:Signal name="u1" />
+-- 										<oms:Signal name="u2" />
+-- 									</oms:Signals>
+-- 								</oms:Bus>
+-- 							</oms:Buses>
+-- 							<oms:Buses>
+-- 								<oms:Bus name="tlm" type="tlm" domain="mechanical" dimensions="1" interpolation="none">
+-- 									<oms:Signals>
+-- 										<oms:Signal name="f" type="effort" />
+-- 										<oms:Signal name="v" type="flow" />
+-- 										<oms:Signal name="x" type="state" />
+-- 									</oms:Signals>
+-- 								</oms:Bus>
+-- 							</oms:Buses>
+-- 							<oms:SimulationInformation>
+-- 								<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+-- 							</oms:SimulationInformation>
+-- 						</oms:Annotations>
+-- 					</ssc:Annotation>
+-- 				</ssd:Annotations>
+-- 			</ssd:System>
+-- 			<ssd:System name="foo">
+-- 				<ssd:Connectors>
+-- 					<ssd:Connector name="f" kind="input">
+-- 						<ssc:Real />
+-- 					</ssd:Connector>
+-- 					<ssd:Connector name="x" kind="output">
+-- 						<ssc:Real />
+-- 					</ssd:Connector>
+-- 					<ssd:Connector name="v" kind="output">
+-- 						<ssc:Real />
+-- 					</ssd:Connector>
+-- 					<ssd:Connector name="y1" kind="output">
+-- 						<ssc:Real />
+-- 					</ssd:Connector>
+-- 					<ssd:Connector name="y2" kind="output">
+-- 						<ssc:Real />
+-- 					</ssd:Connector>
+-- 				</ssd:Connectors>
+-- 				<ssd:Elements>
+-- 					<ssd:System name="goo">
+-- 						<ssd:Annotations>
+-- 							<ssc:Annotation type="org.openmodelica">
+-- 								<oms:Annotations>
+-- 									<oms:SimulationInformation>
+-- 										<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+-- 									</oms:SimulationInformation>
+-- 								</oms:Annotations>
+-- 							</ssc:Annotation>
+-- 						</ssd:Annotations>
+-- 					</ssd:System>
+-- 					<ssd:Component name="T" type="application/table" source="resources/0002_T.csv">
+-- 						<ssd:Connectors>
+-- 							<ssd:Connector name="time" kind="output">
+-- 								<ssc:Real />
+-- 								<ssd:ConnectorGeometry x="1.000000" y="0.333333" />
+-- 							</ssd:Connector>
+-- 							<ssd:Connector name="speed" kind="output">
+-- 								<ssc:Real />
+-- 								<ssd:ConnectorGeometry x="1.000000" y="0.666667" />
+-- 							</ssd:Connector>
+-- 						</ssd:Connectors>
+-- 					</ssd:Component>
+-- 					<ssd:Component name="A" type="application/x-fmu-sharedlibrary" source="resources/0001_A.fmu">
+-- 						<ssd:Connectors>
+-- 							<ssd:Connector name="y" kind="output">
+-- 								<ssc:Real />
+-- 								<ssd:ConnectorGeometry x="1.000000" y="0.500000" />
+-- 							</ssd:Connector>
+-- 							<ssd:Connector name="A" kind="parameter">
+-- 								<ssc:Real />
+-- 							</ssd:Connector>
+-- 							<ssd:Connector name="omega" kind="parameter">
+-- 								<ssc:Real />
+-- 							</ssd:Connector>
+-- 						</ssd:Connectors>
+-- 					</ssd:Component>
+-- 				</ssd:Elements>
+-- 				<ssd:Annotations>
+-- 					<ssc:Annotation type="org.openmodelica">
+-- 						<oms:Annotations>
+-- 							<oms:Buses>
+-- 								<oms:Bus name="bus">
+-- 									<oms:Signals>
+-- 										<oms:Signal name="y1" />
+-- 										<oms:Signal name="y2" />
+-- 									</oms:Signals>
+-- 								</oms:Bus>
+-- 							</oms:Buses>
+-- 							<oms:Buses>
+-- 								<oms:Bus name="tlm" type="tlm" domain="mechanical" dimensions="1" interpolation="none">
+-- 									<oms:Signals>
+-- 										<oms:Signal name="f" type="effort" />
+-- 										<oms:Signal name="v" type="flow" />
+-- 										<oms:Signal name="x" type="state" />
+-- 									</oms:Signals>
+-- 								</oms:Bus>
+-- 							</oms:Buses>
+-- 							<oms:SimulationInformation>
+-- 								<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+-- 							</oms:SimulationInformation>
+-- 						</oms:Annotations>
+-- 					</ssc:Annotation>
+-- 				</ssd:Annotations>
+-- 			</ssd:System>
+-- 		</ssd:Elements>
+-- 		<ssd:Connections>
+-- 			<ssd:Connection startElement="foo" startConnector="y1" endElement="foo2" endConnector="u1" />
+-- 			<ssd:Connection startElement="foo" startConnector="y2" endElement="foo2" endConnector="u2" />
+-- 		</ssd:Connections>
+-- 		<ssd:Annotations>
+-- 			<ssc:Annotation type="org.openmodelica">
+-- 				<oms:Annotations>
+-- 					<oms:Connections>
+-- 						<oms:Connection startElement="foo" startConnector="tlm" endElement="foo2" endConnector="tlm" delay="0.001000" alpha="0.300000" linearimpedance="100.000000" angularimpedance="0.000000" />
+-- 						<oms:Connection startElement="foo" startConnector="bus" endElement="foo2" endConnector="bus" />
+-- 					</oms:Connections>
+-- 					<oms:SimulationInformation>
+-- 						<oms:TlmMaster ip="" managerport="0" monitorport="0" />
+-- 					</oms:SimulationInformation>
+-- 				</oms:Annotations>
+-- 			</ssc:Annotation>
+-- 		</ssd:Annotations>
+-- 	</ssd:System>
+-- 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
+-- 		<ssd:Annotations>
+-- 			<ssc:Annotation type="org.openmodelica">
+-- 				<oms:Annotations>
+-- 					<oms:SimulationInformation resultFile="test_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter=".*" />
+-- 				</oms:Annotations>
+-- 			</ssc:Annotation>
+-- 		</ssd:Annotations>
+-- 	</ssd:DefaultExperiment>
 -- </ssd:SystemStructureDescription>
 --
 -- status:  [correct] ok

--- a/testsuite/OMSimulator/import_export.py
+++ b/testsuite/OMSimulator/import_export.py
@@ -194,159 +194,165 @@ printStatus(status, 0)
 ## status:  [correct] ok
 ## <?xml version="1.0"?>
 ## <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="test" version="1.0">
-##     <ssd:System name="eoo">
-##         <ssd:Elements>
-##             <ssd:System name="foo2">
-##                 <ssd:Connectors>
-##                     <ssd:Connector name="f" kind="input">
-##                         <ssc:Real />
-##                     </ssd:Connector>
-##                     <ssd:Connector name="x" kind="output">
-##                         <ssc:Real />
-##                     </ssd:Connector>
-##                     <ssd:Connector name="v" kind="output">
-##                         <ssc:Real />
-##                     </ssd:Connector>
-##                     <ssd:Connector name="u1" kind="input">
-##                         <ssc:Real />
-##                     </ssd:Connector>
-##                     <ssd:Connector name="u2" kind="input">
-##                         <ssc:Real />
-##                     </ssd:Connector>
-##                 </ssd:Connectors>
-##                 <ssd:Annotations>
-##                     <ssc:Annotation type="org.openmodelica">
-##                         <oms:Bus name="bus">
-##                             <oms:Signals>
-##                                 <oms:Signal name="u1" />
-##                                 <oms:Signal name="u2" />
-##                             </oms:Signals>
-##                         </oms:Bus>
-##                         <oms:Bus name="tlm" type="tlm" domain="mechanical" dimensions="1" interpolation="none">
-##                             <oms:Signals>
-##                                 <oms:Signal name="f" type="effort" />
-##                                 <oms:Signal name="v" type="flow" />
-##                                 <oms:Signal name="x" type="state" />
-##                             </oms:Signals>
-##                         </oms:Bus>
-##                     </ssc:Annotation>
-##                 </ssd:Annotations>
-##                 <ssd:Annotations>
-##                     <ssc:Annotation type="org.openmodelica">
-##                         <oms:SimulationInformation>
-##                             <oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
-##                         </oms:SimulationInformation>
-##                     </ssc:Annotation>
-##                 </ssd:Annotations>
-##             </ssd:System>
-##             <ssd:System name="foo">
-##                 <ssd:Connectors>
-##                     <ssd:Connector name="f" kind="input">
-##                         <ssc:Real />
-##                     </ssd:Connector>
-##                     <ssd:Connector name="x" kind="output">
-##                         <ssc:Real />
-##                     </ssd:Connector>
-##                     <ssd:Connector name="v" kind="output">
-##                         <ssc:Real />
-##                     </ssd:Connector>
-##                     <ssd:Connector name="y1" kind="output">
-##                         <ssc:Real />
-##                     </ssd:Connector>
-##                     <ssd:Connector name="y2" kind="output">
-##                         <ssc:Real />
-##                     </ssd:Connector>
-##                 </ssd:Connectors>
-##                 <ssd:Elements>
-##                     <ssd:System name="goo">
-##                         <ssd:Annotations>
-##                             <ssc:Annotation type="org.openmodelica">
-##                                 <oms:SimulationInformation>
-##                                     <oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
-##                                 </oms:SimulationInformation>
-##                             </ssc:Annotation>
-##                         </ssd:Annotations>
-##                     </ssd:System>
-##                     <ssd:Component name="T" type="application/table" source="resources/0002_T.csv">
-##                         <ssd:Connectors>
-##                             <ssd:Connector name="time" kind="output">
-##                                 <ssc:Real />
-##                                 <ssd:ConnectorGeometry x="1.000000" y="0.333333" />
-##                             </ssd:Connector>
-##                             <ssd:Connector name="speed" kind="output">
-##                                 <ssc:Real />
-##                                 <ssd:ConnectorGeometry x="1.000000" y="0.666667" />
-##                             </ssd:Connector>
-##                         </ssd:Connectors>
-##                     </ssd:Component>
-##                     <ssd:Component name="A" type="application/x-fmu-sharedlibrary" source="resources/0001_A.fmu">
-##                         <ssd:Connectors>
-##                             <ssd:Connector name="y" kind="output">
-##                                 <ssc:Real />
-##                                 <ssd:ConnectorGeometry x="1.000000" y="0.500000" />
-##                             </ssd:Connector>
-##                             <ssd:Connector name="A" kind="parameter">
-##                                 <ssc:Real />
-##                             </ssd:Connector>
-##                             <ssd:Connector name="omega" kind="parameter">
-##                                 <ssc:Real />
-##                             </ssd:Connector>
-##                         </ssd:Connectors>
-##                     </ssd:Component>
-##                 </ssd:Elements>
-##                 <ssd:Annotations>
-##                     <ssc:Annotation type="org.openmodelica">
-##                         <oms:Bus name="bus">
-##                             <oms:Signals>
-##                                 <oms:Signal name="y1" />
-##                                 <oms:Signal name="y2" />
-##                             </oms:Signals>
-##                         </oms:Bus>
-##                         <oms:Bus name="tlm" type="tlm" domain="mechanical" dimensions="1" interpolation="none">
-##                             <oms:Signals>
-##                                 <oms:Signal name="f" type="effort" />
-##                                 <oms:Signal name="v" type="flow" />
-##                                 <oms:Signal name="x" type="state" />
-##                             </oms:Signals>
-##                         </oms:Bus>
-##                     </ssc:Annotation>
-##                 </ssd:Annotations>
-##                 <ssd:Annotations>
-##                     <ssc:Annotation type="org.openmodelica">
-##                         <oms:SimulationInformation>
-##                             <oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
-##                         </oms:SimulationInformation>
-##                     </ssc:Annotation>
-##                 </ssd:Annotations>
-##             </ssd:System>
-##         </ssd:Elements>
-##         <ssd:Connections>
-##             <ssd:Connection startElement="foo" startConnector="y1" endElement="foo2" endConnector="u1" />
-##             <ssd:Connection startElement="foo" startConnector="y2" endElement="foo2" endConnector="u2" />
-##         </ssd:Connections>
-##         <ssd:Annotations>
-##             <ssc:Annotation type="org.openmodelica">
-##                 <oms:Connections>
-##                     <oms:Connection startElement="foo" startConnector="tlm" endElement="foo2" endConnector="tlm" delay="0.001000" alpha="0.300000" linearimpedance="100.000000" angularimpedance="0.000000" />
-##                     <oms:Connection startElement="foo" startConnector="bus" endElement="foo2" endConnector="bus" />
-##                 </oms:Connections>
-##             </ssc:Annotation>
-##         </ssd:Annotations>
-##         <ssd:Annotations>
-##             <ssc:Annotation type="org.openmodelica">
-##                 <oms:SimulationInformation>
-##                     <oms:TlmMaster ip="127.0.1.1" managerport="11111" monitorport="11121" />
-##                 </oms:SimulationInformation>
-##             </ssc:Annotation>
-##         </ssd:Annotations>
-##     </ssd:System>
-##     <ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
-##         <ssd:Annotations>
-##             <ssc:Annotation type="org.openmodelica">
-##                 <oms:SimulationInformation resultFile="test_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter=".*" />
-##             </ssc:Annotation>
-##         </ssd:Annotations>
-##     </ssd:DefaultExperiment>
+## 	<ssd:System name="eoo">
+## 		<ssd:Elements>
+## 			<ssd:System name="foo2">
+## 				<ssd:Connectors>
+## 					<ssd:Connector name="f" kind="input">
+## 						<ssc:Real />
+## 					</ssd:Connector>
+## 					<ssd:Connector name="x" kind="output">
+## 						<ssc:Real />
+## 					</ssd:Connector>
+## 					<ssd:Connector name="v" kind="output">
+## 						<ssc:Real />
+## 					</ssd:Connector>
+## 					<ssd:Connector name="u1" kind="input">
+## 						<ssc:Real />
+## 					</ssd:Connector>
+## 					<ssd:Connector name="u2" kind="input">
+## 						<ssc:Real />
+## 					</ssd:Connector>
+## 				</ssd:Connectors>
+## 				<ssd:Annotations>
+## 					<ssc:Annotation type="org.openmodelica">
+## 						<oms:Annotations>
+## 							<oms:Buses>
+## 								<oms:Bus name="bus">
+## 									<oms:Signals>
+## 										<oms:Signal name="u1" />
+## 										<oms:Signal name="u2" />
+## 									</oms:Signals>
+## 								</oms:Bus>
+## 							</oms:Buses>
+## 							<oms:Buses>
+## 								<oms:Bus name="tlm" type="tlm" domain="mechanical" dimensions="1" interpolation="none">
+## 									<oms:Signals>
+## 										<oms:Signal name="f" type="effort" />
+## 										<oms:Signal name="v" type="flow" />
+## 										<oms:Signal name="x" type="state" />
+## 									</oms:Signals>
+## 								</oms:Bus>
+## 							</oms:Buses>
+## 							<oms:SimulationInformation>
+## 								<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+## 							</oms:SimulationInformation>
+## 						</oms:Annotations>
+## 					</ssc:Annotation>
+## 				</ssd:Annotations>
+## 			</ssd:System>
+## 			<ssd:System name="foo">
+## 				<ssd:Connectors>
+## 					<ssd:Connector name="f" kind="input">
+## 						<ssc:Real />
+## 					</ssd:Connector>
+## 					<ssd:Connector name="x" kind="output">
+## 						<ssc:Real />
+## 					</ssd:Connector>
+## 					<ssd:Connector name="v" kind="output">
+## 						<ssc:Real />
+## 					</ssd:Connector>
+## 					<ssd:Connector name="y1" kind="output">
+## 						<ssc:Real />
+## 					</ssd:Connector>
+## 					<ssd:Connector name="y2" kind="output">
+## 						<ssc:Real />
+## 					</ssd:Connector>
+## 				</ssd:Connectors>
+## 				<ssd:Elements>
+## 					<ssd:System name="goo">
+## 						<ssd:Annotations>
+## 							<ssc:Annotation type="org.openmodelica">
+## 								<oms:Annotations>
+## 									<oms:SimulationInformation>
+## 										<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+## 									</oms:SimulationInformation>
+## 								</oms:Annotations>
+## 							</ssc:Annotation>
+## 						</ssd:Annotations>
+## 					</ssd:System>
+## 					<ssd:Component name="T" type="application/table" source="resources/0002_T.csv">
+## 						<ssd:Connectors>
+## 							<ssd:Connector name="time" kind="output">
+## 								<ssc:Real />
+## 								<ssd:ConnectorGeometry x="1.000000" y="0.333333" />
+## 							</ssd:Connector>
+## 							<ssd:Connector name="speed" kind="output">
+## 								<ssc:Real />
+## 								<ssd:ConnectorGeometry x="1.000000" y="0.666667" />
+## 							</ssd:Connector>
+## 						</ssd:Connectors>
+## 					</ssd:Component>
+## 					<ssd:Component name="A" type="application/x-fmu-sharedlibrary" source="resources/0001_A.fmu">
+## 						<ssd:Connectors>
+## 							<ssd:Connector name="y" kind="output">
+## 								<ssc:Real />
+## 								<ssd:ConnectorGeometry x="1.000000" y="0.500000" />
+## 							</ssd:Connector>
+## 							<ssd:Connector name="A" kind="parameter">
+## 								<ssc:Real />
+## 							</ssd:Connector>
+## 							<ssd:Connector name="omega" kind="parameter">
+## 								<ssc:Real />
+## 							</ssd:Connector>
+## 						</ssd:Connectors>
+## 					</ssd:Component>
+## 				</ssd:Elements>
+## 				<ssd:Annotations>
+## 					<ssc:Annotation type="org.openmodelica">
+## 						<oms:Annotations>
+## 							<oms:Buses>
+## 								<oms:Bus name="bus">
+## 									<oms:Signals>
+## 										<oms:Signal name="y1" />
+## 										<oms:Signal name="y2" />
+## 									</oms:Signals>
+## 								</oms:Bus>
+## 							</oms:Buses>
+## 							<oms:Buses>
+## 								<oms:Bus name="tlm" type="tlm" domain="mechanical" dimensions="1" interpolation="none">
+## 									<oms:Signals>
+## 										<oms:Signal name="f" type="effort" />
+## 										<oms:Signal name="v" type="flow" />
+## 										<oms:Signal name="x" type="state" />
+## 									</oms:Signals>
+## 								</oms:Bus>
+## 							</oms:Buses>
+## 							<oms:SimulationInformation>
+## 								<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+## 							</oms:SimulationInformation>
+## 						</oms:Annotations>
+## 					</ssc:Annotation>
+## 				</ssd:Annotations>
+## 			</ssd:System>
+## 		</ssd:Elements>
+## 		<ssd:Connections>
+## 			<ssd:Connection startElement="foo" startConnector="y1" endElement="foo2" endConnector="u1" />
+## 			<ssd:Connection startElement="foo" startConnector="y2" endElement="foo2" endConnector="u2" />
+## 		</ssd:Connections>
+## 		<ssd:Annotations>
+## 			<ssc:Annotation type="org.openmodelica">
+## 				<oms:Annotations>
+## 					<oms:Connections>
+## 						<oms:Connection startElement="foo" startConnector="tlm" endElement="foo2" endConnector="tlm" delay="0.001000" alpha="0.300000" linearimpedance="100.000000" angularimpedance="0.000000" />
+## 						<oms:Connection startElement="foo" startConnector="bus" endElement="foo2" endConnector="bus" />
+## 					</oms:Connections>
+## 					<oms:SimulationInformation>
+## 						<oms:TlmMaster ip="127.0.1.1" managerport="11111" monitorport="11121" />
+## 					</oms:SimulationInformation>
+## 				</oms:Annotations>
+## 			</ssc:Annotation>
+## 		</ssd:Annotations>
+## 	</ssd:System>
+## 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
+## 		<ssd:Annotations>
+## 			<ssc:Annotation type="org.openmodelica">
+## 				<oms:Annotations>
+## 					<oms:SimulationInformation resultFile="test_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter=".*" />
+## 				</oms:Annotations>
+## 			</ssc:Annotation>
+## 		</ssd:Annotations>
+## 	</ssd:DefaultExperiment>
 ## </ssd:SystemStructureDescription>
 ##
 ## status:  [correct] ok
@@ -355,159 +361,165 @@ printStatus(status, 0)
 ## status:  [correct] ok
 ## <?xml version="1.0"?>
 ## <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="test" version="1.0">
-##     <ssd:System name="eoo">
-##         <ssd:Elements>
-##             <ssd:System name="foo2">
-##                 <ssd:Connectors>
-##                     <ssd:Connector name="f" kind="input">
-##                         <ssc:Real />
-##                     </ssd:Connector>
-##                     <ssd:Connector name="x" kind="output">
-##                         <ssc:Real />
-##                     </ssd:Connector>
-##                     <ssd:Connector name="v" kind="output">
-##                         <ssc:Real />
-##                     </ssd:Connector>
-##                     <ssd:Connector name="u1" kind="input">
-##                         <ssc:Real />
-##                     </ssd:Connector>
-##                     <ssd:Connector name="u2" kind="input">
-##                         <ssc:Real />
-##                     </ssd:Connector>
-##                 </ssd:Connectors>
-##                 <ssd:Annotations>
-##                     <ssc:Annotation type="org.openmodelica">
-##                         <oms:Bus name="bus">
-##                             <oms:Signals>
-##                                 <oms:Signal name="u1" />
-##                                 <oms:Signal name="u2" />
-##                             </oms:Signals>
-##                         </oms:Bus>
-##                         <oms:Bus name="tlm" type="tlm" domain="mechanical" dimensions="1" interpolation="none">
-##                             <oms:Signals>
-##                                 <oms:Signal name="f" type="effort" />
-##                                 <oms:Signal name="v" type="flow" />
-##                                 <oms:Signal name="x" type="state" />
-##                             </oms:Signals>
-##                         </oms:Bus>
-##                     </ssc:Annotation>
-##                 </ssd:Annotations>
-##                 <ssd:Annotations>
-##                     <ssc:Annotation type="org.openmodelica">
-##                         <oms:SimulationInformation>
-##                             <oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
-##                         </oms:SimulationInformation>
-##                     </ssc:Annotation>
-##                 </ssd:Annotations>
-##             </ssd:System>
-##             <ssd:System name="foo">
-##                 <ssd:Connectors>
-##                     <ssd:Connector name="f" kind="input">
-##                         <ssc:Real />
-##                     </ssd:Connector>
-##                     <ssd:Connector name="x" kind="output">
-##                         <ssc:Real />
-##                     </ssd:Connector>
-##                     <ssd:Connector name="v" kind="output">
-##                         <ssc:Real />
-##                     </ssd:Connector>
-##                     <ssd:Connector name="y1" kind="output">
-##                         <ssc:Real />
-##                     </ssd:Connector>
-##                     <ssd:Connector name="y2" kind="output">
-##                         <ssc:Real />
-##                     </ssd:Connector>
-##                 </ssd:Connectors>
-##                 <ssd:Elements>
-##                     <ssd:System name="goo">
-##                         <ssd:Annotations>
-##                             <ssc:Annotation type="org.openmodelica">
-##                                 <oms:SimulationInformation>
-##                                     <oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
-##                                 </oms:SimulationInformation>
-##                             </ssc:Annotation>
-##                         </ssd:Annotations>
-##                     </ssd:System>
-##                     <ssd:Component name="T" type="application/table" source="resources/0002_T.csv">
-##                         <ssd:Connectors>
-##                             <ssd:Connector name="time" kind="output">
-##                                 <ssc:Real />
-##                                 <ssd:ConnectorGeometry x="1.000000" y="0.333333" />
-##                             </ssd:Connector>
-##                             <ssd:Connector name="speed" kind="output">
-##                                 <ssc:Real />
-##                                 <ssd:ConnectorGeometry x="1.000000" y="0.666667" />
-##                             </ssd:Connector>
-##                         </ssd:Connectors>
-##                     </ssd:Component>
-##                     <ssd:Component name="A" type="application/x-fmu-sharedlibrary" source="resources/0001_A.fmu">
-##                         <ssd:Connectors>
-##                             <ssd:Connector name="y" kind="output">
-##                                 <ssc:Real />
-##                                 <ssd:ConnectorGeometry x="1.000000" y="0.500000" />
-##                             </ssd:Connector>
-##                             <ssd:Connector name="A" kind="parameter">
-##                                 <ssc:Real />
-##                             </ssd:Connector>
-##                             <ssd:Connector name="omega" kind="parameter">
-##                                 <ssc:Real />
-##                             </ssd:Connector>
-##                         </ssd:Connectors>
-##                     </ssd:Component>
-##                 </ssd:Elements>
-##                 <ssd:Annotations>
-##                     <ssc:Annotation type="org.openmodelica">
-##                         <oms:Bus name="bus">
-##                             <oms:Signals>
-##                                 <oms:Signal name="y1" />
-##                                 <oms:Signal name="y2" />
-##                             </oms:Signals>
-##                         </oms:Bus>
-##                         <oms:Bus name="tlm" type="tlm" domain="mechanical" dimensions="1" interpolation="none">
-##                             <oms:Signals>
-##                                 <oms:Signal name="f" type="effort" />
-##                                 <oms:Signal name="v" type="flow" />
-##                                 <oms:Signal name="x" type="state" />
-##                             </oms:Signals>
-##                         </oms:Bus>
-##                     </ssc:Annotation>
-##                 </ssd:Annotations>
-##                 <ssd:Annotations>
-##                     <ssc:Annotation type="org.openmodelica">
-##                         <oms:SimulationInformation>
-##                             <oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
-##                         </oms:SimulationInformation>
-##                     </ssc:Annotation>
-##                 </ssd:Annotations>
-##             </ssd:System>
-##         </ssd:Elements>
-##         <ssd:Connections>
-##             <ssd:Connection startElement="foo" startConnector="y1" endElement="foo2" endConnector="u1" />
-##             <ssd:Connection startElement="foo" startConnector="y2" endElement="foo2" endConnector="u2" />
-##         </ssd:Connections>
-##         <ssd:Annotations>
-##             <ssc:Annotation type="org.openmodelica">
-##                 <oms:Connections>
-##                     <oms:Connection startElement="foo" startConnector="tlm" endElement="foo2" endConnector="tlm" delay="0.001000" alpha="0.300000" linearimpedance="100.000000" angularimpedance="0.000000" />
-##                     <oms:Connection startElement="foo" startConnector="bus" endElement="foo2" endConnector="bus" />
-##                 </oms:Connections>
-##             </ssc:Annotation>
-##         </ssd:Annotations>
-##         <ssd:Annotations>
-##             <ssc:Annotation type="org.openmodelica">
-##                 <oms:SimulationInformation>
-##                     <oms:TlmMaster ip="" managerport="0" monitorport="0" />
-##                 </oms:SimulationInformation>
-##             </ssc:Annotation>
-##         </ssd:Annotations>
-##     </ssd:System>
-##     <ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
-##         <ssd:Annotations>
-##             <ssc:Annotation type="org.openmodelica">
-##                 <oms:SimulationInformation resultFile="test_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter=".*" />
-##             </ssc:Annotation>
-##         </ssd:Annotations>
-##     </ssd:DefaultExperiment>
+## 	<ssd:System name="eoo">
+## 		<ssd:Elements>
+## 			<ssd:System name="foo2">
+## 				<ssd:Connectors>
+## 					<ssd:Connector name="f" kind="input">
+## 						<ssc:Real />
+## 					</ssd:Connector>
+## 					<ssd:Connector name="x" kind="output">
+## 						<ssc:Real />
+## 					</ssd:Connector>
+## 					<ssd:Connector name="v" kind="output">
+## 						<ssc:Real />
+## 					</ssd:Connector>
+## 					<ssd:Connector name="u1" kind="input">
+## 						<ssc:Real />
+## 					</ssd:Connector>
+## 					<ssd:Connector name="u2" kind="input">
+## 						<ssc:Real />
+## 					</ssd:Connector>
+## 				</ssd:Connectors>
+## 				<ssd:Annotations>
+## 					<ssc:Annotation type="org.openmodelica">
+## 						<oms:Annotations>
+## 							<oms:Buses>
+## 								<oms:Bus name="bus">
+## 									<oms:Signals>
+## 										<oms:Signal name="u1" />
+## 										<oms:Signal name="u2" />
+## 									</oms:Signals>
+## 								</oms:Bus>
+## 							</oms:Buses>
+## 							<oms:Buses>
+## 								<oms:Bus name="tlm" type="tlm" domain="mechanical" dimensions="1" interpolation="none">
+## 									<oms:Signals>
+## 										<oms:Signal name="f" type="effort" />
+## 										<oms:Signal name="v" type="flow" />
+## 										<oms:Signal name="x" type="state" />
+## 									</oms:Signals>
+## 								</oms:Bus>
+## 							</oms:Buses>
+## 							<oms:SimulationInformation>
+## 								<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+## 							</oms:SimulationInformation>
+## 						</oms:Annotations>
+## 					</ssc:Annotation>
+## 				</ssd:Annotations>
+## 			</ssd:System>
+## 			<ssd:System name="foo">
+## 				<ssd:Connectors>
+## 					<ssd:Connector name="f" kind="input">
+## 						<ssc:Real />
+## 					</ssd:Connector>
+## 					<ssd:Connector name="x" kind="output">
+## 						<ssc:Real />
+## 					</ssd:Connector>
+## 					<ssd:Connector name="v" kind="output">
+## 						<ssc:Real />
+## 					</ssd:Connector>
+## 					<ssd:Connector name="y1" kind="output">
+## 						<ssc:Real />
+## 					</ssd:Connector>
+## 					<ssd:Connector name="y2" kind="output">
+## 						<ssc:Real />
+## 					</ssd:Connector>
+## 				</ssd:Connectors>
+## 				<ssd:Elements>
+## 					<ssd:System name="goo">
+## 						<ssd:Annotations>
+## 							<ssc:Annotation type="org.openmodelica">
+## 								<oms:Annotations>
+## 									<oms:SimulationInformation>
+## 										<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+## 									</oms:SimulationInformation>
+## 								</oms:Annotations>
+## 							</ssc:Annotation>
+## 						</ssd:Annotations>
+## 					</ssd:System>
+## 					<ssd:Component name="T" type="application/table" source="resources/0002_T.csv">
+## 						<ssd:Connectors>
+## 							<ssd:Connector name="time" kind="output">
+## 								<ssc:Real />
+## 								<ssd:ConnectorGeometry x="1.000000" y="0.333333" />
+## 							</ssd:Connector>
+## 							<ssd:Connector name="speed" kind="output">
+## 								<ssc:Real />
+## 								<ssd:ConnectorGeometry x="1.000000" y="0.666667" />
+## 							</ssd:Connector>
+## 						</ssd:Connectors>
+## 					</ssd:Component>
+## 					<ssd:Component name="A" type="application/x-fmu-sharedlibrary" source="resources/0001_A.fmu">
+## 						<ssd:Connectors>
+## 							<ssd:Connector name="y" kind="output">
+## 								<ssc:Real />
+## 								<ssd:ConnectorGeometry x="1.000000" y="0.500000" />
+## 							</ssd:Connector>
+## 							<ssd:Connector name="A" kind="parameter">
+## 								<ssc:Real />
+## 							</ssd:Connector>
+## 							<ssd:Connector name="omega" kind="parameter">
+## 								<ssc:Real />
+## 							</ssd:Connector>
+## 						</ssd:Connectors>
+## 					</ssd:Component>
+## 				</ssd:Elements>
+## 				<ssd:Annotations>
+## 					<ssc:Annotation type="org.openmodelica">
+## 						<oms:Annotations>
+## 							<oms:Buses>
+## 								<oms:Bus name="bus">
+## 									<oms:Signals>
+## 										<oms:Signal name="y1" />
+## 										<oms:Signal name="y2" />
+## 									</oms:Signals>
+## 								</oms:Bus>
+## 							</oms:Buses>
+## 							<oms:Buses>
+## 								<oms:Bus name="tlm" type="tlm" domain="mechanical" dimensions="1" interpolation="none">
+## 									<oms:Signals>
+## 										<oms:Signal name="f" type="effort" />
+## 										<oms:Signal name="v" type="flow" />
+## 										<oms:Signal name="x" type="state" />
+## 									</oms:Signals>
+## 								</oms:Bus>
+## 							</oms:Buses>
+## 							<oms:SimulationInformation>
+## 								<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+## 							</oms:SimulationInformation>
+## 						</oms:Annotations>
+## 					</ssc:Annotation>
+## 				</ssd:Annotations>
+## 			</ssd:System>
+## 		</ssd:Elements>
+## 		<ssd:Connections>
+## 			<ssd:Connection startElement="foo" startConnector="y1" endElement="foo2" endConnector="u1" />
+## 			<ssd:Connection startElement="foo" startConnector="y2" endElement="foo2" endConnector="u2" />
+## 		</ssd:Connections>
+## 		<ssd:Annotations>
+## 			<ssc:Annotation type="org.openmodelica">
+## 				<oms:Annotations>
+## 					<oms:Connections>
+## 						<oms:Connection startElement="foo" startConnector="tlm" endElement="foo2" endConnector="tlm" delay="0.001000" alpha="0.300000" linearimpedance="100.000000" angularimpedance="0.000000" />
+## 						<oms:Connection startElement="foo" startConnector="bus" endElement="foo2" endConnector="bus" />
+## 					</oms:Connections>
+## 					<oms:SimulationInformation>
+## 						<oms:TlmMaster ip="" managerport="0" monitorport="0" />
+## 					</oms:SimulationInformation>
+## 				</oms:Annotations>
+## 			</ssc:Annotation>
+## 		</ssd:Annotations>
+## 	</ssd:System>
+## 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
+## 		<ssd:Annotations>
+## 			<ssc:Annotation type="org.openmodelica">
+## 				<oms:Annotations>
+## 					<oms:SimulationInformation resultFile="test_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter=".*" />
+## 				</oms:Annotations>
+## 			</ssc:Annotation>
+## 		</ssd:Annotations>
+## 	</ssd:DefaultExperiment>
 ## </ssd:SystemStructureDescription>
 ##
 ## status:  [correct] ok

--- a/testsuite/OMSimulator/import_export_parameters_inline.lua
+++ b/testsuite/OMSimulator/import_export_parameters_inline.lua
@@ -176,9 +176,11 @@ oms_delete("import_export_parameters")
 -- 				</ssd:ParameterBindings>
 -- 				<ssd:Annotations>
 -- 					<ssc:Annotation type="org.openmodelica">
--- 						<oms:SimulationInformation>
--- 							<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
--- 						</oms:SimulationInformation>
+-- 						<oms:Annotations>
+-- 							<oms:SimulationInformation>
+-- 								<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+-- 							</oms:SimulationInformation>
+-- 						</oms:Annotations>
 -- 					</ssc:Annotation>
 -- 				</ssd:Annotations>
 -- 			</ssd:System>
@@ -286,16 +288,20 @@ oms_delete("import_export_parameters")
 -- 		</ssd:Connections>
 -- 		<ssd:Annotations>
 -- 			<ssc:Annotation type="org.openmodelica">
--- 				<oms:SimulationInformation>
--- 					<oms:FixedStepMaster description="oms-ma" stepSize="0.001000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
--- 				</oms:SimulationInformation>
+-- 				<oms:Annotations>
+-- 					<oms:SimulationInformation>
+-- 						<oms:FixedStepMaster description="oms-ma" stepSize="0.001000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+-- 					</oms:SimulationInformation>
+-- 				</oms:Annotations>
 -- 			</ssc:Annotation>
 -- 		</ssd:Annotations>
 -- 	</ssd:System>
 -- 	<ssd:DefaultExperiment startTime="0.000000" stopTime="4.000000">
 -- 		<ssd:Annotations>
 -- 			<ssc:Annotation type="org.openmodelica">
--- 				<oms:SimulationInformation resultFile="import_export_parameters_inline.mat" loggingInterval="0.000000" bufferSize="100" signalFilter=".*" />
+-- 				<oms:Annotations>
+-- 					<oms:SimulationInformation resultFile="import_export_parameters_inline.mat" loggingInterval="0.000000" bufferSize="100" signalFilter=".*" />
+-- 				</oms:Annotations>
 -- 			</ssc:Annotation>
 -- 		</ssd:Annotations>
 -- 	</ssd:DefaultExperiment>

--- a/testsuite/OMSimulator/import_export_parameters_to_ssv.lua
+++ b/testsuite/OMSimulator/import_export_parameters_to_ssv.lua
@@ -147,9 +147,11 @@ oms_delete("import_export_parameters")
 -- 				</ssd:Connectors>
 -- 				<ssd:Annotations>
 -- 					<ssc:Annotation type="org.openmodelica">
--- 						<oms:SimulationInformation>
--- 							<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
--- 						</oms:SimulationInformation>
+-- 						<oms:Annotations>
+-- 							<oms:SimulationInformation>
+-- 								<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+-- 							</oms:SimulationInformation>
+-- 						</oms:Annotations>
 -- 					</ssc:Annotation>
 -- 				</ssd:Annotations>
 -- 			</ssd:System>
@@ -228,16 +230,20 @@ oms_delete("import_export_parameters")
 -- 		</ssd:Connections>
 -- 		<ssd:Annotations>
 -- 			<ssc:Annotation type="org.openmodelica">
--- 				<oms:SimulationInformation>
--- 					<oms:FixedStepMaster description="oms-ma" stepSize="0.001000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
--- 				</oms:SimulationInformation>
+-- 				<oms:Annotations>
+-- 					<oms:SimulationInformation>
+-- 						<oms:FixedStepMaster description="oms-ma" stepSize="0.001000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+-- 					</oms:SimulationInformation>
+-- 				</oms:Annotations>
 -- 			</ssc:Annotation>
 -- 		</ssd:Annotations>
 -- 	</ssd:System>
 -- 	<ssd:DefaultExperiment startTime="0.000000" stopTime="4.000000">
 -- 		<ssd:Annotations>
 -- 			<ssc:Annotation type="org.openmodelica">
--- 				<oms:SimulationInformation resultFile="import_export_parameters.mat" loggingInterval="0.000000" bufferSize="100" signalFilter=".*" />
+-- 				<oms:Annotations>
+-- 					<oms:SimulationInformation resultFile="import_export_parameters.mat" loggingInterval="0.000000" bufferSize="100" signalFilter=".*" />
+-- 				</oms:Annotations>
 -- 			</ssc:Annotation>
 -- 		</ssd:Annotations>
 -- 	</ssd:DefaultExperiment>

--- a/testsuite/OMSimulator/import_export_snapshot.lua
+++ b/testsuite/OMSimulator/import_export_snapshot.lua
@@ -85,16 +85,20 @@ oms_delete("import_export_snapshot")
 -- 		</ssd:Elements>
 -- 		<ssd:Annotations>
 -- 			<ssc:Annotation type="org.openmodelica">
--- 				<oms:SimulationInformation>
--- 					<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
--- 				</oms:SimulationInformation>
+-- 				<oms:Annotations>
+-- 					<oms:SimulationInformation>
+-- 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+-- 					</oms:SimulationInformation>
+-- 				</oms:Annotations>
 -- 			</ssc:Annotation>
 -- 		</ssd:Annotations>
 -- 	</ssd:System>
 -- 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
 -- 		<ssd:Annotations>
 -- 			<ssc:Annotation type="org.openmodelica">
--- 				<oms:SimulationInformation resultFile="import_export_snapshot_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter=".*" />
+-- 				<oms:Annotations>
+-- 					<oms:SimulationInformation resultFile="import_export_snapshot_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter=".*" />
+-- 				</oms:Annotations>
 -- 			</ssc:Annotation>
 -- 		</ssd:Annotations>
 -- 	</ssd:DefaultExperiment>
@@ -139,16 +143,20 @@ oms_delete("import_export_snapshot")
 -- 				</ssd:Elements>
 -- 				<ssd:Annotations>
 -- 					<ssc:Annotation type="org.openmodelica">
--- 						<oms:SimulationInformation>
--- 							<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
--- 						</oms:SimulationInformation>
+-- 						<oms:Annotations>
+-- 							<oms:SimulationInformation>
+-- 								<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+-- 							</oms:SimulationInformation>
+-- 						</oms:Annotations>
 -- 					</ssc:Annotation>
 -- 				</ssd:Annotations>
 -- 			</ssd:System>
 -- 			<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
 -- 				<ssd:Annotations>
 -- 					<ssc:Annotation type="org.openmodelica">
--- 						<oms:SimulationInformation resultFile="import_export_snapshot_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter=".*" />
+-- 						<oms:Annotations>
+-- 							<oms:SimulationInformation resultFile="import_export_snapshot_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter=".*" />
+-- 						</oms:Annotations>
 -- 					</ssc:Annotation>
 -- 				</ssd:Annotations>
 -- 			</ssd:DefaultExperiment>

--- a/testsuite/OMSimulator/setExternalInputs.lua
+++ b/testsuite/OMSimulator/setExternalInputs.lua
@@ -66,16 +66,20 @@ oms_delete("setExternalInputs")
 -- 		</ssd:Elements>
 -- 		<ssd:Annotations>
 -- 			<ssc:Annotation type="org.openmodelica">
--- 				<oms:SimulationInformation>
--- 					<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
--- 				</oms:SimulationInformation>
+-- 				<oms:Annotations>
+-- 					<oms:SimulationInformation>
+-- 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+-- 					</oms:SimulationInformation>
+-- 				</oms:Annotations>
 -- 			</ssc:Annotation>
 -- 		</ssd:Annotations>
 -- 	</ssd:System>
 -- 	<ssd:DefaultExperiment startTime="0.000000" stopTime="5.000000">
 -- 		<ssd:Annotations>
 -- 			<ssc:Annotation type="org.openmodelica">
--- 				<oms:SimulationInformation resultFile="setExternalInputs_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter=".*" />
+-- 				<oms:Annotations>
+-- 					<oms:SimulationInformation resultFile="setExternalInputs_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter=".*" />
+-- 				</oms:Annotations>
 -- 			</ssc:Annotation>
 -- 		</ssd:Annotations>
 -- 	</ssd:DefaultExperiment>

--- a/testsuite/OMSimulator/snapshot.lua
+++ b/testsuite/OMSimulator/snapshot.lua
@@ -68,16 +68,20 @@ oms_delete("snapshot")
 -- 				</ssd:Elements>
 -- 				<ssd:Annotations>
 -- 					<ssc:Annotation type="org.openmodelica">
--- 						<oms:SimulationInformation>
--- 							<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
--- 						</oms:SimulationInformation>
+-- 						<oms:Annotations>
+-- 							<oms:SimulationInformation>
+-- 								<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+-- 							</oms:SimulationInformation>
+-- 						</oms:Annotations>
 -- 					</ssc:Annotation>
 -- 				</ssd:Annotations>
 -- 			</ssd:System>
 -- 			<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
 -- 				<ssd:Annotations>
 -- 					<ssc:Annotation type="org.openmodelica">
--- 						<oms:SimulationInformation resultFile="snapshot_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter=".*" />
+-- 						<oms:Annotations>
+-- 							<oms:SimulationInformation resultFile="snapshot_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter=".*" />
+-- 						</oms:Annotations>
 -- 					</ssc:Annotation>
 -- 				</ssd:Annotations>
 -- 			</ssd:DefaultExperiment>

--- a/testsuite/OMSimulator/snapshot.py
+++ b/testsuite/OMSimulator/snapshot.py
@@ -72,16 +72,20 @@ oms.delete("snapshot")
 ## 				</ssd:Elements>
 ## 				<ssd:Annotations>
 ## 					<ssc:Annotation type="org.openmodelica">
-## 						<oms:SimulationInformation>
-## 							<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
-## 						</oms:SimulationInformation>
+## 						<oms:Annotations>
+## 							<oms:SimulationInformation>
+## 								<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+## 							</oms:SimulationInformation>
+## 						</oms:Annotations>
 ## 					</ssc:Annotation>
 ## 				</ssd:Annotations>
 ## 			</ssd:System>
 ## 			<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
 ## 				<ssd:Annotations>
 ## 					<ssc:Annotation type="org.openmodelica">
-## 						<oms:SimulationInformation resultFile="snapshot_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter=".*" />
+## 						<oms:Annotations>
+## 							<oms:SimulationInformation resultFile="snapshot_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter=".*" />
+## 						</oms:Annotations>
 ## 					</ssc:Annotation>
 ## 				</ssd:Annotations>
 ## 			</ssd:DefaultExperiment>

--- a/testsuite/api/buses.lua
+++ b/testsuite/api/buses.lua
@@ -120,19 +120,19 @@ printStatus(status, 0)
 -- 			</ssd:Connectors>
 -- 			<ssd:Annotations>
 -- 				<ssc:Annotation type="org.openmodelica">
--- 					<oms:Bus name="bus2">
--- 						<oms:Signals>
--- 							<oms:Signal name="y1" />
--- 							<oms:Signal name="y2" />
--- 						</oms:Signals>
--- 					</oms:Bus>
--- 				</ssc:Annotation>
--- 			</ssd:Annotations>
--- 			<ssd:Annotations>
--- 				<ssc:Annotation type="org.openmodelica">
--- 					<oms:SimulationInformation>
--- 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
--- 					</oms:SimulationInformation>
+-- 					<oms:Annotations>
+-- 						<oms:Buses>
+-- 							<oms:Bus name="bus2">
+-- 								<oms:Signals>
+-- 									<oms:Signal name="y1" />
+-- 									<oms:Signal name="y2" />
+-- 								</oms:Signals>
+-- 							</oms:Bus>
+-- 						</oms:Buses>
+-- 						<oms:SimulationInformation>
+-- 							<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+-- 						</oms:SimulationInformation>
+-- 					</oms:Annotations>
 -- 				</ssc:Annotation>
 -- 			</ssd:Annotations>
 -- 		</ssd:System>
@@ -150,20 +150,20 @@ printStatus(status, 0)
 -- 			</ssd:Connectors>
 -- 			<ssd:Annotations>
 -- 				<ssc:Annotation type="org.openmodelica">
--- 					<oms:Bus name="bus1">
--- 						<oms:Signals>
--- 							<oms:Signal name="u1" />
--- 							<oms:Signal name="u2" />
--- 							<oms:Signal name="y" />
--- 						</oms:Signals>
--- 					</oms:Bus>
--- 				</ssc:Annotation>
--- 			</ssd:Annotations>
--- 			<ssd:Annotations>
--- 				<ssc:Annotation type="org.openmodelica">
--- 					<oms:SimulationInformation>
--- 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
--- 					</oms:SimulationInformation>
+-- 					<oms:Annotations>
+-- 						<oms:Buses>
+-- 							<oms:Bus name="bus1">
+-- 								<oms:Signals>
+-- 									<oms:Signal name="u1" />
+-- 									<oms:Signal name="u2" />
+-- 									<oms:Signal name="y" />
+-- 								</oms:Signals>
+-- 							</oms:Bus>
+-- 						</oms:Buses>
+-- 						<oms:SimulationInformation>
+-- 							<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+-- 						</oms:SimulationInformation>
+-- 					</oms:Annotations>
 -- 				</ssc:Annotation>
 -- 			</ssd:Annotations>
 -- 		</ssd:System>
@@ -174,16 +174,14 @@ printStatus(status, 0)
 -- 	</ssd:Connections>
 -- 	<ssd:Annotations>
 -- 		<ssc:Annotation type="org.openmodelica">
--- 			<oms:Connections>
--- 				<oms:Connection startElement="wc1" startConnector="bus1" endElement="wc2" endConnector="bus2" />
--- 			</oms:Connections>
--- 		</ssc:Annotation>
--- 	</ssd:Annotations>
--- 	<ssd:Annotations>
--- 		<ssc:Annotation type="org.openmodelica">
--- 			<oms:SimulationInformation>
--- 				<oms:TlmMaster ip="" managerport="0" monitorport="0" />
--- 			</oms:SimulationInformation>
+-- 			<oms:Annotations>
+-- 				<oms:Connections>
+-- 					<oms:Connection startElement="wc1" startConnector="bus1" endElement="wc2" endConnector="bus2" />
+-- 				</oms:Connections>
+-- 				<oms:SimulationInformation>
+-- 					<oms:TlmMaster ip="" managerport="0" monitorport="0" />
+-- 				</oms:SimulationInformation>
+-- 			</oms:Annotations>
 -- 		</ssc:Annotation>
 -- 	</ssd:Annotations>
 -- </ssd:System>
@@ -206,19 +204,19 @@ printStatus(status, 0)
 -- 			</ssd:Connectors>
 -- 			<ssd:Annotations>
 -- 				<ssc:Annotation type="org.openmodelica">
--- 					<oms:Bus name="bus2">
--- 						<oms:Signals>
--- 							<oms:Signal name="y1" />
--- 							<oms:Signal name="y2" />
--- 						</oms:Signals>
--- 					</oms:Bus>
--- 				</ssc:Annotation>
--- 			</ssd:Annotations>
--- 			<ssd:Annotations>
--- 				<ssc:Annotation type="org.openmodelica">
--- 					<oms:SimulationInformation>
--- 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
--- 					</oms:SimulationInformation>
+-- 					<oms:Annotations>
+-- 						<oms:Buses>
+-- 							<oms:Bus name="bus2">
+-- 								<oms:Signals>
+-- 									<oms:Signal name="y1" />
+-- 									<oms:Signal name="y2" />
+-- 								</oms:Signals>
+-- 							</oms:Bus>
+-- 						</oms:Buses>
+-- 						<oms:SimulationInformation>
+-- 							<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+-- 						</oms:SimulationInformation>
+-- 					</oms:Annotations>
 -- 				</ssc:Annotation>
 -- 			</ssd:Annotations>
 -- 		</ssd:System>
@@ -236,19 +234,19 @@ printStatus(status, 0)
 -- 			</ssd:Connectors>
 -- 			<ssd:Annotations>
 -- 				<ssc:Annotation type="org.openmodelica">
--- 					<oms:Bus name="bus1">
--- 						<oms:Signals>
--- 							<oms:Signal name="u1" />
--- 							<oms:Signal name="u2" />
--- 						</oms:Signals>
--- 					</oms:Bus>
--- 				</ssc:Annotation>
--- 			</ssd:Annotations>
--- 			<ssd:Annotations>
--- 				<ssc:Annotation type="org.openmodelica">
--- 					<oms:SimulationInformation>
--- 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
--- 					</oms:SimulationInformation>
+-- 					<oms:Annotations>
+-- 						<oms:Buses>
+-- 							<oms:Bus name="bus1">
+-- 								<oms:Signals>
+-- 									<oms:Signal name="u1" />
+-- 									<oms:Signal name="u2" />
+-- 								</oms:Signals>
+-- 							</oms:Bus>
+-- 						</oms:Buses>
+-- 						<oms:SimulationInformation>
+-- 							<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+-- 						</oms:SimulationInformation>
+-- 					</oms:Annotations>
 -- 				</ssc:Annotation>
 -- 			</ssd:Annotations>
 -- 		</ssd:System>
@@ -259,16 +257,14 @@ printStatus(status, 0)
 -- 	</ssd:Connections>
 -- 	<ssd:Annotations>
 -- 		<ssc:Annotation type="org.openmodelica">
--- 			<oms:Connections>
--- 				<oms:Connection startElement="wc1" startConnector="bus1" endElement="wc2" endConnector="bus2" />
--- 			</oms:Connections>
--- 		</ssc:Annotation>
--- 	</ssd:Annotations>
--- 	<ssd:Annotations>
--- 		<ssc:Annotation type="org.openmodelica">
--- 			<oms:SimulationInformation>
--- 				<oms:TlmMaster ip="" managerport="0" monitorport="0" />
--- 			</oms:SimulationInformation>
+-- 			<oms:Annotations>
+-- 				<oms:Connections>
+-- 					<oms:Connection startElement="wc1" startConnector="bus1" endElement="wc2" endConnector="bus2" />
+-- 				</oms:Connections>
+-- 				<oms:SimulationInformation>
+-- 					<oms:TlmMaster ip="" managerport="0" monitorport="0" />
+-- 				</oms:SimulationInformation>
+-- 			</oms:Annotations>
 -- 		</ssc:Annotation>
 -- 	</ssd:Annotations>
 -- </ssd:System>

--- a/testsuite/api/buses.py
+++ b/testsuite/api/buses.py
@@ -119,19 +119,19 @@ printStatus(status, 0)
 ## 			</ssd:Connectors>
 ## 			<ssd:Annotations>
 ## 				<ssc:Annotation type="org.openmodelica">
-## 					<oms:Bus name="bus2">
-## 						<oms:Signals>
-## 							<oms:Signal name="y1" />
-## 							<oms:Signal name="y2" />
-## 						</oms:Signals>
-## 					</oms:Bus>
-## 				</ssc:Annotation>
-## 			</ssd:Annotations>
-## 			<ssd:Annotations>
-## 				<ssc:Annotation type="org.openmodelica">
-## 					<oms:SimulationInformation>
-## 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
-## 					</oms:SimulationInformation>
+## 					<oms:Annotations>
+## 						<oms:Buses>
+## 							<oms:Bus name="bus2">
+## 								<oms:Signals>
+## 									<oms:Signal name="y1" />
+## 									<oms:Signal name="y2" />
+## 								</oms:Signals>
+## 							</oms:Bus>
+## 						</oms:Buses>
+## 						<oms:SimulationInformation>
+## 							<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+## 						</oms:SimulationInformation>
+## 					</oms:Annotations>
 ## 				</ssc:Annotation>
 ## 			</ssd:Annotations>
 ## 		</ssd:System>
@@ -149,20 +149,20 @@ printStatus(status, 0)
 ## 			</ssd:Connectors>
 ## 			<ssd:Annotations>
 ## 				<ssc:Annotation type="org.openmodelica">
-## 					<oms:Bus name="bus1">
-## 						<oms:Signals>
-## 							<oms:Signal name="u1" />
-## 							<oms:Signal name="u2" />
-## 							<oms:Signal name="y" />
-## 						</oms:Signals>
-## 					</oms:Bus>
-## 				</ssc:Annotation>
-## 			</ssd:Annotations>
-## 			<ssd:Annotations>
-## 				<ssc:Annotation type="org.openmodelica">
-## 					<oms:SimulationInformation>
-## 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
-## 					</oms:SimulationInformation>
+## 					<oms:Annotations>
+## 						<oms:Buses>
+## 							<oms:Bus name="bus1">
+## 								<oms:Signals>
+## 									<oms:Signal name="u1" />
+## 									<oms:Signal name="u2" />
+## 									<oms:Signal name="y" />
+## 								</oms:Signals>
+## 							</oms:Bus>
+## 						</oms:Buses>
+## 						<oms:SimulationInformation>
+## 							<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+## 						</oms:SimulationInformation>
+## 					</oms:Annotations>
 ## 				</ssc:Annotation>
 ## 			</ssd:Annotations>
 ## 		</ssd:System>
@@ -173,16 +173,14 @@ printStatus(status, 0)
 ## 	</ssd:Connections>
 ## 	<ssd:Annotations>
 ## 		<ssc:Annotation type="org.openmodelica">
-## 			<oms:Connections>
-## 				<oms:Connection startElement="wc1" startConnector="bus1" endElement="wc2" endConnector="bus2" />
-## 			</oms:Connections>
-## 		</ssc:Annotation>
-## 	</ssd:Annotations>
-## 	<ssd:Annotations>
-## 		<ssc:Annotation type="org.openmodelica">
-## 			<oms:SimulationInformation>
-## 				<oms:TlmMaster ip="" managerport="0" monitorport="0" />
-## 			</oms:SimulationInformation>
+## 			<oms:Annotations>
+## 				<oms:Connections>
+## 					<oms:Connection startElement="wc1" startConnector="bus1" endElement="wc2" endConnector="bus2" />
+## 				</oms:Connections>
+## 				<oms:SimulationInformation>
+## 					<oms:TlmMaster ip="" managerport="0" monitorport="0" />
+## 				</oms:SimulationInformation>
+## 			</oms:Annotations>
 ## 		</ssc:Annotation>
 ## 	</ssd:Annotations>
 ## </ssd:System>
@@ -205,19 +203,19 @@ printStatus(status, 0)
 ## 			</ssd:Connectors>
 ## 			<ssd:Annotations>
 ## 				<ssc:Annotation type="org.openmodelica">
-## 					<oms:Bus name="bus2">
-## 						<oms:Signals>
-## 							<oms:Signal name="y1" />
-## 							<oms:Signal name="y2" />
-## 						</oms:Signals>
-## 					</oms:Bus>
-## 				</ssc:Annotation>
-## 			</ssd:Annotations>
-## 			<ssd:Annotations>
-## 				<ssc:Annotation type="org.openmodelica">
-## 					<oms:SimulationInformation>
-## 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
-## 					</oms:SimulationInformation>
+## 					<oms:Annotations>
+## 						<oms:Buses>
+## 							<oms:Bus name="bus2">
+## 								<oms:Signals>
+## 									<oms:Signal name="y1" />
+## 									<oms:Signal name="y2" />
+## 								</oms:Signals>
+## 							</oms:Bus>
+## 						</oms:Buses>
+## 						<oms:SimulationInformation>
+## 							<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+## 						</oms:SimulationInformation>
+## 					</oms:Annotations>
 ## 				</ssc:Annotation>
 ## 			</ssd:Annotations>
 ## 		</ssd:System>
@@ -235,19 +233,19 @@ printStatus(status, 0)
 ## 			</ssd:Connectors>
 ## 			<ssd:Annotations>
 ## 				<ssc:Annotation type="org.openmodelica">
-## 					<oms:Bus name="bus1">
-## 						<oms:Signals>
-## 							<oms:Signal name="u1" />
-## 							<oms:Signal name="u2" />
-## 						</oms:Signals>
-## 					</oms:Bus>
-## 				</ssc:Annotation>
-## 			</ssd:Annotations>
-## 			<ssd:Annotations>
-## 				<ssc:Annotation type="org.openmodelica">
-## 					<oms:SimulationInformation>
-## 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
-## 					</oms:SimulationInformation>
+## 					<oms:Annotations>
+## 						<oms:Buses>
+## 							<oms:Bus name="bus1">
+## 								<oms:Signals>
+## 									<oms:Signal name="u1" />
+## 									<oms:Signal name="u2" />
+## 								</oms:Signals>
+## 							</oms:Bus>
+## 						</oms:Buses>
+## 						<oms:SimulationInformation>
+## 							<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+## 						</oms:SimulationInformation>
+## 					</oms:Annotations>
 ## 				</ssc:Annotation>
 ## 			</ssd:Annotations>
 ## 		</ssd:System>
@@ -258,16 +256,14 @@ printStatus(status, 0)
 ## 	</ssd:Connections>
 ## 	<ssd:Annotations>
 ## 		<ssc:Annotation type="org.openmodelica">
-## 			<oms:Connections>
-## 				<oms:Connection startElement="wc1" startConnector="bus1" endElement="wc2" endConnector="bus2" />
-## 			</oms:Connections>
-## 		</ssc:Annotation>
-## 	</ssd:Annotations>
-## 	<ssd:Annotations>
-## 		<ssc:Annotation type="org.openmodelica">
-## 			<oms:SimulationInformation>
-## 				<oms:TlmMaster ip="" managerport="0" monitorport="0" />
-## 			</oms:SimulationInformation>
+## 			<oms:Annotations>
+## 				<oms:Connections>
+## 					<oms:Connection startElement="wc1" startConnector="bus1" endElement="wc2" endConnector="bus2" />
+## 				</oms:Connections>
+## 				<oms:SimulationInformation>
+## 					<oms:TlmMaster ip="" managerport="0" monitorport="0" />
+## 				</oms:SimulationInformation>
+## 			</oms:Annotations>
 ## 		</ssc:Annotation>
 ## 	</ssd:Annotations>
 ## </ssd:System>

--- a/testsuite/api/connections.lua
+++ b/testsuite/api/connections.lua
@@ -109,9 +109,11 @@ printStatus(status, 0)
 -- 			</ssd:Connectors>
 -- 			<ssd:Annotations>
 -- 				<ssc:Annotation type="org.openmodelica">
--- 					<oms:SimulationInformation>
--- 						<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
--- 					</oms:SimulationInformation>
+-- 					<oms:Annotations>
+-- 						<oms:SimulationInformation>
+-- 							<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+-- 						</oms:SimulationInformation>
+-- 					</oms:Annotations>
 -- 				</ssc:Annotation>
 -- 			</ssd:Annotations>
 -- 		</ssd:System>
@@ -129,9 +131,11 @@ printStatus(status, 0)
 -- 			</ssd:Connectors>
 -- 			<ssd:Annotations>
 -- 				<ssc:Annotation type="org.openmodelica">
--- 					<oms:SimulationInformation>
--- 						<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
--- 					</oms:SimulationInformation>
+-- 					<oms:Annotations>
+-- 						<oms:SimulationInformation>
+-- 							<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+-- 						</oms:SimulationInformation>
+-- 					</oms:Annotations>
 -- 				</ssc:Annotation>
 -- 			</ssd:Annotations>
 -- 		</ssd:System>
@@ -141,9 +145,11 @@ printStatus(status, 0)
 -- 	</ssd:Connections>
 -- 	<ssd:Annotations>
 -- 		<ssc:Annotation type="org.openmodelica">
--- 			<oms:SimulationInformation>
--- 				<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
--- 			</oms:SimulationInformation>
+-- 			<oms:Annotations>
+-- 				<oms:SimulationInformation>
+-- 					<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+-- 				</oms:SimulationInformation>
+-- 			</oms:Annotations>
 -- 		</ssc:Annotation>
 -- 	</ssd:Annotations>
 -- </ssd:System>
@@ -166,9 +172,11 @@ printStatus(status, 0)
 -- 			</ssd:Connectors>
 -- 			<ssd:Annotations>
 -- 				<ssc:Annotation type="org.openmodelica">
--- 					<oms:SimulationInformation>
--- 						<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
--- 					</oms:SimulationInformation>
+-- 					<oms:Annotations>
+-- 						<oms:SimulationInformation>
+-- 							<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+-- 						</oms:SimulationInformation>
+-- 					</oms:Annotations>
 -- 				</ssc:Annotation>
 -- 			</ssd:Annotations>
 -- 		</ssd:System>
@@ -186,18 +194,22 @@ printStatus(status, 0)
 -- 			</ssd:Connectors>
 -- 			<ssd:Annotations>
 -- 				<ssc:Annotation type="org.openmodelica">
--- 					<oms:SimulationInformation>
--- 						<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
--- 					</oms:SimulationInformation>
+-- 					<oms:Annotations>
+-- 						<oms:SimulationInformation>
+-- 							<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+-- 						</oms:SimulationInformation>
+-- 					</oms:Annotations>
 -- 				</ssc:Annotation>
 -- 			</ssd:Annotations>
 -- 		</ssd:System>
 -- 	</ssd:Elements>
 -- 	<ssd:Annotations>
 -- 		<ssc:Annotation type="org.openmodelica">
--- 			<oms:SimulationInformation>
--- 				<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
--- 			</oms:SimulationInformation>
+-- 			<oms:Annotations>
+-- 				<oms:SimulationInformation>
+-- 					<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+-- 				</oms:SimulationInformation>
+-- 			</oms:Annotations>
 -- 		</ssc:Annotation>
 -- 	</ssd:Annotations>
 -- </ssd:System>

--- a/testsuite/api/connections.py
+++ b/testsuite/api/connections.py
@@ -109,9 +109,11 @@ printStatus(status, 0)
 ## 			</ssd:Connectors>
 ## 			<ssd:Annotations>
 ## 				<ssc:Annotation type="org.openmodelica">
-## 					<oms:SimulationInformation>
-## 						<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
-## 					</oms:SimulationInformation>
+## 					<oms:Annotations>
+## 						<oms:SimulationInformation>
+## 							<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+## 						</oms:SimulationInformation>
+## 					</oms:Annotations>
 ## 				</ssc:Annotation>
 ## 			</ssd:Annotations>
 ## 		</ssd:System>
@@ -129,9 +131,11 @@ printStatus(status, 0)
 ## 			</ssd:Connectors>
 ## 			<ssd:Annotations>
 ## 				<ssc:Annotation type="org.openmodelica">
-## 					<oms:SimulationInformation>
-## 						<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
-## 					</oms:SimulationInformation>
+## 					<oms:Annotations>
+## 						<oms:SimulationInformation>
+## 							<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+## 						</oms:SimulationInformation>
+## 					</oms:Annotations>
 ## 				</ssc:Annotation>
 ## 			</ssd:Annotations>
 ## 		</ssd:System>
@@ -141,9 +145,11 @@ printStatus(status, 0)
 ## 	</ssd:Connections>
 ## 	<ssd:Annotations>
 ## 		<ssc:Annotation type="org.openmodelica">
-## 			<oms:SimulationInformation>
-## 				<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
-## 			</oms:SimulationInformation>
+## 			<oms:Annotations>
+## 				<oms:SimulationInformation>
+## 					<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+## 				</oms:SimulationInformation>
+## 			</oms:Annotations>
 ## 		</ssc:Annotation>
 ## 	</ssd:Annotations>
 ## </ssd:System>
@@ -166,9 +172,11 @@ printStatus(status, 0)
 ## 			</ssd:Connectors>
 ## 			<ssd:Annotations>
 ## 				<ssc:Annotation type="org.openmodelica">
-## 					<oms:SimulationInformation>
-## 						<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
-## 					</oms:SimulationInformation>
+## 					<oms:Annotations>
+## 						<oms:SimulationInformation>
+## 							<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+## 						</oms:SimulationInformation>
+## 					</oms:Annotations>
 ## 				</ssc:Annotation>
 ## 			</ssd:Annotations>
 ## 		</ssd:System>
@@ -186,18 +194,22 @@ printStatus(status, 0)
 ## 			</ssd:Connectors>
 ## 			<ssd:Annotations>
 ## 				<ssc:Annotation type="org.openmodelica">
-## 					<oms:SimulationInformation>
-## 						<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
-## 					</oms:SimulationInformation>
+## 					<oms:Annotations>
+## 						<oms:SimulationInformation>
+## 							<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+## 						</oms:SimulationInformation>
+## 					</oms:Annotations>
 ## 				</ssc:Annotation>
 ## 			</ssd:Annotations>
 ## 		</ssd:System>
 ## 	</ssd:Elements>
 ## 	<ssd:Annotations>
 ## 		<ssc:Annotation type="org.openmodelica">
-## 			<oms:SimulationInformation>
-## 				<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
-## 			</oms:SimulationInformation>
+## 			<oms:Annotations>
+## 				<oms:SimulationInformation>
+## 					<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+## 				</oms:SimulationInformation>
+## 			</oms:Annotations>
 ## 		</ssc:Annotation>
 ## 	</ssd:Annotations>
 ## </ssd:System>

--- a/testsuite/api/test01.lua
+++ b/testsuite/api/test01.lua
@@ -93,25 +93,31 @@ printStatus(status, 3)
 -- 			<ssd:System name="goo">
 -- 				<ssd:Annotations>
 -- 					<ssc:Annotation type="org.openmodelica">
--- 						<oms:SimulationInformation>
--- 							<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
--- 						</oms:SimulationInformation>
+-- 						<oms:Annotations>
+-- 							<oms:SimulationInformation>
+-- 								<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+-- 							</oms:SimulationInformation>
+-- 						</oms:Annotations>
 -- 					</ssc:Annotation>
 -- 				</ssd:Annotations>
 -- 			</ssd:System>
 -- 		</ssd:Elements>
 -- 		<ssd:Annotations>
 -- 			<ssc:Annotation type="org.openmodelica">
--- 				<oms:SimulationInformation>
--- 					<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
--- 				</oms:SimulationInformation>
+-- 				<oms:Annotations>
+-- 					<oms:SimulationInformation>
+-- 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+-- 					</oms:SimulationInformation>
+-- 				</oms:Annotations>
 -- 			</ssc:Annotation>
 -- 		</ssd:Annotations>
 -- 	</ssd:System>
 -- 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
 -- 		<ssd:Annotations>
 -- 			<ssc:Annotation type="org.openmodelica">
--- 				<oms:SimulationInformation resultFile="test_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter=".*" />
+-- 				<oms:Annotations>
+-- 					<oms:SimulationInformation resultFile="test_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter=".*" />
+-- 				</oms:Annotations>
 -- 			</ssc:Annotation>
 -- 		</ssd:Annotations>
 -- 	</ssd:DefaultExperiment>
@@ -123,18 +129,22 @@ printStatus(status, 3)
 -- 		<ssd:System name="goo">
 -- 			<ssd:Annotations>
 -- 				<ssc:Annotation type="org.openmodelica">
--- 					<oms:SimulationInformation>
--- 						<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
--- 					</oms:SimulationInformation>
+-- 					<oms:Annotations>
+-- 						<oms:SimulationInformation>
+-- 							<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+-- 						</oms:SimulationInformation>
+-- 					</oms:Annotations>
 -- 				</ssc:Annotation>
 -- 			</ssd:Annotations>
 -- 		</ssd:System>
 -- 	</ssd:Elements>
 -- 	<ssd:Annotations>
 -- 		<ssc:Annotation type="org.openmodelica">
--- 			<oms:SimulationInformation>
--- 				<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
--- 			</oms:SimulationInformation>
+-- 			<oms:Annotations>
+-- 				<oms:SimulationInformation>
+-- 					<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+-- 				</oms:SimulationInformation>
+-- 			</oms:Annotations>
 -- 		</ssc:Annotation>
 -- 	</ssd:Annotations>
 -- </ssd:System>
@@ -143,9 +153,11 @@ printStatus(status, 3)
 -- <ssd:System name="goo">
 -- 	<ssd:Annotations>
 -- 		<ssc:Annotation type="org.openmodelica">
--- 			<oms:SimulationInformation>
--- 				<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
--- 			</oms:SimulationInformation>
+-- 			<oms:Annotations>
+-- 				<oms:SimulationInformation>
+-- 					<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+-- 				</oms:SimulationInformation>
+-- 			</oms:Annotations>
 -- 		</ssc:Annotation>
 -- 	</ssd:Annotations>
 -- </ssd:System>
@@ -162,7 +174,9 @@ printStatus(status, 3)
 -- 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
 -- 		<ssd:Annotations>
 -- 			<ssc:Annotation type="org.openmodelica">
--- 				<oms:SimulationInformation resultFile="test_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter=".*" />
+-- 				<oms:Annotations>
+-- 					<oms:SimulationInformation resultFile="test_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter=".*" />
+-- 				</oms:Annotations>
 -- 			</ssc:Annotation>
 -- 		</ssd:Annotations>
 -- 	</ssd:DefaultExperiment>

--- a/testsuite/api/test01.py
+++ b/testsuite/api/test01.py
@@ -92,25 +92,31 @@ printStatus(status, 3)
 ## 			<ssd:System name="goo">
 ## 				<ssd:Annotations>
 ## 					<ssc:Annotation type="org.openmodelica">
-## 						<oms:SimulationInformation>
-## 							<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
-## 						</oms:SimulationInformation>
+## 						<oms:Annotations>
+## 							<oms:SimulationInformation>
+## 								<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+## 							</oms:SimulationInformation>
+## 						</oms:Annotations>
 ## 					</ssc:Annotation>
 ## 				</ssd:Annotations>
 ## 			</ssd:System>
 ## 		</ssd:Elements>
 ## 		<ssd:Annotations>
 ## 			<ssc:Annotation type="org.openmodelica">
-## 				<oms:SimulationInformation>
-## 					<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
-## 				</oms:SimulationInformation>
+## 				<oms:Annotations>
+## 					<oms:SimulationInformation>
+## 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+## 					</oms:SimulationInformation>
+## 				</oms:Annotations>
 ## 			</ssc:Annotation>
 ## 		</ssd:Annotations>
 ## 	</ssd:System>
 ## 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
 ## 		<ssd:Annotations>
 ## 			<ssc:Annotation type="org.openmodelica">
-## 				<oms:SimulationInformation resultFile="test_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter=".*" />
+## 				<oms:Annotations>
+## 					<oms:SimulationInformation resultFile="test_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter=".*" />
+## 				</oms:Annotations>
 ## 			</ssc:Annotation>
 ## 		</ssd:Annotations>
 ## 	</ssd:DefaultExperiment>
@@ -122,18 +128,22 @@ printStatus(status, 3)
 ## 		<ssd:System name="goo">
 ## 			<ssd:Annotations>
 ## 				<ssc:Annotation type="org.openmodelica">
-## 					<oms:SimulationInformation>
-## 						<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
-## 					</oms:SimulationInformation>
+## 					<oms:Annotations>
+## 						<oms:SimulationInformation>
+## 							<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+## 						</oms:SimulationInformation>
+## 					</oms:Annotations>
 ## 				</ssc:Annotation>
 ## 			</ssd:Annotations>
 ## 		</ssd:System>
 ## 	</ssd:Elements>
 ## 	<ssd:Annotations>
 ## 		<ssc:Annotation type="org.openmodelica">
-## 			<oms:SimulationInformation>
-## 				<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
-## 			</oms:SimulationInformation>
+## 			<oms:Annotations>
+## 				<oms:SimulationInformation>
+## 					<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+## 				</oms:SimulationInformation>
+## 			</oms:Annotations>
 ## 		</ssc:Annotation>
 ## 	</ssd:Annotations>
 ## </ssd:System>
@@ -142,9 +152,11 @@ printStatus(status, 3)
 ## <ssd:System name="goo">
 ## 	<ssd:Annotations>
 ## 		<ssc:Annotation type="org.openmodelica">
-## 			<oms:SimulationInformation>
-## 				<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
-## 			</oms:SimulationInformation>
+## 			<oms:Annotations>
+## 				<oms:SimulationInformation>
+## 					<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+## 				</oms:SimulationInformation>
+## 			</oms:Annotations>
 ## 		</ssc:Annotation>
 ## 	</ssd:Annotations>
 ## </ssd:System>
@@ -161,7 +173,9 @@ printStatus(status, 3)
 ## 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
 ## 		<ssd:Annotations>
 ## 			<ssc:Annotation type="org.openmodelica">
-## 				<oms:SimulationInformation resultFile="test_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter=".*" />
+## 				<oms:Annotations>
+## 					<oms:SimulationInformation resultFile="test_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter=".*" />
+## 				</oms:Annotations>
 ## 			</ssc:Annotation>
 ## 		</ssd:Annotations>
 ## 	</ssd:DefaultExperiment>

--- a/testsuite/api/test03.lua
+++ b/testsuite/api/test03.lua
@@ -96,16 +96,20 @@ oms_delete("test")
 -- 		</ssd:Elements>
 -- 		<ssd:Annotations>
 -- 			<ssc:Annotation type="org.openmodelica">
--- 				<oms:SimulationInformation>
--- 					<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
--- 				</oms:SimulationInformation>
+-- 				<oms:Annotations>
+-- 					<oms:SimulationInformation>
+-- 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+-- 					</oms:SimulationInformation>
+-- 				</oms:Annotations>
 -- 			</ssc:Annotation>
 -- 		</ssd:Annotations>
 -- 	</ssd:System>
 -- 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
 -- 		<ssd:Annotations>
 -- 			<ssc:Annotation type="org.openmodelica">
--- 				<oms:SimulationInformation resultFile="test_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter=".*" />
+-- 				<oms:Annotations>
+-- 					<oms:SimulationInformation resultFile="test_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter=".*" />
+-- 				</oms:Annotations>
 -- 			</ssc:Annotation>
 -- 		</ssd:Annotations>
 -- 	</ssd:DefaultExperiment>
@@ -143,16 +147,20 @@ oms_delete("test")
 -- 		</ssd:Elements>
 -- 		<ssd:Annotations>
 -- 			<ssc:Annotation type="org.openmodelica">
--- 				<oms:SimulationInformation>
--- 					<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
--- 				</oms:SimulationInformation>
+-- 				<oms:Annotations>
+-- 					<oms:SimulationInformation>
+-- 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+-- 					</oms:SimulationInformation>
+-- 				</oms:Annotations>
 -- 			</ssc:Annotation>
 -- 		</ssd:Annotations>
 -- 	</ssd:System>
 -- 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
 -- 		<ssd:Annotations>
 -- 			<ssc:Annotation type="org.openmodelica">
--- 				<oms:SimulationInformation resultFile="test_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter=".*" />
+-- 				<oms:Annotations>
+-- 					<oms:SimulationInformation resultFile="test_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter=".*" />
+-- 				</oms:Annotations>
 -- 			</ssc:Annotation>
 -- 		</ssd:Annotations>
 -- 	</ssd:DefaultExperiment>

--- a/testsuite/api/test03.py
+++ b/testsuite/api/test03.py
@@ -88,16 +88,20 @@ oms.delete("test")
 ## 		</ssd:Elements>
 ## 		<ssd:Annotations>
 ## 			<ssc:Annotation type="org.openmodelica">
-## 				<oms:SimulationInformation>
-## 					<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
-## 				</oms:SimulationInformation>
+## 				<oms:Annotations>
+## 					<oms:SimulationInformation>
+## 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+## 					</oms:SimulationInformation>
+## 				</oms:Annotations>
 ## 			</ssc:Annotation>
 ## 		</ssd:Annotations>
 ## 	</ssd:System>
 ## 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
 ## 		<ssd:Annotations>
 ## 			<ssc:Annotation type="org.openmodelica">
-## 				<oms:SimulationInformation resultFile="test_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter=".*" />
+## 				<oms:Annotations>
+## 					<oms:SimulationInformation resultFile="test_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter=".*" />
+## 				</oms:Annotations>
 ## 			</ssc:Annotation>
 ## 		</ssd:Annotations>
 ## 	</ssd:DefaultExperiment>
@@ -135,16 +139,20 @@ oms.delete("test")
 ## 		</ssd:Elements>
 ## 		<ssd:Annotations>
 ## 			<ssc:Annotation type="org.openmodelica">
-## 				<oms:SimulationInformation>
-## 					<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
-## 				</oms:SimulationInformation>
+## 				<oms:Annotations>
+## 					<oms:SimulationInformation>
+## 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+## 					</oms:SimulationInformation>
+## 				</oms:Annotations>
 ## 			</ssc:Annotation>
 ## 		</ssd:Annotations>
 ## 	</ssd:System>
 ## 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
 ## 		<ssd:Annotations>
 ## 			<ssc:Annotation type="org.openmodelica">
-## 				<oms:SimulationInformation resultFile="test_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter=".*" />
+## 				<oms:Annotations>
+## 					<oms:SimulationInformation resultFile="test_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter=".*" />
+## 				</oms:Annotations>
 ## 			</ssc:Annotation>
 ## 		</ssd:Annotations>
 ## 	</ssd:DefaultExperiment>

--- a/testsuite/api/test_omsExport.lua
+++ b/testsuite/api/test_omsExport.lua
@@ -64,16 +64,20 @@ printStatus(status, 0)
 -- 	<ssd:System name="sc">
 -- 		<ssd:Annotations>
 -- 			<ssc:Annotation type="org.openmodelica">
--- 				<oms:SimulationInformation>
--- 					<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
--- 				</oms:SimulationInformation>
+-- 				<oms:Annotations>
+-- 					<oms:SimulationInformation>
+-- 						<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+-- 					</oms:SimulationInformation>
+-- 				</oms:Annotations>
 -- 			</ssc:Annotation>
 -- 		</ssd:Annotations>
 -- 	</ssd:System>
 -- 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
 -- 		<ssd:Annotations>
 -- 			<ssc:Annotation type="org.openmodelica">
--- 				<oms:SimulationInformation resultFile="model_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter="[AB]" />
+-- 				<oms:Annotations>
+-- 					<oms:SimulationInformation resultFile="model_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter="[AB]" />
+-- 				</oms:Annotations>
 -- 			</ssc:Annotation>
 -- 		</ssd:Annotations>
 -- 	</ssd:DefaultExperiment>
@@ -89,16 +93,20 @@ printStatus(status, 0)
 -- 	<ssd:System name="sc">
 -- 		<ssd:Annotations>
 -- 			<ssc:Annotation type="org.openmodelica">
--- 				<oms:SimulationInformation>
--- 					<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
--- 				</oms:SimulationInformation>
+-- 				<oms:Annotations>
+-- 					<oms:SimulationInformation>
+-- 						<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+-- 					</oms:SimulationInformation>
+-- 				</oms:Annotations>
 -- 			</ssc:Annotation>
 -- 		</ssd:Annotations>
 -- 	</ssd:System>
 -- 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
 -- 		<ssd:Annotations>
 -- 			<ssc:Annotation type="org.openmodelica">
--- 				<oms:SimulationInformation resultFile="model_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter="[AB]" />
+-- 				<oms:Annotations>
+-- 					<oms:SimulationInformation resultFile="model_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter="[AB]" />
+-- 				</oms:Annotations>
 -- 			</ssc:Annotation>
 -- 		</ssd:Annotations>
 -- 	</ssd:DefaultExperiment>

--- a/testsuite/api/test_omsExport.py
+++ b/testsuite/api/test_omsExport.py
@@ -64,16 +64,20 @@ printStatus(status, 0)
 ## 	<ssd:System name="sc">
 ## 		<ssd:Annotations>
 ## 			<ssc:Annotation type="org.openmodelica">
-## 				<oms:SimulationInformation>
-## 					<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
-## 				</oms:SimulationInformation>
+## 				<oms:Annotations>
+## 					<oms:SimulationInformation>
+## 						<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+## 					</oms:SimulationInformation>
+## 				</oms:Annotations>
 ## 			</ssc:Annotation>
 ## 		</ssd:Annotations>
 ## 	</ssd:System>
 ## 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
 ## 		<ssd:Annotations>
 ## 			<ssc:Annotation type="org.openmodelica">
-## 				<oms:SimulationInformation resultFile="model_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter="[AB]" />
+## 				<oms:Annotations>
+## 					<oms:SimulationInformation resultFile="model_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter="[AB]" />
+## 				</oms:Annotations>
 ## 			</ssc:Annotation>
 ## 		</ssd:Annotations>
 ## 	</ssd:DefaultExperiment>
@@ -89,16 +93,20 @@ printStatus(status, 0)
 ## 	<ssd:System name="sc">
 ## 		<ssd:Annotations>
 ## 			<ssc:Annotation type="org.openmodelica">
-## 				<oms:SimulationInformation>
-## 					<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
-## 				</oms:SimulationInformation>
+## 				<oms:Annotations>
+## 					<oms:SimulationInformation>
+## 						<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+## 					</oms:SimulationInformation>
+## 				</oms:Annotations>
 ## 			</ssc:Annotation>
 ## 		</ssd:Annotations>
 ## 	</ssd:System>
 ## 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
 ## 		<ssd:Annotations>
 ## 			<ssc:Annotation type="org.openmodelica">
-## 				<oms:SimulationInformation resultFile="model_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter="[AB]" />
+## 				<oms:Annotations>
+## 					<oms:SimulationInformation resultFile="model_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter="[AB]" />
+## 				</oms:Annotations>
 ## 			</ssc:Annotation>
 ## 		</ssd:Annotations>
 ## 	</ssd:DefaultExperiment>

--- a/testsuite/tlm/externalmodels.lua
+++ b/testsuite/tlm/externalmodels.lua
@@ -39,11 +39,21 @@ printStatus(status, 0)
 
 status = oms_addTLMBus("model.tlm.external.tlmbus", oms_tlm_domain_mechanical, 1, oms_tlm_no_interpolation)
 
-src, status = oms_list("model.tlm")
+src, status = oms_list("model")
 print(src)
+
+oms_export("model", "tlm.ssp")
 
 status = oms_delete("model")
 printStatus(status, 0)
+
+oms_importFile("tlm.ssp")
+
+src, status = oms_list("model")
+print(src)
+
+status = oms_delete("model")
+
 
 -- Result:
 -- status:  [correct] ok
@@ -51,29 +61,91 @@ printStatus(status, 0)
 -- status:  [correct] ok
 -- status:  [correct] ok
 -- <?xml version="1.0"?>
--- <ssd:System name="tlm">
--- 	<ssd:Elements>
--- 		<ssd:Component name="external" source="resources/external.mo">
--- 			<ssd:Annotations>
--- 				<ssc:Annotation type="org.openmodelica">
--- 					<oms:Bus name="tlmbus" type="tlm" domain="mechanical" dimensions="1" interpolation="none">
--- 						<oms:Signals />
--- 					</oms:Bus>
+-- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="model" version="1.0">
+-- 	<ssd:System name="tlm">
+-- 		<ssd:Elements>
+-- 			<ssd:Component name="external" source="resources/external.mo">
+-- 				<ssd:Annotations>
+-- 					<ssc:Annotation type="org.openmodelica">
+-- 						<oms:Annotations>
+-- 							<oms:Buses>
+-- 								<oms:Bus name="tlmbus" type="tlm" domain="mechanical" dimensions="1" interpolation="none">
+-- 									<oms:Signals />
+-- 								</oms:Bus>
+-- 							</oms:Buses>
+-- 							<oms:SimulationInformation>
+-- 								<oms:ExternalModel startscript="resources/startscript.sh" />
+-- 							</oms:SimulationInformation>
+-- 						</oms:Annotations>
+-- 					</ssc:Annotation>
+-- 				</ssd:Annotations>
+-- 			</ssd:Component>
+-- 		</ssd:Elements>
+-- 		<ssd:Annotations>
+-- 			<ssc:Annotation type="org.openmodelica">
+-- 				<oms:Annotations>
 -- 					<oms:SimulationInformation>
--- 						<oms:ExternalModel startscript="resources/startscript.sh" />
+-- 						<oms:TlmMaster ip="" managerport="0" monitorport="0" />
 -- 					</oms:SimulationInformation>
--- 				</ssc:Annotation>
--- 			</ssd:Annotations>
--- 		</ssd:Component>
--- 	</ssd:Elements>
--- 	<ssd:Annotations>
--- 		<ssc:Annotation type="org.openmodelica">
--- 			<oms:SimulationInformation>
--- 				<oms:TlmMaster ip="" managerport="0" monitorport="0" />
--- 			</oms:SimulationInformation>
--- 		</ssc:Annotation>
--- 	</ssd:Annotations>
--- </ssd:System>
+-- 				</oms:Annotations>
+-- 			</ssc:Annotation>
+-- 		</ssd:Annotations>
+-- 	</ssd:System>
+-- 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
+-- 		<ssd:Annotations>
+-- 			<ssc:Annotation type="org.openmodelica">
+-- 				<oms:Annotations>
+-- 					<oms:SimulationInformation resultFile="model_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter=".*" />
+-- 				</oms:Annotations>
+-- 			</ssc:Annotation>
+-- 		</ssd:Annotations>
+-- 	</ssd:DefaultExperiment>
+-- </ssd:SystemStructureDescription>
 --
 -- status:  [correct] ok
+-- error:   [addSignalsToResults] Not implemented
+-- <?xml version="1.0"?>
+-- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="model" version="1.0">
+-- 	<ssd:System name="tlm">
+-- 		<ssd:Elements>
+-- 			<ssd:Component name="external" source="resources/external.mo">
+-- 				<ssd:Annotations>
+-- 					<ssc:Annotation type="org.openmodelica">
+-- 						<oms:Annotations>
+-- 							<oms:Buses>
+-- 								<oms:Bus name="tlmbus" type="tlm" domain="mechanical" dimensions="1" interpolation="none">
+-- 									<oms:Signals />
+-- 								</oms:Bus>
+-- 							</oms:Buses>
+-- 							<oms:SimulationInformation>
+-- 								<oms:ExternalModel startscript="resources/startscript.sh" />
+-- 							</oms:SimulationInformation>
+-- 						</oms:Annotations>
+-- 					</ssc:Annotation>
+-- 				</ssd:Annotations>
+-- 			</ssd:Component>
+-- 		</ssd:Elements>
+-- 		<ssd:Annotations>
+-- 			<ssc:Annotation type="org.openmodelica">
+-- 				<oms:Annotations>
+-- 					<oms:SimulationInformation>
+-- 						<oms:TlmMaster ip="" managerport="0" monitorport="0" />
+-- 					</oms:SimulationInformation>
+-- 				</oms:Annotations>
+-- 			</ssc:Annotation>
+-- 		</ssd:Annotations>
+-- 	</ssd:System>
+-- 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
+-- 		<ssd:Annotations>
+-- 			<ssc:Annotation type="org.openmodelica">
+-- 				<oms:Annotations>
+-- 					<oms:SimulationInformation resultFile="model_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter=".*" />
+-- 				</oms:Annotations>
+-- 			</ssc:Annotation>
+-- 		</ssd:Annotations>
+-- 	</ssd:DefaultExperiment>
+-- </ssd:SystemStructureDescription>
+--
+-- info:    0 warnings
+-- info:    1 errors
 -- endResult

--- a/testsuite/tlm/externalmodels.py
+++ b/testsuite/tlm/externalmodels.py
@@ -56,21 +56,27 @@ printStatus(status, 0)
 ## 		<ssd:Component name="external" source="resources/external.mo">
 ## 			<ssd:Annotations>
 ## 				<ssc:Annotation type="org.openmodelica">
-## 					<oms:Bus name="tlmbus" type="tlm" domain="mechanical" dimensions="1" interpolation="none">
-## 						<oms:Signals />
-## 					</oms:Bus>
-## 					<oms:SimulationInformation>
-## 						<oms:ExternalModel startscript="resources/startscript.sh" />
-## 					</oms:SimulationInformation>
+## 					<oms:Annotations>
+## 						<oms:Buses>
+## 							<oms:Bus name="tlmbus" type="tlm" domain="mechanical" dimensions="1" interpolation="none">
+## 								<oms:Signals />
+## 							</oms:Bus>
+## 						</oms:Buses>
+## 						<oms:SimulationInformation>
+## 							<oms:ExternalModel startscript="resources/startscript.sh" />
+## 						</oms:SimulationInformation>
+## 					</oms:Annotations>
 ## 				</ssc:Annotation>
 ## 			</ssd:Annotations>
 ## 		</ssd:Component>
 ## 	</ssd:Elements>
 ## 	<ssd:Annotations>
 ## 		<ssc:Annotation type="org.openmodelica">
-## 			<oms:SimulationInformation>
-## 				<oms:TlmMaster ip="" managerport="0" monitorport="0" />
-## 			</oms:SimulationInformation>
+## 			<oms:Annotations>
+## 				<oms:SimulationInformation>
+## 					<oms:TlmMaster ip="" managerport="0" monitorport="0" />
+## 				</oms:SimulationInformation>
+## 			</oms:Annotations>
 ## 		</ssc:Annotation>
 ## 	</ssd:Annotations>
 ## </ssd:System>

--- a/testsuite/tlm/tlmbuses.lua
+++ b/testsuite/tlm/tlmbuses.lua
@@ -128,18 +128,18 @@ printStatus(status, 0)
 -- 			</ssd:Connectors>
 -- 			<ssd:Annotations>
 -- 				<ssc:Annotation type="org.openmodelica">
--- 					<oms:Bus name="bus2" type="tlm" domain="output" dimensions="1" interpolation="none">
--- 						<oms:Signals>
--- 							<oms:Signal name="y" type="value" />
--- 						</oms:Signals>
--- 					</oms:Bus>
--- 				</ssc:Annotation>
--- 			</ssd:Annotations>
--- 			<ssd:Annotations>
--- 				<ssc:Annotation type="org.openmodelica">
--- 					<oms:SimulationInformation>
--- 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
--- 					</oms:SimulationInformation>
+-- 					<oms:Annotations>
+-- 						<oms:Buses>
+-- 							<oms:Bus name="bus2" type="tlm" domain="output" dimensions="1" interpolation="none">
+-- 								<oms:Signals>
+-- 									<oms:Signal name="y" type="value" />
+-- 								</oms:Signals>
+-- 							</oms:Bus>
+-- 						</oms:Buses>
+-- 						<oms:SimulationInformation>
+-- 							<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+-- 						</oms:SimulationInformation>
+-- 					</oms:Annotations>
 -- 				</ssc:Annotation>
 -- 			</ssd:Annotations>
 -- 		</ssd:System>
@@ -160,41 +160,39 @@ printStatus(status, 0)
 -- 			</ssd:Connectors>
 -- 			<ssd:Annotations>
 -- 				<ssc:Annotation type="org.openmodelica">
--- 					<oms:Bus name="bus1" type="tlm" domain="input" dimensions="1" interpolation="none">
--- 						<oms:Signals>
--- 							<oms:Signal name="y" type="value" />
--- 						</oms:Signals>
--- 					</oms:Bus>
--- 					<oms:Bus name="bus2" type="tlm" domain="mechanical" dimensions="1" interpolation="none">
--- 						<oms:Signals>
--- 							<oms:Signal name="f" type="effort" />
--- 							<oms:Signal name="v" type="flow" />
--- 							<oms:Signal name="x" type="state" />
--- 						</oms:Signals>
--- 					</oms:Bus>
--- 				</ssc:Annotation>
--- 			</ssd:Annotations>
--- 			<ssd:Annotations>
--- 				<ssc:Annotation type="org.openmodelica">
--- 					<oms:SimulationInformation>
--- 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
--- 					</oms:SimulationInformation>
+-- 					<oms:Annotations>
+-- 						<oms:Buses>
+-- 							<oms:Bus name="bus1" type="tlm" domain="input" dimensions="1" interpolation="none">
+-- 								<oms:Signals>
+-- 									<oms:Signal name="y" type="value" />
+-- 								</oms:Signals>
+-- 							</oms:Bus>
+-- 							<oms:Bus name="bus2" type="tlm" domain="mechanical" dimensions="1" interpolation="none">
+-- 								<oms:Signals>
+-- 									<oms:Signal name="f" type="effort" />
+-- 									<oms:Signal name="v" type="flow" />
+-- 									<oms:Signal name="x" type="state" />
+-- 								</oms:Signals>
+-- 							</oms:Bus>
+-- 						</oms:Buses>
+-- 						<oms:SimulationInformation>
+-- 							<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+-- 						</oms:SimulationInformation>
+-- 					</oms:Annotations>
 -- 				</ssc:Annotation>
 -- 			</ssd:Annotations>
 -- 		</ssd:System>
 -- 	</ssd:Elements>
 -- 	<ssd:Annotations>
 -- 		<ssc:Annotation type="org.openmodelica">
--- 			<oms:Connections>
--- 				<oms:Connection startElement="wc1" startConnector="bus1" endElement="wc2" endConnector="bus2" delay="0.001000" alpha="0.300000" linearimpedance="100.000000" angularimpedance="0.000000" />
--- 			</oms:Connections>
--- 		</ssc:Annotation>
--- 	</ssd:Annotations>
--- 	<ssd:Annotations>
--- 		<ssc:Annotation type="org.openmodelica">
--- 			<oms:SimulationInformation>
--- 				<oms:TlmMaster ip="127.0.1.1" managerport="11111" monitorport="11121" />
--- 			</oms:SimulationInformation>
+-- 			<oms:Annotations>
+-- 				<oms:Connections>
+-- 					<oms:Connection startElement="wc1" startConnector="bus1" endElement="wc2" endConnector="bus2" delay="0.001000" alpha="0.300000" linearimpedance="100.000000" angularimpedance="0.000000" />
+-- 				</oms:Connections>
+-- 				<oms:SimulationInformation>
+-- 					<oms:TlmMaster ip="127.0.1.1" managerport="11111" monitorport="11121" />
+-- 				</oms:SimulationInformation>
+-- 			</oms:Annotations>
 -- 		</ssc:Annotation>
 -- 	</ssd:Annotations>
 -- </ssd:System>
@@ -220,18 +218,18 @@ printStatus(status, 0)
 -- 			</ssd:Connectors>
 -- 			<ssd:Annotations>
 -- 				<ssc:Annotation type="org.openmodelica">
--- 					<oms:Bus name="bus2" type="tlm" domain="output" dimensions="1" interpolation="none">
--- 						<oms:Signals>
--- 							<oms:Signal name="y" type="value" />
--- 						</oms:Signals>
--- 					</oms:Bus>
--- 				</ssc:Annotation>
--- 			</ssd:Annotations>
--- 			<ssd:Annotations>
--- 				<ssc:Annotation type="org.openmodelica">
--- 					<oms:SimulationInformation>
--- 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
--- 					</oms:SimulationInformation>
+-- 					<oms:Annotations>
+-- 						<oms:Buses>
+-- 							<oms:Bus name="bus2" type="tlm" domain="output" dimensions="1" interpolation="none">
+-- 								<oms:Signals>
+-- 									<oms:Signal name="y" type="value" />
+-- 								</oms:Signals>
+-- 							</oms:Bus>
+-- 						</oms:Buses>
+-- 						<oms:SimulationInformation>
+-- 							<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+-- 						</oms:SimulationInformation>
+-- 					</oms:Annotations>
 -- 				</ssc:Annotation>
 -- 			</ssd:Annotations>
 -- 		</ssd:System>
@@ -252,40 +250,38 @@ printStatus(status, 0)
 -- 			</ssd:Connectors>
 -- 			<ssd:Annotations>
 -- 				<ssc:Annotation type="org.openmodelica">
--- 					<oms:Bus name="bus1" type="tlm" domain="input" dimensions="1" interpolation="none">
--- 						<oms:Signals>
--- 							<oms:Signal name="y" type="value" />
--- 						</oms:Signals>
--- 					</oms:Bus>
--- 					<oms:Bus name="bus2" type="tlm" domain="mechanical" dimensions="1" interpolation="none">
--- 						<oms:Signals>
--- 							<oms:Signal name="f" type="effort" />
--- 							<oms:Signal name="v" type="flow" />
--- 						</oms:Signals>
--- 					</oms:Bus>
--- 				</ssc:Annotation>
--- 			</ssd:Annotations>
--- 			<ssd:Annotations>
--- 				<ssc:Annotation type="org.openmodelica">
--- 					<oms:SimulationInformation>
--- 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
--- 					</oms:SimulationInformation>
+-- 					<oms:Annotations>
+-- 						<oms:Buses>
+-- 							<oms:Bus name="bus1" type="tlm" domain="input" dimensions="1" interpolation="none">
+-- 								<oms:Signals>
+-- 									<oms:Signal name="y" type="value" />
+-- 								</oms:Signals>
+-- 							</oms:Bus>
+-- 							<oms:Bus name="bus2" type="tlm" domain="mechanical" dimensions="1" interpolation="none">
+-- 								<oms:Signals>
+-- 									<oms:Signal name="f" type="effort" />
+-- 									<oms:Signal name="v" type="flow" />
+-- 								</oms:Signals>
+-- 							</oms:Bus>
+-- 						</oms:Buses>
+-- 						<oms:SimulationInformation>
+-- 							<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+-- 						</oms:SimulationInformation>
+-- 					</oms:Annotations>
 -- 				</ssc:Annotation>
 -- 			</ssd:Annotations>
 -- 		</ssd:System>
 -- 	</ssd:Elements>
 -- 	<ssd:Annotations>
 -- 		<ssc:Annotation type="org.openmodelica">
--- 			<oms:Connections>
--- 				<oms:Connection startElement="wc1" startConnector="bus1" endElement="wc2" endConnector="bus2" delay="0.001000" alpha="0.300000" linearimpedance="100.000000" angularimpedance="0.000000" />
--- 			</oms:Connections>
--- 		</ssc:Annotation>
--- 	</ssd:Annotations>
--- 	<ssd:Annotations>
--- 		<ssc:Annotation type="org.openmodelica">
--- 			<oms:SimulationInformation>
--- 				<oms:TlmMaster ip="127.0.1.1" managerport="11111" monitorport="11121" />
--- 			</oms:SimulationInformation>
+-- 			<oms:Annotations>
+-- 				<oms:Connections>
+-- 					<oms:Connection startElement="wc1" startConnector="bus1" endElement="wc2" endConnector="bus2" delay="0.001000" alpha="0.300000" linearimpedance="100.000000" angularimpedance="0.000000" />
+-- 				</oms:Connections>
+-- 				<oms:SimulationInformation>
+-- 					<oms:TlmMaster ip="127.0.1.1" managerport="11111" monitorport="11121" />
+-- 				</oms:SimulationInformation>
+-- 			</oms:Annotations>
 -- 		</ssc:Annotation>
 -- 	</ssd:Annotations>
 -- </ssd:System>

--- a/testsuite/tlm/tlmbuses.py
+++ b/testsuite/tlm/tlmbuses.py
@@ -128,18 +128,18 @@ printStatus(status, 0)
 ## 			</ssd:Connectors>
 ## 			<ssd:Annotations>
 ## 				<ssc:Annotation type="org.openmodelica">
-## 					<oms:Bus name="bus2" type="tlm" domain="output" dimensions="1" interpolation="none">
-## 						<oms:Signals>
-## 							<oms:Signal name="y" type="value" />
-## 						</oms:Signals>
-## 					</oms:Bus>
-## 				</ssc:Annotation>
-## 			</ssd:Annotations>
-## 			<ssd:Annotations>
-## 				<ssc:Annotation type="org.openmodelica">
-## 					<oms:SimulationInformation>
-## 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
-## 					</oms:SimulationInformation>
+## 					<oms:Annotations>
+## 						<oms:Buses>
+## 							<oms:Bus name="bus2" type="tlm" domain="output" dimensions="1" interpolation="none">
+## 								<oms:Signals>
+## 									<oms:Signal name="y" type="value" />
+## 								</oms:Signals>
+## 							</oms:Bus>
+## 						</oms:Buses>
+## 						<oms:SimulationInformation>
+## 							<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+## 						</oms:SimulationInformation>
+## 					</oms:Annotations>
 ## 				</ssc:Annotation>
 ## 			</ssd:Annotations>
 ## 		</ssd:System>
@@ -160,41 +160,39 @@ printStatus(status, 0)
 ## 			</ssd:Connectors>
 ## 			<ssd:Annotations>
 ## 				<ssc:Annotation type="org.openmodelica">
-## 					<oms:Bus name="bus1" type="tlm" domain="input" dimensions="1" interpolation="none">
-## 						<oms:Signals>
-## 							<oms:Signal name="y" type="value" />
-## 						</oms:Signals>
-## 					</oms:Bus>
-## 					<oms:Bus name="bus2" type="tlm" domain="mechanical" dimensions="1" interpolation="none">
-## 						<oms:Signals>
-## 							<oms:Signal name="f" type="effort" />
-## 							<oms:Signal name="v" type="flow" />
-## 							<oms:Signal name="x" type="state" />
-## 						</oms:Signals>
-## 					</oms:Bus>
-## 				</ssc:Annotation>
-## 			</ssd:Annotations>
-## 			<ssd:Annotations>
-## 				<ssc:Annotation type="org.openmodelica">
-## 					<oms:SimulationInformation>
-## 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
-## 					</oms:SimulationInformation>
+## 					<oms:Annotations>
+## 						<oms:Buses>
+## 							<oms:Bus name="bus1" type="tlm" domain="input" dimensions="1" interpolation="none">
+## 								<oms:Signals>
+## 									<oms:Signal name="y" type="value" />
+## 								</oms:Signals>
+## 							</oms:Bus>
+## 							<oms:Bus name="bus2" type="tlm" domain="mechanical" dimensions="1" interpolation="none">
+## 								<oms:Signals>
+## 									<oms:Signal name="f" type="effort" />
+## 									<oms:Signal name="v" type="flow" />
+## 									<oms:Signal name="x" type="state" />
+## 								</oms:Signals>
+## 							</oms:Bus>
+## 						</oms:Buses>
+## 						<oms:SimulationInformation>
+## 							<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+## 						</oms:SimulationInformation>
+## 					</oms:Annotations>
 ## 				</ssc:Annotation>
 ## 			</ssd:Annotations>
 ## 		</ssd:System>
 ## 	</ssd:Elements>
 ## 	<ssd:Annotations>
 ## 		<ssc:Annotation type="org.openmodelica">
-## 			<oms:Connections>
-## 				<oms:Connection startElement="wc1" startConnector="bus1" endElement="wc2" endConnector="bus2" delay="0.001000" alpha="0.300000" linearimpedance="100.000000" angularimpedance="0.000000" />
-## 			</oms:Connections>
-## 		</ssc:Annotation>
-## 	</ssd:Annotations>
-## 	<ssd:Annotations>
-## 		<ssc:Annotation type="org.openmodelica">
-## 			<oms:SimulationInformation>
-## 				<oms:TlmMaster ip="127.0.1.1" managerport="11111" monitorport="11121" />
-## 			</oms:SimulationInformation>
+## 			<oms:Annotations>
+## 				<oms:Connections>
+## 					<oms:Connection startElement="wc1" startConnector="bus1" endElement="wc2" endConnector="bus2" delay="0.001000" alpha="0.300000" linearimpedance="100.000000" angularimpedance="0.000000" />
+## 				</oms:Connections>
+## 				<oms:SimulationInformation>
+## 					<oms:TlmMaster ip="127.0.1.1" managerport="11111" monitorport="11121" />
+## 				</oms:SimulationInformation>
+## 			</oms:Annotations>
 ## 		</ssc:Annotation>
 ## 	</ssd:Annotations>
 ## </ssd:System>
@@ -220,18 +218,18 @@ printStatus(status, 0)
 ## 			</ssd:Connectors>
 ## 			<ssd:Annotations>
 ## 				<ssc:Annotation type="org.openmodelica">
-## 					<oms:Bus name="bus2" type="tlm" domain="output" dimensions="1" interpolation="none">
-## 						<oms:Signals>
-## 							<oms:Signal name="y" type="value" />
-## 						</oms:Signals>
-## 					</oms:Bus>
-## 				</ssc:Annotation>
-## 			</ssd:Annotations>
-## 			<ssd:Annotations>
-## 				<ssc:Annotation type="org.openmodelica">
-## 					<oms:SimulationInformation>
-## 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
-## 					</oms:SimulationInformation>
+## 					<oms:Annotations>
+## 						<oms:Buses>
+## 							<oms:Bus name="bus2" type="tlm" domain="output" dimensions="1" interpolation="none">
+## 								<oms:Signals>
+## 									<oms:Signal name="y" type="value" />
+## 								</oms:Signals>
+## 							</oms:Bus>
+## 						</oms:Buses>
+## 						<oms:SimulationInformation>
+## 							<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+## 						</oms:SimulationInformation>
+## 					</oms:Annotations>
 ## 				</ssc:Annotation>
 ## 			</ssd:Annotations>
 ## 		</ssd:System>
@@ -252,40 +250,38 @@ printStatus(status, 0)
 ## 			</ssd:Connectors>
 ## 			<ssd:Annotations>
 ## 				<ssc:Annotation type="org.openmodelica">
-## 					<oms:Bus name="bus1" type="tlm" domain="input" dimensions="1" interpolation="none">
-## 						<oms:Signals>
-## 							<oms:Signal name="y" type="value" />
-## 						</oms:Signals>
-## 					</oms:Bus>
-## 					<oms:Bus name="bus2" type="tlm" domain="mechanical" dimensions="1" interpolation="none">
-## 						<oms:Signals>
-## 							<oms:Signal name="f" type="effort" />
-## 							<oms:Signal name="v" type="flow" />
-## 						</oms:Signals>
-## 					</oms:Bus>
-## 				</ssc:Annotation>
-## 			</ssd:Annotations>
-## 			<ssd:Annotations>
-## 				<ssc:Annotation type="org.openmodelica">
-## 					<oms:SimulationInformation>
-## 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
-## 					</oms:SimulationInformation>
+## 					<oms:Annotations>
+## 						<oms:Buses>
+## 							<oms:Bus name="bus1" type="tlm" domain="input" dimensions="1" interpolation="none">
+## 								<oms:Signals>
+## 									<oms:Signal name="y" type="value" />
+## 								</oms:Signals>
+## 							</oms:Bus>
+## 							<oms:Bus name="bus2" type="tlm" domain="mechanical" dimensions="1" interpolation="none">
+## 								<oms:Signals>
+## 									<oms:Signal name="f" type="effort" />
+## 									<oms:Signal name="v" type="flow" />
+## 								</oms:Signals>
+## 							</oms:Bus>
+## 						</oms:Buses>
+## 						<oms:SimulationInformation>
+## 							<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+## 						</oms:SimulationInformation>
+## 					</oms:Annotations>
 ## 				</ssc:Annotation>
 ## 			</ssd:Annotations>
 ## 		</ssd:System>
 ## 	</ssd:Elements>
 ## 	<ssd:Annotations>
 ## 		<ssc:Annotation type="org.openmodelica">
-## 			<oms:Connections>
-## 				<oms:Connection startElement="wc1" startConnector="bus1" endElement="wc2" endConnector="bus2" delay="0.001000" alpha="0.300000" linearimpedance="100.000000" angularimpedance="0.000000" />
-## 			</oms:Connections>
-## 		</ssc:Annotation>
-## 	</ssd:Annotations>
-## 	<ssd:Annotations>
-## 		<ssc:Annotation type="org.openmodelica">
-## 			<oms:SimulationInformation>
-## 				<oms:TlmMaster ip="127.0.1.1" managerport="11111" monitorport="11121" />
-## 			</oms:SimulationInformation>
+## 			<oms:Annotations>
+## 				<oms:Connections>
+## 					<oms:Connection startElement="wc1" startConnector="bus1" endElement="wc2" endConnector="bus2" delay="0.001000" alpha="0.300000" linearimpedance="100.000000" angularimpedance="0.000000" />
+## 				</oms:Connections>
+## 				<oms:SimulationInformation>
+## 					<oms:TlmMaster ip="127.0.1.1" managerport="11111" monitorport="11121" />
+## 				</oms:SimulationInformation>
+## 			</oms:Annotations>
 ## 		</ssc:Annotation>
 ## 	</ssd:Annotations>
 ## </ssd:System>


### PR DESCRIPTION
### Purpose

The PR  adds `<oms:Annotations>`  as root node to handle all oms annotations , so that the SSP's generated from OMSimulator are valid in [easy-ssp](https://www.easy-ssp.com/app/?lng=en) 

### example
```
<ssd:Annotations>
    <ssc:Annotation type="org.openmodelica">
        <oms:Annotations>
            <oms:SimulationInformation>
                <oms:FixedStepMaster description="oms-ma" stepSize="0.001000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
            </oms:SimulationInformation>
        </oms:Annotations>
    </ssc:Annotation>
</ssd:Annotations>
```