### PR TITLE
add oms_exportSSMTemplate to export SSM template file

### DIFF
--- a/doc/UsersGuide/source/api/exportSSMTemplate.rst
+++ b/doc/UsersGuide/source/api/exportSSMTemplate.rst
@@ -1,0 +1,39 @@
+#CAPTION#
+exportSSMTemplate
+-----------------
+
+Exports all signals that have start values of one or multiple FMUs to a SSM file that are read from modelDescription.xml with a mapping entry. The mapping entry specifies a single mapping between a parameter in the source and a parameter of the system or component being parameterized.
+The mapping entry contains two attributes namely source and target. The source attribute will be empty and needs to be manually mapped by the users associated with the parameter name defined in the SSV file, the target contains the name of parameter in the system or component to be parameterized.
+The function can be called for a top level model or a certain FMU component. If called for a top level model, start values of all FMUs are exported to the SSM file. If called for a component, start values of just this FMU are exported to the SSM file.
+#END#
+
+#LUA#
+.. code-block:: lua
+
+  status = oms_exportSSMTemplate(cref, filename)
+
+#END#
+
+#PYTHON#
+.. code-block:: python
+
+  status = oms.exportSSMTemplate(cref, filename)
+
+#END#
+
+#CAPI#
+.. code-block:: c
+
+  oms_status_enu_t oms_exportSSMTemplate(const char* cref, const char* filename)
+
+#END#
+
+#OMC#
+.. code-block:: Modelica
+
+  # not available
+
+#END#
+
+#DESCRIPTION#
+#END#

--- a/src/OMSimulatorLib/Component.h
+++ b/src/OMSimulatorLib/Component.h
@@ -86,6 +86,7 @@ namespace oms
 
     virtual oms_status_enu_t exportToSSD(pugi::xml_node& node, pugi::xml_node& ssvNode) const = 0;
     virtual oms_status_enu_t exportToSSVTemplate(pugi::xml_node& ssvNode) {return logError_NotImplemented;}
+    virtual oms_status_enu_t exportToSSMTemplate(pugi::xml_node& ssmNode) {return logError_NotImplemented;}
     virtual oms_status_enu_t instantiate() = 0;
     virtual oms_status_enu_t initialize() = 0;
     virtual oms_status_enu_t terminate() = 0;

--- a/src/OMSimulatorLib/ComponentFMUCS.cpp
+++ b/src/OMSimulatorLib/ComponentFMUCS.cpp
@@ -359,6 +359,12 @@ oms_status_enu_t oms::ComponentFMUCS::exportToSSVTemplate(pugi::xml_node& ssvNod
   return oms_status_ok;
 }
 
+oms_status_enu_t oms::ComponentFMUCS::exportToSSMTemplate(pugi::xml_node& ssmNode)
+{
+  values.exportToSSMTemplate(ssmNode, getCref());
+  return oms_status_ok;
+}
+
 oms_status_enu_t oms::ComponentFMUCS::initializeDependencyGraph_initialUnknowns()
 {
   if (initialUnknownsGraph.getEdges().size() > 0)

--- a/src/OMSimulatorLib/ComponentFMUCS.h
+++ b/src/OMSimulatorLib/ComponentFMUCS.h
@@ -60,6 +60,7 @@ namespace oms
 
     oms_status_enu_t exportToSSD(pugi::xml_node& node, pugi::xml_node& ssvNode) const;
     oms_status_enu_t exportToSSVTemplate(pugi::xml_node& ssvNode);
+    oms_status_enu_t exportToSSMTemplate(pugi::xml_node& ssmNode);
     oms_status_enu_t instantiate();
     oms_status_enu_t initialize();
     oms_status_enu_t terminate();

--- a/src/OMSimulatorLib/ComponentFMUME.cpp
+++ b/src/OMSimulatorLib/ComponentFMUME.cpp
@@ -361,6 +361,12 @@ oms_status_enu_t oms::ComponentFMUME::exportToSSVTemplate(pugi::xml_node& ssvNod
   return oms_status_ok;
 }
 
+oms_status_enu_t oms::ComponentFMUME::exportToSSMTemplate(pugi::xml_node& ssmNode)
+{
+  values.exportToSSMTemplate(ssmNode, getCref());
+  return oms_status_ok;
+}
+
 oms_status_enu_t oms::ComponentFMUME::initializeDependencyGraph_initialUnknowns()
 {
   if (initialUnknownsGraph.getEdges().size() > 0)

--- a/src/OMSimulatorLib/ComponentFMUME.h
+++ b/src/OMSimulatorLib/ComponentFMUME.h
@@ -58,6 +58,7 @@ namespace oms
 
     oms_status_enu_t exportToSSD(pugi::xml_node& node, pugi::xml_node& ssvNode) const;
     oms_status_enu_t exportToSSVTemplate(pugi::xml_node& ssvNode);
+    oms_status_enu_t exportToSSMTemplate(pugi::xml_node& ssmNode);
     oms_status_enu_t instantiate();
     oms_status_enu_t initialize();
     oms_status_enu_t terminate();

--- a/src/OMSimulatorLib/ComponentTable.h
+++ b/src/OMSimulatorLib/ComponentTable.h
@@ -56,6 +56,7 @@ namespace oms
 
     oms_status_enu_t exportToSSD(pugi::xml_node& node, pugi::xml_node& ssvNode) const;
     oms_status_enu_t exportToSSVTemplate(pugi::xml_node& ssvNode) {return oms_status_ok;}
+    oms_status_enu_t exportToSSMTemplate(pugi::xml_node& ssmNode) {return oms_status_ok;}
     oms_status_enu_t instantiate();
     oms_status_enu_t initialize() {return oms_status_ok;}
     oms_status_enu_t terminate() {return oms_status_ok;}

--- a/src/OMSimulatorLib/Model.h
+++ b/src/OMSimulatorLib/Model.h
@@ -73,6 +73,7 @@ namespace oms
     oms_status_enu_t exportToSSD(pugi::xml_node& node, pugi::xml_node& ssvNode) const;
     oms_status_enu_t exportSnapshot(const ComRef& cref, char** contents);
     oms_status_enu_t exportSSVTemplate(const ComRef& cref, const std::string& filename);
+    oms_status_enu_t exportSSMTemplate(const ComRef& cref, const std::string& filename);
     oms_status_enu_t importFromSSD(const pugi::xml_node& node);
     oms_status_enu_t importSnapshot(const char* snapshot);
     oms_status_enu_t exportToFile(const std::string& filename) const;

--- a/src/OMSimulatorLib/OMSimulator.cpp
+++ b/src/OMSimulatorLib/OMSimulator.cpp
@@ -236,6 +236,17 @@ oms_status_enu_t oms_exportSSVTemplate(const char* cref_, const char* filename)
   return model->exportSSVTemplate(tail, std::string(filename));
 }
 
+oms_status_enu_t oms_exportSSMTemplate(const char * cref_, const char * filename)
+{
+  oms::ComRef tail(cref_);
+  oms::ComRef front = tail.pop_front();
+  oms::Model * model = oms::Scope::GetInstance().getModel(front);
+  if (!model)
+    return logError_ModelNotInScope(front);
+
+  return model->exportSSMTemplate(tail, std::string(filename));
+}
+
 oms_status_enu_t oms_listUnconnectedConnectors(const char* cref_, char** contents)
 {
   oms::ComRef tail(cref_);

--- a/src/OMSimulatorLib/OMSimulator.h
+++ b/src/OMSimulatorLib/OMSimulator.h
@@ -84,6 +84,7 @@ OMSAPI oms_status_enu_t OMSCALL oms_export(const char* cref, const char* filenam
 OMSAPI oms_status_enu_t OMSCALL oms_exportDependencyGraphs(const char* cref, const char* initialization, const char* event, const char* simulation);
 OMSAPI oms_status_enu_t OMSCALL oms_exportSnapshot(const char* cref, char** contents);
 OMSAPI oms_status_enu_t OMSCALL oms_exportSSVTemplate(const char* cref, const char* filename);
+OMSAPI oms_status_enu_t OMSCALL oms_exportSSMTemplate(const char * cref, const char * filename);
 OMSAPI oms_status_enu_t OMSCALL oms_extractFMIKind(const char* filename, oms_fmi_kind_enu_t* kind);
 OMSAPI oms_status_enu_t OMSCALL oms_fetchExternalModelInterfaces(const char* cref, char*** names, char*** domains, int** dimensions);
 OMSAPI void OMSCALL oms_freeMemory(void* obj);

--- a/src/OMSimulatorLib/Values.cpp
+++ b/src/OMSimulatorLib/Values.cpp
@@ -244,6 +244,44 @@ oms_status_enu_t oms::Values::exportToSSVTemplate(pugi::xml_node& node, const Co
   return oms_status_ok;
 }
 
+/*
+ * exports the start values read from modeldescription.xml to ssm template
+ * with attributes source and target (eg.) <ssm:MappingEntry target="controller_2.bandwidth" source=""/>
+ * the source attribute will be empty and needs to be manually updated by the user
+ */
+oms_status_enu_t oms::Values::exportToSSMTemplate(pugi::xml_node& node, const ComRef& cref)
+{
+  // skip this if there is nothing to export
+  if (modelDescriptionRealStartValues.empty() && modelDescriptionIntegerStartValues.empty() && modelDescriptionBooleanStartValues.empty())
+    return oms_status_ok;
+
+  // realStartValues
+  for (const auto& r : modelDescriptionRealStartValues)
+  {
+    pugi::xml_node node_parameterMappingEntry = node.append_child(oms::ssp::Version1_0::ssm::parameter_mapping_entry);
+    node_parameterMappingEntry.append_attribute("source") = "";
+    node_parameterMappingEntry.append_attribute("target") = std::string(cref + r.first).c_str();
+  }
+
+  // integerStartValues
+  for (const auto& i : modelDescriptionIntegerStartValues)
+  {
+    pugi::xml_node node_parameterMappingEntry = node.append_child(oms::ssp::Version1_0::ssm::parameter_mapping_entry);
+    node_parameterMappingEntry.append_attribute("source") = "";
+    node_parameterMappingEntry.append_attribute("target") = std::string(cref + i.first).c_str();
+  }
+
+  // boolStartValues
+  for (const auto& b : modelDescriptionBooleanStartValues)
+  {
+    pugi::xml_node node_parameterMappingEntry = node.append_child(oms::ssp::Version1_0::ssm::parameter_mapping_entry);
+    node_parameterMappingEntry.append_attribute("source") = "";
+    node_parameterMappingEntry.append_attribute("target") = std::string(cref + b.first).c_str();
+  }
+
+  return oms_status_ok;
+}
+
 oms_status_enu_t oms::Values::importStartValuesHelper(pugi::xml_node& parameters)
 {
   if (parameters)

--- a/src/OMSimulatorLib/Values.h
+++ b/src/OMSimulatorLib/Values.h
@@ -54,7 +54,8 @@ namespace oms
     oms_status_enu_t deleteStartValue(const ComRef& cref);
 
     oms_status_enu_t exportToSSV(pugi::xml_node& ssvNode) const;
-    oms_status_enu_t exportToSSVTemplate(pugi::xml_node& ssvNode, const ComRef& cref);  ///< start values read from modelDescription.xml
+    oms_status_enu_t exportToSSVTemplate(pugi::xml_node& ssvNode, const ComRef& cref);  ///< start values read from modelDescription.xml and creates a ssv template
+    oms_status_enu_t exportToSSMTemplate(pugi::xml_node& ssmNode, const ComRef& cref);  ///< start values read from modelDescription.xml and creates a ssm template
     oms_status_enu_t exportStartValuesHelper(pugi::xml_node& node) const;
     oms_status_enu_t importStartValuesHelper(pugi::xml_node& parameters);
     oms_status_enu_t parseModelDescription(const char *filename);

--- a/src/OMSimulatorLib/ssd/Tags.cpp
+++ b/src/OMSimulatorLib/ssd/Tags.cpp
@@ -93,3 +93,6 @@ const char* oms::ssp::Version1_0::ssv::enumeration_type                = "ssv:En
 const char* oms::ssp::Version1_0::ssv::binary_type                     = "ssv:Binary";
 
 const char* oms::ssp::Version1_0::ssc::annotation                      = "ssc:Annotation";
+
+const char* oms::ssp::Version1_0::ssm::parameter_mapping               = "ssm:ParameterMapping";
+const char* oms::ssp::Version1_0::ssm::parameter_mapping_entry         = "ssm:MappingEntry";

--- a/src/OMSimulatorLib/ssd/Tags.h
+++ b/src/OMSimulatorLib/ssd/Tags.h
@@ -55,6 +55,12 @@ namespace oms
         extern const char* parameter_values;
       }
 
+      namespace ssm
+      {
+        extern const char* parameter_mapping;
+        extern const char* parameter_mapping_entry;
+      }
+
       namespace ssv
       {
         extern const char* parameter_set;

--- a/src/OMSimulatorLua/OMSimulatorLua.c
+++ b/src/OMSimulatorLua/OMSimulatorLua.c
@@ -294,6 +294,22 @@ static int OMSimulatorLua_oms_exportSSVTemplate(lua_State *L)
   return 1;
 }
 
+//oms_status_enu_t oms_exportSSMTemplate(const char* cref, const char* filename);
+static int OMSimulatorLua_oms_exportSSMTemplate(lua_State *L)
+{
+  if (lua_gettop(L) != 2)
+    return luaL_error(L, "expecting exactly 2 arguments");
+  luaL_checktype(L, 1, LUA_TSTRING);
+  luaL_checktype(L, 2, LUA_TSTRING);
+
+  const char* cref = lua_tostring(L, 1);
+  const char* filename = lua_tostring(L, 2);
+  oms_status_enu_t status = oms_exportSSMTemplate(cref, filename);
+
+  lua_pushinteger(L, status);
+  return 1;
+}
+
 //oms_status_enu_t oms_listUnconnectedConnectors(const char* cref, char** contents);
 static int OMSimulatorLua_oms_listUnconnectedConnectors(lua_State *L)
 {
@@ -1286,6 +1302,7 @@ DLLEXPORT int luaopen_OMSimulatorLua(lua_State *L)
   REGISTER_LUA_CALL(oms_exportDependencyGraphs);
   REGISTER_LUA_CALL(oms_exportSnapshot);
   REGISTER_LUA_CALL(oms_exportSSVTemplate);
+  REGISTER_LUA_CALL(oms_exportSSMTemplate);
   REGISTER_LUA_CALL(oms_faultInjection);
   REGISTER_LUA_CALL(oms_getBoolean);
   REGISTER_LUA_CALL(oms_getFixedStepSize);

--- a/src/OMSimulatorPython/OMSimulator.py
+++ b/src/OMSimulatorPython/OMSimulator.py
@@ -110,6 +110,8 @@ class OMSimulator:
     self.obj.oms_exportSnapshot.restype = ctypes.c_int
     self.obj.oms_exportSSVTemplate.argtypes = [ctypes.c_char_p, ctypes.c_char_p]
     self.obj.oms_exportSSVTemplate.restype = ctypes.c_int
+    self.obj.oms_exportSSMTemplate.argtypes = [ctypes.c_char_p, ctypes.c_char_p]
+    self.obj.oms_exportSSMTemplate.restype = ctypes.c_int
     self.obj.oms_faultInjection.argtypes = [ctypes.c_char_p, ctypes.c_int, ctypes.c_double]
     self.obj.oms_faultInjection.restype = ctypes.c_int
     self.obj.oms_getBoolean.argtypes = [ctypes.c_char_p, ctypes.POINTER(ctypes.c_bool)]
@@ -283,6 +285,8 @@ class OMSimulator:
     return [self.checkstring(contents.value), status]
   def exportSSVTemplate(self, ident, filename):
     return self.obj.oms_exportSSVTemplate(self.checkstring(ident), self.checkstring(filename))
+  def exportSSMTemplate(self, ident, filename):
+    return self.obj.oms_exportSSMTemplate(self.checkstring(ident), self.checkstring(filename))
   def listUnconnectedConnectors(self, ident):
     contents = ctypes.c_char_p()
     status = self.obj.oms_listUnconnectedConnectors(self.checkstring(ident), ctypes.byref(contents))

--- a/testsuite/OMSimulator/exportSSMTemplate.lua
+++ b/testsuite/OMSimulator/exportSSMTemplate.lua
@@ -1,0 +1,61 @@
+-- status: correct
+-- linux: yes
+-- mingw: no
+-- win: no
+-- mac: no
+
+oms_setCommandLineOption("--suppressPath=true")
+oms_setTempDirectory("./exportssmtemplate_lua/")
+
+
+function readFile(filename)
+  local f = assert(io.open(filename, "r"))
+  local content = f:read("*all")
+  print(content)
+  f:close()
+end
+
+
+oms_newModel("test")
+
+oms_addSystem("test.Root", oms_system_wc)
+
+oms_addSubModel("test.Root.Gain", "../resources/Modelica.Blocks.Math.Gain.fmu")
+oms_addSubModel("test.Root.add", "../resources/Modelica.Blocks.Math.Add.fmu")
+
+oms_exportSSMTemplate("test", "template.ssm")
+readFile("template.ssm")
+
+oms_exportSSMTemplate("test.Root.add", "add.ssm")
+readFile("add.ssm")
+
+oms_exportSSMTemplate("test.Root.Gain", "gain.ssm")
+readFile("gain.ssm")
+
+
+-- Result:
+-- <?xml version="1.0" encoding="UTF-8"?>
+-- <ssm:ParameterMapping xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" version="1.0">
+-- 	<ssm:MappingEntry source="" target="add.u2" />
+-- 	<ssm:MappingEntry source="" target="add.u1" />
+-- 	<ssm:MappingEntry source="" target="add.k2" />
+-- 	<ssm:MappingEntry source="" target="add.k1" />
+-- 	<ssm:MappingEntry source="" target="Gain.u" />
+-- 	<ssm:MappingEntry source="" target="Gain.k" />
+-- </ssm:ParameterMapping>
+-- 
+-- <?xml version="1.0" encoding="UTF-8"?>
+-- <ssm:ParameterMapping xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" version="1.0">
+-- 	<ssm:MappingEntry source="" target="add.u2" />
+-- 	<ssm:MappingEntry source="" target="add.u1" />
+-- 	<ssm:MappingEntry source="" target="add.k2" />
+-- 	<ssm:MappingEntry source="" target="add.k1" />
+-- </ssm:ParameterMapping>
+-- 
+-- <?xml version="1.0" encoding="UTF-8"?>
+-- <ssm:ParameterMapping xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" version="1.0">
+-- 	<ssm:MappingEntry source="" target="Gain.u" />
+-- 	<ssm:MappingEntry source="" target="Gain.k" />
+-- </ssm:ParameterMapping>
+-- 
+-- endResult

--- a/testsuite/OMSimulator/exportSSMTemplate.py
+++ b/testsuite/OMSimulator/exportSSMTemplate.py
@@ -1,0 +1,64 @@
+## status: correct
+## linux: yes
+## mingw: no
+## win: no
+## mac: no
+
+from OMSimulator import OMSimulator
+oms = OMSimulator()
+
+oms.setCommandLineOption("--suppressPath=true")
+oms.setTempDirectory("./exportssmtemplate_py/")
+
+
+def readFile(filename):
+  f = open(filename, "r")
+  content = f.read()
+  print(content)
+  f:close()
+
+
+
+oms.newModel("test")
+
+oms.addSystem("test.Root", oms.system_wc)
+
+oms.addSubModel("test.Root.Gain", "../resources/Modelica.Blocks.Math.Gain.fmu")
+oms.addSubModel("test.Root.add", "../resources/Modelica.Blocks.Math.Add.fmu")
+
+oms.exportSSMTemplate("test", "template.ssm")
+readFile("template.ssm")
+
+oms.exportSSMTemplate("test.Root.add", "add.ssm")
+readFile("add.ssm")
+
+oms.exportSSMTemplate("test.Root.Gain", "gain.ssm")
+readFile("gain.ssm")
+
+
+## Result:
+## <?xml version="1.0" encoding="UTF-8"?>
+## <ssm:ParameterMapping xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" version="1.0">
+## 	<ssm:MappingEntry source="" target="add.u2" />
+## 	<ssm:MappingEntry source="" target="add.u1" />
+## 	<ssm:MappingEntry source="" target="add.k2" />
+## 	<ssm:MappingEntry source="" target="add.k1" />
+## 	<ssm:MappingEntry source="" target="Gain.u" />
+## 	<ssm:MappingEntry source="" target="Gain.k" />
+## </ssm:ParameterMapping>
+## 
+## <?xml version="1.0" encoding="UTF-8"?>
+## <ssm:ParameterMapping xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" version="1.0">
+## 	<ssm:MappingEntry source="" target="add.u2" />
+## 	<ssm:MappingEntry source="" target="add.u1" />
+## 	<ssm:MappingEntry source="" target="add.k2" />
+## 	<ssm:MappingEntry source="" target="add.k1" />
+## </ssm:ParameterMapping>
+## 
+## <?xml version="1.0" encoding="UTF-8"?>
+## <ssm:ParameterMapping xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" version="1.0">
+## 	<ssm:MappingEntry source="" target="Gain.u" />
+## 	<ssm:MappingEntry source="" target="Gain.k" />
+## </ssm:ParameterMapping>
+## 
+## endResult


### PR DESCRIPTION
### Related Issues

https://github.com/OpenModelica/OMSimulator/issues/735

### Purpose

This PR adds support to export `SSM` template file with a mapping entry associated with the `SSV` file. The SSM file contains all the signals read from `modeldescription.xml` that has start values and generates a `SSM` template file.
 
### Approach
The SSM template file has a mapping entry for the parameters defined in the SSV file. The mapping entry contains two attributes namely source and target, 
 
1. The `source` attribute will be empty and needs to be manually mapped by the users associated with the parameter name defined  in the SSV file.
2.  The `target` attribute contains the name of parameter in the system or component to be parameterized

### Example
```
<ssm:ParameterMapping xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" version="1.0">
 	<ssm:MappingEntry source="" target="add.u2" />
 	<ssm:MappingEntry source="" target="add.u1" />
 	<ssm:MappingEntry source="" target="add.k2" />
 	<ssm:MappingEntry source="" target="add.k1" />
</ssm:ParameterMapping>
```