### PR TITLE
Fix FMI Cross Check with Wine

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -574,6 +574,25 @@ EXIT /b 1
       }
     }
 
+    stage('cross-compilation') {
+      agent {
+        docker {
+          image 'anheuermann/ompython:wine-bionic'
+          label 'linux'
+          alwaysPull true
+        }
+      }
+      environment {
+        HOME = "${env.WORKSPACE}"
+      }
+      steps {
+        unstash name: 'mingw64-install'
+        sh """
+        wine64 install/mingw/bin/OMSimulator.exe --version
+        """
+      }
+    }
+
     stage('upload') {
       parallel {
 

--- a/testsuite/fmi-cross-check/generateHTML.py
+++ b/testsuite/fmi-cross-check/generateHTML.py
@@ -99,7 +99,10 @@ def generateOverviewHTML(crossCheckDir, platform, omsVersion, omsVersionShort, t
   commitshort = subprocess.check_output(['git', 'rev-parse', '--short', 'HEAD'], cwd=crossCheckDir).decode('utf-8')
   commitfull = subprocess.check_output(['git', 'rev-parse', 'HEAD'], cwd=crossCheckDir).decode('utf-8')
 
-  omscommitshort = re.search(r"-g.+-",omsVersion).group()[2:9]
+  if re.search(r"-g.+-",omsVersion):
+    omscommitshort = re.search(r"-g.+-",omsVersion).group()[2:9]
+  else:
+    omscommitshort = "unknown"
 
   htmltpl=open("fmi-cross-check.html.tpl").read()
 


### PR DESCRIPTION
### Related Issues

All tests from fmi-cross-check were broken for the tagged version without a commit hash in the OMSimulator version.
See https://test.openmodelica.org/jenkins/job/Sandbox/job/Andreas/job/OMSimulator-FMI-Cross-Check/

Also the Windows test with wine is failing, see #924.

### Approach

- Just add a "unknown" commit into the html.
- Link with `-static-libstdc++` on MINGW
 - Add check to Jenkins to see if wine can execute MINGW OMSimulator binary

