### PR TITLE
Don't add static C / C++ lib to dynamic libs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,6 @@ ELSEIF(APPLE)
   set(PLATFORM_STRING "mac")
 ELSE()
   set(PLATFORM_STRING "linux")
-  set(STATIC_LIBGCC "-static-libgcc")
 ENDIF()
 
 # Don't allow in-source build

--- a/src/OMSimulatorLib/CMakeLists.txt
+++ b/src/OMSimulatorLib/CMakeLists.txt
@@ -154,7 +154,7 @@ IF (WIN32 AND MSVC)
   add_definitions(-DBOOST_ALL_DYN_LINK)
 ENDIF ()
 
-target_link_libraries(OMSimulatorLib fmilib sundials_kinsol sundials_cvode sundials_nvecserial minizip ${LIB_ATOMIC} ${Boost_LIBRARIES} ${OMTLM_LINKFLAGS} ${CMAKE_DL_LIBS} ${CMAKE_THREAD_LIBS_INIT} ${CPP_FS_LIBS} ${STATIC_LIBGCC})
+target_link_libraries(OMSimulatorLib fmilib sundials_kinsol sundials_cvode sundials_nvecserial minizip ${LIB_ATOMIC} ${Boost_LIBRARIES} ${OMTLM_LINKFLAGS} ${CMAKE_DL_LIBS} ${CMAKE_THREAD_LIBS_INIT} ${CPP_FS_LIBS})
 target_link_libraries(OMSimulatorLib_static fmilib sundials_kinsol sundials_cvode sundials_nvecserial minizip lua ${CMAKE_DL_LIBS} ${LIB_ATOMIC} ${CMAKE_THREAD_LIBS_INIT} ${Boost_LIBRARIES} ${OMTLM_LINKFLAGS} ${CPP_FS_LIBS} ${STATIC_LIBGCC})
 
 IF (WIN32 AND MINGW)
@@ -163,7 +163,6 @@ IF (WIN32 AND MINGW)
 ENDIF ()
 
 IF (NOT (WIN32 OR MSVC))
-  target_link_libraries(OMSimulatorLib "-static-libstdc++")
   target_link_libraries(OMSimulatorLib_static "-static-libstdc++")
 ENDIF ()
 

--- a/src/OMSimulatorLib/CMakeLists.txt
+++ b/src/OMSimulatorLib/CMakeLists.txt
@@ -155,15 +155,11 @@ IF (WIN32 AND MSVC)
 ENDIF ()
 
 target_link_libraries(OMSimulatorLib fmilib sundials_kinsol sundials_cvode sundials_nvecserial minizip ${LIB_ATOMIC} ${Boost_LIBRARIES} ${OMTLM_LINKFLAGS} ${CMAKE_DL_LIBS} ${CMAKE_THREAD_LIBS_INIT} ${CPP_FS_LIBS})
-target_link_libraries(OMSimulatorLib_static fmilib sundials_kinsol sundials_cvode sundials_nvecserial minizip lua ${CMAKE_DL_LIBS} ${LIB_ATOMIC} ${CMAKE_THREAD_LIBS_INIT} ${Boost_LIBRARIES} ${OMTLM_LINKFLAGS} ${CPP_FS_LIBS} ${STATIC_LIBGCC})
+target_link_libraries(OMSimulatorLib_static fmilib sundials_kinsol sundials_cvode sundials_nvecserial minizip lua ${CMAKE_DL_LIBS} ${LIB_ATOMIC} ${CMAKE_THREAD_LIBS_INIT} ${Boost_LIBRARIES} ${OMTLM_LINKFLAGS} ${CPP_FS_LIBS})
 
 IF (WIN32 AND MINGW)
   target_link_libraries(OMSimulatorLib shlwapi)
   target_link_libraries(OMSimulatorLib_static shlwapi)
-ENDIF ()
-
-IF (NOT (WIN32 OR MSVC))
-  target_link_libraries(OMSimulatorLib_static "-static-libstdc++")
 ENDIF ()
 
 IF (WIN32)


### PR DESCRIPTION
### Related Issues

https://github.com/OpenModelica/OMSimulator/issues/909

### Purpose

Stop Python from crashing when loading libOMSimulator.so on Linux.

### Approach

Don't link the static C and C++ libs to the dynamic build target.
