### PR TITLE
Fix initial unknowns

### DIFF
--- a/src/OMSimulatorLib/ComponentFMUCS.cpp
+++ b/src/OMSimulatorLib/ComponentFMUCS.cpp
@@ -163,11 +163,12 @@ oms::Component* oms::ComponentFMUCS::NewComponent(const oms::ComRef& cref, oms::
     fmi2_import_variable_t* varState = (fmi2_import_variable_t*)fmi2_import_get_real_variable_derivative_of(varReal);
     if (varState)
     {
-      fmi2_value_reference_t state_vr = fmi2_import_get_variable_vr(varState);
+      // IMPORTANT: vr is not unique!!! Do lookup with proper index or name
+      const oms::ComRef stateName(fmi2_import_get_variable_name(varState));
       bool found = false;
-      for (size_t i = 0; i < component->allVariables.size(); i++)
+      for (size_t i=0; i < component->allVariables.size(); i++)
       {
-        if (state_vr == component->allVariables[i].getValueReference())
+        if (stateName == component->allVariables[i].getCref())
         {
           component->allVariables[i].markAsState();
           found = true;

--- a/src/OMSimulatorLib/ComponentFMUME.cpp
+++ b/src/OMSimulatorLib/ComponentFMUME.cpp
@@ -165,11 +165,12 @@ oms::Component* oms::ComponentFMUME::NewComponent(const oms::ComRef& cref, oms::
     fmi2_import_variable_t* varState = (fmi2_import_variable_t*)fmi2_import_get_real_variable_derivative_of(varReal);
     if (varState)
     {
-      fmi2_value_reference_t state_vr = fmi2_import_get_variable_vr(varState);
+      // IMPORTANT: vr is not unique!!! Do lookup with proper index or name
+      const oms::ComRef stateName(fmi2_import_get_variable_name(varState));
       bool found = false;
-      for (size_t i = 0; i < component->allVariables.size(); i++)
+      for (size_t i=0; i < component->allVariables.size(); i++)
       {
-        if (state_vr == component->allVariables[i].getValueReference())
+        if (stateName == component->allVariables[i].getCref())
         {
           component->allVariables[i].markAsState();
           found = true;

--- a/src/OMSimulatorLib/Variable.cpp
+++ b/src/OMSimulatorLib/Variable.cpp
@@ -37,7 +37,7 @@
 #include <JM/jm_portability.h>
 
 
-oms::Variable::Variable(fmi2_import_variable_t *var, unsigned int index)
+oms::Variable::Variable(fmi2_import_variable_t* var, unsigned int index)
   : is_state(false), is_der(false), cref(fmi2_import_get_variable_name(var)), index(index)
 {
   // extract the attributes

--- a/src/OMSimulatorLib/Variable.h
+++ b/src/OMSimulatorLib/Variable.h
@@ -45,7 +45,7 @@ namespace oms
   class Variable
   {
   public:
-    Variable(fmi2_import_variable_t *var, unsigned int index);
+    Variable(fmi2_import_variable_t* var, unsigned int index);
     ~Variable();
 
     void markAsState() { is_state = true; }

--- a/testsuite/OMSimulator/Makefile
+++ b/testsuite/OMSimulator/Makefile
@@ -21,7 +21,6 @@ import_parameter_mapping_from_ssm.lua \
 import_parameter_mapping_inline.lua \
 importPartialSnapshot.lua \
 importStartValues.lua \
-importStartValues.lua \
 multipleConnections.lua \
 partialSnapshot.lua \
 PI_Controller.lua \


### PR DESCRIPTION
### Related Issues

Not reported.

### Purpose

The initial unknowns were flagged as wrong for certain FMUs. This was apparently wrong and caused by a lookup issue with value references which are not unique in FMI.

### Approach

Do the loopup with name instead of vr, because the name is unique according to the FMI specification.
