### PR TITLE
Overload oms::Snapshot::oeprator[]

### DIFF
--- a/src/OMSimulatorLib/Model.cpp
+++ b/src/OMSimulatorLib/Model.cpp
@@ -155,7 +155,7 @@ oms_status_enu_t oms::Model::loadSnapshot(const pugi::xml_node& node)
   system = NULL;
 
   Snapshot snapshot; // this is a temporary workaroud, loadSnapshot will be removed later
-  snapshot.importResourcesXML("SystemStructure.ssd", node);
+  snapshot.importResourceNode("SystemStructure.ssd", node);
   //snapshot.debugPrintAll();
 
   bool old_copyResources = copyResources();
@@ -188,7 +188,7 @@ oms_status_enu_t oms::Model::importSnapshot(const char* snapshot_)
   //snapshot.debugPrintAll();
 
   // get ssd:SystemStructureDescription
-  pugi::xml_node ssdNode = snapshot.getResourcesFile("SystemStructure.ssd");
+  pugi::xml_node ssdNode = snapshot.getResourceNode("SystemStructure.ssd");
 
   ComRef new_cref = ComRef(ssdNode.attribute("name").as_string());
   std::string ssdVersion = ssdNode.attribute("version").as_string();
@@ -608,7 +608,7 @@ oms_status_enu_t oms::Model::exportToSSD(pugi::xml_node& node, pugi::xml_node& s
 
 oms_status_enu_t oms::Model::importFromSnapshot(const Snapshot& snapshot)
 {
-  pugi::xml_node ssdNode = snapshot.getResourcesFile("SystemStructure.ssd");
+  pugi::xml_node ssdNode = snapshot.getResourceNode("SystemStructure.ssd");
   if (!ssdNode)
     return logError("loading <oms:file> \"SystemStructure.ssd\" from <oms:snapshot> failed");
 

--- a/src/OMSimulatorLib/Model.cpp
+++ b/src/OMSimulatorLib/Model.cpp
@@ -188,7 +188,7 @@ oms_status_enu_t oms::Model::importSnapshot(const char* snapshot_)
   //snapshot.debugPrintAll();
 
   // get ssd:SystemStructureDescription
-  pugi::xml_node ssdNode = snapshot.getResourcesFile( "SystemStructure.ssd");
+  pugi::xml_node ssdNode = snapshot["SystemStructure.ssd"];
 
   ComRef new_cref = ComRef(ssdNode.attribute("name").as_string());
   std::string ssdVersion = ssdNode.attribute("version").as_string();
@@ -608,7 +608,7 @@ oms_status_enu_t oms::Model::exportToSSD(pugi::xml_node& node, pugi::xml_node& s
 
 oms_status_enu_t oms::Model::importFromSnapshot(const Snapshot& snapshot)
 {
-  pugi::xml_node ssdNode = snapshot.getResourcesFile("SystemStructure.ssd");
+  pugi::xml_node ssdNode = snapshot["SystemStructure.ssd"];
   if (!ssdNode)
     return logError("loading <oms:file> \"SystemStructure.ssd\" from <oms:snapshot> failed");
 

--- a/src/OMSimulatorLib/Model.cpp
+++ b/src/OMSimulatorLib/Model.cpp
@@ -188,7 +188,7 @@ oms_status_enu_t oms::Model::importSnapshot(const char* snapshot_)
   //snapshot.debugPrintAll();
 
   // get ssd:SystemStructureDescription
-  pugi::xml_node ssdNode = snapshot["SystemStructure.ssd"];
+  pugi::xml_node ssdNode = snapshot.getResourcesFile("SystemStructure.ssd");
 
   ComRef new_cref = ComRef(ssdNode.attribute("name").as_string());
   std::string ssdVersion = ssdNode.attribute("version").as_string();
@@ -608,7 +608,7 @@ oms_status_enu_t oms::Model::exportToSSD(pugi::xml_node& node, pugi::xml_node& s
 
 oms_status_enu_t oms::Model::importFromSnapshot(const Snapshot& snapshot)
 {
-  pugi::xml_node ssdNode = snapshot["SystemStructure.ssd"];
+  pugi::xml_node ssdNode = snapshot.getResourcesFile("SystemStructure.ssd");
   if (!ssdNode)
     return logError("loading <oms:file> \"SystemStructure.ssd\" from <oms:snapshot> failed");
 

--- a/src/OMSimulatorLib/OMSimulator.cpp
+++ b/src/OMSimulatorLib/OMSimulator.cpp
@@ -1643,7 +1643,7 @@ oms_status_enu_t oms_extractFMIKind(const char* filename, oms_fmi_kind_enu_t* ki
   oms::Snapshot snapshot;
   if (oms_status_ok != snapshot.importResourcesFile("modelDescription.xml", oms::Scope::GetInstance().getTempDirectory()))
     return logError("Failed to import");
-  const pugi::xml_node node = snapshot["modelDescription.xml"];
+  const pugi::xml_node node = snapshot.getResourcesFile("modelDescription.xml");
 
   bool cs = (std::string(node.child("CoSimulation").attribute("modelIdentifier").as_string()) != "");
   bool me = (std::string(node.child("ModelExchange").attribute("modelIdentifier").as_string()) != "");

--- a/src/OMSimulatorLib/OMSimulator.cpp
+++ b/src/OMSimulatorLib/OMSimulator.cpp
@@ -1643,7 +1643,7 @@ oms_status_enu_t oms_extractFMIKind(const char* filename, oms_fmi_kind_enu_t* ki
   oms::Snapshot snapshot;
   if (oms_status_ok != snapshot.importResourcesFile("modelDescription.xml", oms::Scope::GetInstance().getTempDirectory()))
     return logError("Failed to import");
-  const pugi::xml_node node = snapshot.getResourcesFile("modelDescription.xml");
+  const pugi::xml_node node = snapshot["modelDescription.xml"];
 
   bool cs = (std::string(node.child("CoSimulation").attribute("modelIdentifier").as_string()) != "");
   bool me = (std::string(node.child("ModelExchange").attribute("modelIdentifier").as_string()) != "");

--- a/src/OMSimulatorLib/OMSimulator.cpp
+++ b/src/OMSimulatorLib/OMSimulator.cpp
@@ -1641,9 +1641,9 @@ oms_status_enu_t oms_extractFMIKind(const char* filename, oms_fmi_kind_enu_t* ki
     return logError("failed to extract modelDescription.xml from \"" + std::string(filename) + "\"");
 
   oms::Snapshot snapshot;
-  if (oms_status_ok != snapshot.importResourcesFile("modelDescription.xml", oms::Scope::GetInstance().getTempDirectory()))
+  if (oms_status_ok != snapshot.importResourceFile("modelDescription.xml", oms::Scope::GetInstance().getTempDirectory()))
     return logError("Failed to import");
-  const pugi::xml_node node = snapshot.getResourcesFile("modelDescription.xml");
+  const pugi::xml_node node = snapshot.getResourceNode("modelDescription.xml");
 
   bool cs = (std::string(node.child("CoSimulation").attribute("modelIdentifier").as_string()) != "");
   bool me = (std::string(node.child("ModelExchange").attribute("modelIdentifier").as_string()) != "");

--- a/src/OMSimulatorLib/Scope.cpp
+++ b/src/OMSimulatorLib/Scope.cpp
@@ -202,7 +202,7 @@ oms_status_enu_t oms::Scope::importModel(const std::string& filename, char** _cr
 
   Snapshot snapshot;
   snapshot.importResourcesFile("SystemStructure.ssd", temp_root);
-  const pugi::xml_node node = snapshot.getResourcesFile("SystemStructure.ssd");
+  const pugi::xml_node node = snapshot["SystemStructure.ssd"];
   if (!node)
     return logError("failed to load \"SystemStructure.ssd\"");
 

--- a/src/OMSimulatorLib/Scope.cpp
+++ b/src/OMSimulatorLib/Scope.cpp
@@ -201,8 +201,8 @@ oms_status_enu_t oms::Scope::importModel(const std::string& filename, char** _cr
     return logError("failed to extract \"SystemStructure.ssd\" from \"" + filename + "\"");
 
   Snapshot snapshot;
-  snapshot.importResourcesFile("SystemStructure.ssd", temp_root);
-  const pugi::xml_node node = snapshot.getResourcesFile("SystemStructure.ssd");
+  snapshot.importResourceFile("SystemStructure.ssd", temp_root);
+  const pugi::xml_node node = snapshot.getResourceNode("SystemStructure.ssd");
   if (!node)
     return logError("failed to load \"SystemStructure.ssd\"");
 
@@ -229,7 +229,7 @@ oms_status_enu_t oms::Scope::importModel(const std::string& filename, char** _cr
   for (const auto &entry : OMS_RECURSIVE_DIRECTORY_ITERATOR(model->getTempDirectory()))
     if (entry.path().has_extension())
       if (".ssv" == entry.path().extension() || ".ssm" == entry.path().extension() || ".xml" == entry.path().extension())
-        snapshot.importResourcesFile(naive_uncomplete(entry.path(), model->getTempDirectory()), model->getTempDirectory());
+        snapshot.importResourceFile(naive_uncomplete(entry.path(), model->getTempDirectory()), model->getTempDirectory());
 
   // snapshot.debugPrintAll();
 

--- a/src/OMSimulatorLib/Scope.cpp
+++ b/src/OMSimulatorLib/Scope.cpp
@@ -202,7 +202,7 @@ oms_status_enu_t oms::Scope::importModel(const std::string& filename, char** _cr
 
   Snapshot snapshot;
   snapshot.importResourcesFile("SystemStructure.ssd", temp_root);
-  const pugi::xml_node node = snapshot["SystemStructure.ssd"];
+  const pugi::xml_node node = snapshot.getResourcesFile("SystemStructure.ssd");
   if (!node)
     return logError("failed to load \"SystemStructure.ssd\"");
 

--- a/src/OMSimulatorLib/Snapshot.cpp
+++ b/src/OMSimulatorLib/Snapshot.cpp
@@ -114,10 +114,11 @@ pugi::xml_node oms::Snapshot::getResourceNode(const filesystem::path& filename) 
   pugi::xml_node oms_snapshot = doc.document_element();
   pugi::xml_node node = oms_snapshot.find_child_by_attribute(oms::ssp::Version1_0::oms_file, "name", filename.generic_string().c_str());
 
-  if (!node)
-    logError("Failed to find node \"" + filename.generic_string() + "\"");
+  if (node)
+    return node.first_child();
 
-  return node.first_child();
+  logError("Failed to find node \"" + filename.generic_string() + "\"");
+  return node;
 }
 
 pugi::xml_node oms::Snapshot::operator[](const filesystem::path& filename)

--- a/src/OMSimulatorLib/Snapshot.cpp
+++ b/src/OMSimulatorLib/Snapshot.cpp
@@ -45,7 +45,7 @@ oms::Snapshot::~Snapshot()
 {
 }
 
-pugi::xml_node oms::Snapshot::newResourcesFile(const filesystem::path& filename)
+pugi::xml_node oms::Snapshot::newResourceNode(const filesystem::path& filename)
 {
   pugi::xml_node oms_snapshot = doc.document_element();
   pugi::xml_node node = oms_snapshot.find_child_by_attribute(oms::ssp::Version1_0::oms_file, "name", filename.generic_string().c_str());
@@ -70,7 +70,7 @@ oms_status_enu_t oms::Snapshot::import(const char* snapshot)
   return oms_status_ok;
 }
 
-oms_status_enu_t oms::Snapshot::importResourcesFile(const filesystem::path& filename, const filesystem::path& root)
+oms_status_enu_t oms::Snapshot::importResourceFile(const filesystem::path& filename, const filesystem::path& root)
 {
   filesystem::path p = root / filename;
 
@@ -79,20 +79,20 @@ oms_status_enu_t oms::Snapshot::importResourcesFile(const filesystem::path& file
   if (!result)
     return logError("loading resource \"" + p.generic_string() + "\" failed (" + std::string(result.description()) + ")");
 
-  return importResourcesXML(filename, tmp_doc.document_element());
+  return importResourceNode(filename, tmp_doc.document_element());
 }
 
-oms_status_enu_t oms::Snapshot::importResourcesMemory(const filesystem::path& filename, const char* contents)
+oms_status_enu_t oms::Snapshot::importResourceMemory(const filesystem::path& filename, const char* contents)
 {
   pugi::xml_document tmp_doc;
   pugi::xml_parse_result result = tmp_doc.load_string(contents);
   if (!result)
     return logError("loading resource \"" + filename.generic_string() + "\" failed (" + std::string(result.description()) + ")");
 
-  return importResourcesXML(filename, tmp_doc.document_element());
+  return importResourceNode(filename, tmp_doc.document_element());
 }
 
-oms_status_enu_t oms::Snapshot::importResourcesXML(const filesystem::path& filename, const pugi::xml_node& node)
+oms_status_enu_t oms::Snapshot::importResourceNode(const filesystem::path& filename, const pugi::xml_node& node)
 {
   pugi::xml_node oms_snapshot = doc.document_element();
   pugi::xml_node oms_file = oms_snapshot.append_child(oms::ssp::Version1_0::oms_file);
@@ -109,7 +109,7 @@ void oms::Snapshot::getResources(std::vector<std::string>& resources) const
     resources.push_back(it.attribute("name").as_string());
 }
 
-pugi::xml_node oms::Snapshot::getResourcesFile(const filesystem::path& filename) const
+pugi::xml_node oms::Snapshot::getResourceNode(const filesystem::path& filename) const
 {
   pugi::xml_node oms_snapshot = doc.document_element();
   pugi::xml_node node = oms_snapshot.find_child_by_attribute(oms::ssp::Version1_0::oms_file, "name", filename.generic_string().c_str());
@@ -128,12 +128,12 @@ pugi::xml_node oms::Snapshot::operator[](const filesystem::path& filename)
   if (node)
     return node.first_child();
 
-  return newResourcesFile(filename);
+  return newResourceNode(filename);
 }
 
 void oms::Snapshot::debugPrintNode(const filesystem::path& filename) const
 {
-  pugi::xml_node node = getResourcesFile(filename);
+  pugi::xml_node node = getResourceNode(filename);
 
   if (node)
     node.print(std::cout, "  ");

--- a/src/OMSimulatorLib/Snapshot.cpp
+++ b/src/OMSimulatorLib/Snapshot.cpp
@@ -45,6 +45,22 @@ oms::Snapshot::~Snapshot()
 {
 }
 
+pugi::xml_node oms::Snapshot::newResourcesFile(const filesystem::path& filename) const
+{
+  pugi::xml_node oms_snapshot = doc.document_element();
+  pugi::xml_node node = oms_snapshot.find_child_by_attribute(oms::ssp::Version1_0::oms_file, "name", filename.generic_string().c_str());
+
+  if (node)
+  {
+    logError("Node \"" + filename.generic_string() + "\" does already exist");
+    return node.first_child();
+  }
+
+  pugi::xml_node new_node = oms_snapshot.append_child(oms::ssp::Version1_0::oms_file);
+  new_node.append_attribute("name") = filename.generic_string().c_str();
+  return new_node;
+}
+
 oms_status_enu_t oms::Snapshot::import(const char* snapshot)
 {
   doc.reset();
@@ -86,7 +102,7 @@ oms_status_enu_t oms::Snapshot::importResourcesXML(const filesystem::path& filen
   return oms_status_ok;
 }
 
-void oms::Snapshot::getResources(std::vector<std::string>& resources)
+void oms::Snapshot::getResources(std::vector<std::string>& resources) const
 {
   pugi::xml_node oms_snapshot = doc.document_element();
   for (const auto& it : oms_snapshot.children())
@@ -106,7 +122,13 @@ pugi::xml_node oms::Snapshot::getResourcesFile(const filesystem::path& filename)
 
 pugi::xml_node oms::Snapshot::operator[](const filesystem::path& filename) const
 {
-  return this->getResourcesFile(filename);
+  pugi::xml_node oms_snapshot = doc.document_element();
+  pugi::xml_node node = oms_snapshot.find_child_by_attribute(oms::ssp::Version1_0::oms_file, "name", filename.generic_string().c_str());
+
+  if (node)
+    return node.first_child();
+
+  return newResourcesFile(filename);
 }
 
 void oms::Snapshot::debugPrintNode(const filesystem::path& filename) const

--- a/src/OMSimulatorLib/Snapshot.cpp
+++ b/src/OMSimulatorLib/Snapshot.cpp
@@ -104,6 +104,11 @@ pugi::xml_node oms::Snapshot::getResourcesFile(const filesystem::path& filename)
   return node.first_child();
 }
 
+pugi::xml_node oms::Snapshot::operator[](const filesystem::path& filename) const
+{
+  return this->getResourcesFile(filename);
+}
+
 void oms::Snapshot::debugPrintNode(const filesystem::path& filename) const
 {
   pugi::xml_node node = getResourcesFile(filename);

--- a/src/OMSimulatorLib/Snapshot.cpp
+++ b/src/OMSimulatorLib/Snapshot.cpp
@@ -45,7 +45,7 @@ oms::Snapshot::~Snapshot()
 {
 }
 
-pugi::xml_node oms::Snapshot::newResourcesFile(const filesystem::path& filename) const
+pugi::xml_node oms::Snapshot::newResourcesFile(const filesystem::path& filename)
 {
   pugi::xml_node oms_snapshot = doc.document_element();
   pugi::xml_node node = oms_snapshot.find_child_by_attribute(oms::ssp::Version1_0::oms_file, "name", filename.generic_string().c_str());
@@ -120,7 +120,7 @@ pugi::xml_node oms::Snapshot::getResourcesFile(const filesystem::path& filename)
   return node.first_child();
 }
 
-pugi::xml_node oms::Snapshot::operator[](const filesystem::path& filename) const
+pugi::xml_node oms::Snapshot::operator[](const filesystem::path& filename)
 {
   pugi::xml_node oms_snapshot = doc.document_element();
   pugi::xml_node node = oms_snapshot.find_child_by_attribute(oms::ssp::Version1_0::oms_file, "name", filename.generic_string().c_str());

--- a/src/OMSimulatorLib/Snapshot.h
+++ b/src/OMSimulatorLib/Snapshot.h
@@ -53,7 +53,9 @@ namespace oms
     oms_status_enu_t importResourcesMemory(const filesystem::path& filename, const char* contents);
     oms_status_enu_t importResourcesXML(const filesystem::path& filename, const pugi::xml_node& node);
     void getResources(std::vector<std::string>& resources);
+
     pugi::xml_node getResourcesFile(const filesystem::path& filename) const;
+    pugi::xml_node operator[](const filesystem::path& filename) const;
 
     void debugPrintNode(const filesystem::path& filename) const;
     void debugPrintAll() const;

--- a/src/OMSimulatorLib/Snapshot.h
+++ b/src/OMSimulatorLib/Snapshot.h
@@ -49,15 +49,15 @@ namespace oms
     ~Snapshot();
 
     oms_status_enu_t import(const char* snapshot);
-    oms_status_enu_t importResourcesFile(const filesystem::path& filename, const filesystem::path& root);
-    oms_status_enu_t importResourcesMemory(const filesystem::path& filename, const char* contents);
-    oms_status_enu_t importResourcesXML(const filesystem::path& filename, const pugi::xml_node& node);
+    oms_status_enu_t importResourceFile(const filesystem::path& filename, const filesystem::path& root);
+    oms_status_enu_t importResourceMemory(const filesystem::path& filename, const char* contents);
+    oms_status_enu_t importResourceNode(const filesystem::path& filename, const pugi::xml_node& node);
 
-    pugi::xml_node newResourcesFile(const filesystem::path& filename);
+    pugi::xml_node newResourceNode(const filesystem::path& filename);
     pugi::xml_node operator[](const filesystem::path& filename);
 
     void getResources(std::vector<std::string>& resources) const;
-    pugi::xml_node getResourcesFile(const filesystem::path& filename) const;
+    pugi::xml_node getResourceNode(const filesystem::path& filename) const;
 
     void debugPrintNode(const filesystem::path& filename) const;
     void debugPrintAll() const;

--- a/src/OMSimulatorLib/Snapshot.h
+++ b/src/OMSimulatorLib/Snapshot.h
@@ -48,13 +48,16 @@ namespace oms
     Snapshot();
     ~Snapshot();
 
+    pugi::xml_node newResourcesFile(const filesystem::path& filename) const;
+
     oms_status_enu_t import(const char* snapshot);
     oms_status_enu_t importResourcesFile(const filesystem::path& filename, const filesystem::path& root);
     oms_status_enu_t importResourcesMemory(const filesystem::path& filename, const char* contents);
     oms_status_enu_t importResourcesXML(const filesystem::path& filename, const pugi::xml_node& node);
-    void getResources(std::vector<std::string>& resources);
 
+    void getResources(std::vector<std::string>& resources) const;
     pugi::xml_node getResourcesFile(const filesystem::path& filename) const;
+
     pugi::xml_node operator[](const filesystem::path& filename) const;
 
     void debugPrintNode(const filesystem::path& filename) const;

--- a/src/OMSimulatorLib/Snapshot.h
+++ b/src/OMSimulatorLib/Snapshot.h
@@ -48,17 +48,16 @@ namespace oms
     Snapshot();
     ~Snapshot();
 
-    pugi::xml_node newResourcesFile(const filesystem::path& filename) const;
-
     oms_status_enu_t import(const char* snapshot);
     oms_status_enu_t importResourcesFile(const filesystem::path& filename, const filesystem::path& root);
     oms_status_enu_t importResourcesMemory(const filesystem::path& filename, const char* contents);
     oms_status_enu_t importResourcesXML(const filesystem::path& filename, const pugi::xml_node& node);
 
+    pugi::xml_node newResourcesFile(const filesystem::path& filename);
+    pugi::xml_node operator[](const filesystem::path& filename);
+
     void getResources(std::vector<std::string>& resources) const;
     pugi::xml_node getResourcesFile(const filesystem::path& filename) const;
-
-    pugi::xml_node operator[](const filesystem::path& filename) const;
 
     void debugPrintNode(const filesystem::path& filename) const;
     void debugPrintAll() const;

--- a/src/OMSimulatorLib/System.cpp
+++ b/src/OMSimulatorLib/System.cpp
@@ -2411,7 +2411,7 @@ oms_status_enu_t oms::System::importStartValuesFromSSV(const std::string& ssvPat
   if (!ssmPath.empty())
     importParameterMappingFromSSM(ssmPath, snapshot, mappedEntry);
 
-  pugi::xml_node parameterSet = snapshot.getResourcesFile(ssvPath);
+  pugi::xml_node parameterSet = snapshot.getResourceNode(ssvPath);
   pugi::xml_node parameters = parameterSet.child(oms::ssp::Version1_0::ssv::parameters);
 
   for (pugi::xml_node_iterator it = parameters.begin(); it != parameters.end(); ++it)
@@ -2511,7 +2511,7 @@ oms_status_enu_t oms::System::updateAlgebraicLoops(const std::vector< oms_ssc_t 
 
 void oms::System::importParameterMappingFromSSM(const std::string& ssmPath, const Snapshot& snapshot, std::multimap<ComRef, ComRef>& mappedEntry)
 {
-  pugi::xml_node parameterMapping = snapshot.getResourcesFile(ssmPath);
+  pugi::xml_node parameterMapping = snapshot.getResourceNode(ssmPath);
 
   for (pugi::xml_node_iterator it = parameterMapping.begin(); it != parameterMapping.end(); ++it)
   {

--- a/src/OMSimulatorLib/System.cpp
+++ b/src/OMSimulatorLib/System.cpp
@@ -2411,7 +2411,7 @@ oms_status_enu_t oms::System::importStartValuesFromSSV(const std::string& ssvPat
   if (!ssmPath.empty())
     importParameterMappingFromSSM(ssmPath, snapshot, mappedEntry);
 
-  pugi::xml_node parameterSet = snapshot[ssvPath];
+  pugi::xml_node parameterSet = snapshot.getResourcesFile(ssvPath);
   pugi::xml_node parameters = parameterSet.child(oms::ssp::Version1_0::ssv::parameters);
 
   for (pugi::xml_node_iterator it = parameters.begin(); it != parameters.end(); ++it)
@@ -2511,7 +2511,7 @@ oms_status_enu_t oms::System::updateAlgebraicLoops(const std::vector< oms_ssc_t 
 
 void oms::System::importParameterMappingFromSSM(const std::string& ssmPath, const Snapshot& snapshot, std::multimap<ComRef, ComRef>& mappedEntry)
 {
-  pugi::xml_node parameterMapping = snapshot[ssmPath];
+  pugi::xml_node parameterMapping = snapshot.getResourcesFile(ssmPath);
 
   for (pugi::xml_node_iterator it = parameterMapping.begin(); it != parameterMapping.end(); ++it)
   {

--- a/src/OMSimulatorLib/System.cpp
+++ b/src/OMSimulatorLib/System.cpp
@@ -2411,7 +2411,7 @@ oms_status_enu_t oms::System::importStartValuesFromSSV(const std::string& ssvPat
   if (!ssmPath.empty())
     importParameterMappingFromSSM(ssmPath, snapshot, mappedEntry);
 
-  pugi::xml_node parameterSet = snapshot.getResourcesFile(ssvPath);
+  pugi::xml_node parameterSet = snapshot[ssvPath];
   pugi::xml_node parameters = parameterSet.child(oms::ssp::Version1_0::ssv::parameters);
 
   for (pugi::xml_node_iterator it = parameters.begin(); it != parameters.end(); ++it)
@@ -2511,7 +2511,7 @@ oms_status_enu_t oms::System::updateAlgebraicLoops(const std::vector< oms_ssc_t 
 
 void oms::System::importParameterMappingFromSSM(const std::string& ssmPath, const Snapshot& snapshot, std::multimap<ComRef, ComRef>& mappedEntry)
 {
-  pugi::xml_node parameterMapping = snapshot.getResourcesFile(ssmPath);
+  pugi::xml_node parameterMapping = snapshot[ssmPath];
 
   for (pugi::xml_node_iterator it = parameterMapping.begin(); it != parameterMapping.end(); ++it)
   {

--- a/src/OMSimulatorLib/Values.cpp
+++ b/src/OMSimulatorLib/Values.cpp
@@ -130,7 +130,7 @@ oms_status_enu_t oms::Values::importFromSnapshot(const pugi::xml_node& node, con
 
     if (!ssvFile.empty()) // parameter binding provided with .ssv file
     {
-      pugi::xml_node parameterSet = snapshot.getResourcesFile(ssvFile);
+      pugi::xml_node parameterSet = snapshot[ssvFile];
       if (!parameterSet)
         return logError("loading <oms:file> \"" + ssvFile + "\" from <oms:snapshot> failed");
 
@@ -145,7 +145,7 @@ oms_status_enu_t oms::Values::importFromSnapshot(const pugi::xml_node& node, con
         std::string ssmFileSource = ssd_parameterMapping.attribute("source").as_string();
         if (!ssmFileSource.empty())
         {
-          pugi::xml_node ssm_parameterMapping = snapshot.getResourcesFile(ssmFileSource);
+          pugi::xml_node ssm_parameterMapping = snapshot[ssmFileSource];
           if (!ssm_parameterMapping)
             return logError("loading <oms:file> \"" + ssmFileSource + "\" from <oms:snapshot> failed");
 
@@ -439,7 +439,7 @@ oms_status_enu_t oms::Values::parseModelDescription(const filesystem::path& root
 {
   Snapshot snapshot;
   snapshot.importResourcesFile("modelDescription.xml", root);
-  const pugi::xml_node node = snapshot.getResourcesFile("modelDescription.xml");
+  const pugi::xml_node node = snapshot["modelDescription.xml"];
 
   if (!node)
     return logError("Failed to load modelDescription.xml");

--- a/src/OMSimulatorLib/Values.cpp
+++ b/src/OMSimulatorLib/Values.cpp
@@ -130,7 +130,7 @@ oms_status_enu_t oms::Values::importFromSnapshot(const pugi::xml_node& node, con
 
     if (!ssvFile.empty()) // parameter binding provided with .ssv file
     {
-      pugi::xml_node parameterSet = snapshot[ssvFile];
+      pugi::xml_node parameterSet = snapshot.getResourcesFile(ssvFile);
       if (!parameterSet)
         return logError("loading <oms:file> \"" + ssvFile + "\" from <oms:snapshot> failed");
 
@@ -145,7 +145,7 @@ oms_status_enu_t oms::Values::importFromSnapshot(const pugi::xml_node& node, con
         std::string ssmFileSource = ssd_parameterMapping.attribute("source").as_string();
         if (!ssmFileSource.empty())
         {
-          pugi::xml_node ssm_parameterMapping = snapshot[ssmFileSource];
+          pugi::xml_node ssm_parameterMapping = snapshot.getResourcesFile(ssmFileSource);
           if (!ssm_parameterMapping)
             return logError("loading <oms:file> \"" + ssmFileSource + "\" from <oms:snapshot> failed");
 
@@ -439,7 +439,7 @@ oms_status_enu_t oms::Values::parseModelDescription(const filesystem::path& root
 {
   Snapshot snapshot;
   snapshot.importResourcesFile("modelDescription.xml", root);
-  const pugi::xml_node node = snapshot["modelDescription.xml"];
+  const pugi::xml_node node = snapshot.getResourcesFile("modelDescription.xml");
 
   if (!node)
     return logError("Failed to load modelDescription.xml");

--- a/src/OMSimulatorLib/Values.cpp
+++ b/src/OMSimulatorLib/Values.cpp
@@ -130,7 +130,7 @@ oms_status_enu_t oms::Values::importFromSnapshot(const pugi::xml_node& node, con
 
     if (!ssvFile.empty()) // parameter binding provided with .ssv file
     {
-      pugi::xml_node parameterSet = snapshot.getResourcesFile(ssvFile);
+      pugi::xml_node parameterSet = snapshot.getResourceNode(ssvFile);
       if (!parameterSet)
         return logError("loading <oms:file> \"" + ssvFile + "\" from <oms:snapshot> failed");
 
@@ -145,7 +145,7 @@ oms_status_enu_t oms::Values::importFromSnapshot(const pugi::xml_node& node, con
         std::string ssmFileSource = ssd_parameterMapping.attribute("source").as_string();
         if (!ssmFileSource.empty())
         {
-          pugi::xml_node ssm_parameterMapping = snapshot.getResourcesFile(ssmFileSource);
+          pugi::xml_node ssm_parameterMapping = snapshot.getResourceNode(ssmFileSource);
           if (!ssm_parameterMapping)
             return logError("loading <oms:file> \"" + ssmFileSource + "\" from <oms:snapshot> failed");
 
@@ -438,8 +438,8 @@ oms_status_enu_t oms::Values::importStartValuesHelper(const pugi::xml_node& para
 oms_status_enu_t oms::Values::parseModelDescription(const filesystem::path& root)
 {
   Snapshot snapshot;
-  snapshot.importResourcesFile("modelDescription.xml", root);
-  const pugi::xml_node node = snapshot.getResourcesFile("modelDescription.xml");
+  snapshot.importResourceFile("modelDescription.xml", root);
+  const pugi::xml_node node = snapshot.getResourceNode("modelDescription.xml");
 
   if (!node)
     return logError("Failed to load modelDescription.xml");


### PR DESCRIPTION
getResource* returns a node if it exists or <false> together with a warning.
newResource returns a new empty node if it didn't exists or the already existing node together with a warning

the oeprator[] returns either a new or an existing node, without warning 