### PR TITLE
Try to fix installation within the OpenModelica super project

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,12 +85,12 @@ ifeq ($(OMBUILDDIR),)
 else
 	TOP_INSTALL_DIR=$(OMBUILDDIR)
 	CMAKE_INSTALL_PREFIX=-DCMAKE_INSTALL_PREFIX=$(OMBUILDDIR)
-ifeq ($(host_short),)
-	HOST_SHORT=
-else
-	HOST_SHORT_OMC=$(host_short)/omc
-	HOST_SHORT=-DHOST_SHORT=$(HOST_SHORT_OMC)
-endif
+	ifeq ($(host_short),)
+		HOST_SHORT=-DHOST_SHORT=
+	else
+		HOST_SHORT_OMC=$(host_short)/omc
+		HOST_SHORT=-DHOST_SHORT=$(HOST_SHORT_OMC)
+	endif
 endif
 
 ifeq ($(detected_OS),Darwin)

--- a/src/OMSimulatorServer/CMakeLists.txt
+++ b/src/OMSimulatorServer/CMakeLists.txt
@@ -1,6 +1,6 @@
 project(OMSimulatorServer)
 
 # install only if build as part of the OpenModelica super project
-if(DEFINED CMAKE_INSTALL_PREFIX)
+if(DEFINED OMBUILDDIR)
   install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/OMSimulatorServer.py" DESTINATION ${CMAKE_INSTALL_PREFIX}/share/OMSimulator/scripts)
 endif()

--- a/src/OMSimulatorServer/CMakeLists.txt
+++ b/src/OMSimulatorServer/CMakeLists.txt
@@ -1,6 +1,6 @@
 project(OMSimulatorServer)
 
 # install only if build as part of the OpenModelica super project
-if(DEFINED OMBUILDDIR)
+if(DEFINED HOST_SHORT)
   install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/OMSimulatorServer.py" DESTINATION ${CMAKE_INSTALL_PREFIX}/share/OMSimulator/scripts)
 endif()

--- a/src/OMSimulatorServer/CMakeLists.txt
+++ b/src/OMSimulatorServer/CMakeLists.txt
@@ -1,6 +1,6 @@
 project(OMSimulatorServer)
 
 # install only if build as part of the OpenModelica super project
-if(DEFINED HOST_SHORT)
+if(DEFINED CMAKE_INSTALL_PREFIX)
   install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/OMSimulatorServer.py" DESTINATION ${CMAKE_INSTALL_PREFIX}/share/OMSimulator/scripts)
 endif()


### PR DESCRIPTION
The installation of the simulation server doesn't work on Windows. It works fine on Linux though.

This is an attempt to fix it. The simulation server should only be installed if it is compiled as part of the OpenModelica super project.