### PR TITLE
Fix connection geometry for connections from end-to-start

### DIFF
--- a/src/OMSimulatorLib/Connection.cpp
+++ b/src/OMSimulatorLib/Connection.cpp
@@ -139,12 +139,12 @@ oms_status_enu_t oms::Connection::exportToSSD(pugi::xml_node &root) const
   return oms_status_ok;
 }
 
-void oms::Connection::setGeometry(const oms::ssd::ConnectionGeometry* newGeometry)
+void oms::Connection::setGeometry(const oms::ssd::ConnectionGeometry* newGeometry, bool inverse)
 {
   oms::ssd::ConnectionGeometry* geometry_ = reinterpret_cast<oms::ssd::ConnectionGeometry*>(this->geometry);
   if (geometry_)
     delete geometry_;
-  geometry_ = new oms::ssd::ConnectionGeometry(*newGeometry);
+  geometry_ = new oms::ssd::ConnectionGeometry(*newGeometry, inverse);
   this->geometry = reinterpret_cast<ssd_connection_geometry_t*>(geometry_);
 }
 
@@ -169,6 +169,11 @@ void oms::Connection::setTLMParameters(double delay, double alpha, double linear
   tlmparameters->alpha = alpha;
   tlmparameters->linearimpedance = linearimpedance;
   tlmparameters->angularimpedance = angualrimpedance;
+}
+
+bool oms::Connection::isStrictEqual(const oms::ComRef& signalA, const oms::ComRef& signalB) const
+{
+  return signalA == oms::ComRef(this->conA) && signalB == oms::ComRef(this->conB);
 }
 
 bool oms::Connection::isEqual(const oms::ComRef& signalA, const oms::ComRef& signalB) const

--- a/src/OMSimulatorLib/Connection.h
+++ b/src/OMSimulatorLib/Connection.h
@@ -60,7 +60,7 @@ namespace oms
     const oms::ComRef getSignalB() const {return oms::ComRef(conB);}
 
     const oms::ssd::ConnectionGeometry* getGeometry() const {return reinterpret_cast<oms::ssd::ConnectionGeometry*>(geometry);}
-    void setGeometry(const oms::ssd::ConnectionGeometry* newGeometry);
+    void setGeometry(const oms::ssd::ConnectionGeometry* newGeometry, bool inverse=false);
     void setTLMParameters(const oms_tlm_connection_parameters_t* parameters);
     void setTLMParameters(double delay, double alpha, double linearimpedance, double angualrimpedance);
     oms_tlm_connection_parameters_t* getTLMParameters() const {return tlmparameters;}
@@ -68,7 +68,8 @@ namespace oms
     oms_connection_type_enu_t getType() const {return type;}
 
     bool isEqual(const oms::Connection& connection) const;
-    bool isEqual(const oms::ComRef& signalA, const oms::ComRef& signalB) const;
+    bool isEqual(const oms::ComRef& signalA, const oms::ComRef& signalB) const; ///< "A->B" and "B->A" are treated the same
+    bool isStrictEqual(const oms::ComRef& signalA, const oms::ComRef& signalB) const; ///< "A->B" is not strict equal "B->A"
     bool containsSignal(const oms::ComRef& signal) const;
     bool containsSignalB(const oms::ComRef& signal) const;
 

--- a/src/OMSimulatorLib/System.cpp
+++ b/src/OMSimulatorLib/System.cpp
@@ -1452,7 +1452,7 @@ oms_status_enu_t oms::System::setConnectionGeometry(const oms::ComRef& crefA, co
   for (auto& connection : connections)
     if (connection && connection->isEqual(crefA, crefB))
     {
-      connection->setGeometry(geometry);
+      connection->setGeometry(geometry, connection->isStrictEqual(crefB, crefA));
       return oms_status_ok;
     }
 

--- a/src/OMSimulatorLib/System.cpp
+++ b/src/OMSimulatorLib/System.cpp
@@ -1452,7 +1452,8 @@ oms_status_enu_t oms::System::setConnectionGeometry(const oms::ComRef& crefA, co
   for (auto& connection : connections)
     if (connection && connection->isEqual(crefA, crefB))
     {
-      connection->setGeometry(geometry, connection->isStrictEqual(crefB, crefA));
+      bool inverse = connection->isStrictEqual(crefB, crefA);
+      connection->setGeometry(geometry, inverse);
       return oms_status_ok;
     }
 

--- a/src/OMSimulatorLib/Util.h
+++ b/src/OMSimulatorLib/Util.h
@@ -77,4 +77,16 @@ static inline bool almostEqualRelativeAndAbs(double a, double b, double reltol=D
   return false;
 }
 
+template <class T>
+void reverseArray(T* array, unsigned int length)
+{
+  T tmp;
+  for (unsigned int start = 0, end = length-1; start < end; start++, end--)
+  {
+    tmp = array[start];
+    array[start] = array[end];
+    array[end] = tmp;
+  }
+}
+
 #endif

--- a/src/OMSimulatorLib/ssd/ConnectionGeometry.cpp
+++ b/src/OMSimulatorLib/ssd/ConnectionGeometry.cpp
@@ -33,6 +33,7 @@
 
 #include "../Logging.h"
 #include "Tags.h"
+#include "Util.h"
 
 #include <string.h>
 #include <sstream>
@@ -45,17 +46,6 @@ oms::ssd::ConnectionGeometry::ConnectionGeometry()
   this->pointsX = NULL;
   this->pointsY = NULL;
   this->n = 0;
-}
-
-void reverseArray(double* arr, unsigned int length)
-{
-  double tmp;
-  for (unsigned int start = 0, end = length-1; start < end; start++, end--)
-  {
-    tmp = arr[start];
-    arr[start] = arr[end];
-    arr[end] = tmp;
-  }
 }
 
 oms::ssd::ConnectionGeometry::ConnectionGeometry(const oms::ssd::ConnectionGeometry& rhs, bool inverse)

--- a/src/OMSimulatorLib/ssd/ConnectionGeometry.cpp
+++ b/src/OMSimulatorLib/ssd/ConnectionGeometry.cpp
@@ -47,7 +47,18 @@ oms::ssd::ConnectionGeometry::ConnectionGeometry()
   this->n = 0;
 }
 
-oms::ssd::ConnectionGeometry::ConnectionGeometry(const oms::ssd::ConnectionGeometry& rhs)
+void reverseArray(double* arr, unsigned int length)
+{
+  double tmp;
+  for (unsigned int start = 0, end = length-1; start < end; start++, end--)
+  {
+    tmp = arr[start];
+    arr[start] = arr[end];
+    arr[end] = tmp;
+  }
+}
+
+oms::ssd::ConnectionGeometry::ConnectionGeometry(const oms::ssd::ConnectionGeometry& rhs, bool inverse)
 {
   logTrace();
 
@@ -59,6 +70,11 @@ oms::ssd::ConnectionGeometry::ConnectionGeometry(const oms::ssd::ConnectionGeome
     this->pointsY = new double[rhs.n];
     memcpy(this->pointsX, rhs.pointsX, n*sizeof(double));
     memcpy(this->pointsY, rhs.pointsY, n*sizeof(double));
+    if (inverse)
+    {
+      reverseArray(this->pointsX, this->n);
+      reverseArray(this->pointsY, this->n);
+    }
   }
   else
   {

--- a/src/OMSimulatorLib/ssd/ConnectionGeometry.h
+++ b/src/OMSimulatorLib/ssd/ConnectionGeometry.h
@@ -46,7 +46,7 @@ namespace oms
     {
     public:
       ConnectionGeometry();
-      ConnectionGeometry(const ConnectionGeometry& rhs);
+      ConnectionGeometry(const ConnectionGeometry& rhs, bool inverse=false);
       ~ConnectionGeometry();
 
       ConnectionGeometry& operator=(ConnectionGeometry const& rhs);


### PR DESCRIPTION
### Related Issues

I think there was no issue reported for this problem.

### Description

This fixes connections in OMEdit that previously appeared weird looking if drawn from end-point to start-point, e.g.,:
![image](https://user-images.githubusercontent.com/8457302/106891802-80d93b80-66eb-11eb-9dc7-367dd35718ba.png)
