### PR TITLE
allow input connectors to multiple components connector

### DIFF
--- a/src/OMSimulatorLib/Connection.cpp
+++ b/src/OMSimulatorLib/Connection.cpp
@@ -188,6 +188,11 @@ bool oms::Connection::containsSignal(const oms::ComRef& signal)
   return signal.isRootOf(oms::ComRef(this->conA)) || signal.isRootOf(oms::ComRef(this->conB));
 }
 
+bool oms::Connection::containsSignalB(const oms::ComRef& signal)
+{
+  return signal.isRootOf(oms::ComRef(this->conB));
+}
+
 bool oms::Connection::isValid(const ComRef& crefA, const ComRef& crefB, const Connector& conA, const Connector& conB)
 {
   bool connectorA, connectorB;

--- a/src/OMSimulatorLib/Connection.cpp
+++ b/src/OMSimulatorLib/Connection.cpp
@@ -183,12 +183,12 @@ bool oms::Connection::isEqual(const oms::Connection& connection) const
   return isEqual(conA_, conB_);
 }
 
-bool oms::Connection::containsSignal(const oms::ComRef& signal)
+bool oms::Connection::containsSignal(const oms::ComRef& signal) const
 {
   return signal.isRootOf(oms::ComRef(this->conA)) || signal.isRootOf(oms::ComRef(this->conB));
 }
 
-bool oms::Connection::containsSignalB(const oms::ComRef& signal)
+bool oms::Connection::containsSignalB(const oms::ComRef& signal) const
 {
   return signal.isRootOf(oms::ComRef(this->conB));
 }

--- a/src/OMSimulatorLib/Connection.h
+++ b/src/OMSimulatorLib/Connection.h
@@ -69,8 +69,8 @@ namespace oms
 
     bool isEqual(const oms::Connection& connection) const;
     bool isEqual(const oms::ComRef& signalA, const oms::ComRef& signalB) const;
-    bool containsSignal(const oms::ComRef& signal);
-    bool containsSignalB(const oms::ComRef& signal);
+    bool containsSignal(const oms::ComRef& signal) const;
+    bool containsSignalB(const oms::ComRef& signal) const;
 
     /**
     * \brief Checks a connection based on SSP-1.0 connection table

--- a/src/OMSimulatorLib/Connection.h
+++ b/src/OMSimulatorLib/Connection.h
@@ -70,6 +70,7 @@ namespace oms
     bool isEqual(const oms::Connection& connection) const;
     bool isEqual(const oms::ComRef& signalA, const oms::ComRef& signalB) const;
     bool containsSignal(const oms::ComRef& signal);
+    bool containsSignalB(const oms::ComRef& signal);
 
     /**
     * \brief Checks a connection based on SSP-1.0 connection table

--- a/src/OMSimulatorLib/System.cpp
+++ b/src/OMSimulatorLib/System.cpp
@@ -1075,10 +1075,9 @@ oms_status_enu_t oms::System::addConnection(const oms::ComRef& crefA, const oms:
 
   for (auto& connection : connections)
   {
-    if (connection && conA->getCausality() == oms_causality_input && connection->containsSignal(crefA))
-      return logError("Connector is already connected: " + std::string(crefA));
-    if (connection && conB->getCausality() == oms_causality_input && connection->containsSignal(crefB))
-      return logError("Connector is already connected: " + std::string(crefB));
+    // do not allow multiple connections to same connector which is already connected, check for connector-B has connection
+    if (connection && connection->containsSignal(crefB))
+       return logError("Connector is already connected: " + std::string(crefB));
   }
 
   // check if the connections are valid, according to the SSP-1.0 allowed connection table

--- a/src/OMSimulatorLib/System.cpp
+++ b/src/OMSimulatorLib/System.cpp
@@ -1076,7 +1076,7 @@ oms_status_enu_t oms::System::addConnection(const oms::ComRef& crefA, const oms:
   for (auto& connection : connections)
   {
     // do not allow multiple connections to same connector which is already connected, check for connector-B has connection
-    if (connection && connection->containsSignal(crefB))
+    if (connection && connection->containsSignalB(crefB))
     {
       return logError("Connector " + std::string(crefB) + " is already connected to " + std::string(connection->getSignalA()));
     }
@@ -1091,6 +1091,14 @@ oms_status_enu_t oms::System::addConnection(const oms::ComRef& crefA, const oms:
   // flipped causality check
   else if (oms::Connection::isValid(crefB, crefA, *conB, *conA))
   {
+    // flipped connection checks for already connected connectors
+    for (auto &connection : connections)
+    {
+      if (connection && connection->containsSignalB(crefA))
+      {
+        return logError("Connector " + std::string(crefA) + " is already connected to " + std::string(connection->getSignalA()));
+      }
+    }
     connections.back() = new oms::Connection(crefB, crefA);
     connections.push_back(NULL);
   }

--- a/src/OMSimulatorLib/System.cpp
+++ b/src/OMSimulatorLib/System.cpp
@@ -1073,13 +1073,14 @@ oms_status_enu_t oms::System::addConnection(const oms::ComRef& crefA, const oms:
     return logError("Type mismatch in connection: " + std::string(crefA) + " -> " + std::string(crefB));
   }
 
+  // Do not allow multiple connections to same 'input' connector
+  // (signal B). The 'input' connector (signal B) can actually be an
+  // output connector, e.g. if connecting a component to a system
+  // connector.
   for (auto& connection : connections)
   {
-    // do not allow multiple connections to same connector which is already connected, check for connector-B has connection
     if (connection && connection->containsSignalB(crefB))
-    {
       return logError("Connector " + std::string(crefB) + " is already connected to " + std::string(connection->getSignalA()));
-    }
   }
 
   // check if the connections are valid, according to the SSP-1.0 allowed connection table
@@ -1091,13 +1092,15 @@ oms_status_enu_t oms::System::addConnection(const oms::ComRef& crefA, const oms:
   // flipped causality check
   else if (oms::Connection::isValid(crefB, crefA, *conB, *conA))
   {
-    // flipped connection checks for already connected connectors
+    // ! Flipped connection checks !
+    // Do not allow multiple connections to same 'input' connector
+    // (signal A!). The 'input' connector (signal A!) can actually be
+    // an output connector, e.g. if connecting a component to a system
+    // connector.
     for (auto &connection : connections)
     {
       if (connection && connection->containsSignalB(crefA))
-      {
         return logError("Connector " + std::string(crefA) + " is already connected to " + std::string(connection->getSignalA()));
-      }
     }
     connections.back() = new oms::Connection(crefB, crefA);
     connections.push_back(NULL);

--- a/src/OMSimulatorLib/System.cpp
+++ b/src/OMSimulatorLib/System.cpp
@@ -1077,7 +1077,9 @@ oms_status_enu_t oms::System::addConnection(const oms::ComRef& crefA, const oms:
   {
     // do not allow multiple connections to same connector which is already connected, check for connector-B has connection
     if (connection && connection->containsSignal(crefB))
-       return logError("Connector is already connected: " + std::string(crefB));
+    {
+      return logError("Connector " + std::string(crefB) + " is already connected to " + std::string(connection->getSignalA()));
+    }
   }
 
   // check if the connections are valid, according to the SSP-1.0 allowed connection table

--- a/testsuite/OMSimulator/Makefile
+++ b/testsuite/OMSimulator/Makefile
@@ -19,6 +19,7 @@ import_hierarchical_ssv_sources.lua \
 import_parameter_mapping_from_ssm.lua \
 import_parameter_mapping_inline.lua \
 importStartValues.lua \
+multipleConnections.lua \
 PI_Controller.lua \
 QuarterCarModel.DisplacementDisplacement.lua \
 setExternalInputs.lua \

--- a/testsuite/OMSimulator/import_export_parameters_inline.lua
+++ b/testsuite/OMSimulator/import_export_parameters_inline.lua
@@ -117,7 +117,7 @@ oms_terminate("import_export_parameters")
 oms_delete("import_export_parameters")
 
 -- Result:
--- error:   [addConnection] Causality mismatch in connection: foo.F_cref -> addP.k1
+-- error:   [addConnection] Connector addP.k1 is already connected to k_cref
 -- <?xml version="1.0"?>
 -- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="import_export_parameters" version="1.0">
 -- 	<ssd:System name="co_sim">

--- a/testsuite/OMSimulator/import_export_parameters_to_ssv.lua
+++ b/testsuite/OMSimulator/import_export_parameters_to_ssv.lua
@@ -117,7 +117,7 @@ oms_terminate("import_export_parameters")
 oms_delete("import_export_parameters")
 
 -- Result:
--- error:   [addConnection] Causality mismatch in connection: foo.F_cref -> addP.k1
+-- error:   [addConnection] Connector addP.k1 is already connected to k_cref
 -- <?xml version="1.0"?>
 -- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="import_export_parameters" version="1.0">
 -- 	<ssd:System name="co_sim">

--- a/testsuite/OMSimulator/multipleConnections.lua
+++ b/testsuite/OMSimulator/multipleConnections.lua
@@ -1,0 +1,74 @@
+-- status: correct
+-- linux: yes
+-- mingw: yes
+-- win: no
+-- mac: no
+
+oms_setCommandLineOption("--suppressPath=true")
+oms_setTempDirectory("./multipleinputconnections/")
+
+oms_newModel("model")
+
+oms_addSystem("model.System", oms_system_wc)
+oms_addConnector("model.System.Input1", oms_causality_input, oms_signal_type_real)
+oms_addConnector("model.System.Input2", oms_causality_input, oms_signal_type_real)
+oms_addConnector("model.System.parameter1", oms_causality_parameter, oms_signal_type_real)
+oms_addConnector("model.System.parameter2", oms_causality_parameter, oms_signal_type_real)
+
+oms_addConnector("model.System.Output1", oms_causality_output, oms_signal_type_real)
+
+oms_setReal("model.System.Input1", 10)
+oms_setReal("model.System.Input2", 20)
+oms_setReal("model.System.parameter1", 30)
+oms_setReal("model.System.parameter1", 40)
+
+-- instantiate FMUs
+oms_addSubModel("model.System.add", "../resources/Modelica.Blocks.Math.Add.fmu")
+oms_addSubModel("model.System.gain", "../resources/Modelica.Blocks.Math.Gain.fmu")
+
+-- valid connections, inputs -> multiple components inputs
+oms_addConnection("model.System.Input1", "model.System.add.u1")
+oms_addConnection("model.System.Input1", "model.System.gain.u")
+oms_addConnection("model.System.parameter1", "model.System.gain.k")
+oms_addConnection("model.System.gain.y", "model.System.add.u2")
+
+-- illegal connections
+-- input -> already connected input
+oms_addConnection("model.System.Input2", "model.System.add.u1")
+-- parameter -> already connected parameter
+oms_addConnection("model.System.parameter2", "model.System.gain.k")
+-- output -> already connected input
+oms_addConnection("model.System.Output1", "model.System.add.u2")
+
+oms_instantiate("model")
+
+oms_initialize("model")
+
+oms_simulate("model")
+
+print("info:    Simulation")
+print("info:      model.System.Input1         : " .. oms_getReal("model.System.Input1"))
+print("info:      model.System.Input2         : " .. oms_getReal("model.System.Input2"))
+print("info:      model.System.parameter1     : " .. oms_getReal("model.System.parameter1"))
+
+print("info:      model.System.add.u1         : " .. oms_getReal("model.System.add.u1"))
+print("info:      model.System.add.u2         : " .. oms_getReal("model.System.add.u2"))
+print("info:      model.System.gain.u         : " .. oms_getReal("model.System.gain.u"))
+print("info:      model.System.gain.k         : " .. oms_getReal("model.System.gain.k"))
+
+-- Result:
+-- error:   [addConnection] Connector is already connected: add.u1
+-- error:   [addConnection] Connector is already connected: gain.k
+-- error:   [addConnection] Connector is already connected: add.u2
+-- info:    Result file: model_res.mat (bufferSize=10)
+-- info:    Simulation
+-- info:      model.System.Input1         : 10.0
+-- info:      model.System.Input2         : 20.0
+-- info:      model.System.parameter1     : 40.0
+-- info:      model.System.add.u1         : 10.0
+-- info:      model.System.add.u2         : 400.0
+-- info:      model.System.gain.u         : 10.0
+-- info:      model.System.gain.k         : 40.0
+-- info:    0 warnings
+-- info:    3 errors
+-- endResult

--- a/testsuite/OMSimulator/multipleConnections.lua
+++ b/testsuite/OMSimulator/multipleConnections.lua
@@ -57,9 +57,9 @@ print("info:      model.System.gain.u         : " .. oms_getReal("model.System.g
 print("info:      model.System.gain.k         : " .. oms_getReal("model.System.gain.k"))
 
 -- Result:
--- error:   [addConnection] Connector is already connected: add.u1
--- error:   [addConnection] Connector is already connected: gain.k
--- error:   [addConnection] Connector is already connected: add.u2
+-- error:   [addConnection] Connector add.u1 is already connected to Input1
+-- error:   [addConnection] Connector gain.k is already connected to parameter1
+-- error:   [addConnection] Connector add.u2 is already connected to gain.y
 -- info:    Result file: model_res.mat (bufferSize=10)
 -- info:    Simulation
 -- info:      model.System.Input1         : 10.0

--- a/testsuite/OMSimulator/multipleConnections.lua
+++ b/testsuite/OMSimulator/multipleConnections.lua
@@ -41,9 +41,7 @@ oms_addConnection("model.System.parameter2", "model.System.gain.k")
 oms_addConnection("model.System.Output1", "model.System.add.u2")
 
 oms_instantiate("model")
-
 oms_initialize("model")
-
 oms_simulate("model")
 
 print("info:    Simulation")

--- a/testsuite/api/connections.lua
+++ b/testsuite/api/connections.lua
@@ -53,7 +53,7 @@ printStatus(status, 0)
 status = oms_addConnection("model.wc.sc1.u1", "model.wc.sc2.y1")
 printStatus(status, 0)
 
---Connecting input to input (illegal)
+--Connecting output to output (illegal)
 status = oms_addConnection("model.wc.sc1.y", "model.wc.sc2.y3")
 printStatus(status, 3)
 
@@ -90,7 +90,8 @@ printStatus(status, 0)
 -- status:  [correct] error
 -- error:   [addConnection] Type mismatch in connection: sc1.u2 -> sc2.y2
 -- status:  [correct] error
--- status:  [wrong] ok
+-- error:   [addConnection] Connector sc1.u1 is already connected to sc2.y1
+-- status:  [correct] error
 -- <?xml version="1.0"?>
 -- <ssd:System name="wc">
 -- 	<ssd:Elements>
@@ -141,7 +142,6 @@ printStatus(status, 0)
 -- 	</ssd:Elements>
 -- 	<ssd:Connections>
 -- 		<ssd:Connection startElement="sc2" startConnector="y1" endElement="sc1" endConnector="u1" />
--- 		<ssd:Connection startElement="sc2" startConnector="y3" endElement="sc1" endConnector="u1" />
 -- 	</ssd:Connections>
 -- 	<ssd:Annotations>
 -- 		<ssc:Annotation type="org.openmodelica">
@@ -203,9 +203,6 @@ printStatus(status, 0)
 -- 			</ssd:Annotations>
 -- 		</ssd:System>
 -- 	</ssd:Elements>
--- 	<ssd:Connections>
--- 		<ssd:Connection startElement="sc2" startConnector="y3" endElement="sc1" endConnector="u1" />
--- 	</ssd:Connections>
 -- 	<ssd:Annotations>
 -- 		<ssc:Annotation type="org.openmodelica">
 -- 			<oms:Annotations>
@@ -219,5 +216,5 @@ printStatus(status, 0)
 --
 -- status:  [correct] ok
 -- info:    0 warnings
--- info:    2 errors
+-- info:    3 errors
 -- endResult

--- a/testsuite/api/connections.lua
+++ b/testsuite/api/connections.lua
@@ -90,8 +90,7 @@ printStatus(status, 0)
 -- status:  [correct] error
 -- error:   [addConnection] Type mismatch in connection: sc1.u2 -> sc2.y2
 -- status:  [correct] error
--- error:   [addConnection] Connector is already connected: sc1.u1
--- status:  [correct] error
+-- status:  [wrong] ok
 -- <?xml version="1.0"?>
 -- <ssd:System name="wc">
 -- 	<ssd:Elements>
@@ -142,6 +141,7 @@ printStatus(status, 0)
 -- 	</ssd:Elements>
 -- 	<ssd:Connections>
 -- 		<ssd:Connection startElement="sc2" startConnector="y1" endElement="sc1" endConnector="u1" />
+-- 		<ssd:Connection startElement="sc2" startConnector="y3" endElement="sc1" endConnector="u1" />
 -- 	</ssd:Connections>
 -- 	<ssd:Annotations>
 -- 		<ssc:Annotation type="org.openmodelica">
@@ -203,6 +203,9 @@ printStatus(status, 0)
 -- 			</ssd:Annotations>
 -- 		</ssd:System>
 -- 	</ssd:Elements>
+-- 	<ssd:Connections>
+-- 		<ssd:Connection startElement="sc2" startConnector="y3" endElement="sc1" endConnector="u1" />
+-- 	</ssd:Connections>
 -- 	<ssd:Annotations>
 -- 		<ssc:Annotation type="org.openmodelica">
 -- 			<oms:Annotations>
@@ -216,5 +219,5 @@ printStatus(status, 0)
 --
 -- status:  [correct] ok
 -- info:    0 warnings
--- info:    3 errors
+-- info:    2 errors
 -- endResult

--- a/testsuite/api/connections.py
+++ b/testsuite/api/connections.py
@@ -90,7 +90,8 @@ printStatus(status, 0)
 ## status:  [correct] error
 ## error:   [addConnection] Type mismatch in connection: sc1.u2 -> sc2.y2
 ## status:  [correct] error
-## status:  [wrong] ok
+## error:   [addConnection] Connector sc1.u1 is already connected to sc2.y1
+## status:  [correct] error
 ## <?xml version="1.0"?>
 ## <ssd:System name="wc">
 ## 	<ssd:Elements>
@@ -141,7 +142,6 @@ printStatus(status, 0)
 ## 	</ssd:Elements>
 ## 	<ssd:Connections>
 ## 		<ssd:Connection startElement="sc2" startConnector="y1" endElement="sc1" endConnector="u1" />
-## 		<ssd:Connection startElement="sc2" startConnector="y3" endElement="sc1" endConnector="u1" />
 ## 	</ssd:Connections>
 ## 	<ssd:Annotations>
 ## 		<ssc:Annotation type="org.openmodelica">
@@ -203,9 +203,6 @@ printStatus(status, 0)
 ## 			</ssd:Annotations>
 ## 		</ssd:System>
 ## 	</ssd:Elements>
-## 	<ssd:Connections>
-## 		<ssd:Connection startElement="sc2" startConnector="y3" endElement="sc1" endConnector="u1" />
-## 	</ssd:Connections>
 ## 	<ssd:Annotations>
 ## 		<ssc:Annotation type="org.openmodelica">
 ## 			<oms:Annotations>
@@ -219,5 +216,5 @@ printStatus(status, 0)
 ##
 ## status:  [correct] ok
 ## info:    0 warnings
-## info:    2 errors
+## info:    3 errors
 ## endResult

--- a/testsuite/api/connections.py
+++ b/testsuite/api/connections.py
@@ -90,8 +90,7 @@ printStatus(status, 0)
 ## status:  [correct] error
 ## error:   [addConnection] Type mismatch in connection: sc1.u2 -> sc2.y2
 ## status:  [correct] error
-## error:   [addConnection] Connector is already connected: sc1.u1
-## status:  [correct] error
+## status:  [wrong] ok
 ## <?xml version="1.0"?>
 ## <ssd:System name="wc">
 ## 	<ssd:Elements>
@@ -142,6 +141,7 @@ printStatus(status, 0)
 ## 	</ssd:Elements>
 ## 	<ssd:Connections>
 ## 		<ssd:Connection startElement="sc2" startConnector="y1" endElement="sc1" endConnector="u1" />
+## 		<ssd:Connection startElement="sc2" startConnector="y3" endElement="sc1" endConnector="u1" />
 ## 	</ssd:Connections>
 ## 	<ssd:Annotations>
 ## 		<ssc:Annotation type="org.openmodelica">
@@ -203,6 +203,9 @@ printStatus(status, 0)
 ## 			</ssd:Annotations>
 ## 		</ssd:System>
 ## 	</ssd:Elements>
+## 	<ssd:Connections>
+## 		<ssd:Connection startElement="sc2" startConnector="y3" endElement="sc1" endConnector="u1" />
+## 	</ssd:Connections>
 ## 	<ssd:Annotations>
 ## 		<ssc:Annotation type="org.openmodelica">
 ## 			<oms:Annotations>
@@ -216,5 +219,5 @@ printStatus(status, 0)
 ##
 ## status:  [correct] ok
 ## info:    0 warnings
-## info:    3 errors
+## info:    2 errors
 ## endResult


### PR DESCRIPTION
### Related Issues

https://github.com/OpenModelica/OMSimulator/issues/919

### Purpose

This PR allows` input connector` to be connected with `multiple component input connector` which has no previous connections defined.  According to `SSP-1.0 ` specification multiple connections to already connected  connectors of type input/output/parameter should not exist.

