### PR TITLE
import parameter bindings at hierarchical level

### DIFF
--- a/src/OMSimulatorLib/Model.cpp
+++ b/src/OMSimulatorLib/Model.cpp
@@ -507,9 +507,9 @@ oms_status_enu_t oms::Model::updateParameterBindingsToSSD(pugi::xml_node& node, 
     // update the ssd with the top level parameterBindings (e.g)  <ParameterBinding source="resources/ControlledTemperature.ssv">
     for(pugi::xml_node_iterator it = node.begin(); it != node.end(); ++it)
     {
-      if (std::string(it->name()) == oms::ssp::Draft20180219::ssd::connectors) // insert the parameter bindings after top-level connectors node
+      if (std::string(it->name()) == oms::ssp::Draft20180219::ssd::elements) // insert the parameter bindings after top-level connectors node
       {
-        pugi::xml_node node_parameters_bindings = node.insert_child_after(oms::ssp::Version1_0::ssd::parameter_bindings, *it);
+        pugi::xml_node node_parameters_bindings = node.insert_child_before(oms::ssp::Version1_0::ssd::parameter_bindings, *it);
         pugi::xml_node node_parameter_binding  = node_parameters_bindings.append_child(oms::ssp::Version1_0::ssd::parameter_binding);
         std::string ssvFileName = "resources/" + std::string(this->getCref()) + ".ssv";
         node_parameter_binding.append_attribute("source") = ssvFileName.c_str();
@@ -787,10 +787,10 @@ oms_status_enu_t oms::Model::exportToFile(const std::string& filename) const
     // update the ssd with the top level parameterBindings (e.g)  <ParameterBinding source="resources/ControlledTemperature.ssv">
     for(pugi::xml_node_iterator it = node.begin(); it != node.end(); ++it)
     {
-      pugi::xml_node node_connectors = it->child(oms::ssp::Draft20180219::ssd::connectors);
-      if (node_connectors) // insert the parameter bindings after top-level connectors node
+      pugi::xml_node node_elements = it->child(oms::ssp::Draft20180219::ssd::elements);
+      if (node_elements) // insert the parameter bindings before <ssd:Elements>
       {
-        pugi::xml_node node_parameters_bindings = it->insert_child_after(oms::ssp::Version1_0::ssd::parameter_bindings, node_connectors);
+        pugi::xml_node node_parameters_bindings = it->insert_child_before(oms::ssp::Version1_0::ssd::parameter_bindings, node_elements);
         pugi::xml_node node_parameter_binding  = node_parameters_bindings.append_child(oms::ssp::Version1_0::ssd::parameter_binding);
         node_parameter_binding.append_attribute("source") = ssvFileName.c_str();
         break;

--- a/src/OMSimulatorLib/System.h
+++ b/src/OMSimulatorLib/System.h
@@ -216,7 +216,7 @@ namespace oms
     oms_status_enu_t importBusConnectorGeometry(const pugi::xml_node& node);
     oms_status_enu_t importStartValuesFromSSV();
     oms_status_enu_t importStartValuesFromSSVHelper(std::string fileName, std::multimap<ComRef, ComRef> &mappedEntry);
-    oms_status_enu_t importParamterMappingFromSSM(std::string fileName, std::multimap<ComRef, ComRef> &mappedEntry);
+    oms_status_enu_t importParameterMappingFromSSM(std::string fileName, std::multimap<ComRef, ComRef> &mappedEntry);
   };
 }
 

--- a/src/OMSimulatorLib/Values.h
+++ b/src/OMSimulatorLib/Values.h
@@ -59,7 +59,7 @@ namespace oms
     oms_status_enu_t exportStartValuesHelper(pugi::xml_node& node) const;
     oms_status_enu_t exportParameterMappingInline(pugi::xml_node& node) const;
     oms_status_enu_t importStartValuesHelper(pugi::xml_node& parameters);
-    oms_status_enu_t importParameterMappingInline(pugi::xml_node& parameterMapping);
+    oms_status_enu_t importParameterMapping(pugi::xml_node& parameterMapping);
     oms_status_enu_t parseModelDescription(const char *filename);
 
     oms::ComRef getMappedCrefEntry(ComRef cref) const;

--- a/testsuite/OMSimulator/Makefile
+++ b/testsuite/OMSimulator/Makefile
@@ -15,6 +15,7 @@ import_export_parameters_to_ssv.lua \
 import_export_snapshot.lua \
 import_export.lua \
 import_export.py \
+import_hierarchical_ssv_sources.lua \
 import_parameter_mapping_from_ssm.lua \
 import_parameter_mapping_inline.lua \
 importStartValues.lua \

--- a/testsuite/OMSimulator/import_hierarchical_ssv_sources.lua
+++ b/testsuite/OMSimulator/import_hierarchical_ssv_sources.lua
@@ -1,0 +1,76 @@
+-- status: correct
+-- linux: yes
+-- mingw: yes
+-- win: no
+-- mac: no
+
+oms_setCommandLineOption("--suppressPath=true")
+oms_setTempDirectory("./import_hierarchical_ssv_sources_lua/")
+
+oms_importFile("../resources/import_hierarchical_ssv_sources.ssp");
+
+oms_instantiate("import_hierarchical_ssv_sources")
+
+print("info:    Instantiation")
+print("info:      import_hierarchical_ssv_sources.root.System1.Input_1     : " .. oms_getReal("import_hierarchical_ssv_sources.root.System1.Input_1"))
+print("info:      import_hierarchical_ssv_sources.root.System1.parameter_1 : " .. oms_getReal("import_hierarchical_ssv_sources.root.System1.parameter_1"))
+print("info:      import_hierarchical_ssv_sources.root.System2.Input_1     : " .. oms_getReal("import_hierarchical_ssv_sources.root.System2.Input_1"))
+print("info:      import_hierarchical_ssv_sources.root.System2.Input_2     : " .. oms_getReal("import_hierarchical_ssv_sources.root.System2.Input_2"))
+print("info:      import_hierarchical_ssv_sources.root.System2.parameter_1 : " .. oms_getReal("import_hierarchical_ssv_sources.root.System2.parameter_1"))
+print("info:      import_hierarchical_ssv_sources.root.System3.Input_1     : " .. oms_getReal("import_hierarchical_ssv_sources.root.System3.Input_1"))
+print("info:      import_hierarchical_ssv_sources.root.System3.parameter_1 : " .. oms_getReal("import_hierarchical_ssv_sources.root.System3.parameter_1"))
+
+oms_initialize("import_hierarchical_ssv_sources")
+print("info:    Initialization")
+print("info:      import_hierarchical_ssv_sources.root.System1.Input_1     : " .. oms_getReal("import_hierarchical_ssv_sources.root.System1.Input_1"))
+print("info:      import_hierarchical_ssv_sources.root.System1.parameter_1 : " .. oms_getReal("import_hierarchical_ssv_sources.root.System1.parameter_1"))
+print("info:      import_hierarchical_ssv_sources.root.System2.Input_1     : " .. oms_getReal("import_hierarchical_ssv_sources.root.System2.Input_1"))
+print("info:      import_hierarchical_ssv_sources.root.System2.Input_2     : " .. oms_getReal("import_hierarchical_ssv_sources.root.System2.Input_2"))
+print("info:      import_hierarchical_ssv_sources.root.System2.parameter_1 : " .. oms_getReal("import_hierarchical_ssv_sources.root.System2.parameter_1"))
+print("info:      import_hierarchical_ssv_sources.root.System3.Input_1     : " .. oms_getReal("import_hierarchical_ssv_sources.root.System3.Input_1"))
+print("info:      import_hierarchical_ssv_sources.root.System3.parameter_1 : " .. oms_getReal("import_hierarchical_ssv_sources.root.System3.parameter_1"))
+
+oms_simulate("import_hierarchical_ssv_sources")
+print("info:    Simulate")
+print("info:      import_hierarchical_ssv_sources.root.System1.Input_1     : " .. oms_getReal("import_hierarchical_ssv_sources.root.System1.Input_1"))
+print("info:      import_hierarchical_ssv_sources.root.System1.parameter_1 : " .. oms_getReal("import_hierarchical_ssv_sources.root.System1.parameter_1"))
+print("info:      import_hierarchical_ssv_sources.root.System2.Input_1     : " .. oms_getReal("import_hierarchical_ssv_sources.root.System2.Input_1"))
+print("info:      import_hierarchical_ssv_sources.root.System2.Input_2     : " .. oms_getReal("import_hierarchical_ssv_sources.root.System2.Input_2"))
+print("info:      import_hierarchical_ssv_sources.root.System2.parameter_1 : " .. oms_getReal("import_hierarchical_ssv_sources.root.System2.parameter_1"))
+print("info:      import_hierarchical_ssv_sources.root.System3.Input_1     : " .. oms_getReal("import_hierarchical_ssv_sources.root.System3.Input_1"))
+print("info:      import_hierarchical_ssv_sources.root.System3.parameter_1 : " .. oms_getReal("import_hierarchical_ssv_sources.root.System3.parameter_1"))
+
+oms_terminate("import_hierarchical_ssv_sources")
+oms_delete("import_hierarchical_ssv_sources")
+
+
+-- Result:
+-- info:    model doesn't contain any continuous state
+-- info:    model doesn't contain any continuous state
+-- info:    model doesn't contain any continuous state
+-- info:    Instantiation
+-- info:      import_hierarchical_ssv_sources.root.System1.Input_1     : -10.0
+-- info:      import_hierarchical_ssv_sources.root.System1.parameter_1 : -20.0
+-- info:      import_hierarchical_ssv_sources.root.System2.Input_1     : -30.0
+-- info:      import_hierarchical_ssv_sources.root.System2.Input_2     : -100.0
+-- info:      import_hierarchical_ssv_sources.root.System2.parameter_1 : -40.0
+-- info:      import_hierarchical_ssv_sources.root.System3.Input_1     : -70.0
+-- info:      import_hierarchical_ssv_sources.root.System3.parameter_1 : -70.0
+-- info:    Result file: import_hierarchical_ssv_sources_res.mat (bufferSize=10)
+-- info:    Initialization
+-- info:      import_hierarchical_ssv_sources.root.System1.Input_1     : -10.0
+-- info:      import_hierarchical_ssv_sources.root.System1.parameter_1 : -20.0
+-- info:      import_hierarchical_ssv_sources.root.System2.Input_1     : -30.0
+-- info:      import_hierarchical_ssv_sources.root.System2.Input_2     : -100.0
+-- info:      import_hierarchical_ssv_sources.root.System2.parameter_1 : -40.0
+-- info:      import_hierarchical_ssv_sources.root.System3.Input_1     : -70.0
+-- info:      import_hierarchical_ssv_sources.root.System3.parameter_1 : -70.0
+-- info:    Simulate
+-- info:      import_hierarchical_ssv_sources.root.System1.Input_1     : -10.0
+-- info:      import_hierarchical_ssv_sources.root.System1.parameter_1 : -20.0
+-- info:      import_hierarchical_ssv_sources.root.System2.Input_1     : -30.0
+-- info:      import_hierarchical_ssv_sources.root.System2.Input_2     : -100.0
+-- info:      import_hierarchical_ssv_sources.root.System2.parameter_1 : -40.0
+-- info:      import_hierarchical_ssv_sources.root.System3.Input_1     : -70.0
+-- info:      import_hierarchical_ssv_sources.root.System3.parameter_1 : -70.0
+-- endResult

--- a/testsuite/OMSimulator/import_parameter_mapping_from_ssm.lua
+++ b/testsuite/OMSimulator/import_parameter_mapping_from_ssm.lua
@@ -66,6 +66,9 @@ print("info:      import_parameter_mapping.co_sim.System2.Input_2      : " .. om
 print("info:      import_parameter_mapping.co_sim.System2.parameter_1  : " .. oms_getReal("import_parameter_mapping.co_sim.System2.parameter_1"))
 print("info:      import_parameter_mapping.co_sim.System2.parameter_2  : " .. oms_getReal("import_parameter_mapping.co_sim.System2.parameter_2"))
 
+oms_terminate("import_parameter_mapping")
+oms_delete("import_parameter_mapping")
+
 -- Result:
 -- info:    model doesn't contain any continuous state
 -- info:    model doesn't contain any continuous state

--- a/testsuite/OMSimulator/import_parameter_mapping_inline.lua
+++ b/testsuite/OMSimulator/import_parameter_mapping_inline.lua
@@ -69,6 +69,10 @@ print("info:      import_parameter_mapping.co_sim.System2.Input_2      : " .. om
 print("info:      import_parameter_mapping.co_sim.System2.parameter_1  : " .. oms_getReal("import_parameter_mapping.co_sim.System2.parameter_1"))
 print("info:      import_parameter_mapping.co_sim.System2.parameter_2  : " .. oms_getReal("import_parameter_mapping.co_sim.System2.parameter_2"))
 
+oms_terminate("import_parameter_mapping")
+oms_delete("import_parameter_mapping")
+
+
 -- Result:
 -- <?xml version="1.0"?>
 -- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="import_parameter_mapping" version="1.0">
@@ -245,7 +249,7 @@ print("info:      import_parameter_mapping.co_sim.System2.parameter_2  : " .. om
 -- 		</ssd:Annotations>
 -- 	</ssd:DefaultExperiment>
 -- </ssd:SystemStructureDescription>
--- 
+--
 -- info:    model doesn't contain any continuous state
 -- info:    model doesn't contain any continuous state
 -- info:      Instantiation

--- a/testsuite/resources/Makefile
+++ b/testsuite/resources/Makefile
@@ -50,6 +50,7 @@ SSPs = \
 importStartValues \
 importParameterMapping \
 importParameterMappingInline \
+import_hierarchical_ssv_sources \
 
 
 MOSs = \

--- a/testsuite/resources/import_hierarchical_ssv_sources/SystemStructure.ssd
+++ b/testsuite/resources/import_hierarchical_ssv_sources/SystemStructure.ssd
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="import_hierarchical_ssv_sources" version="1.0">
+    <ssd:System name="root">
+        <ssd:Elements>
+            <ssd:System name="System3">
+                <ssd:Connectors>
+                    <ssd:Connector name="Input_1" kind="input">
+                        <ssc:Real />
+                    </ssd:Connector>
+                    <ssd:Connector name="parameter_1" kind="parameter">
+                        <ssc:Real />
+                    </ssd:Connector>
+                </ssd:Connectors>
+                <ssd:ParameterBindings>
+                    <ssd:ParameterBinding source="resources/import_hierarchical_ssv_sources_system3.ssv">
+                        <ssd:ParameterMapping source="resources/import_hierarchical_ssv_sources_system3.ssm" />
+                    </ssd:ParameterBinding>
+                </ssd:ParameterBindings>
+                <ssd:Annotations>
+                    <ssc:Annotation type="org.openmodelica">
+                        <oms:Annotations>
+                            <oms:SimulationInformation>
+                                <oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+                            </oms:SimulationInformation>
+                        </oms:Annotations>
+                    </ssc:Annotation>
+                </ssd:Annotations>
+            </ssd:System>
+            <ssd:System name="System2">
+                <ssd:Connectors>
+                    <ssd:Connector name="Input_1" kind="input">
+                        <ssc:Real />
+                    </ssd:Connector>
+                    <ssd:Connector name="Input_2" kind="input">
+                        <ssc:Real />
+                    </ssd:Connector>
+                    <ssd:Connector name="parameter_1" kind="parameter">
+                        <ssc:Real />
+                    </ssd:Connector>
+                </ssd:Connectors>
+                <ssd:ParameterBindings>
+                    <ssd:ParameterBinding>
+                        <ssd:ParameterValues>
+                            <ssv:ParameterSet version="1.0" name="parameters">
+                                <ssv:Parameters>
+                                    <ssv:Parameter name="Input_2">
+                                        <ssv:Real value="-100" />
+                                    </ssv:Parameter>
+                                </ssv:Parameters>
+                            </ssv:ParameterSet>
+                        </ssd:ParameterValues>
+                    </ssd:ParameterBinding>
+                    <ssd:ParameterBinding source="resources/import_hierarchical_ssv_sources_system2.ssv" />
+                </ssd:ParameterBindings>
+                <ssd:Annotations>
+                    <ssc:Annotation type="org.openmodelica">
+                        <oms:Annotations>
+                            <oms:SimulationInformation>
+                                <oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+                            </oms:SimulationInformation>
+                        </oms:Annotations>
+                    </ssc:Annotation>
+                </ssd:Annotations>
+            </ssd:System>
+            <ssd:System name="System1">
+                <ssd:Connectors>
+                    <ssd:Connector name="Input_1" kind="input">
+                        <ssc:Real />
+                    </ssd:Connector>
+                    <ssd:Connector name="parameter_1" kind="parameter">
+                        <ssc:Real />
+                    </ssd:Connector>
+                </ssd:Connectors>
+                <ssd:ParameterBindings>
+                    <ssd:ParameterBinding source="resources/import_hierarchical_ssv_sources_system1.ssv" />
+                </ssd:ParameterBindings>
+                <ssd:Annotations>
+                    <ssc:Annotation type="org.openmodelica">
+                        <oms:Annotations>
+                            <oms:SimulationInformation>
+                                <oms:VariableStepSolver description="cvode" absoluteTolerance="0.000100" relativeTolerance="0.000100" minimumStepSize="0.000100" maximumStepSize="0.100000" initialStepSize="0.000100" />
+                            </oms:SimulationInformation>
+                        </oms:Annotations>
+                    </ssc:Annotation>
+                </ssd:Annotations>
+            </ssd:System>
+        </ssd:Elements>
+        <ssd:Annotations>
+            <ssc:Annotation type="org.openmodelica">
+                <oms:Annotations>
+                    <oms:SimulationInformation>
+                        <oms:FixedStepMaster description="oms-ma" stepSize="0.100000" absoluteTolerance="0.000100" relativeTolerance="0.000100" />
+                    </oms:SimulationInformation>
+                </oms:Annotations>
+            </ssc:Annotation>
+        </ssd:Annotations>
+    </ssd:System>
+    <ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
+        <ssd:Annotations>
+            <ssc:Annotation type="org.openmodelica">
+                <oms:Annotations>
+                    <oms:SimulationInformation resultFile="import_hierarchical_ssv_sources_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter=".*" />
+                </oms:Annotations>
+            </ssc:Annotation>
+        </ssd:Annotations>
+    </ssd:DefaultExperiment>
+</ssd:SystemStructureDescription>

--- a/testsuite/resources/import_hierarchical_ssv_sources/resources/import_hierarchical_ssv_sources_system1.ssv
+++ b/testsuite/resources/import_hierarchical_ssv_sources/resources/import_hierarchical_ssv_sources_system1.ssv
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ssv:ParameterSet xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" version="1.0" name="parameters">
+	<ssv:Parameters>
+		<ssv:Parameter name="parameter_1">
+			<ssv:Real value="-20" />
+		</ssv:Parameter>
+		<ssv:Parameter name="Input_1">
+			<ssv:Real value="-10" />
+		</ssv:Parameter>
+	</ssv:Parameters>
+</ssv:ParameterSet>

--- a/testsuite/resources/import_hierarchical_ssv_sources/resources/import_hierarchical_ssv_sources_system2.ssv
+++ b/testsuite/resources/import_hierarchical_ssv_sources/resources/import_hierarchical_ssv_sources_system2.ssv
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ssv:ParameterSet xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" version="1.0" name="parameters">
+	<ssv:Parameters>
+		<ssv:Parameter name="parameter_1">
+			<ssv:Real value="-40" />
+		</ssv:Parameter>
+		<ssv:Parameter name="Input_1">
+			<ssv:Real value="-30" />
+		</ssv:Parameter>
+	</ssv:Parameters>
+</ssv:ParameterSet>

--- a/testsuite/resources/import_hierarchical_ssv_sources/resources/import_hierarchical_ssv_sources_system3.ssm
+++ b/testsuite/resources/import_hierarchical_ssv_sources/resources/import_hierarchical_ssv_sources_system3.ssm
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ssm:ParameterMapping xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" version="1.0">
+    <ssm:MappingEntry source="system3_start_values" target="Input_1" />
+    <ssm:MappingEntry source="system3_start_values" target="parameter_1" />
+</ssm:ParameterMapping>

--- a/testsuite/resources/import_hierarchical_ssv_sources/resources/import_hierarchical_ssv_sources_system3.ssv
+++ b/testsuite/resources/import_hierarchical_ssv_sources/resources/import_hierarchical_ssv_sources_system3.ssv
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ssv:ParameterSet xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" version="1.0" name="parameters">
+	<ssv:Parameters>
+		<ssv:Parameter name="system3_start_values">
+			<ssv:Real value="-70" />
+		</ssv:Parameter>
+	</ssv:Parameters>
+</ssv:ParameterSet>


### PR DESCRIPTION
### Purpose

This PR imports parameter bindings  from ssv files at hierarchical level. Also update the `<ssd:parameterBindings>` before `<ssd:Elements>` as `<ssd:connectors>` node can be empty

### Example

```
<ssd:Elements>
    <ssd:System name="System3">
        <ssd:ParameterBindings>
            <ssd:ParameterBinding source="resources/import_hierarchical_ssv_sources_system3.ssv">
                <ssd:ParameterMapping source="resources/import_hierarchical_ssv_sources_system3.ssm" />
            </ssd:ParameterBinding>
        </ssd:ParameterBindings>
    </ssd:System>  

    <ssd:System name="System2">
        <ssd:ParameterBindings>
            <ssd:ParameterBinding source="resources/import_hierarchical_ssv_sources_system2.ssv /">
        </ssd:ParameterBindings>
    </ssd:System>                  
</ssd:Elements>
```