### PR TITLE
Fixing error introduced in 6aace93

### DIFF
--- a/src/OMSimulatorPython/OMSimulator.py
+++ b/src/OMSimulatorPython/OMSimulator.py
@@ -10,11 +10,11 @@ class OMSimulator:
       dirname = os.path.dirname(__file__)
       omslib = os.path.join(dirname, "@OMSIMULATORLIB_DIR_STRING@", "@OMSIMULATORLIB_STRING@")
 
-    if os.name == 'nt': # If on Windows
-      ddlDir = os.add_dll_directory(os.path.dirname(omslib))
+    if os.name == 'nt': # On Windows
+      dllDir = os.add_dll_directory(os.path.dirname(omslib))
     self.obj=ctypes.CDLL(omslib)
-    if os.name == 'nt': # If on Windows
-      close(ddlDir)
+    if os.name == 'nt':
+      dllDir.close()
 
     ## oms_status_enu_t
     self.status_ok = 0


### PR DESCRIPTION
Fixxing error from 6aace93.
  - That's why we need to test on Windows again

Jenkins test from #896 
reported
```
Stacktrace
Output mismatch (see stdout for details)
Standard Output
+ buses.py                                                                          ... execution failed
==== Log /tmp/oms-rtest-adrpo33/apitmp_1398/log-buses.py
Traceback (most recent call last):
  File "buses.py", line 9, in <module>
    oms = OMSimulator()
  File "C:/dev/jenkins/ws/OMSimulator_PR-896/install/mingw/lib/OMSimulator/OMSimulator.py", line 17, in __init__
    close(ddlDir)
NameError: name 'close' is not defined
== 1 out of 1 tests failed [api, time: 1]
```

Of course it has to be `ddlDir.close()`.
