### PR TITLE
import parameter mapping from .ssm and inline

### DIFF
--- a/src/OMSimulatorLib/System.h
+++ b/src/OMSimulatorLib/System.h
@@ -164,7 +164,7 @@ namespace oms
     ctpl::thread_pool& getThreadPool();
 
     std::string getUniqueID() const;
-    std::vector<std::string> ssvFileSources;
+    std::map<std::string, std::string> startValuesFileSources;  ///< ssvFileSource mapped with ssmFilesource if mapping is provided, otherwise only ssvFilesource entry is made
   protected:
     System(const ComRef& cref, oms_system_enu_t type, Model* parentModel, System* parentSystem, oms_solver_enu_t solverMethod);
 
@@ -215,6 +215,8 @@ namespace oms
     oms_status_enu_t importBusConnectorSignals(const pugi::xml_node& node);
     oms_status_enu_t importBusConnectorGeometry(const pugi::xml_node& node);
     oms_status_enu_t importStartValuesFromSSV();
+    oms_status_enu_t importStartValuesFromSSVHelper(std::string fileName, std::multimap<ComRef, ComRef> &mappedEntry);
+    oms_status_enu_t importParamterMappingFromSSM(std::string fileName, std::multimap<ComRef, ComRef> &mappedEntry);
   };
 }
 

--- a/src/OMSimulatorLib/Values.h
+++ b/src/OMSimulatorLib/Values.h
@@ -58,6 +58,7 @@ namespace oms
     oms_status_enu_t exportToSSMTemplate(pugi::xml_node& ssmNode, const ComRef& cref);  ///< start values read from modelDescription.xml and creates a ssm template
     oms_status_enu_t exportStartValuesHelper(pugi::xml_node& node) const;
     oms_status_enu_t importStartValuesHelper(pugi::xml_node& parameters);
+    oms_status_enu_t importParameterMappingInline(pugi::xml_node& parameterMapping);
     oms_status_enu_t parseModelDescription(const char *filename);
 
     std::map<ComRef, double> realStartValues;  ///< parameters and start values defined before instantiating the FMU
@@ -71,6 +72,8 @@ namespace oms
     std::map<ComRef, double> modelDescriptionRealStartValues;  ///< real start values read from modelDescription.xml
     std::map<ComRef, int> modelDescriptionIntegerStartValues;  ///< integer start values read from modelDescription.xml
     std::map<ComRef, bool> modelDescriptionBooleanStartValues;  ///< boolean start values read from modelDescription.xml
+
+    std::multimap<ComRef, ComRef> mappedEntry;  ///< parameter names and values provided in the parameter source are to be mapped to the parameters of the component or system
 
   };
 }

--- a/src/OMSimulatorLib/Values.h
+++ b/src/OMSimulatorLib/Values.h
@@ -57,9 +57,12 @@ namespace oms
     oms_status_enu_t exportToSSVTemplate(pugi::xml_node& ssvNode, const ComRef& cref);  ///< start values read from modelDescription.xml and creates a ssv template
     oms_status_enu_t exportToSSMTemplate(pugi::xml_node& ssmNode, const ComRef& cref);  ///< start values read from modelDescription.xml and creates a ssm template
     oms_status_enu_t exportStartValuesHelper(pugi::xml_node& node) const;
+    oms_status_enu_t exportParameterMappingInline(pugi::xml_node& node) const;
     oms_status_enu_t importStartValuesHelper(pugi::xml_node& parameters);
     oms_status_enu_t importParameterMappingInline(pugi::xml_node& parameterMapping);
     oms_status_enu_t parseModelDescription(const char *filename);
+
+    oms::ComRef getMappedCrefEntry(ComRef cref) const;
 
     std::map<ComRef, double> realStartValues;  ///< parameters and start values defined before instantiating the FMU
     std::map<ComRef, int> integerStartValues;  ///< parameters and start values defined before instantiating the FMU

--- a/src/OMSimulatorLib/ssd/Tags.cpp
+++ b/src/OMSimulatorLib/ssd/Tags.cpp
@@ -73,6 +73,7 @@ const char* oms::ssp::Version1_0::ssm_file                             = "oms:ss
 const char* oms::ssp::Version1_0::ssd::parameter_bindings              = "ssd:ParameterBindings";
 const char* oms::ssp::Version1_0::ssd::parameter_binding               = "ssd:ParameterBinding";
 const char* oms::ssp::Version1_0::ssd::parameter_values                = "ssd:ParameterValues";
+const char* oms::ssp::Version1_0::ssd::parameter_mapping               = "ssd:ParameterMapping";
 
 const char* oms::ssp::Version1_0::ssv::parameter_set                   = "ssv:ParameterSet";
 const char* oms::ssp::Version1_0::ssv::parameters                      = "ssv:Parameters";

--- a/src/OMSimulatorLib/ssd/Tags.h
+++ b/src/OMSimulatorLib/ssd/Tags.h
@@ -53,6 +53,7 @@ namespace oms
         extern const char* parameter_bindings;
         extern const char* parameter_binding;
         extern const char* parameter_values;
+        extern const char* parameter_mapping;
       }
 
       namespace ssm

--- a/testsuite/OMSimulator/Makefile
+++ b/testsuite/OMSimulator/Makefile
@@ -15,6 +15,8 @@ import_export_parameters_to_ssv.lua \
 import_export_snapshot.lua \
 import_export.lua \
 import_export.py \
+import_parameter_mapping_from_ssm.lua \
+import_parameter_mapping_inline.lua \
 importStartValues.lua \
 PI_Controller.lua \
 QuarterCarModel.DisplacementDisplacement.lua \

--- a/testsuite/OMSimulator/import_parameter_mapping_from_ssm.lua
+++ b/testsuite/OMSimulator/import_parameter_mapping_from_ssm.lua
@@ -1,0 +1,115 @@
+-- status: correct
+-- linux: yes
+-- mingw: yes
+-- win: no
+-- mac: no
+
+oms_setCommandLineOption("--suppressPath=true")
+oms_setTempDirectory("./import_parameter_mapping_inline_lua/")
+
+oms_importFile("../resources/importParameterMapping.ssp");
+
+oms_instantiate("import_parameter_mapping")
+
+print("info:      Instantiation ")
+print("info:      import_parameter_mapping.co_sim.Input_1              : " .. oms_getReal("import_parameter_mapping.co_sim.Input_1"))
+print("info:      import_parameter_mapping.co_sim.Input_2              : " .. oms_getReal("import_parameter_mapping.co_sim.Input_2"))
+print("info:      import_parameter_mapping.co_sim.Input_3              : " .. oms_getReal("import_parameter_mapping.co_sim.Input_3"))
+print("info:      import_parameter_mapping.co_sim.parameter_1          : " .. oms_getReal("import_parameter_mapping.co_sim.parameter_1"))
+print("info:      import_parameter_mapping.co_sim.parameter_2          : " .. oms_getReal("import_parameter_mapping.co_sim.parameter_2"))
+
+print("info:      import_parameter_mapping.co_sim.System1.Input_1      : " .. oms_getReal("import_parameter_mapping.co_sim.System1.Input_1"))
+print("info:      import_parameter_mapping.co_sim.System1.Input_2      : " .. oms_getReal("import_parameter_mapping.co_sim.System1.Input_2"))
+print("info:      import_parameter_mapping.co_sim.System1.parameter_1  : " .. oms_getReal("import_parameter_mapping.co_sim.System1.parameter_1"))
+print("info:      import_parameter_mapping.co_sim.System1.parameter_2  : " .. oms_getReal("import_parameter_mapping.co_sim.System1.parameter_2"))
+
+print("info:      import_parameter_mapping.co_sim.System2.Input_1      : " .. oms_getReal("import_parameter_mapping.co_sim.System2.Input_1"))
+print("info:      import_parameter_mapping.co_sim.System2.Input_2      : " .. oms_getReal("import_parameter_mapping.co_sim.System2.Input_2"))
+print("info:      import_parameter_mapping.co_sim.System2.parameter_1  : " .. oms_getReal("import_parameter_mapping.co_sim.System2.parameter_1"))
+print("info:      import_parameter_mapping.co_sim.System2.parameter_2  : " .. oms_getReal("import_parameter_mapping.co_sim.System2.parameter_2"))
+
+
+oms_initialize("import_parameter_mapping")
+print("info:    Initialization")
+print("info:      import_parameter_mapping.co_sim.Input_1              : " .. oms_getReal("import_parameter_mapping.co_sim.Input_1"))
+print("info:      import_parameter_mapping.co_sim.Input_2              : " .. oms_getReal("import_parameter_mapping.co_sim.Input_2"))
+print("info:      import_parameter_mapping.co_sim.Input_3              : " .. oms_getReal("import_parameter_mapping.co_sim.Input_3"))
+print("info:      import_parameter_mapping.co_sim.parameter_1          : " .. oms_getReal("import_parameter_mapping.co_sim.parameter_1"))
+print("info:      import_parameter_mapping.co_sim.parameter_2          : " .. oms_getReal("import_parameter_mapping.co_sim.parameter_2"))
+
+print("info:      import_parameter_mapping.co_sim.System1.Input_1      : " .. oms_getReal("import_parameter_mapping.co_sim.System1.Input_1"))
+print("info:      import_parameter_mapping.co_sim.System1.Input_2      : " .. oms_getReal("import_parameter_mapping.co_sim.System1.Input_2"))
+print("info:      import_parameter_mapping.co_sim.System1.parameter_1  : " .. oms_getReal("import_parameter_mapping.co_sim.System1.parameter_1"))
+print("info:      import_parameter_mapping.co_sim.System1.parameter_2  : " .. oms_getReal("import_parameter_mapping.co_sim.System1.parameter_2"))
+
+print("info:      import_parameter_mapping.co_sim.System2.Input_1      : " .. oms_getReal("import_parameter_mapping.co_sim.System2.Input_1"))
+print("info:      import_parameter_mapping.co_sim.System2.Input_2      : " .. oms_getReal("import_parameter_mapping.co_sim.System2.Input_2"))
+print("info:      import_parameter_mapping.co_sim.System2.parameter_1  : " .. oms_getReal("import_parameter_mapping.co_sim.System2.parameter_1"))
+print("info:      import_parameter_mapping.co_sim.System2.parameter_2  : " .. oms_getReal("import_parameter_mapping.co_sim.System2.parameter_2"))
+
+
+oms_simulate("import_parameter_mapping")
+print("info:    Simulation")
+print("info:      import_parameter_mapping.co_sim.Input_1              : " .. oms_getReal("import_parameter_mapping.co_sim.Input_1"))
+print("info:      import_parameter_mapping.co_sim.Input_2              : " .. oms_getReal("import_parameter_mapping.co_sim.Input_2"))
+print("info:      import_parameter_mapping.co_sim.Input_3              : " .. oms_getReal("import_parameter_mapping.co_sim.Input_3"))
+print("info:      import_parameter_mapping.co_sim.parameter_1          : " .. oms_getReal("import_parameter_mapping.co_sim.parameter_1"))
+print("info:      import_parameter_mapping.co_sim.parameter_2          : " .. oms_getReal("import_parameter_mapping.co_sim.parameter_2"))
+
+print("info:      import_parameter_mapping.co_sim.System1.Input_1      : " .. oms_getReal("import_parameter_mapping.co_sim.System1.Input_1"))
+print("info:      import_parameter_mapping.co_sim.System1.Input_2      : " .. oms_getReal("import_parameter_mapping.co_sim.System1.Input_2"))
+print("info:      import_parameter_mapping.co_sim.System1.parameter_1  : " .. oms_getReal("import_parameter_mapping.co_sim.System1.parameter_1"))
+print("info:      import_parameter_mapping.co_sim.System1.parameter_2  : " .. oms_getReal("import_parameter_mapping.co_sim.System1.parameter_2"))
+
+print("info:      import_parameter_mapping.co_sim.System2.Input_1      : " .. oms_getReal("import_parameter_mapping.co_sim.System2.Input_1"))
+print("info:      import_parameter_mapping.co_sim.System2.Input_2      : " .. oms_getReal("import_parameter_mapping.co_sim.System2.Input_2"))
+print("info:      import_parameter_mapping.co_sim.System2.parameter_1  : " .. oms_getReal("import_parameter_mapping.co_sim.System2.parameter_1"))
+print("info:      import_parameter_mapping.co_sim.System2.parameter_2  : " .. oms_getReal("import_parameter_mapping.co_sim.System2.parameter_2"))
+
+-- Result:
+-- info:    model doesn't contain any continuous state
+-- info:    model doesn't contain any continuous state
+-- info:      Instantiation
+-- info:      import_parameter_mapping.co_sim.Input_1              : 20.0
+-- info:      import_parameter_mapping.co_sim.Input_2              : 20.0
+-- info:      import_parameter_mapping.co_sim.Input_3              : 50.0
+-- info:      import_parameter_mapping.co_sim.parameter_1          : -30.0
+-- info:      import_parameter_mapping.co_sim.parameter_2          : -40.0
+-- info:      import_parameter_mapping.co_sim.System1.Input_1      : 20.0
+-- info:      import_parameter_mapping.co_sim.System1.Input_2      : 20.0
+-- info:      import_parameter_mapping.co_sim.System1.parameter_1  : -30.0
+-- info:      import_parameter_mapping.co_sim.System1.parameter_2  : 0.0
+-- info:      import_parameter_mapping.co_sim.System2.Input_1      : 20.0
+-- info:      import_parameter_mapping.co_sim.System2.Input_2      : 20.0
+-- info:      import_parameter_mapping.co_sim.System2.parameter_1  : -30.0
+-- info:      import_parameter_mapping.co_sim.System2.parameter_2  : 0.0
+-- info:    Result file: import_parameter_mapping_res.mat (bufferSize=10)
+-- info:    Initialization
+-- info:      import_parameter_mapping.co_sim.Input_1              : 20.0
+-- info:      import_parameter_mapping.co_sim.Input_2              : 20.0
+-- info:      import_parameter_mapping.co_sim.Input_3              : 50.0
+-- info:      import_parameter_mapping.co_sim.parameter_1          : -30.0
+-- info:      import_parameter_mapping.co_sim.parameter_2          : -40.0
+-- info:      import_parameter_mapping.co_sim.System1.Input_1      : 20.0
+-- info:      import_parameter_mapping.co_sim.System1.Input_2      : 20.0
+-- info:      import_parameter_mapping.co_sim.System1.parameter_1  : -30.0
+-- info:      import_parameter_mapping.co_sim.System1.parameter_2  : 0.0
+-- info:      import_parameter_mapping.co_sim.System2.Input_1      : 20.0
+-- info:      import_parameter_mapping.co_sim.System2.Input_2      : 20.0
+-- info:      import_parameter_mapping.co_sim.System2.parameter_1  : -30.0
+-- info:      import_parameter_mapping.co_sim.System2.parameter_2  : 0.0
+-- info:    Simulation
+-- info:      import_parameter_mapping.co_sim.Input_1              : 20.0
+-- info:      import_parameter_mapping.co_sim.Input_2              : 20.0
+-- info:      import_parameter_mapping.co_sim.Input_3              : 50.0
+-- info:      import_parameter_mapping.co_sim.parameter_1          : -30.0
+-- info:      import_parameter_mapping.co_sim.parameter_2          : -40.0
+-- info:      import_parameter_mapping.co_sim.System1.Input_1      : 20.0
+-- info:      import_parameter_mapping.co_sim.System1.Input_2      : 20.0
+-- info:      import_parameter_mapping.co_sim.System1.parameter_1  : -30.0
+-- info:      import_parameter_mapping.co_sim.System1.parameter_2  : 0.0
+-- info:      import_parameter_mapping.co_sim.System2.Input_1      : 20.0
+-- info:      import_parameter_mapping.co_sim.System2.Input_2      : 20.0
+-- info:      import_parameter_mapping.co_sim.System2.parameter_1  : -30.0
+-- info:      import_parameter_mapping.co_sim.System2.parameter_2  : 0.0
+-- endResult

--- a/testsuite/OMSimulator/import_parameter_mapping_from_ssm.lua
+++ b/testsuite/OMSimulator/import_parameter_mapping_from_ssm.lua
@@ -5,7 +5,7 @@
 -- mac: no
 
 oms_setCommandLineOption("--suppressPath=true")
-oms_setTempDirectory("./import_parameter_mapping_inline_lua/")
+oms_setTempDirectory("./import_parameter_mapping_ssm_lua/")
 
 oms_importFile("../resources/importParameterMapping.ssp");
 

--- a/testsuite/OMSimulator/import_parameter_mapping_inline.lua
+++ b/testsuite/OMSimulator/import_parameter_mapping_inline.lua
@@ -1,0 +1,115 @@
+-- status: correct
+-- linux: yes
+-- mingw: yes
+-- win: no
+-- mac: no
+
+oms_setCommandLineOption("--suppressPath=true")
+oms_setTempDirectory("./import_parameter_mapping_inline_lua/")
+
+oms_importFile("../resources/importParameterMappingInline.ssp");
+
+oms_instantiate("import_parameter_mapping")
+
+print("info:      Instantiation ")
+print("info:      import_parameter_mapping.co_sim.Input_1              : " .. oms_getReal("import_parameter_mapping.co_sim.Input_1"))
+print("info:      import_parameter_mapping.co_sim.Input_2              : " .. oms_getReal("import_parameter_mapping.co_sim.Input_2"))
+print("info:      import_parameter_mapping.co_sim.Input_3              : " .. oms_getReal("import_parameter_mapping.co_sim.Input_3"))
+print("info:      import_parameter_mapping.co_sim.parameter_1          : " .. oms_getReal("import_parameter_mapping.co_sim.parameter_1"))
+print("info:      import_parameter_mapping.co_sim.parameter_2          : " .. oms_getReal("import_parameter_mapping.co_sim.parameter_2"))
+
+print("info:      import_parameter_mapping.co_sim.System1.Input_1      : " .. oms_getReal("import_parameter_mapping.co_sim.System1.Input_1"))
+print("info:      import_parameter_mapping.co_sim.System1.Input_2      : " .. oms_getReal("import_parameter_mapping.co_sim.System1.Input_2"))
+print("info:      import_parameter_mapping.co_sim.System1.parameter_1  : " .. oms_getReal("import_parameter_mapping.co_sim.System1.parameter_1"))
+print("info:      import_parameter_mapping.co_sim.System1.parameter_2  : " .. oms_getReal("import_parameter_mapping.co_sim.System1.parameter_2"))
+
+print("info:      import_parameter_mapping.co_sim.System2.Input_1      : " .. oms_getReal("import_parameter_mapping.co_sim.System2.Input_1"))
+print("info:      import_parameter_mapping.co_sim.System2.Input_2      : " .. oms_getReal("import_parameter_mapping.co_sim.System2.Input_2"))
+print("info:      import_parameter_mapping.co_sim.System2.parameter_1  : " .. oms_getReal("import_parameter_mapping.co_sim.System2.parameter_1"))
+print("info:      import_parameter_mapping.co_sim.System2.parameter_2  : " .. oms_getReal("import_parameter_mapping.co_sim.System2.parameter_2"))
+
+
+oms_initialize("import_parameter_mapping")
+print("info:    Initialization")
+print("info:      import_parameter_mapping.co_sim.Input_1              : " .. oms_getReal("import_parameter_mapping.co_sim.Input_1"))
+print("info:      import_parameter_mapping.co_sim.Input_2              : " .. oms_getReal("import_parameter_mapping.co_sim.Input_2"))
+print("info:      import_parameter_mapping.co_sim.Input_3              : " .. oms_getReal("import_parameter_mapping.co_sim.Input_3"))
+print("info:      import_parameter_mapping.co_sim.parameter_1          : " .. oms_getReal("import_parameter_mapping.co_sim.parameter_1"))
+print("info:      import_parameter_mapping.co_sim.parameter_2          : " .. oms_getReal("import_parameter_mapping.co_sim.parameter_2"))
+
+print("info:      import_parameter_mapping.co_sim.System1.Input_1      : " .. oms_getReal("import_parameter_mapping.co_sim.System1.Input_1"))
+print("info:      import_parameter_mapping.co_sim.System1.Input_2      : " .. oms_getReal("import_parameter_mapping.co_sim.System1.Input_2"))
+print("info:      import_parameter_mapping.co_sim.System1.parameter_1  : " .. oms_getReal("import_parameter_mapping.co_sim.System1.parameter_1"))
+print("info:      import_parameter_mapping.co_sim.System1.parameter_2  : " .. oms_getReal("import_parameter_mapping.co_sim.System1.parameter_2"))
+
+print("info:      import_parameter_mapping.co_sim.System2.Input_1      : " .. oms_getReal("import_parameter_mapping.co_sim.System2.Input_1"))
+print("info:      import_parameter_mapping.co_sim.System2.Input_2      : " .. oms_getReal("import_parameter_mapping.co_sim.System2.Input_2"))
+print("info:      import_parameter_mapping.co_sim.System2.parameter_1  : " .. oms_getReal("import_parameter_mapping.co_sim.System2.parameter_1"))
+print("info:      import_parameter_mapping.co_sim.System2.parameter_2  : " .. oms_getReal("import_parameter_mapping.co_sim.System2.parameter_2"))
+
+
+oms_simulate("import_parameter_mapping")
+print("info:    Simulation")
+print("info:      import_parameter_mapping.co_sim.Input_1              : " .. oms_getReal("import_parameter_mapping.co_sim.Input_1"))
+print("info:      import_parameter_mapping.co_sim.Input_2              : " .. oms_getReal("import_parameter_mapping.co_sim.Input_2"))
+print("info:      import_parameter_mapping.co_sim.Input_3              : " .. oms_getReal("import_parameter_mapping.co_sim.Input_3"))
+print("info:      import_parameter_mapping.co_sim.parameter_1          : " .. oms_getReal("import_parameter_mapping.co_sim.parameter_1"))
+print("info:      import_parameter_mapping.co_sim.parameter_2          : " .. oms_getReal("import_parameter_mapping.co_sim.parameter_2"))
+
+print("info:      import_parameter_mapping.co_sim.System1.Input_1      : " .. oms_getReal("import_parameter_mapping.co_sim.System1.Input_1"))
+print("info:      import_parameter_mapping.co_sim.System1.Input_2      : " .. oms_getReal("import_parameter_mapping.co_sim.System1.Input_2"))
+print("info:      import_parameter_mapping.co_sim.System1.parameter_1  : " .. oms_getReal("import_parameter_mapping.co_sim.System1.parameter_1"))
+print("info:      import_parameter_mapping.co_sim.System1.parameter_2  : " .. oms_getReal("import_parameter_mapping.co_sim.System1.parameter_2"))
+
+print("info:      import_parameter_mapping.co_sim.System2.Input_1      : " .. oms_getReal("import_parameter_mapping.co_sim.System2.Input_1"))
+print("info:      import_parameter_mapping.co_sim.System2.Input_2      : " .. oms_getReal("import_parameter_mapping.co_sim.System2.Input_2"))
+print("info:      import_parameter_mapping.co_sim.System2.parameter_1  : " .. oms_getReal("import_parameter_mapping.co_sim.System2.parameter_1"))
+print("info:      import_parameter_mapping.co_sim.System2.parameter_2  : " .. oms_getReal("import_parameter_mapping.co_sim.System2.parameter_2"))
+
+-- Result:
+-- info:    model doesn't contain any continuous state
+-- info:    model doesn't contain any continuous state
+-- info:      Instantiation 
+-- info:      import_parameter_mapping.co_sim.Input_1              : 20.0
+-- info:      import_parameter_mapping.co_sim.Input_2              : 20.0
+-- info:      import_parameter_mapping.co_sim.Input_3              : 50.0
+-- info:      import_parameter_mapping.co_sim.parameter_1          : -30.0
+-- info:      import_parameter_mapping.co_sim.parameter_2          : -40.0
+-- info:      import_parameter_mapping.co_sim.System1.Input_1      : -100.0
+-- info:      import_parameter_mapping.co_sim.System1.Input_2      : -100.0
+-- info:      import_parameter_mapping.co_sim.System1.parameter_1  : -50.0
+-- info:      import_parameter_mapping.co_sim.System1.parameter_2  : -50.0
+-- info:      import_parameter_mapping.co_sim.System2.Input_1      : 70.0
+-- info:      import_parameter_mapping.co_sim.System2.Input_2      : 70.0
+-- info:      import_parameter_mapping.co_sim.System2.parameter_1  : 70.0
+-- info:      import_parameter_mapping.co_sim.System2.parameter_2  : 70.0
+-- info:    Result file: import_parameter_mapping_res.mat (bufferSize=10)
+-- info:    Initialization
+-- info:      import_parameter_mapping.co_sim.Input_1              : 20.0
+-- info:      import_parameter_mapping.co_sim.Input_2              : 20.0
+-- info:      import_parameter_mapping.co_sim.Input_3              : 50.0
+-- info:      import_parameter_mapping.co_sim.parameter_1          : -30.0
+-- info:      import_parameter_mapping.co_sim.parameter_2          : -40.0
+-- info:      import_parameter_mapping.co_sim.System1.Input_1      : -100.0
+-- info:      import_parameter_mapping.co_sim.System1.Input_2      : -100.0
+-- info:      import_parameter_mapping.co_sim.System1.parameter_1  : -50.0
+-- info:      import_parameter_mapping.co_sim.System1.parameter_2  : -50.0
+-- info:      import_parameter_mapping.co_sim.System2.Input_1      : 70.0
+-- info:      import_parameter_mapping.co_sim.System2.Input_2      : 70.0
+-- info:      import_parameter_mapping.co_sim.System2.parameter_1  : 70.0
+-- info:      import_parameter_mapping.co_sim.System2.parameter_2  : 70.0
+-- info:    Simulation
+-- info:      import_parameter_mapping.co_sim.Input_1              : 20.0
+-- info:      import_parameter_mapping.co_sim.Input_2              : 20.0
+-- info:      import_parameter_mapping.co_sim.Input_3              : 50.0
+-- info:      import_parameter_mapping.co_sim.parameter_1          : -30.0
+-- info:      import_parameter_mapping.co_sim.parameter_2          : -40.0
+-- info:      import_parameter_mapping.co_sim.System1.Input_1      : -100.0
+-- info:      import_parameter_mapping.co_sim.System1.Input_2      : -100.0
+-- info:      import_parameter_mapping.co_sim.System1.parameter_1  : -50.0
+-- info:      import_parameter_mapping.co_sim.System1.parameter_2  : -50.0
+-- info:      import_parameter_mapping.co_sim.System2.Input_1      : 70.0
+-- info:      import_parameter_mapping.co_sim.System2.Input_2      : 70.0
+-- info:      import_parameter_mapping.co_sim.System2.parameter_1  : 70.0
+-- info:      import_parameter_mapping.co_sim.System2.parameter_2  : 70.0
+-- endResult

--- a/testsuite/OMSimulator/import_parameter_mapping_inline.lua
+++ b/testsuite/OMSimulator/import_parameter_mapping_inline.lua
@@ -9,9 +9,12 @@ oms_setTempDirectory("./import_parameter_mapping_inline_lua/")
 
 oms_importFile("../resources/importParameterMappingInline.ssp");
 
+src, status = oms_list("import_parameter_mapping")
+print(src)
+
 oms_instantiate("import_parameter_mapping")
 
-print("info:      Instantiation ")
+print("info:      Instantiation")
 print("info:      import_parameter_mapping.co_sim.Input_1              : " .. oms_getReal("import_parameter_mapping.co_sim.Input_1"))
 print("info:      import_parameter_mapping.co_sim.Input_2              : " .. oms_getReal("import_parameter_mapping.co_sim.Input_2"))
 print("info:      import_parameter_mapping.co_sim.Input_3              : " .. oms_getReal("import_parameter_mapping.co_sim.Input_3"))
@@ -67,9 +70,185 @@ print("info:      import_parameter_mapping.co_sim.System2.parameter_1  : " .. om
 print("info:      import_parameter_mapping.co_sim.System2.parameter_2  : " .. oms_getReal("import_parameter_mapping.co_sim.System2.parameter_2"))
 
 -- Result:
+-- <?xml version="1.0"?>
+-- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="import_parameter_mapping" version="1.0">
+-- 	<ssd:System name="co_sim">
+-- 		<ssd:Connectors>
+-- 			<ssd:Connector name="Input_1" kind="input">
+-- 				<ssc:Real />
+-- 			</ssd:Connector>
+-- 			<ssd:Connector name="Input_2" kind="input">
+-- 				<ssc:Real />
+-- 			</ssd:Connector>
+-- 			<ssd:Connector name="Input_3" kind="input">
+-- 				<ssc:Real />
+-- 			</ssd:Connector>
+-- 			<ssd:Connector name="Output_cref" kind="output">
+-- 				<ssc:Real />
+-- 			</ssd:Connector>
+-- 			<ssd:Connector name="parameter_1" kind="parameter">
+-- 				<ssc:Real />
+-- 			</ssd:Connector>
+-- 			<ssd:Connector name="parameter_2" kind="parameter">
+-- 				<ssc:Real />
+-- 			</ssd:Connector>
+-- 		</ssd:Connectors>
+-- 		<ssd:ParameterBindings>
+-- 			<ssd:ParameterBinding>
+-- 				<ssd:ParameterValues>
+-- 					<ssv:ParameterSet version="1.0" name="parameters">
+-- 						<ssv:Parameters>
+-- 							<ssv:Parameter name="parameter_2">
+-- 								<ssv:Real value="-40" />
+-- 							</ssv:Parameter>
+-- 							<ssv:Parameter name="cosim_parameters">
+-- 								<ssv:Real value="-30" />
+-- 							</ssv:Parameter>
+-- 							<ssv:Parameter name="Input_3">
+-- 								<ssv:Real value="50" />
+-- 							</ssv:Parameter>
+-- 							<ssv:Parameter name="cosim_inputs">
+-- 								<ssv:Real value="20" />
+-- 							</ssv:Parameter>
+-- 						</ssv:Parameters>
+-- 					</ssv:ParameterSet>
+-- 				</ssd:ParameterValues>
+-- 				<ssd:ParameterMapping>
+-- 					<ssm:ParameterMapping>
+-- 						<ssm:MappingEntry source="cosim_parameters" target="parameter_1" />
+-- 						<ssm:MappingEntry source="cosim_inputs" target="Input_1" />
+-- 						<ssm:MappingEntry source="cosim_inputs" target="Input_2" />
+-- 					</ssm:ParameterMapping>
+-- 				</ssd:ParameterMapping>
+-- 			</ssd:ParameterBinding>
+-- 		</ssd:ParameterBindings>
+-- 		<ssd:Elements>
+-- 			<ssd:System name="System2">
+-- 				<ssd:Connectors>
+-- 					<ssd:Connector name="Input_1" kind="input">
+-- 						<ssc:Real />
+-- 					</ssd:Connector>
+-- 					<ssd:Connector name="Input_2" kind="input">
+-- 						<ssc:Real />
+-- 					</ssd:Connector>
+-- 					<ssd:Connector name="parameter_1" kind="parameter">
+-- 						<ssc:Real />
+-- 					</ssd:Connector>
+-- 					<ssd:Connector name="parameter_2" kind="parameter">
+-- 						<ssc:Real />
+-- 					</ssd:Connector>
+-- 					<ssd:Connector name="output" kind="output">
+-- 						<ssc:Real />
+-- 					</ssd:Connector>
+-- 				</ssd:Connectors>
+-- 				<ssd:ParameterBindings>
+-- 					<ssd:ParameterBinding>
+-- 						<ssd:ParameterValues>
+-- 							<ssv:ParameterSet version="1.0" name="parameters">
+-- 								<ssv:Parameters>
+-- 									<ssv:Parameter name="system2_inputs">
+-- 										<ssv:Real value="70" />
+-- 									</ssv:Parameter>
+-- 								</ssv:Parameters>
+-- 							</ssv:ParameterSet>
+-- 						</ssd:ParameterValues>
+-- 						<ssd:ParameterMapping>
+-- 							<ssm:ParameterMapping>
+-- 								<ssm:MappingEntry source="system2_inputs" target="Input_1" />
+-- 								<ssm:MappingEntry source="system2_inputs" target="Input_2" />
+-- 								<ssm:MappingEntry source="system2_inputs" target="parameter_1" />
+-- 								<ssm:MappingEntry source="system2_inputs" target="parameter_2" />
+-- 							</ssm:ParameterMapping>
+-- 						</ssd:ParameterMapping>
+-- 					</ssd:ParameterBinding>
+-- 				</ssd:ParameterBindings>
+-- 				<ssd:Annotations>
+-- 					<ssc:Annotation type="org.openmodelica">
+-- 						<oms:Annotations>
+-- 							<oms:SimulationInformation>
+-- 								<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+-- 							</oms:SimulationInformation>
+-- 						</oms:Annotations>
+-- 					</ssc:Annotation>
+-- 				</ssd:Annotations>
+-- 			</ssd:System>
+-- 			<ssd:System name="System1">
+-- 				<ssd:Connectors>
+-- 					<ssd:Connector name="Input_1" kind="input">
+-- 						<ssc:Real />
+-- 					</ssd:Connector>
+-- 					<ssd:Connector name="Input_2" kind="input">
+-- 						<ssc:Real />
+-- 					</ssd:Connector>
+-- 					<ssd:Connector name="parameter_1" kind="parameter">
+-- 						<ssc:Real />
+-- 					</ssd:Connector>
+-- 					<ssd:Connector name="parameter_2" kind="parameter">
+-- 						<ssc:Real />
+-- 					</ssd:Connector>
+-- 					<ssd:Connector name="output" kind="output">
+-- 						<ssc:Real />
+-- 					</ssd:Connector>
+-- 				</ssd:Connectors>
+-- 				<ssd:ParameterBindings>
+-- 					<ssd:ParameterBinding>
+-- 						<ssd:ParameterValues>
+-- 							<ssv:ParameterSet version="1.0" name="parameters">
+-- 								<ssv:Parameters>
+-- 									<ssv:Parameter name="system1_parameters">
+-- 										<ssv:Real value="-50" />
+-- 									</ssv:Parameter>
+-- 									<ssv:Parameter name="system1_inputs">
+-- 										<ssv:Real value="-100" />
+-- 									</ssv:Parameter>
+-- 								</ssv:Parameters>
+-- 							</ssv:ParameterSet>
+-- 						</ssd:ParameterValues>
+-- 						<ssd:ParameterMapping>
+-- 							<ssm:ParameterMapping>
+-- 								<ssm:MappingEntry source="system1_parameters" target="parameter_1" />
+-- 								<ssm:MappingEntry source="system1_parameters" target="parameter_2" />
+-- 								<ssm:MappingEntry source="system1_inputs" target="Input_1" />
+-- 								<ssm:MappingEntry source="system1_inputs" target="Input_2" />
+-- 							</ssm:ParameterMapping>
+-- 						</ssd:ParameterMapping>
+-- 					</ssd:ParameterBinding>
+-- 				</ssd:ParameterBindings>
+-- 				<ssd:Annotations>
+-- 					<ssc:Annotation type="org.openmodelica">
+-- 						<oms:Annotations>
+-- 							<oms:SimulationInformation>
+-- 								<oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+-- 							</oms:SimulationInformation>
+-- 						</oms:Annotations>
+-- 					</ssc:Annotation>
+-- 				</ssd:Annotations>
+-- 			</ssd:System>
+-- 		</ssd:Elements>
+-- 		<ssd:Annotations>
+-- 			<ssc:Annotation type="org.openmodelica">
+-- 				<oms:Annotations>
+-- 					<oms:SimulationInformation>
+-- 						<oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+-- 					</oms:SimulationInformation>
+-- 				</oms:Annotations>
+-- 			</ssc:Annotation>
+-- 		</ssd:Annotations>
+-- 	</ssd:System>
+-- 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
+-- 		<ssd:Annotations>
+-- 			<ssc:Annotation type="org.openmodelica">
+-- 				<oms:Annotations>
+-- 					<oms:SimulationInformation resultFile="import_parameter_mapping_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter=".*" />
+-- 				</oms:Annotations>
+-- 			</ssc:Annotation>
+-- 		</ssd:Annotations>
+-- 	</ssd:DefaultExperiment>
+-- </ssd:SystemStructureDescription>
+-- 
 -- info:    model doesn't contain any continuous state
 -- info:    model doesn't contain any continuous state
--- info:      Instantiation 
+-- info:      Instantiation
 -- info:      import_parameter_mapping.co_sim.Input_1              : 20.0
 -- info:      import_parameter_mapping.co_sim.Input_2              : 20.0
 -- info:      import_parameter_mapping.co_sim.Input_3              : 50.0

--- a/testsuite/resources/Makefile
+++ b/testsuite/resources/Makefile
@@ -48,6 +48,8 @@ tlm.UpperPendulumFG \
 
 SSPs = \
 importStartValues \
+importParameterMapping \
+importParameterMappingInline \
 
 
 MOSs = \

--- a/testsuite/resources/importParameterMapping/SystemStructure.ssd
+++ b/testsuite/resources/importParameterMapping/SystemStructure.ssd
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="import_parameter_mapping" version="1.0">
+    <ssd:System name="co_sim">
+        <ssd:Connectors>
+            <ssd:Connector name="Input_1" kind="input">
+                <ssc:Real />
+            </ssd:Connector>
+            <ssd:Connector name="Input_2" kind="input">
+                <ssc:Real />
+            </ssd:Connector>
+            <ssd:Connector name="Input_3" kind="input">
+                <ssc:Real />
+            </ssd:Connector>
+            <ssd:Connector name="Output_cref" kind="output">
+                <ssc:Real />
+            </ssd:Connector>
+            <ssd:Connector name="parameter_1" kind="parameter">
+                <ssc:Real />
+            </ssd:Connector>
+            <ssd:Connector name="parameter_2" kind="parameter">
+                <ssc:Real />
+            </ssd:Connector>
+        </ssd:Connectors>
+        <ssd:ParameterBindings>
+            <ssd:ParameterBinding source="resources/import_parameter_mapping.ssv">
+                <ssd:ParameterMapping source="resources/import_parameter_mapping.ssm" />
+            </ssd:ParameterBinding>
+        </ssd:ParameterBindings>
+        <ssd:Elements>
+            <ssd:System name="System2">
+                <ssd:Connectors>
+                    <ssd:Connector name="Input_1" kind="input">
+                        <ssc:Real />
+                    </ssd:Connector>
+                    <ssd:Connector name="Input_2" kind="input">
+                        <ssc:Real />
+                    </ssd:Connector>
+                    <ssd:Connector name="parameter_1" kind="parameter">
+                        <ssc:Real />
+                    </ssd:Connector>
+                    <ssd:Connector name="parameter_2" kind="parameter">
+                        <ssc:Real />
+                    </ssd:Connector>
+                    <ssd:Connector name="output" kind="output">
+                        <ssc:Real />
+                    </ssd:Connector>
+                </ssd:Connectors>
+                <ssd:Annotations>
+                    <ssc:Annotation type="org.openmodelica">
+                        <oms:Annotations>
+                            <oms:SimulationInformation>
+                                <oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+                            </oms:SimulationInformation>
+                        </oms:Annotations>
+                    </ssc:Annotation>
+                </ssd:Annotations>
+            </ssd:System>
+            <ssd:System name="System1">
+                <ssd:Connectors>
+                    <ssd:Connector name="Input_1" kind="input">
+                        <ssc:Real />
+                    </ssd:Connector>
+                    <ssd:Connector name="Input_2" kind="input">
+                        <ssc:Real />
+                    </ssd:Connector>
+                    <ssd:Connector name="parameter_1" kind="parameter">
+                        <ssc:Real />
+                    </ssd:Connector>
+                    <ssd:Connector name="parameter_2" kind="parameter">
+                        <ssc:Real />
+                    </ssd:Connector>
+                    <ssd:Connector name="output" kind="output">
+                        <ssc:Real />
+                    </ssd:Connector>
+                </ssd:Connectors>
+                <ssd:Annotations>
+                    <ssc:Annotation type="org.openmodelica">
+                        <oms:Annotations>
+                            <oms:SimulationInformation>
+                                <oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+                            </oms:SimulationInformation>
+                        </oms:Annotations>
+                    </ssc:Annotation>
+                </ssd:Annotations>
+            </ssd:System>
+        </ssd:Elements>
+        <ssd:Annotations>
+            <ssc:Annotation type="org.openmodelica">
+                <oms:Annotations>
+                    <oms:SimulationInformation>
+                        <oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+                    </oms:SimulationInformation>
+                </oms:Annotations>
+            </ssc:Annotation>
+        </ssd:Annotations>
+    </ssd:System>
+    <ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
+        <ssd:Annotations>
+            <ssc:Annotation type="org.openmodelica">
+                <oms:Annotations>
+                    <oms:SimulationInformation resultFile="import_parameter_mapping_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter=".*" />
+                </oms:Annotations>
+            </ssc:Annotation>
+        </ssd:Annotations>
+    </ssd:DefaultExperiment>
+</ssd:SystemStructureDescription>

--- a/testsuite/resources/importParameterMapping/resources/import_parameter_mapping.ssm
+++ b/testsuite/resources/importParameterMapping/resources/import_parameter_mapping.ssm
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ssm:ParameterMapping xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" version="1.0">
+    <ssm:MappingEntry source="cosim_input" target="Input_1" />
+    <ssm:MappingEntry source="cosim_input" target="Input_2" />
+    <ssm:MappingEntry source="cosim_input" target="System1.Input_1" />
+    <ssm:MappingEntry source="cosim_input" target="System1.Input_2" />
+    <ssm:MappingEntry source="cosim_input" target="System2.Input_1" />
+    <ssm:MappingEntry source="cosim_input" target="System2.Input_2" />
+    <ssm:MappingEntry source="cosim_parameters" target="parameter_1" />
+    <ssm:MappingEntry source="cosim_parameters" target="System1.parameter_1" />
+    <ssm:MappingEntry source="cosim_parameters" target="System2.parameter_1" />
+</ssm:ParameterMapping>

--- a/testsuite/resources/importParameterMapping/resources/import_parameter_mapping.ssv
+++ b/testsuite/resources/importParameterMapping/resources/import_parameter_mapping.ssv
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ssv:ParameterSet xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" version="1.0" name="parameters">
+    <ssv:Parameters>
+        <ssv:Parameter name="cosim_input">
+            <ssv:Real value="20" />
+        </ssv:Parameter>
+         <ssv:Parameter name="Input_3">
+            <ssv:Real value="50" />
+        </ssv:Parameter>
+        <ssv:Parameter name="cosim_parameters">
+            <ssv:Real value="-30" />
+        </ssv:Parameter>
+        <ssv:Parameter name="parameter_2">
+            <ssv:Real value="-40" />
+        </ssv:Parameter>
+    </ssv:Parameters>
+</ssv:ParameterSet>

--- a/testsuite/resources/importParameterMappingInline/SystemStructure.ssd
+++ b/testsuite/resources/importParameterMappingInline/SystemStructure.ssd
@@ -1,0 +1,175 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="import_parameter_mapping" version="1.0">
+    <ssd:System name="co_sim">
+        <ssd:Connectors>
+            <ssd:Connector name="Input_1" kind="input">
+                <ssc:Real />
+            </ssd:Connector>
+            <ssd:Connector name="Input_2" kind="input">
+                <ssc:Real />
+            </ssd:Connector>
+            <ssd:Connector name="Input_3" kind="input">
+                <ssc:Real />
+            </ssd:Connector>
+            <ssd:Connector name="Output_cref" kind="output">
+                <ssc:Real />
+            </ssd:Connector>
+            <ssd:Connector name="parameter_1" kind="parameter">
+                <ssc:Real />
+            </ssd:Connector>
+            <ssd:Connector name="parameter_2" kind="parameter">
+                <ssc:Real />
+            </ssd:Connector>
+        </ssd:Connectors>
+        <ssd:ParameterBindings>
+            <ssd:ParameterBinding>
+                <ssd:ParameterValues>
+                    <ssv:ParameterSet version="1.0" name="parameters">
+                        <ssv:Parameters>
+                            <ssv:Parameter name="cosim_parameters">
+                                <ssv:Real value="-30" />
+                            </ssv:Parameter>
+                            <ssv:Parameter name="cosim_inputs">
+                                <ssv:Real value="20" />
+                            </ssv:Parameter>
+                            <ssv:Parameter name="Input_3">
+                                <ssv:Real value="50" />
+                            </ssv:Parameter>
+                            <ssv:Parameter name="parameter_2">
+                                <ssv:Real value="-40" />
+                            </ssv:Parameter>
+                        </ssv:Parameters>
+                    </ssv:ParameterSet>
+                </ssd:ParameterValues>
+                <ssd:ParameterMapping>
+                    <ssm:ParameterMapping version="1.0">
+                        <ssm:MappingEntry source="cosim_inputs" target="Input_1" />
+                        <ssm:MappingEntry source="cosim_inputs" target="Input_2" />
+                        <ssm:MappingEntry source="cosim_parameters" target="parameter_1" />
+                    </ssm:ParameterMapping>
+                </ssd:ParameterMapping>
+            </ssd:ParameterBinding>
+        </ssd:ParameterBindings>
+        <ssd:Elements>
+            <ssd:System name="System2">
+                <ssd:Connectors>
+                    <ssd:Connector name="Input_1" kind="input">
+                        <ssc:Real />
+                    </ssd:Connector>
+                    <ssd:Connector name="Input_2" kind="input">
+                        <ssc:Real />
+                    </ssd:Connector>
+                    <ssd:Connector name="parameter_1" kind="parameter">
+                        <ssc:Real />
+                    </ssd:Connector>
+                    <ssd:Connector name="parameter_2" kind="parameter">
+                        <ssc:Real />
+                    </ssd:Connector>
+                    <ssd:Connector name="output" kind="output">
+                        <ssc:Real />
+                    </ssd:Connector>
+                </ssd:Connectors>
+                <ssd:ParameterBindings>
+                    <ssd:ParameterBinding>
+                        <ssd:ParameterValues>
+                            <ssv:ParameterSet version="1.0" name="parameters">
+                                <ssv:Parameters>
+                                    <ssv:Parameter name="system2_inputs">
+                                        <ssv:Real value="70" />
+                                    </ssv:Parameter>
+                                </ssv:Parameters>
+                            </ssv:ParameterSet>
+                        </ssd:ParameterValues>
+                        <ssd:ParameterMapping>
+                            <ssm:ParameterMapping version="1.0">
+                                <ssm:MappingEntry source="system2_inputs" target="Input_1" />
+                                <ssm:MappingEntry source="system2_inputs" target="Input_2" />
+                                <ssm:MappingEntry source="system2_inputs" target="parameter_1" />
+                                <ssm:MappingEntry source="system2_inputs" target="parameter_2" />
+                            </ssm:ParameterMapping>
+                        </ssd:ParameterMapping>
+                    </ssd:ParameterBinding>
+                </ssd:ParameterBindings>
+                <ssd:Annotations>
+                    <ssc:Annotation type="org.openmodelica">
+                        <oms:Annotations>
+                            <oms:SimulationInformation>
+                                <oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+                            </oms:SimulationInformation>
+                        </oms:Annotations>
+                    </ssc:Annotation>
+                </ssd:Annotations>
+            </ssd:System>
+            <ssd:System name="System1">
+                <ssd:Connectors>
+                    <ssd:Connector name="Input_1" kind="input">
+                        <ssc:Real />
+                    </ssd:Connector>
+                    <ssd:Connector name="Input_2" kind="input">
+                        <ssc:Real />
+                    </ssd:Connector>
+                    <ssd:Connector name="parameter_1" kind="parameter">
+                        <ssc:Real />
+                    </ssd:Connector>
+                    <ssd:Connector name="parameter_2" kind="parameter">
+                        <ssc:Real />
+                    </ssd:Connector>
+                    <ssd:Connector name="output" kind="output">
+                        <ssc:Real />
+                    </ssd:Connector>
+                </ssd:Connectors>
+                <ssd:ParameterBindings>
+                    <ssd:ParameterBinding>
+                        <ssd:ParameterValues>
+                            <ssv:ParameterSet version="1.0" name="parameters">
+                                <ssv:Parameters>
+                                    <ssv:Parameter name="system1_parameters">
+                                        <ssv:Real value="-50" />
+                                    </ssv:Parameter>
+                                    <ssv:Parameter name="system1_inputs">
+                                        <ssv:Real value="-100" />
+                                    </ssv:Parameter>
+                                </ssv:Parameters>
+                            </ssv:ParameterSet>
+                        </ssd:ParameterValues>
+                        <ssd:ParameterMapping>
+                            <ssm:ParameterMapping version="1.0">
+                                <ssm:MappingEntry source="system1_inputs" target="Input_1" />
+                                <ssm:MappingEntry source="system1_inputs" target="Input_2" />
+                                <ssm:MappingEntry source="system1_parameters" target="parameter_1" />
+                                <ssm:MappingEntry source="system1_parameters" target="parameter_2" />
+                            </ssm:ParameterMapping>
+                        </ssd:ParameterMapping>
+                    </ssd:ParameterBinding>
+                </ssd:ParameterBindings>
+                <ssd:Annotations>
+                    <ssc:Annotation type="org.openmodelica">
+                        <oms:Annotations>
+                            <oms:SimulationInformation>
+                                <oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+                            </oms:SimulationInformation>
+                        </oms:Annotations>
+                    </ssc:Annotation>
+                </ssd:Annotations>
+            </ssd:System>
+        </ssd:Elements>
+        <ssd:Annotations>
+            <ssc:Annotation type="org.openmodelica">
+                <oms:Annotations>
+                    <oms:SimulationInformation>
+                        <oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+                    </oms:SimulationInformation>
+                </oms:Annotations>
+            </ssc:Annotation>
+        </ssd:Annotations>
+    </ssd:System>
+    <ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
+        <ssd:Annotations>
+            <ssc:Annotation type="org.openmodelica">
+                <oms:Annotations>
+                    <oms:SimulationInformation resultFile="import_parameter_mapping_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter=".*" />
+                </oms:Annotations>
+            </ssc:Annotation>
+        </ssd:Annotations>
+    </ssd:DefaultExperiment>
+</ssd:SystemStructureDescription>


### PR DESCRIPTION
### Related Issues

https://github.com/OpenModelica/OMSimulator/issues/735

### Purpose

This PR supports importing` parameter mapping` from `.ssm` file and `inline`, according to `SSP-1.0`

### Approach 
Currently only importing of `parameter mapping` is supported.

### example
```
<ssd:ParameterBindings>
    <ssd:ParameterBinding source="resources/import_parameter_mapping.ssv">
        <ssd:ParameterMapping source="resources/import_parameter_mapping.ssm" />
    </ssd:ParameterBinding>
</ssd:ParameterBindings>

```