### PR TITLE
Refactor loadSnapshot

### DIFF
--- a/src/OMSimulatorLib/Model.cpp
+++ b/src/OMSimulatorLib/Model.cpp
@@ -143,26 +143,13 @@ oms_status_enu_t oms::Model::rename(const ComRef& cref, const ComRef& newCref)
   return logError("Model \"" + std::string(getCref()) + "\" does not contain system \"" + std::string(front) + "\"");
 }
 
-oms_status_enu_t oms::Model::loadSnapshot(const char* snapshot)
+oms_status_enu_t oms::Model::loadSnapshot(const pugi::xml_node node)
 {
+  // This method will not change the name of the model.
+  // If a renaming is requested then it will happen in Scope::loadSnapshot.
+
   if (!validState(oms_modelState_virgin))
     return logError_ModelInWrongState(this);
-
-  pugi::xml_document doc;
-  pugi::xml_parse_result result = doc.load(snapshot);
-  if (!result)
-    return logError("loading snapshot failed (" + std::string(result.description()) + ")");
-
-  const pugi::xml_node node = doc.document_element(); // ssd:SystemStructureDescription
-
-  ComRef new_cref = ComRef(node.attribute("name").as_string());
-  std::string ssdVersion = node.attribute("version").as_string();
-
-  if (new_cref != getCref())
-    return logError("this API cannot be used to rename a model");
-
-  if (ssdVersion != "Draft20180219" && ssdVersion != "1.0")
-    logWarning("Unknown SSD version: " + ssdVersion);
 
   System* old_root_system = system;
   system = NULL;

--- a/src/OMSimulatorLib/Model.h
+++ b/src/OMSimulatorLib/Model.h
@@ -125,7 +125,7 @@ namespace oms
     bool useThreadPool() {return (pool != nullptr);}
     ctpl::thread_pool& getThreadPool() {assert(pool); return *pool;}
 
-    oms_status_enu_t loadSnapshot(const char* snapshot);
+    oms_status_enu_t loadSnapshot(const pugi::xml_node node);
 
     pugi::xml_node getSnapshot() {return snapShot;}
 

--- a/src/OMSimulatorLib/Scope.cpp
+++ b/src/OMSimulatorLib/Scope.cpp
@@ -405,7 +405,7 @@ oms_status_enu_t oms::Scope::loadSnapshot(const oms::ComRef& cref, const char* s
 
   std::string ssdVersion = node.attribute("version").as_string();
   if (ssdVersion != "Draft20180219" && ssdVersion != "1.0")
-    logWarning("Unknown SSD version \"" + ssdVersion + "\"; import will continue anyways. Supported version are \"1.0\" and \"Draft20180219\".");
+    return logError("Unknown SSD version \"" + ssdVersion + "\"; supported version are \"1.0\" and \"Draft20180219\".");
 
   oms_status_enu_t status = getModel(cref)->loadSnapshot(node);
 

--- a/src/OMSimulatorLib/Scope.cpp
+++ b/src/OMSimulatorLib/Scope.cpp
@@ -405,7 +405,7 @@ oms_status_enu_t oms::Scope::loadSnapshot(const oms::ComRef& cref, const char* s
 
   std::string ssdVersion = node.attribute("version").as_string();
   if (ssdVersion != "Draft20180219" && ssdVersion != "1.0")
-    return logError("Unknown SSD version: " + ssdVersion + " Supported version are 1.0 and Draft20180219.");
+    logWarning("Unknown SSD version \"" + ssdVersion + "\"; import will continue anyways. Supported version are \"1.0\" and \"Draft20180219\".");
 
   oms_status_enu_t status = getModel(cref)->loadSnapshot(node);
 


### PR DESCRIPTION
### Purpose

This requires the xml snapshot only once to be parsed.
It also provides a cleaner separation between the Scope and Model class.

@arun3688 I changed the version check from a warning to an error. But I think we had it intentionally as warning. Do you remember it?