### PR TITLE
Temporarily disable warning for OMEdit

### DIFF
--- a/src/OMSimulatorLib/Snapshot.cpp
+++ b/src/OMSimulatorLib/Snapshot.cpp
@@ -137,7 +137,8 @@ pugi::xml_node oms::Snapshot::getResourceNode(const filesystem::path& filename) 
   if (node)
     return node.first_child();
 
-  logError("Failed to find node \"" + filename.generic_string() + "\"");
+  if  ("resources/signalFilter.xml" != filename)  // TEMPORARILY DISABLE WARNING FOR OMEDIT - REVERT THIS ASAP
+    logError("Failed to find node \"" + filename.generic_string() + "\"");
   return node;
 }
 


### PR DESCRIPTION
### Purpose

OMEdit is still using the old api (list/loadSnapshot) because the new api has some memory issues. This pull request disables some related warnings temporarily.