### PR TITLE
Changed Dll search meachanism with Python 3.8

### DIFF
--- a/src/OMSimulatorPython/OMSimulator.py
+++ b/src/OMSimulatorPython/OMSimulator.py
@@ -10,7 +10,11 @@ class OMSimulator:
       dirname = os.path.dirname(__file__)
       omslib = os.path.join(dirname, "@OMSIMULATORLIB_DIR_STRING@", "@OMSIMULATORLIB_STRING@")
 
+    if os.name == 'nt': # If on Windows
+      ddlDir = os.add_dll_directory(os.path.dirname(omslib))
     self.obj=ctypes.CDLL(omslib)
+    if os.name == 'nt': # If on Windows
+      close(ddlDir)
 
     ## oms_status_enu_t
     self.status_ok = 0


### PR DESCRIPTION
Added add_dll_directory to add path to DLL search path.
Needed for Windows tests.

### Related Issues

Fixes #897