### PR TITLE
fix renaming connectors and values

### DIFF
--- a/src/OMSimulatorLib/Component.cpp
+++ b/src/OMSimulatorLib/Component.cpp
@@ -233,5 +233,6 @@ oms_status_enu_t oms::Component::deleteConnector(const ComRef& cref)
 oms_status_enu_t oms::Component::rename(const oms::ComRef& newCref)
 {
   this->cref = newCref;
+  this->renameValues(newCref); // rename values in ssv files (only for FMUs)
   return oms_status_ok;
 }

--- a/src/OMSimulatorLib/Component.h
+++ b/src/OMSimulatorLib/Component.h
@@ -122,7 +122,6 @@ namespace oms
 
     virtual void getFilteredSignals(std::vector<Connector>& filteredSignals) const = 0;
 
-    virtual oms_status_enu_t renameValues(const ComRef& newCref) { return oms_status_ok; }
 
   protected:
     Component(const ComRef& cref, oms_component_enu_t type, System* parentSystem, const std::string& path);
@@ -130,6 +129,8 @@ namespace oms
     // stop the compiler generating methods copying the object
     Component(Component const&);            ///< not implemented
     Component& operator=(Component const&); ///< not implemented
+
+    virtual oms_status_enu_t renameValues(const ComRef& newCref) { return oms_status_ok; }
 
   protected:
     DirectedGraph initialUnknownsGraph;

--- a/src/OMSimulatorLib/Component.h
+++ b/src/OMSimulatorLib/Component.h
@@ -122,6 +122,8 @@ namespace oms
 
     virtual void getFilteredSignals(std::vector<Connector>& filteredSignals) const = 0;
 
+    virtual oms_status_enu_t renameValues(const ComRef& newCref) { return oms_status_ok; }
+
   protected:
     Component(const ComRef& cref, oms_component_enu_t type, System* parentSystem, const std::string& path);
 

--- a/src/OMSimulatorLib/Component.h
+++ b/src/OMSimulatorLib/Component.h
@@ -122,7 +122,6 @@ namespace oms
 
     virtual void getFilteredSignals(std::vector<Connector>& filteredSignals) const = 0;
 
-
   protected:
     Component(const ComRef& cref, oms_component_enu_t type, System* parentSystem, const std::string& path);
 

--- a/src/OMSimulatorLib/ComponentFMUCS.cpp
+++ b/src/OMSimulatorLib/ComponentFMUCS.cpp
@@ -1251,5 +1251,5 @@ void oms::ComponentFMUCS::getFilteredSignals(std::vector<Connector>& filteredSig
 
 oms_status_enu_t oms::ComponentFMUCS::renameValues(const ComRef& newCref)
 {
-  return values.renameValues(newCref);
+  return values.rename(newCref);
 }

--- a/src/OMSimulatorLib/ComponentFMUCS.cpp
+++ b/src/OMSimulatorLib/ComponentFMUCS.cpp
@@ -1248,3 +1248,8 @@ void oms::ComponentFMUCS::getFilteredSignals(std::vector<Connector>& filteredSig
       filteredSignals.push_back(allVariables[i].makeConnector(this->getFullCref()));
   }
 }
+
+oms_status_enu_t oms::ComponentFMUCS::renameValues(const ComRef& newCref)
+{
+  return values.renameValues(newCref);
+}

--- a/src/OMSimulatorLib/ComponentFMUCS.h
+++ b/src/OMSimulatorLib/ComponentFMUCS.h
@@ -108,7 +108,6 @@ namespace oms
     oms_status_enu_t setFaultInjection(const ComRef& signal, oms_fault_type_enu_t faultType, double faultValue);
 
     void getFilteredSignals(std::vector<Connector>& filteredSignals) const;
-    oms_status_enu_t renameValues(const ComRef& newCref);
 
   protected:
     ComponentFMUCS(const ComRef& cref, System* parentSystem, const std::string& fmuPath);
@@ -116,6 +115,8 @@ namespace oms
     // stop the compiler generating methods copying the object
     ComponentFMUCS(ComponentFMUCS const& copy);            ///< not implemented
     ComponentFMUCS& operator=(ComponentFMUCS const& copy); ///< not implemented
+
+    oms_status_enu_t renameValues(const ComRef& newCref);
 
   private:
     jm_callbacks callbacks;

--- a/src/OMSimulatorLib/ComponentFMUCS.h
+++ b/src/OMSimulatorLib/ComponentFMUCS.h
@@ -108,6 +108,7 @@ namespace oms
     oms_status_enu_t setFaultInjection(const ComRef& signal, oms_fault_type_enu_t faultType, double faultValue);
 
     void getFilteredSignals(std::vector<Connector>& filteredSignals) const;
+    oms_status_enu_t renameValues(const ComRef& newCref);
 
   protected:
     ComponentFMUCS(const ComRef& cref, System* parentSystem, const std::string& fmuPath);

--- a/src/OMSimulatorLib/ComponentFMUME.cpp
+++ b/src/OMSimulatorLib/ComponentFMUME.cpp
@@ -1207,3 +1207,9 @@ void oms::ComponentFMUME::getFilteredSignals(std::vector<Connector>& filteredSig
       filteredSignals.push_back(allVariables[i].makeConnector(this->getFullCref()));
   }
 }
+
+oms_status_enu_t oms::ComponentFMUME::renameValues(const ComRef& newCref)
+{
+  return values.renameValues(newCref);
+}
+

--- a/src/OMSimulatorLib/ComponentFMUME.cpp
+++ b/src/OMSimulatorLib/ComponentFMUME.cpp
@@ -1210,6 +1210,5 @@ void oms::ComponentFMUME::getFilteredSignals(std::vector<Connector>& filteredSig
 
 oms_status_enu_t oms::ComponentFMUME::renameValues(const ComRef& newCref)
 {
-  return values.renameValues(newCref);
+  return values.rename(newCref);
 }
-

--- a/src/OMSimulatorLib/ComponentFMUME.h
+++ b/src/OMSimulatorLib/ComponentFMUME.h
@@ -105,6 +105,7 @@ namespace oms
     oms_status_enu_t setFaultInjection(const ComRef& signal, oms_fault_type_enu_t faultType, double faultValue);
 
     void getFilteredSignals(std::vector<Connector>& filteredSignals) const;
+    oms_status_enu_t renameValues(const ComRef& newCref);
 
   protected:
     ComponentFMUME(const ComRef& cref, System* parentSystem, const std::string& fmuPath);

--- a/src/OMSimulatorLib/ComponentFMUME.h
+++ b/src/OMSimulatorLib/ComponentFMUME.h
@@ -105,7 +105,6 @@ namespace oms
     oms_status_enu_t setFaultInjection(const ComRef& signal, oms_fault_type_enu_t faultType, double faultValue);
 
     void getFilteredSignals(std::vector<Connector>& filteredSignals) const;
-    oms_status_enu_t renameValues(const ComRef& newCref);
 
   protected:
     ComponentFMUME(const ComRef& cref, System* parentSystem, const std::string& fmuPath);
@@ -113,6 +112,8 @@ namespace oms
     // stop the compiler generating methods copying the object
     ComponentFMUME(ComponentFMUME const& copy);            ///< not implemented
     ComponentFMUME& operator=(ComponentFMUME const& copy); ///< not implemented
+
+    oms_status_enu_t renameValues(const ComRef& newCref);
 
   private:
     jm_callbacks callbacks;

--- a/src/OMSimulatorLib/ComponentTable.h
+++ b/src/OMSimulatorLib/ComponentTable.h
@@ -82,6 +82,7 @@ namespace oms
     oms_status_enu_t restoreState();
 
     void getFilteredSignals(std::vector<Connector>& filteredSignals) const;
+    oms_status_enu_t renameValues(const ComRef& newCref) {return oms_status_ok;}
 
   protected:
     ComponentTable(const ComRef& cref, System* parentSystem, const std::string& path);

--- a/src/OMSimulatorLib/ComponentTable.h
+++ b/src/OMSimulatorLib/ComponentTable.h
@@ -82,7 +82,6 @@ namespace oms
     oms_status_enu_t restoreState();
 
     void getFilteredSignals(std::vector<Connector>& filteredSignals) const;
-    oms_status_enu_t renameValues(const ComRef& newCref) {return oms_status_ok;}
 
   protected:
     ComponentTable(const ComRef& cref, System* parentSystem, const std::string& path);

--- a/src/OMSimulatorLib/Connector.cpp
+++ b/src/OMSimulatorLib/Connector.cpp
@@ -265,6 +265,16 @@ void oms::Connector::setName(const oms::ComRef& name)
   strcpy(this->name, str.c_str());
 }
 
+void oms::Connector::setOwner(const ComRef& owner)
+{
+  if (this->owner)
+    delete[] this->owner;
+
+  std::string str(owner);
+  this->owner = new char[str.size()+1];
+  strcpy(this->owner, str.c_str());
+}
+
 void oms::Connector::setGeometry(const oms::ssd::ConnectorGeometry *newGeometry)
 {
   if (this->geometry)
@@ -340,22 +350,4 @@ std::string oms::Connector::getCausalityString() const
   default:
     return std::string("unknown");
   }
-}
-
-oms_status_enu_t oms::Connector::renameConnectors(const ComRef& newCref)
-{
-  oms::ComRef tailA(this->owner);
-  tailA.pop_front();
-  tailA.pop_front();
-
-  std::string str(newCref);
-  // check for subsystems (e.g) model.root.foo => newCref + foo
-  if (!tailA.isEmpty())
-    std::string str(newCref + tailA);
-
-  if (this->owner) delete[] this->owner;
-  this->owner = new char[str.size()+1];
-  strcpy(this->owner, str.c_str());
-
-  return oms_status_ok;
 }

--- a/src/OMSimulatorLib/Connector.cpp
+++ b/src/OMSimulatorLib/Connector.cpp
@@ -341,3 +341,21 @@ std::string oms::Connector::getCausalityString() const
     return std::string("unknown");
   }
 }
+
+oms_status_enu_t oms::Connector::renameConnectors(const ComRef& newCref)
+{
+  oms::ComRef tailA(this->owner);
+  tailA.pop_front();
+  tailA.pop_front();
+
+  std::string str(newCref);
+  // check for subsystems (e.g) model.root.foo => newCref + foo
+  if (!tailA.isEmpty())
+    std::string str(newCref + tailA);
+
+  if (this->owner) delete[] this->owner;
+  this->owner = new char[str.size()+1];
+  strcpy(this->owner, str.c_str());
+
+  return oms_status_ok;
+}

--- a/src/OMSimulatorLib/Connector.h
+++ b/src/OMSimulatorLib/Connector.h
@@ -67,6 +67,7 @@ namespace oms
     operator std::string() const {return std::string(name);}
 
     void setName(const oms::ComRef& name);
+    void setOwner(const oms::ComRef& owner);
     void setGeometry(const oms::ssd::ConnectorGeometry* newGeometry);
 
     const oms_causality_enu_t getCausality() const {return causality;}
@@ -85,8 +86,6 @@ namespace oms
     bool isTypeReal() const { return oms_signal_type_real == type; }
     bool isTypeInteger() const { return oms_signal_type_integer == type || oms_signal_type_enum == type; }
     bool isTypeBoolean() const { return oms_signal_type_boolean == type; }
-
-    oms_status_enu_t renameConnectors(const oms::ComRef& newCref);
 
   private:
     friend bool operator==(const Connector& v1, const Connector& v2);

--- a/src/OMSimulatorLib/Connector.h
+++ b/src/OMSimulatorLib/Connector.h
@@ -86,6 +86,8 @@ namespace oms
     bool isTypeInteger() const { return oms_signal_type_integer == type || oms_signal_type_enum == type; }
     bool isTypeBoolean() const { return oms_signal_type_boolean == type; }
 
+    oms_status_enu_t renameConnectors(const oms::ComRef& newCref);
+
   private:
     friend bool operator==(const Connector& v1, const Connector& v2);
     friend bool operator!=(const Connector& v1, const Connector& v2);

--- a/src/OMSimulatorLib/Model.cpp
+++ b/src/OMSimulatorLib/Model.cpp
@@ -191,7 +191,7 @@ oms_status_enu_t oms::Model::importSnapshot(const char* snapshot_, char** newCre
   // get the new root cref from the snapshot, this should be done here
   // at the top before importing the full snapshot, as the new cref
   // will be overwritten
-  oms::ComRef rootCref = snapshot.getRootCref();
+  new_root_cref = snapshot.getRootCref();
 
   if (snapshot.isPartialSnapshot())
   {
@@ -219,7 +219,7 @@ oms_status_enu_t oms::Model::importSnapshot(const char* snapshot_, char** newCre
 
   bool old_copyResources = copyResources();
   copyResources(false);
-  oms_status_enu_t status = importFromSnapshot(snapshot, rootCref, newCref);
+  oms_status_enu_t status = importFromSnapshot(snapshot);
   copyResources(old_copyResources);
 
   if (oms_status_ok != status)
@@ -233,6 +233,9 @@ oms_status_enu_t oms::Model::importSnapshot(const char* snapshot_, char** newCre
     delete old_root_system;
     old_root_system = NULL;
   }
+
+  if (newCref)
+    *newCref = (char*)new_root_cref.c_str();
 
   return oms_status_ok;
 }
@@ -584,7 +587,7 @@ oms_status_enu_t oms::Model::exportToSSD(pugi::xml_node& node, pugi::xml_node& s
   return oms_status_ok;
 }
 
-oms_status_enu_t oms::Model::importFromSnapshot(const Snapshot& snapshot, oms::ComRef newRootCref, char** newCref)
+oms_status_enu_t oms::Model::importFromSnapshot(const Snapshot& snapshot)
 {
   pugi::xml_node ssdNode = snapshot.getResourceNode("SystemStructure.ssd");
   if (!ssdNode)

--- a/src/OMSimulatorLib/Model.cpp
+++ b/src/OMSimulatorLib/Model.cpp
@@ -179,7 +179,7 @@ oms_status_enu_t oms::Model::loadSnapshot(const pugi::xml_node& node)
   return oms_status_ok;
 }
 
-oms_status_enu_t oms::Model::importSnapshot(const char* snapshot_)
+oms_status_enu_t oms::Model::importSnapshot(const char* snapshot_, char** newCref)
 {
   if (!validState(oms_modelState_virgin))
     return logError_ModelInWrongState(getCref());
@@ -187,6 +187,9 @@ oms_status_enu_t oms::Model::importSnapshot(const char* snapshot_)
   Snapshot snapshot;
   snapshot.import(snapshot_);
   //snapshot.debugPrintAll();
+
+  // set the newCref for the snapshot, this should be done here at the top before importing fullsnapshot, as the newcref will be overwritten by oldcref
+  *newCref = mallocAndCopyString(snapshot.getNewCref());
 
   if (snapshot.isPartialSnapshot())
   {

--- a/src/OMSimulatorLib/Model.cpp
+++ b/src/OMSimulatorLib/Model.cpp
@@ -179,7 +179,7 @@ oms_status_enu_t oms::Model::loadSnapshot(const pugi::xml_node& node)
   return oms_status_ok;
 }
 
-oms_status_enu_t oms::Model::importSnapshot(const oms::ComRef& cref, const char* snapshot_)
+oms_status_enu_t oms::Model::importSnapshot(const char* snapshot_)
 {
   if (!validState(oms_modelState_virgin))
     return logError_ModelInWrongState(getCref());
@@ -193,7 +193,7 @@ oms_status_enu_t oms::Model::importSnapshot(const oms::ComRef& cref, const char*
     char* fullsnapshot;
     // get full snapshot
     exportSnapshot("", &fullsnapshot);
-    snapshot.importPartialSnapshot(cref, fullsnapshot);
+    snapshot.importPartialSnapshot(fullsnapshot);
     free(fullsnapshot);
   }
 

--- a/src/OMSimulatorLib/Model.h
+++ b/src/OMSimulatorLib/Model.h
@@ -78,7 +78,7 @@ namespace oms
     oms_status_enu_t exportSSVTemplate(const ComRef& cref, const std::string& filename);
     oms_status_enu_t exportSSMTemplate(const ComRef& cref, const std::string& filename);
     void exportSignalFilter(pugi::xml_node &signalfilter) const;
-    oms_status_enu_t importFromSnapshot(const Snapshot& snapshot);
+    oms_status_enu_t importFromSnapshot(const Snapshot& snapshot, char** newCref);
     oms_status_enu_t importSnapshot(const char* snapshot, char** newCref);
     oms_status_enu_t importSignalFilter(const std::string& filename, const Snapshot& snapshot);
     oms_status_enu_t exportToFile(const std::string& filename) const;
@@ -124,8 +124,6 @@ namespace oms
     ctpl::thread_pool& getThreadPool() {assert(pool); return *pool;}
 
     oms_status_enu_t loadSnapshot(const pugi::xml_node& node);
-
-    oms_status_enu_t setNewCref(const std::string& cref, char** newCref);
 
   private: // methods
     Model(const ComRef& cref, const std::string& tempDir);

--- a/src/OMSimulatorLib/Model.h
+++ b/src/OMSimulatorLib/Model.h
@@ -78,7 +78,7 @@ namespace oms
     oms_status_enu_t exportSSVTemplate(const ComRef& cref, const std::string& filename);
     oms_status_enu_t exportSSMTemplate(const ComRef& cref, const std::string& filename);
     void exportSignalFilter(pugi::xml_node &signalfilter) const;
-    oms_status_enu_t importFromSnapshot(const Snapshot& snapshot, char** newCref);
+    oms_status_enu_t importFromSnapshot(const Snapshot& snapshot);
     oms_status_enu_t importSnapshot(const char* snapshot, char** newCref);
     oms_status_enu_t importSignalFilter(const std::string& filename, const Snapshot& snapshot);
     oms_status_enu_t exportToFile(const std::string& filename) const;

--- a/src/OMSimulatorLib/Model.h
+++ b/src/OMSimulatorLib/Model.h
@@ -79,7 +79,7 @@ namespace oms
     oms_status_enu_t exportSSMTemplate(const ComRef& cref, const std::string& filename);
     void exportSignalFilter(pugi::xml_node &signalfilter) const;
     oms_status_enu_t importFromSnapshot(const Snapshot& snapshot);
-    oms_status_enu_t importSnapshot(const oms::ComRef& cref, const char* snapshot);
+    oms_status_enu_t importSnapshot(const char* snapshot);
     oms_status_enu_t importSignalFilter(const std::string& filename, const Snapshot& snapshot);
     oms_status_enu_t exportToFile(const std::string& filename) const;
     oms_system_enu_t getSystemType(const pugi::xml_node& node, const std::string& sspVersion);

--- a/src/OMSimulatorLib/Model.h
+++ b/src/OMSimulatorLib/Model.h
@@ -79,7 +79,7 @@ namespace oms
     oms_status_enu_t exportSSMTemplate(const ComRef& cref, const std::string& filename);
     void exportSignalFilter(pugi::xml_node &signalfilter) const;
     oms_status_enu_t importFromSnapshot(const Snapshot& snapshot);
-    oms_status_enu_t importSnapshot(const char* snapshot);
+    oms_status_enu_t importSnapshot(const char* snapshot, char** newCref);
     oms_status_enu_t importSignalFilter(const std::string& filename, const Snapshot& snapshot);
     oms_status_enu_t exportToFile(const std::string& filename) const;
     oms_system_enu_t getSystemType(const pugi::xml_node& node, const std::string& sspVersion);

--- a/src/OMSimulatorLib/Model.h
+++ b/src/OMSimulatorLib/Model.h
@@ -160,6 +160,8 @@ namespace oms
     bool isolatedFMU = false;
 
     ctpl::thread_pool* pool = nullptr;
+
+    ComRef new_root_cref;
   };
 }
 

--- a/src/OMSimulatorLib/Model.h
+++ b/src/OMSimulatorLib/Model.h
@@ -125,6 +125,8 @@ namespace oms
 
     oms_status_enu_t loadSnapshot(const pugi::xml_node& node);
 
+    oms_status_enu_t setNewCref(const std::string& cref, char** newCref);
+
   private: // methods
     Model(const ComRef& cref, const std::string& tempDir);
 

--- a/src/OMSimulatorLib/Scope.cpp
+++ b/src/OMSimulatorLib/Scope.cpp
@@ -435,24 +435,14 @@ oms_status_enu_t oms::Scope::importSnapshot(const oms::ComRef& cref, const char*
   if (newCref)
     *newCref = NULL;
 
-  oms::ComRef tail(cref);
-  oms::ComRef front = tail.pop_front();
-
-  oms::ComRef modelCref(front);
-  modelCref.pop_suffix();
-
-  oms::Model* model = oms::Scope::GetInstance().getModel(modelCref);
+  oms::Model* model = oms::Scope::GetInstance().getModel(cref);
   if (!model)
-    return logError_ModelNotInScope(front);
+    return logError_ModelNotInScope(cref);
 
-  oms_status_enu_t status;
-  if (tail.isEmpty() && front.hasSuffix())
-    status = model->importSnapshot(oms::ComRef(":" + front.suffix()), snapshot);
-  else
-    status = model->importSnapshot(tail, snapshot);
+  oms_status_enu_t status = model->importSnapshot(snapshot);
 
   if (newCref)
-    *newCref = (char*)getModel(modelCref)->getCref().c_str();
+    *newCref = (char*)getModel(cref)->getCref().c_str();
 
   return status;
 }

--- a/src/OMSimulatorLib/Scope.cpp
+++ b/src/OMSimulatorLib/Scope.cpp
@@ -233,7 +233,7 @@ oms_status_enu_t oms::Scope::importModel(const std::string& filename, char** _cr
 
   // snapshot.debugPrintAll();
 
-  oms_status_enu_t status = model->importFromSnapshot(snapshot, _cref);
+  oms_status_enu_t status = model->importFromSnapshot(snapshot);
   model->copyResources(old_copyResources);
 
   Scope::GetInstance().setWorkingDirectory(cd);
@@ -245,7 +245,7 @@ oms_status_enu_t oms::Scope::importModel(const std::string& filename, char** _cr
   }
 
   if (_cref)
-    *_cref = (char *)model->getCref().c_str();
+    *_cref = (char*)model->getCref().c_str();
 
   return oms_status_ok;
 }

--- a/src/OMSimulatorLib/Scope.cpp
+++ b/src/OMSimulatorLib/Scope.cpp
@@ -233,7 +233,7 @@ oms_status_enu_t oms::Scope::importModel(const std::string& filename, char** _cr
 
   // snapshot.debugPrintAll();
 
-  oms_status_enu_t status = model->importFromSnapshot(snapshot);
+  oms_status_enu_t status = model->importFromSnapshot(snapshot, _cref);
   model->copyResources(old_copyResources);
 
   Scope::GetInstance().setWorkingDirectory(cd);
@@ -243,9 +243,6 @@ oms_status_enu_t oms::Scope::importModel(const std::string& filename, char** _cr
     deleteModel(cref);
     return oms_status_error;
   }
-
-  if (_cref)
-    *_cref = (char*)model->getCref().c_str();
 
   return oms_status_ok;
 }

--- a/src/OMSimulatorLib/Scope.cpp
+++ b/src/OMSimulatorLib/Scope.cpp
@@ -244,6 +244,9 @@ oms_status_enu_t oms::Scope::importModel(const std::string& filename, char** _cr
     return oms_status_error;
   }
 
+  if (_cref)
+    *_cref = (char *)model->getCref().c_str();
+
   return oms_status_ok;
 }
 

--- a/src/OMSimulatorLib/Scope.cpp
+++ b/src/OMSimulatorLib/Scope.cpp
@@ -439,10 +439,7 @@ oms_status_enu_t oms::Scope::importSnapshot(const oms::ComRef& cref, const char*
   if (!model)
     return logError_ModelNotInScope(cref);
 
-  oms_status_enu_t status = model->importSnapshot(snapshot);
-
-  if (newCref)
-    *newCref = (char*)getModel(cref)->getCref().c_str();
+  oms_status_enu_t status = model->importSnapshot(snapshot, newCref);
 
   return status;
 }

--- a/src/OMSimulatorLib/Snapshot.cpp
+++ b/src/OMSimulatorLib/Snapshot.cpp
@@ -216,6 +216,12 @@ pugi::xml_node oms::Snapshot::getTemplateResourceNodeSignalFilter(const filesyst
   return oms_signalFilter;
 }
 
+std::string oms::Snapshot::getNewCref() const
+{
+  pugi::xml_node oms_snapshot = doc.document_element(); // oms:snapshot
+  return oms_snapshot.first_child().first_child().attribute("name").as_string();
+}
+
 oms_status_enu_t oms::Snapshot::exportPartialSnapshot(const ComRef& cref, Snapshot& partialSnapshot)
 {
   ComRef subCref(cref);

--- a/src/OMSimulatorLib/Snapshot.cpp
+++ b/src/OMSimulatorLib/Snapshot.cpp
@@ -221,7 +221,7 @@ oms::ComRef oms::Snapshot::getRootCref() const
   pugi::xml_node oms_snapshot = doc.document_element(); // oms:snapshot
 
   for (const auto& it : oms_snapshot.children())
-    if ("SystemStructure.ssd" == it.attribute("name").as_string())
+    if ("SystemStructure.ssd" == std::string(it.attribute("name").as_string()))
       return oms::ComRef(it.first_child().attribute("name").as_string());
 
   return oms::ComRef();

--- a/src/OMSimulatorLib/Snapshot.cpp
+++ b/src/OMSimulatorLib/Snapshot.cpp
@@ -216,10 +216,23 @@ pugi::xml_node oms::Snapshot::getTemplateResourceNodeSignalFilter(const filesyst
   return oms_signalFilter;
 }
 
-void oms::Snapshot::setNewCref()
+oms::ComRef oms::Snapshot::getRootCref() const
 {
   pugi::xml_node oms_snapshot = doc.document_element(); // oms:snapshot
-  newCref = oms_snapshot.first_child().first_child().attribute("name").as_string();
+
+  for (const auto& it : oms_snapshot.children())
+  {
+    if ("SystemStructure.ssd" != it.attribute("name").as_string())
+      continue;
+
+    oms::ComRef rootCref(it.attribute("node").as_string());
+    oms::ComRef newCref(it.first_child().attribute("name").as_string());
+    // TODO: FIX
+
+    return newCref;
+  }
+
+  return "";
 }
 
 oms_status_enu_t oms::Snapshot::exportPartialSnapshot(const ComRef& cref, Snapshot& partialSnapshot)

--- a/src/OMSimulatorLib/Snapshot.cpp
+++ b/src/OMSimulatorLib/Snapshot.cpp
@@ -216,10 +216,10 @@ pugi::xml_node oms::Snapshot::getTemplateResourceNodeSignalFilter(const filesyst
   return oms_signalFilter;
 }
 
-std::string oms::Snapshot::getNewCref() const
+void oms::Snapshot::setNewCref()
 {
   pugi::xml_node oms_snapshot = doc.document_element(); // oms:snapshot
-  return oms_snapshot.first_child().first_child().attribute("name").as_string();
+  newCref = oms_snapshot.first_child().first_child().attribute("name").as_string();
 }
 
 oms_status_enu_t oms::Snapshot::exportPartialSnapshot(const ComRef& cref, Snapshot& partialSnapshot)

--- a/src/OMSimulatorLib/Snapshot.cpp
+++ b/src/OMSimulatorLib/Snapshot.cpp
@@ -221,12 +221,8 @@ oms::ComRef oms::Snapshot::getRootCref() const
   pugi::xml_node oms_snapshot = doc.document_element(); // oms:snapshot
 
   for (const auto& it : oms_snapshot.children())
-  {
-    if ("SystemStructure.ssd" != it.attribute("name").as_string())
-      continue;
-
-    return oms::ComRef(it.first_child().attribute("name").as_string());
-  }
+    if ("SystemStructure.ssd" == it.attribute("name").as_string())
+      return oms::ComRef(it.first_child().attribute("name").as_string());
 
   return oms::ComRef();
 }

--- a/src/OMSimulatorLib/Snapshot.cpp
+++ b/src/OMSimulatorLib/Snapshot.cpp
@@ -225,14 +225,10 @@ oms::ComRef oms::Snapshot::getRootCref() const
     if ("SystemStructure.ssd" != it.attribute("name").as_string())
       continue;
 
-    oms::ComRef rootCref(it.attribute("node").as_string());
-    oms::ComRef newCref(it.first_child().attribute("name").as_string());
-    // TODO: FIX
-
-    return newCref;
+    return oms::ComRef(it.first_child().attribute("name").as_string());
   }
 
-  return "";
+  return oms::ComRef();
 }
 
 oms_status_enu_t oms::Snapshot::exportPartialSnapshot(const ComRef& cref, Snapshot& partialSnapshot)

--- a/src/OMSimulatorLib/Snapshot.h
+++ b/src/OMSimulatorLib/Snapshot.h
@@ -70,9 +70,7 @@ namespace oms
 
     void debugPrintNode(const filesystem::path& filename) const;
     void debugPrintAll() const;
-
-    void setNewCref();
-    std::string getNewCref() const {return newCref;}
+    oms::ComRef getRootCref() const;
 
     oms_status_enu_t deleteResourceNode(const filesystem::path& filename);
 
@@ -88,7 +86,6 @@ namespace oms
 
   private:
    pugi::xml_document doc; // snapshot document
-   std::string newCref = "";
   };
 }
 

--- a/src/OMSimulatorLib/Snapshot.h
+++ b/src/OMSimulatorLib/Snapshot.h
@@ -66,7 +66,7 @@ namespace oms
     pugi::xml_node getTemplateResourceNodeSSV(const filesystem::path& filename);
     pugi::xml_node getTemplateResourceNodeSignalFilter(const filesystem::path& filename);
     oms_status_enu_t exportPartialSnapshot(const ComRef& cref, Snapshot& partialSnapshot);
-    oms_status_enu_t importPartialSnapshot(const ComRef& cref, const char* fullsnapshot);
+    oms_status_enu_t importPartialSnapshot(const char* fullsnapshot);
 
     void debugPrintNode(const filesystem::path& filename) const;
     void debugPrintAll() const;

--- a/src/OMSimulatorLib/Snapshot.h
+++ b/src/OMSimulatorLib/Snapshot.h
@@ -70,7 +70,9 @@ namespace oms
 
     void debugPrintNode(const filesystem::path& filename) const;
     void debugPrintAll() const;
-    std::string getNewCref() const;
+
+    void setNewCref();
+    std::string getNewCref() const {return newCref;}
 
     oms_status_enu_t deleteResourceNode(const filesystem::path& filename);
 
@@ -86,6 +88,7 @@ namespace oms
 
   private:
    pugi::xml_document doc; // snapshot document
+   std::string newCref = "";
   };
 }
 

--- a/src/OMSimulatorLib/Snapshot.h
+++ b/src/OMSimulatorLib/Snapshot.h
@@ -70,6 +70,7 @@ namespace oms
 
     void debugPrintNode(const filesystem::path& filename) const;
     void debugPrintAll() const;
+    std::string getNewCref() const;
 
     oms_status_enu_t deleteResourceNode(const filesystem::path& filename);
 

--- a/src/OMSimulatorLib/System.cpp
+++ b/src/OMSimulatorLib/System.cpp
@@ -2563,6 +2563,7 @@ oms_status_enu_t oms::System::rename(const ComRef& cref, const ComRef& newCref)
   if (subsystem != subsystems.end())
   {
     subsystem->second->rename(tail, newCref);
+    subsystem->second->values.renameValues(newCref);
     this->renameConnections(cref, newCref);
     subsystems[newCref] = subsystem->second;
     subsystems.erase(subsystem);  // delete the old cref from the lookup

--- a/src/OMSimulatorLib/System.cpp
+++ b/src/OMSimulatorLib/System.cpp
@@ -2563,7 +2563,7 @@ oms_status_enu_t oms::System::rename(const ComRef& cref, const ComRef& newCref)
   if (subsystem != subsystems.end())
   {
     subsystem->second->rename(tail, newCref);
-    subsystem->second->values.renameValues(newCref);
+    subsystem->second->values.rename(newCref);
     this->renameConnections(cref, newCref);
     subsystems[newCref] = subsystem->second;
     subsystems.erase(subsystem);  // delete the old cref from the lookup

--- a/src/OMSimulatorLib/System.cpp
+++ b/src/OMSimulatorLib/System.cpp
@@ -2563,7 +2563,6 @@ oms_status_enu_t oms::System::rename(const ComRef& cref, const ComRef& newCref)
   if (subsystem != subsystems.end())
   {
     subsystem->second->rename(tail, newCref);
-    subsystem->second->values.renameValues(newCref); // rename values in ssv files
     this->renameConnections(cref, newCref);
     subsystems[newCref] = subsystem->second;
     subsystems.erase(subsystem);  // delete the old cref from the lookup
@@ -2579,7 +2578,6 @@ oms_status_enu_t oms::System::rename(const ComRef& cref, const ComRef& newCref)
   if (component != components.end())
   {
     component->second->rename(newCref);
-    component->second->renameValues(newCref); // rename values in ssv files
     this->renameConnections(cref, newCref);
     components[newCref] = component->second;
     components.erase(component);  // delete the old cref from the lookup
@@ -2608,7 +2606,7 @@ oms_status_enu_t oms::System::renameConnectors()
     {
       exportConnectors[getFullCref() + connector->getName()] = exportConnectors[connector->getOwner() + connector->getName()]; // add newCref with value
       exportConnectors.erase(connector->getOwner() + connector->getName()); // remove the old look up
-      connector->renameConnectors(getFullCref());
+      connector->setOwner(getFullCref());
     }
   }
 

--- a/src/OMSimulatorLib/System.cpp
+++ b/src/OMSimulatorLib/System.cpp
@@ -506,7 +506,7 @@ oms_status_enu_t oms::System::exportToSSD(pugi::xml_node& node, pugi::xml_node& 
   return oms_status_ok;
 }
 
-oms_status_enu_t oms::System::importFromSnapshot(const pugi::xml_node& node, const std::string& sspVersion, const Snapshot& snapshot, char** newCref)
+oms_status_enu_t oms::System::importFromSnapshot(const pugi::xml_node& node, const std::string& sspVersion, const Snapshot& snapshot)
 {
   std::map<std::string, std::string> startValuesFileSources;  ///< ssvFileSource mapped with ssmFilesource if mapping is provided, otherwise only ssvFilesource entry is made
 
@@ -629,11 +629,7 @@ oms_status_enu_t oms::System::importFromSnapshot(const pugi::xml_node& node, con
           if (!system)
             return oms_status_error;
 
-          // set newCref for subsystems
-          if (snapshot.getNewCref() == std::string(system->getCref()))
-            *newCref = (char *)system->getCref().c_str();
-
-          if (oms_status_ok != system->importFromSnapshot(*itElements, sspVersion, snapshot, newCref))
+          if (oms_status_ok != system->importFromSnapshot(*itElements, sspVersion, snapshot))
             return oms_status_error;
         }
         else if (name == oms::ssp::Draft20180219::ssd::component)
@@ -747,10 +743,6 @@ oms_status_enu_t oms::System::importFromSnapshot(const pugi::xml_node& node, con
 #endif
           if (component)
           {
-            // set newCref for components
-            if (snapshot.getNewCref() == std::string(component->getCref()))
-              *newCref = (char *)component->getCref().c_str();
-
             components[component->getCref()] = component;
             subelements.back() = reinterpret_cast<oms_element_t*>(component->getElement());
             subelements.push_back(NULL);

--- a/src/OMSimulatorLib/System.cpp
+++ b/src/OMSimulatorLib/System.cpp
@@ -506,7 +506,7 @@ oms_status_enu_t oms::System::exportToSSD(pugi::xml_node& node, pugi::xml_node& 
   return oms_status_ok;
 }
 
-oms_status_enu_t oms::System::importFromSnapshot(const pugi::xml_node& node, const std::string& sspVersion, const Snapshot& snapshot)
+oms_status_enu_t oms::System::importFromSnapshot(const pugi::xml_node& node, const std::string& sspVersion, const Snapshot& snapshot, char** newCref)
 {
   std::map<std::string, std::string> startValuesFileSources;  ///< ssvFileSource mapped with ssmFilesource if mapping is provided, otherwise only ssvFilesource entry is made
 
@@ -629,7 +629,11 @@ oms_status_enu_t oms::System::importFromSnapshot(const pugi::xml_node& node, con
           if (!system)
             return oms_status_error;
 
-          if (oms_status_ok != system->importFromSnapshot(*itElements, sspVersion, snapshot))
+          // set newCref for subsystems
+          if (snapshot.getNewCref() == std::string(system->getCref()))
+            *newCref = (char *)system->getCref().c_str();
+
+          if (oms_status_ok != system->importFromSnapshot(*itElements, sspVersion, snapshot, newCref))
             return oms_status_error;
         }
         else if (name == oms::ssp::Draft20180219::ssd::component)
@@ -743,6 +747,10 @@ oms_status_enu_t oms::System::importFromSnapshot(const pugi::xml_node& node, con
 #endif
           if (component)
           {
+            // set newCref for components
+            if (snapshot.getNewCref() == std::string(component->getCref()))
+              *newCref = (char *)component->getCref().c_str();
+
             components[component->getCref()] = component;
             subelements.back() = reinterpret_cast<oms_element_t*>(component->getElement());
             subelements.push_back(NULL);

--- a/src/OMSimulatorLib/System.h
+++ b/src/OMSimulatorLib/System.h
@@ -97,7 +97,7 @@ namespace oms
     oms_status_enu_t addSubModel(const ComRef& cref, const std::string& fmuPath);
     bool validCref(const ComRef& cref);
     oms_status_enu_t exportToSSD(pugi::xml_node& node, pugi::xml_node& ssvNode, Snapshot& snapshot) const;
-    oms_status_enu_t importFromSnapshot(const pugi::xml_node& node, const std::string& sspVersion, const Snapshot& snapshot, char** newCref);
+    oms_status_enu_t importFromSnapshot(const pugi::xml_node& node, const std::string& sspVersion, const Snapshot& snapshot);
     void setGeometry(const ssd::ElementGeometry& geometry) {element.setGeometry(&geometry);}
     oms_status_enu_t addConnector(const ComRef& cref, oms_causality_enu_t causality, oms_signal_type_enu_t type);
     Connector* getConnector(const ComRef& cref);

--- a/src/OMSimulatorLib/System.h
+++ b/src/OMSimulatorLib/System.h
@@ -97,7 +97,7 @@ namespace oms
     oms_status_enu_t addSubModel(const ComRef& cref, const std::string& fmuPath);
     bool validCref(const ComRef& cref);
     oms_status_enu_t exportToSSD(pugi::xml_node& node, pugi::xml_node& ssvNode, Snapshot& snapshot) const;
-    oms_status_enu_t importFromSnapshot(const pugi::xml_node& node, const std::string& sspVersion, const Snapshot& snapshot);
+    oms_status_enu_t importFromSnapshot(const pugi::xml_node& node, const std::string& sspVersion, const Snapshot& snapshot, char** newCref);
     void setGeometry(const ssd::ElementGeometry& geometry) {element.setGeometry(&geometry);}
     oms_status_enu_t addConnector(const ComRef& cref, oms_causality_enu_t causality, oms_signal_type_enu_t type);
     Connector* getConnector(const ComRef& cref);

--- a/src/OMSimulatorLib/System.h
+++ b/src/OMSimulatorLib/System.h
@@ -157,6 +157,7 @@ namespace oms
     oms_status_enu_t rename(const ComRef& newCref); ///< rename the system itself
     oms_status_enu_t rename(const ComRef& cref, const ComRef& newCref); ///< rename any component within the system
     oms_status_enu_t renameConnections(const ComRef& cref, const ComRef& newCref);
+    oms_status_enu_t renameConnectors();
 
     bool isTopLevelSystem() const {return (parentSystem == NULL);}
 

--- a/src/OMSimulatorLib/TLM/ExternalModel.h
+++ b/src/OMSimulatorLib/TLM/ExternalModel.h
@@ -74,7 +74,6 @@ namespace oms
     oms_status_enu_t removeSignalsFromResults(const char* regex);
 
     void getFilteredSignals(std::vector<Connector>& filteredSignals) const {}
-    oms_status_enu_t renameValues(const ComRef& newCref) {return oms_status_ok;}
 
   protected:
     ExternalModel(const oms::ComRef& cref, System* parentSystem, const std::string& path, const std::string& startscript);

--- a/src/OMSimulatorLib/TLM/ExternalModel.h
+++ b/src/OMSimulatorLib/TLM/ExternalModel.h
@@ -74,6 +74,7 @@ namespace oms
     oms_status_enu_t removeSignalsFromResults(const char* regex);
 
     void getFilteredSignals(std::vector<Connector>& filteredSignals) const {}
+    oms_status_enu_t renameValues(const ComRef& newCref) {return oms_status_ok;}
 
   protected:
     ExternalModel(const oms::ComRef& cref, System* parentSystem, const std::string& path, const std::string& startscript);

--- a/src/OMSimulatorLib/Values.cpp
+++ b/src/OMSimulatorLib/Values.cpp
@@ -494,3 +494,36 @@ void oms::Values::importParameterMapping(const pugi::xml_node& parameterMapping)
       mappedEntry.insert(std::make_pair(source, it->attribute("target").as_string()));
   }
 }
+
+oms_status_enu_t oms::Values::renameValues(const oms::ComRef& newCref)
+{
+  // skip this if there is nothing to export
+  if (this->empty())
+    return oms_status_ok;
+
+  for (const auto &r : realStartValues)
+  {
+    ComRef tail(r.first);
+    ComRef front = tail.pop_front();
+    realStartValues[newCref + tail] = r.second; // update the newCref
+    realStartValues.erase(r.first); // delete the old cref
+  }
+
+  for (const auto &i : integerStartValues)
+  {
+    ComRef tail(i.first);
+    ComRef front = tail.pop_front();
+    integerStartValues[newCref + tail] = i.second; // update the newCref
+    integerStartValues.erase(i.first); // delete the old cref
+  }
+
+  for (const auto &b : booleanStartValues)
+  {
+    ComRef tail(b.first);
+    ComRef front = tail.pop_front();
+    integerStartValues[newCref + tail] = b.second; // update the newCref
+    integerStartValues.erase(b.first); // delete the old cref
+  }
+
+  return oms_status_ok;
+}

--- a/src/OMSimulatorLib/Values.cpp
+++ b/src/OMSimulatorLib/Values.cpp
@@ -495,7 +495,7 @@ void oms::Values::importParameterMapping(const pugi::xml_node& parameterMapping)
   }
 }
 
-oms_status_enu_t oms::Values::renameValues(const oms::ComRef& newCref)
+oms_status_enu_t oms::Values::rename(const oms::ComRef& newCref)
 {
   for (const auto &r : realStartValues)
   {

--- a/src/OMSimulatorLib/Values.cpp
+++ b/src/OMSimulatorLib/Values.cpp
@@ -497,10 +497,6 @@ void oms::Values::importParameterMapping(const pugi::xml_node& parameterMapping)
 
 oms_status_enu_t oms::Values::renameValues(const oms::ComRef& newCref)
 {
-  // skip this if there is nothing to export
-  if (this->empty())
-    return oms_status_ok;
-
   for (const auto &r : realStartValues)
   {
     ComRef tail(r.first);

--- a/src/OMSimulatorLib/Values.h
+++ b/src/OMSimulatorLib/Values.h
@@ -61,6 +61,7 @@ namespace oms
     oms_status_enu_t exportToSSMTemplate(pugi::xml_node& ssmNode, const ComRef& cref);  ///< start values read from modelDescription.xml and creates a ssm template
 
     oms_status_enu_t parseModelDescription(const filesystem::path& root); ///< path without the filename, i.e. modelDescription.xml
+    oms_status_enu_t renameValues(const oms::ComRef& newCref);
 
   private:
     oms_status_enu_t exportStartValuesHelper(pugi::xml_node& node) const;

--- a/src/OMSimulatorLib/Values.h
+++ b/src/OMSimulatorLib/Values.h
@@ -61,7 +61,7 @@ namespace oms
     oms_status_enu_t exportToSSMTemplate(pugi::xml_node& ssmNode, const ComRef& cref);  ///< start values read from modelDescription.xml and creates a ssm template
 
     oms_status_enu_t parseModelDescription(const filesystem::path& root); ///< path without the filename, i.e. modelDescription.xml
-    oms_status_enu_t renameValues(const oms::ComRef& newCref);
+    oms_status_enu_t rename(const oms::ComRef& newCref);
 
   private:
     oms_status_enu_t exportStartValuesHelper(pugi::xml_node& node) const;

--- a/testsuite/OMSimulator/Makefile
+++ b/testsuite/OMSimulator/Makefile
@@ -28,6 +28,7 @@ QuarterCarModel.DisplacementDisplacement.lua \
 rename.lua \
 renameSnapshot.lua \
 renameNewCref.lua \
+renameNewCref_1.lua \
 setExternalInputs.lua \
 simulation.lua \
 simulation.py \

--- a/testsuite/OMSimulator/Makefile
+++ b/testsuite/OMSimulator/Makefile
@@ -26,6 +26,7 @@ partialSnapshot.lua \
 PI_Controller.lua \
 QuarterCarModel.DisplacementDisplacement.lua \
 rename.lua \
+renameSnapshot.lua \
 setExternalInputs.lua \
 simulation.lua \
 simulation.py \

--- a/testsuite/OMSimulator/Makefile
+++ b/testsuite/OMSimulator/Makefile
@@ -27,6 +27,7 @@ PI_Controller.lua \
 QuarterCarModel.DisplacementDisplacement.lua \
 rename.lua \
 renameSnapshot.lua \
+renameNewCref.lua \
 setExternalInputs.lua \
 simulation.lua \
 simulation.py \

--- a/testsuite/OMSimulator/Makefile
+++ b/testsuite/OMSimulator/Makefile
@@ -28,7 +28,6 @@ QuarterCarModel.DisplacementDisplacement.lua \
 rename.lua \
 renameSnapshot.lua \
 renameNewCref.lua \
-renameNewCref_1.lua \
 setExternalInputs.lua \
 simulation.lua \
 simulation.py \

--- a/testsuite/OMSimulator/importPartialSnapshot.lua
+++ b/testsuite/OMSimulator/importPartialSnapshot.lua
@@ -32,7 +32,7 @@ snapshot = oms_exportSnapshot("snapshot:SystemStructure.ssd")
 oms_delete("snapshot.root.add")
 
 print("Case 2 - re-imported")
-newcref, status = oms_importSnapshot("snapshot:SystemStructure.ssd", snapshot)
+newcref, status = oms_importSnapshot("snapshot", snapshot)
 snapshot = oms_exportSnapshot("snapshot")
 print(snapshot)
 
@@ -42,7 +42,7 @@ snapshot = oms_exportSnapshot("snapshot:resources/snapshot.ssv")
 oms_setReal("snapshot.root.add.u1", 10)
 
 print("Case 3 - re-imported")
-newcref, status = oms_importSnapshot("snapshot:resources/snapshot.ssv", snapshot)
+newcref, status = oms_importSnapshot("snapshot", snapshot)
 snapshot = oms_exportSnapshot("snapshot")
 print(snapshot)
 
@@ -51,7 +51,7 @@ snapshot = oms_exportSnapshot("snapshot.root:SystemStructure.ssd")
 oms_delete("snapshot.root.add")
 
 print("Case 4 - re-imported")
-newcref, status = oms_importSnapshot("snapshot.root:SystemStructure.ssd", snapshot)
+newcref, status = oms_importSnapshot("snapshot", snapshot)
 snapshot = oms_exportSnapshot("snapshot")
 print(snapshot)
 
@@ -59,7 +59,7 @@ print(snapshot)
 snapshot = oms_exportSnapshot("snapshot.root.add:SystemStructure.ssd")
 
 print("Case 5 - re-imported")
-newcref, status = oms_importSnapshot("snapshot.root.add:SystemStructure.ssd", snapshot)
+newcref, status = oms_importSnapshot("snapshot", snapshot)
 snapshot = oms_exportSnapshot("snapshot")
 print(snapshot)
 

--- a/testsuite/OMSimulator/renameNewCref.lua
+++ b/testsuite/OMSimulator/renameNewCref.lua
@@ -19,7 +19,7 @@ systemSnapshot = [[
         name="SystemStructure.ssd"
         node="model.root">
         <ssd:System
-          name="root_3">
+          name="root">
           <ssd:Elements>
             <ssd:Component
               name="gain"
@@ -117,6 +117,6 @@ print(newcref)
 
 
 -- Result:
--- root_3
+-- root
 -- gain_1
 -- endResult

--- a/testsuite/OMSimulator/renameNewCref.lua
+++ b/testsuite/OMSimulator/renameNewCref.lua
@@ -19,7 +19,7 @@ systemSnapshot = [[
         name="SystemStructure.ssd"
         node="model.root">
         <ssd:System
-          name="root">
+          name="root_3">
           <ssd:Elements>
             <ssd:Component
               name="gain"
@@ -117,6 +117,6 @@ print(newcref)
 
 
 -- Result:
--- root
+-- root_3
 -- gain_1
 -- endResult

--- a/testsuite/OMSimulator/renameNewCref.lua
+++ b/testsuite/OMSimulator/renameNewCref.lua
@@ -5,7 +5,7 @@
 -- mac: no
 
 oms_setCommandLineOption("--suppressPath=true")
-oms_setTempDirectory("./rename_lua/")
+oms_setTempDirectory("./rename_new_cref_lua/")
 
 oms_newModel("model")
 oms_addSystem("model.root", oms_system_wc)

--- a/testsuite/OMSimulator/renameNewCref.lua
+++ b/testsuite/OMSimulator/renameNewCref.lua
@@ -1,0 +1,93 @@
+-- status: correct
+-- linux: yes
+-- mingw: yes
+-- win: no
+-- mac: no
+
+oms_setCommandLineOption("--suppressPath=true")
+oms_setTempDirectory("./rename_lua/")
+
+oms_newModel("model")
+oms_addSystem("model.root", oms_system_wc)
+oms_addSubModel("model.root.gain", "../resources/Modelica.Blocks.Math.Gain.fmu")
+
+systemSnapshot = [[
+    <?xml version="1.0"?>
+    <oms:snapshot
+      partial="true">
+      <oms:file
+        name="SystemStructure.ssd"
+        node="model.root">
+        <ssd:System
+          name="root_3">
+          <ssd:Annotations>
+            <ssc:Annotation
+              type="org.openmodelica">
+              <oms:Annotations>
+                <oms:SimulationInformation>
+                  <oms:FixedStepMaster
+                    description="oms-ma"
+                    stepSize="0.100000"
+                    absoluteTolerance="0.000100"
+                    relativeTolerance="0.000100" />
+                </oms:SimulationInformation>
+              </oms:Annotations>
+            </ssc:Annotation>
+          </ssd:Annotations>
+        </ssd:System>
+      </oms:file>
+    </oms:snapshot>
+]]
+
+componentSnapshot = [[
+    <?xml version="1.0"?>
+    <oms:snapshot
+      xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
+      partial="true">
+      <oms:file
+        name="SystemStructure.ssd"
+        node="model.root.gain">
+        <ssd:Component
+          name="gain_1"
+          type="application/x-fmu-sharedlibrary"
+          source="resources/0001_gain.fmu">
+          <ssd:Connectors>
+            <ssd:Connector
+              name="u"
+              kind="input">
+              <ssc:Real />
+              <ssd:ConnectorGeometry
+                x="0.000000"
+                y="0.500000" />
+            </ssd:Connector>
+            <ssd:Connector
+              name="y"
+              kind="output">
+              <ssc:Real />
+              <ssd:ConnectorGeometry
+                x="1.000000"
+                y="0.500000" />
+            </ssd:Connector>
+            <ssd:Connector
+              name="k"
+              kind="parameter">
+              <ssc:Real />
+            </ssd:Connector>
+          </ssd:Connectors>
+        </ssd:Component>
+      </oms:file>
+    </oms:snapshot>
+]]
+
+newcref, status = oms_importSnapshot("model", systemSnapshot)
+print(newcref)
+
+newcref, status = oms_importSnapshot("model", componentSnapshot)
+print(newcref)
+
+
+
+-- Result:
+-- root_3
+-- gain_1
+-- endResult

--- a/testsuite/OMSimulator/renameNewCref.lua
+++ b/testsuite/OMSimulator/renameNewCref.lua
@@ -39,6 +39,9 @@ systemSnapshot = [[
     </oms:snapshot>
 ]]
 
+newcref, status = oms_importSnapshot("model", systemSnapshot)
+print(newcref)
+
 componentSnapshot = [[
     <?xml version="1.0"?>
     <oms:snapshot
@@ -79,13 +82,8 @@ componentSnapshot = [[
     </oms:snapshot>
 ]]
 
-newcref, status = oms_importSnapshot("model", systemSnapshot)
-print(newcref)
-
 newcref, status = oms_importSnapshot("model", componentSnapshot)
 print(newcref)
-
-
 
 -- Result:
 -- root_3

--- a/testsuite/OMSimulator/renameNewCref_1.lua
+++ b/testsuite/OMSimulator/renameNewCref_1.lua
@@ -11,45 +11,16 @@ oms_newModel("model")
 oms_addSystem("model.root", oms_system_wc)
 oms_addSubModel("model.root.gain", "../resources/Modelica.Blocks.Math.Gain.fmu")
 
+-- error snapshot as subcomponent gain is missing
 systemSnapshot = [[
-  <?xml version="1.0"?>
+    <?xml version="1.0"?>
     <oms:snapshot
       partial="true">
       <oms:file
         name="SystemStructure.ssd"
         node="model.root">
         <ssd:System
-          name="root">
-          <ssd:Elements>
-            <ssd:Component
-              name="gain"
-              type="application/x-fmu-sharedlibrary"
-              source="resources/0001_gain.fmu">
-              <ssd:Connectors>
-                <ssd:Connector
-                  name="u"
-                  kind="input">
-                  <ssc:Real />
-                  <ssd:ConnectorGeometry
-                    x="0.000000"
-                    y="0.500000" />
-                </ssd:Connector>
-                <ssd:Connector
-                  name="y"
-                  kind="output">
-                  <ssc:Real />
-                  <ssd:ConnectorGeometry
-                    x="1.000000"
-                    y="0.500000" />
-                </ssd:Connector>
-                <ssd:Connector
-                  name="k"
-                  kind="parameter">
-                  <ssc:Real />
-                </ssd:Connector>
-              </ssd:Connectors>
-            </ssd:Component>
-          </ssd:Elements>
+          name="root_3">
           <ssd:Annotations>
             <ssc:Annotation
               type="org.openmodelica">
@@ -67,7 +38,8 @@ systemSnapshot = [[
         </ssd:System>
       </oms:file>
     </oms:snapshot>
-  ]]
+]]
+
 
 newcref, status = oms_importSnapshot("model", systemSnapshot)
 print(newcref)
@@ -111,12 +83,15 @@ componentSnapshot = [[
       </oms:file>
     </oms:snapshot>
 ]]
-
+-- error case, gain_1 cannot be set as newCref because snapshot does not have
 newcref, status = oms_importSnapshot("model", componentSnapshot)
 print(newcref)
 
 
 -- Result:
--- root
--- gain_1
+-- root_3
+-- error:   [setNewCref] NewCref not set for "gain_1" as it could not be associated with snapshot
+-- 
+-- info:    0 warnings
+-- info:    1 errors
 -- endResult

--- a/testsuite/OMSimulator/renameNewCref_1.lua
+++ b/testsuite/OMSimulator/renameNewCref_1.lua
@@ -5,7 +5,7 @@
 -- mac: no
 
 oms_setCommandLineOption("--suppressPath=true")
-oms_setTempDirectory("./rename_lua/")
+oms_setTempDirectory("./rename_new_cref_01_lua/")
 
 oms_newModel("model")
 oms_addSystem("model.root", oms_system_wc)

--- a/testsuite/OMSimulator/renameNewCref_1.lua
+++ b/testsuite/OMSimulator/renameNewCref_1.lua
@@ -90,8 +90,5 @@ print(newcref)
 
 -- Result:
 -- root_3
--- error:   [setNewCref] NewCref not set for "gain_1" as it could not be associated with snapshot
--- 
--- info:    0 warnings
--- info:    1 errors
+--
 -- endResult

--- a/testsuite/OMSimulator/renameNewCref_1.lua
+++ b/testsuite/OMSimulator/renameNewCref_1.lua
@@ -90,5 +90,8 @@ print(newcref)
 
 -- Result:
 -- root_3
---
+-- error:   [setNewCref] NewCref not set for "gain_1" as it could not be associated with snapshot
+-- 
+-- info:    0 warnings
+-- info:    1 errors
 -- endResult

--- a/testsuite/OMSimulator/renameSnapshot.lua
+++ b/testsuite/OMSimulator/renameSnapshot.lua
@@ -56,6 +56,7 @@ print(snapshot)
 -- Case 1 - reference
 -- <?xml version="1.0"?>
 -- <oms:snapshot
+--   xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --   partial="false">
 --   <oms:file
 --     name="SystemStructure.ssd">
@@ -253,6 +254,7 @@ print(snapshot)
 -- Case 2 - rename System
 -- <?xml version="1.0"?>
 -- <oms:snapshot
+--   xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --   partial="false">
 --   <oms:file
 --     name="SystemStructure.ssd">
@@ -450,6 +452,7 @@ print(snapshot)
 -- Case 3 - rename subSystem
 -- <?xml version="1.0"?>
 -- <oms:snapshot
+--   xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --   partial="false">
 --   <oms:file
 --     name="SystemStructure.ssd">
@@ -647,6 +650,7 @@ print(snapshot)
 -- Case 4 - rename subModules
 -- <?xml version="1.0"?>
 -- <oms:snapshot
+--   xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --   partial="false">
 --   <oms:file
 --     name="SystemStructure.ssd">

--- a/testsuite/OMSimulator/renameSnapshot.lua
+++ b/testsuite/OMSimulator/renameSnapshot.lua
@@ -1,0 +1,839 @@
+-- status: correct
+-- teardown_command: rm -rf rename_snapshot_lua/ renameSnapshot.ssp
+-- linux: yes
+-- mingw: yes
+-- win: no
+-- mac: no
+
+oms_setCommandLineOption("--suppressPath=true --exportParametersInline=false")
+status = oms_setTempDirectory("./rename_snapshot_lua/")
+
+oms_newModel("renameSnapshot")
+oms_addSystem("renameSnapshot.root", oms_system_wc)
+
+oms_addConnector("renameSnapshot.root.C1", oms_causality_input, oms_signal_type_real)
+oms_setReal("renameSnapshot.root.C1", -10)
+
+oms_addSystem("renameSnapshot.root.foo", oms_system_sc)
+oms_addConnector("renameSnapshot.root.foo.Input1", oms_causality_input, oms_signal_type_real)
+oms_setReal("renameSnapshot.root.foo.Input1", -20)
+
+
+oms_addSubModel("renameSnapshot.root.add", "../resources/Modelica.Blocks.Math.Add.fmu")
+oms_setReal("renameSnapshot.root.add.u1", 10)
+oms_setReal("renameSnapshot.root.add.k1", 30)
+
+oms_export("renameSnapshot", "renameSnapshot.ssp");
+oms_delete("renameSnapshot")
+
+oms_importFile("renameSnapshot.ssp");
+
+-- (1) correct, querying full snapshot
+print("Case 1 - reference")
+snapshot = oms_exportSnapshot("renameSnapshot")
+print(snapshot)
+
+-- (2) rename system, and query the snapshot
+print("Case 2 - rename System")
+oms_rename("renameSnapshot.root", "root_1")
+snapshot = oms_exportSnapshot("renameSnapshot")
+print(snapshot)
+
+-- (3) rename subsystem, and query the snapshot
+print("Case 3 - rename subSystem")
+oms_rename("renameSnapshot.root_1.foo", "foo_1")
+snapshot = oms_exportSnapshot("renameSnapshot")
+print(snapshot)
+
+-- (4) rename submodule, and query the snapshot
+print("Case 4 - rename subModules")
+oms_rename("renameSnapshot.root_1.add", "add_1")
+snapshot = oms_exportSnapshot("renameSnapshot")
+print(snapshot)
+
+
+-- Result:
+-- Case 1 - reference
+-- <?xml version="1.0"?>
+-- <oms:snapshot
+--   partial="false">
+--   <oms:file
+--     name="SystemStructure.ssd">
+--     <ssd:SystemStructureDescription
+--       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
+--       xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription"
+--       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
+--       xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping"
+--       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
+--       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
+--       name="renameSnapshot"
+--       version="1.0">
+--       <ssd:System
+--         name="root">
+--         <ssd:Connectors>
+--           <ssd:Connector
+--             name="C1"
+--             kind="input">
+--             <ssc:Real />
+--           </ssd:Connector>
+--         </ssd:Connectors>
+--         <ssd:ParameterBindings>
+--           <ssd:ParameterBinding
+--             source="resources/renameSnapshot.ssv" />
+--         </ssd:ParameterBindings>
+--         <ssd:Elements>
+--           <ssd:System
+--             name="foo">
+--             <ssd:Connectors>
+--               <ssd:Connector
+--                 name="Input1"
+--                 kind="input">
+--                 <ssc:Real />
+--               </ssd:Connector>
+--             </ssd:Connectors>
+--             <ssd:Annotations>
+--               <ssc:Annotation
+--                 type="org.openmodelica">
+--                 <oms:Annotations>
+--                   <oms:SimulationInformation>
+--                     <oms:VariableStepSolver
+--                       description="cvode"
+--                       absoluteTolerance="0.000100"
+--                       relativeTolerance="0.000100"
+--                       minimumStepSize="0.000100"
+--                       maximumStepSize="0.100000"
+--                       initialStepSize="0.000100" />
+--                   </oms:SimulationInformation>
+--                 </oms:Annotations>
+--               </ssc:Annotation>
+--             </ssd:Annotations>
+--           </ssd:System>
+--           <ssd:Component
+--             name="add"
+--             type="application/x-fmu-sharedlibrary"
+--             source="resources/0001_add.fmu">
+--             <ssd:Connectors>
+--               <ssd:Connector
+--                 name="u1"
+--                 kind="input">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="0.000000"
+--                   y="0.333333" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="u2"
+--                 kind="input">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="0.000000"
+--                   y="0.666667" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="y"
+--                 kind="output">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="1.000000"
+--                   y="0.500000" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="k1"
+--                 kind="parameter">
+--                 <ssc:Real />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="k2"
+--                 kind="parameter">
+--                 <ssc:Real />
+--               </ssd:Connector>
+--             </ssd:Connectors>
+--           </ssd:Component>
+--         </ssd:Elements>
+--         <ssd:Annotations>
+--           <ssc:Annotation
+--             type="org.openmodelica">
+--             <oms:Annotations>
+--               <oms:SimulationInformation>
+--                 <oms:FixedStepMaster
+--                   description="oms-ma"
+--                   stepSize="0.100000"
+--                   absoluteTolerance="0.000100"
+--                   relativeTolerance="0.000100" />
+--               </oms:SimulationInformation>
+--             </oms:Annotations>
+--           </ssc:Annotation>
+--         </ssd:Annotations>
+--       </ssd:System>
+--       <ssd:DefaultExperiment
+--         startTime="0.000000"
+--         stopTime="1.000000">
+--         <ssd:Annotations>
+--           <ssc:Annotation
+--             type="org.openmodelica">
+--             <oms:Annotations>
+--               <oms:SimulationInformation
+--                 resultFile="renameSnapshot_res.mat"
+--                 loggingInterval="0.000000"
+--                 bufferSize="10"
+--                 signalFilter="resources/signalFilter.xml" />
+--             </oms:Annotations>
+--           </ssc:Annotation>
+--         </ssd:Annotations>
+--       </ssd:DefaultExperiment>
+--     </ssd:SystemStructureDescription>
+--   </oms:file>
+--   <oms:file
+--     name="resources/renameSnapshot.ssv">
+--     <ssv:ParameterSet
+--       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
+--       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
+--       version="1.0"
+--       name="parameters">
+--       <ssv:Parameters>
+--         <ssv:Parameter
+--           name="C1">
+--           <ssv:Real
+--             value="-10" />
+--         </ssv:Parameter>
+--         <ssv:Parameter
+--           name="foo.Input1">
+--           <ssv:Real
+--             value="-20" />
+--         </ssv:Parameter>
+--         <ssv:Parameter
+--           name="add.u1">
+--           <ssv:Real
+--             value="10" />
+--         </ssv:Parameter>
+--         <ssv:Parameter
+--           name="add.k1">
+--           <ssv:Real
+--             value="30" />
+--         </ssv:Parameter>
+--       </ssv:Parameters>
+--     </ssv:ParameterSet>
+--   </oms:file>
+--   <oms:file
+--     name="resources/signalFilter.xml">
+--     <oms:SignalFilter
+--       version="1.0">
+--       <oms:Variable
+--         name="renameSnapshot.root.C1"
+--         type="Real"
+--         kind="input" />
+--       <oms:Variable
+--         name="renameSnapshot.root.add.u1"
+--         type="Real"
+--         kind="input" />
+--       <oms:Variable
+--         name="renameSnapshot.root.add.u2"
+--         type="Real"
+--         kind="input" />
+--       <oms:Variable
+--         name="renameSnapshot.root.add.y"
+--         type="Real"
+--         kind="output" />
+--       <oms:Variable
+--         name="renameSnapshot.root.add.k1"
+--         type="Real"
+--         kind="parameter" />
+--       <oms:Variable
+--         name="renameSnapshot.root.add.k2"
+--         type="Real"
+--         kind="parameter" />
+--       <oms:Variable
+--         name="renameSnapshot.root.foo.Input1"
+--         type="Real"
+--         kind="input" />
+--     </oms:SignalFilter>
+--   </oms:file>
+-- </oms:snapshot>
+--
+-- Case 2 - rename System
+-- <?xml version="1.0"?>
+-- <oms:snapshot
+--   partial="false">
+--   <oms:file
+--     name="SystemStructure.ssd">
+--     <ssd:SystemStructureDescription
+--       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
+--       xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription"
+--       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
+--       xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping"
+--       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
+--       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
+--       name="renameSnapshot"
+--       version="1.0">
+--       <ssd:System
+--         name="root_1">
+--         <ssd:Connectors>
+--           <ssd:Connector
+--             name="C1"
+--             kind="input">
+--             <ssc:Real />
+--           </ssd:Connector>
+--         </ssd:Connectors>
+--         <ssd:ParameterBindings>
+--           <ssd:ParameterBinding
+--             source="resources/renameSnapshot.ssv" />
+--         </ssd:ParameterBindings>
+--         <ssd:Elements>
+--           <ssd:System
+--             name="foo">
+--             <ssd:Connectors>
+--               <ssd:Connector
+--                 name="Input1"
+--                 kind="input">
+--                 <ssc:Real />
+--               </ssd:Connector>
+--             </ssd:Connectors>
+--             <ssd:Annotations>
+--               <ssc:Annotation
+--                 type="org.openmodelica">
+--                 <oms:Annotations>
+--                   <oms:SimulationInformation>
+--                     <oms:VariableStepSolver
+--                       description="cvode"
+--                       absoluteTolerance="0.000100"
+--                       relativeTolerance="0.000100"
+--                       minimumStepSize="0.000100"
+--                       maximumStepSize="0.100000"
+--                       initialStepSize="0.000100" />
+--                   </oms:SimulationInformation>
+--                 </oms:Annotations>
+--               </ssc:Annotation>
+--             </ssd:Annotations>
+--           </ssd:System>
+--           <ssd:Component
+--             name="add"
+--             type="application/x-fmu-sharedlibrary"
+--             source="resources/0001_add.fmu">
+--             <ssd:Connectors>
+--               <ssd:Connector
+--                 name="u1"
+--                 kind="input">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="0.000000"
+--                   y="0.333333" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="u2"
+--                 kind="input">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="0.000000"
+--                   y="0.666667" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="y"
+--                 kind="output">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="1.000000"
+--                   y="0.500000" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="k1"
+--                 kind="parameter">
+--                 <ssc:Real />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="k2"
+--                 kind="parameter">
+--                 <ssc:Real />
+--               </ssd:Connector>
+--             </ssd:Connectors>
+--           </ssd:Component>
+--         </ssd:Elements>
+--         <ssd:Annotations>
+--           <ssc:Annotation
+--             type="org.openmodelica">
+--             <oms:Annotations>
+--               <oms:SimulationInformation>
+--                 <oms:FixedStepMaster
+--                   description="oms-ma"
+--                   stepSize="0.100000"
+--                   absoluteTolerance="0.000100"
+--                   relativeTolerance="0.000100" />
+--               </oms:SimulationInformation>
+--             </oms:Annotations>
+--           </ssc:Annotation>
+--         </ssd:Annotations>
+--       </ssd:System>
+--       <ssd:DefaultExperiment
+--         startTime="0.000000"
+--         stopTime="1.000000">
+--         <ssd:Annotations>
+--           <ssc:Annotation
+--             type="org.openmodelica">
+--             <oms:Annotations>
+--               <oms:SimulationInformation
+--                 resultFile="renameSnapshot_res.mat"
+--                 loggingInterval="0.000000"
+--                 bufferSize="10"
+--                 signalFilter="resources/signalFilter.xml" />
+--             </oms:Annotations>
+--           </ssc:Annotation>
+--         </ssd:Annotations>
+--       </ssd:DefaultExperiment>
+--     </ssd:SystemStructureDescription>
+--   </oms:file>
+--   <oms:file
+--     name="resources/renameSnapshot.ssv">
+--     <ssv:ParameterSet
+--       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
+--       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
+--       version="1.0"
+--       name="parameters">
+--       <ssv:Parameters>
+--         <ssv:Parameter
+--           name="C1">
+--           <ssv:Real
+--             value="-10" />
+--         </ssv:Parameter>
+--         <ssv:Parameter
+--           name="foo.Input1">
+--           <ssv:Real
+--             value="-20" />
+--         </ssv:Parameter>
+--         <ssv:Parameter
+--           name="add.u1">
+--           <ssv:Real
+--             value="10" />
+--         </ssv:Parameter>
+--         <ssv:Parameter
+--           name="add.k1">
+--           <ssv:Real
+--             value="30" />
+--         </ssv:Parameter>
+--       </ssv:Parameters>
+--     </ssv:ParameterSet>
+--   </oms:file>
+--   <oms:file
+--     name="resources/signalFilter.xml">
+--     <oms:SignalFilter
+--       version="1.0">
+--       <oms:Variable
+--         name="renameSnapshot.root_1.C1"
+--         type="Real"
+--         kind="input" />
+--       <oms:Variable
+--         name="renameSnapshot.root_1.add.u1"
+--         type="Real"
+--         kind="input" />
+--       <oms:Variable
+--         name="renameSnapshot.root_1.add.u2"
+--         type="Real"
+--         kind="input" />
+--       <oms:Variable
+--         name="renameSnapshot.root_1.add.y"
+--         type="Real"
+--         kind="output" />
+--       <oms:Variable
+--         name="renameSnapshot.root_1.add.k1"
+--         type="Real"
+--         kind="parameter" />
+--       <oms:Variable
+--         name="renameSnapshot.root_1.add.k2"
+--         type="Real"
+--         kind="parameter" />
+--       <oms:Variable
+--         name="renameSnapshot.root_1.foo.Input1"
+--         type="Real"
+--         kind="input" />
+--     </oms:SignalFilter>
+--   </oms:file>
+-- </oms:snapshot>
+--
+-- Case 3 - rename subSystem
+-- <?xml version="1.0"?>
+-- <oms:snapshot
+--   partial="false">
+--   <oms:file
+--     name="SystemStructure.ssd">
+--     <ssd:SystemStructureDescription
+--       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
+--       xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription"
+--       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
+--       xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping"
+--       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
+--       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
+--       name="renameSnapshot"
+--       version="1.0">
+--       <ssd:System
+--         name="root_1">
+--         <ssd:Connectors>
+--           <ssd:Connector
+--             name="C1"
+--             kind="input">
+--             <ssc:Real />
+--           </ssd:Connector>
+--         </ssd:Connectors>
+--         <ssd:ParameterBindings>
+--           <ssd:ParameterBinding
+--             source="resources/renameSnapshot.ssv" />
+--         </ssd:ParameterBindings>
+--         <ssd:Elements>
+--           <ssd:System
+--             name="foo_1">
+--             <ssd:Connectors>
+--               <ssd:Connector
+--                 name="Input1"
+--                 kind="input">
+--                 <ssc:Real />
+--               </ssd:Connector>
+--             </ssd:Connectors>
+--             <ssd:Annotations>
+--               <ssc:Annotation
+--                 type="org.openmodelica">
+--                 <oms:Annotations>
+--                   <oms:SimulationInformation>
+--                     <oms:VariableStepSolver
+--                       description="cvode"
+--                       absoluteTolerance="0.000100"
+--                       relativeTolerance="0.000100"
+--                       minimumStepSize="0.000100"
+--                       maximumStepSize="0.100000"
+--                       initialStepSize="0.000100" />
+--                   </oms:SimulationInformation>
+--                 </oms:Annotations>
+--               </ssc:Annotation>
+--             </ssd:Annotations>
+--           </ssd:System>
+--           <ssd:Component
+--             name="add"
+--             type="application/x-fmu-sharedlibrary"
+--             source="resources/0001_add.fmu">
+--             <ssd:Connectors>
+--               <ssd:Connector
+--                 name="u1"
+--                 kind="input">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="0.000000"
+--                   y="0.333333" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="u2"
+--                 kind="input">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="0.000000"
+--                   y="0.666667" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="y"
+--                 kind="output">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="1.000000"
+--                   y="0.500000" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="k1"
+--                 kind="parameter">
+--                 <ssc:Real />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="k2"
+--                 kind="parameter">
+--                 <ssc:Real />
+--               </ssd:Connector>
+--             </ssd:Connectors>
+--           </ssd:Component>
+--         </ssd:Elements>
+--         <ssd:Annotations>
+--           <ssc:Annotation
+--             type="org.openmodelica">
+--             <oms:Annotations>
+--               <oms:SimulationInformation>
+--                 <oms:FixedStepMaster
+--                   description="oms-ma"
+--                   stepSize="0.100000"
+--                   absoluteTolerance="0.000100"
+--                   relativeTolerance="0.000100" />
+--               </oms:SimulationInformation>
+--             </oms:Annotations>
+--           </ssc:Annotation>
+--         </ssd:Annotations>
+--       </ssd:System>
+--       <ssd:DefaultExperiment
+--         startTime="0.000000"
+--         stopTime="1.000000">
+--         <ssd:Annotations>
+--           <ssc:Annotation
+--             type="org.openmodelica">
+--             <oms:Annotations>
+--               <oms:SimulationInformation
+--                 resultFile="renameSnapshot_res.mat"
+--                 loggingInterval="0.000000"
+--                 bufferSize="10"
+--                 signalFilter="resources/signalFilter.xml" />
+--             </oms:Annotations>
+--           </ssc:Annotation>
+--         </ssd:Annotations>
+--       </ssd:DefaultExperiment>
+--     </ssd:SystemStructureDescription>
+--   </oms:file>
+--   <oms:file
+--     name="resources/renameSnapshot.ssv">
+--     <ssv:ParameterSet
+--       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
+--       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
+--       version="1.0"
+--       name="parameters">
+--       <ssv:Parameters>
+--         <ssv:Parameter
+--           name="C1">
+--           <ssv:Real
+--             value="-10" />
+--         </ssv:Parameter>
+--         <ssv:Parameter
+--           name="foo_1.Input1">
+--           <ssv:Real
+--             value="-20" />
+--         </ssv:Parameter>
+--         <ssv:Parameter
+--           name="add.u1">
+--           <ssv:Real
+--             value="10" />
+--         </ssv:Parameter>
+--         <ssv:Parameter
+--           name="add.k1">
+--           <ssv:Real
+--             value="30" />
+--         </ssv:Parameter>
+--       </ssv:Parameters>
+--     </ssv:ParameterSet>
+--   </oms:file>
+--   <oms:file
+--     name="resources/signalFilter.xml">
+--     <oms:SignalFilter
+--       version="1.0">
+--       <oms:Variable
+--         name="renameSnapshot.root_1.C1"
+--         type="Real"
+--         kind="input" />
+--       <oms:Variable
+--         name="renameSnapshot.root_1.add.u1"
+--         type="Real"
+--         kind="input" />
+--       <oms:Variable
+--         name="renameSnapshot.root_1.add.u2"
+--         type="Real"
+--         kind="input" />
+--       <oms:Variable
+--         name="renameSnapshot.root_1.add.y"
+--         type="Real"
+--         kind="output" />
+--       <oms:Variable
+--         name="renameSnapshot.root_1.add.k1"
+--         type="Real"
+--         kind="parameter" />
+--       <oms:Variable
+--         name="renameSnapshot.root_1.add.k2"
+--         type="Real"
+--         kind="parameter" />
+--       <oms:Variable
+--         name="renameSnapshot.root_1.foo_1.Input1"
+--         type="Real"
+--         kind="input" />
+--     </oms:SignalFilter>
+--   </oms:file>
+-- </oms:snapshot>
+--
+-- Case 4 - rename subModules
+-- <?xml version="1.0"?>
+-- <oms:snapshot
+--   partial="false">
+--   <oms:file
+--     name="SystemStructure.ssd">
+--     <ssd:SystemStructureDescription
+--       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
+--       xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription"
+--       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
+--       xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping"
+--       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
+--       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
+--       name="renameSnapshot"
+--       version="1.0">
+--       <ssd:System
+--         name="root_1">
+--         <ssd:Connectors>
+--           <ssd:Connector
+--             name="C1"
+--             kind="input">
+--             <ssc:Real />
+--           </ssd:Connector>
+--         </ssd:Connectors>
+--         <ssd:ParameterBindings>
+--           <ssd:ParameterBinding
+--             source="resources/renameSnapshot.ssv" />
+--         </ssd:ParameterBindings>
+--         <ssd:Elements>
+--           <ssd:System
+--             name="foo_1">
+--             <ssd:Connectors>
+--               <ssd:Connector
+--                 name="Input1"
+--                 kind="input">
+--                 <ssc:Real />
+--               </ssd:Connector>
+--             </ssd:Connectors>
+--             <ssd:Annotations>
+--               <ssc:Annotation
+--                 type="org.openmodelica">
+--                 <oms:Annotations>
+--                   <oms:SimulationInformation>
+--                     <oms:VariableStepSolver
+--                       description="cvode"
+--                       absoluteTolerance="0.000100"
+--                       relativeTolerance="0.000100"
+--                       minimumStepSize="0.000100"
+--                       maximumStepSize="0.100000"
+--                       initialStepSize="0.000100" />
+--                   </oms:SimulationInformation>
+--                 </oms:Annotations>
+--               </ssc:Annotation>
+--             </ssd:Annotations>
+--           </ssd:System>
+--           <ssd:Component
+--             name="add_1"
+--             type="application/x-fmu-sharedlibrary"
+--             source="resources/0001_add.fmu">
+--             <ssd:Connectors>
+--               <ssd:Connector
+--                 name="u1"
+--                 kind="input">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="0.000000"
+--                   y="0.333333" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="u2"
+--                 kind="input">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="0.000000"
+--                   y="0.666667" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="y"
+--                 kind="output">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="1.000000"
+--                   y="0.500000" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="k1"
+--                 kind="parameter">
+--                 <ssc:Real />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="k2"
+--                 kind="parameter">
+--                 <ssc:Real />
+--               </ssd:Connector>
+--             </ssd:Connectors>
+--           </ssd:Component>
+--         </ssd:Elements>
+--         <ssd:Annotations>
+--           <ssc:Annotation
+--             type="org.openmodelica">
+--             <oms:Annotations>
+--               <oms:SimulationInformation>
+--                 <oms:FixedStepMaster
+--                   description="oms-ma"
+--                   stepSize="0.100000"
+--                   absoluteTolerance="0.000100"
+--                   relativeTolerance="0.000100" />
+--               </oms:SimulationInformation>
+--             </oms:Annotations>
+--           </ssc:Annotation>
+--         </ssd:Annotations>
+--       </ssd:System>
+--       <ssd:DefaultExperiment
+--         startTime="0.000000"
+--         stopTime="1.000000">
+--         <ssd:Annotations>
+--           <ssc:Annotation
+--             type="org.openmodelica">
+--             <oms:Annotations>
+--               <oms:SimulationInformation
+--                 resultFile="renameSnapshot_res.mat"
+--                 loggingInterval="0.000000"
+--                 bufferSize="10"
+--                 signalFilter="resources/signalFilter.xml" />
+--             </oms:Annotations>
+--           </ssc:Annotation>
+--         </ssd:Annotations>
+--       </ssd:DefaultExperiment>
+--     </ssd:SystemStructureDescription>
+--   </oms:file>
+--   <oms:file
+--     name="resources/renameSnapshot.ssv">
+--     <ssv:ParameterSet
+--       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
+--       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
+--       version="1.0"
+--       name="parameters">
+--       <ssv:Parameters>
+--         <ssv:Parameter
+--           name="C1">
+--           <ssv:Real
+--             value="-10" />
+--         </ssv:Parameter>
+--         <ssv:Parameter
+--           name="foo_1.Input1">
+--           <ssv:Real
+--             value="-20" />
+--         </ssv:Parameter>
+--         <ssv:Parameter
+--           name="add_1.k1">
+--           <ssv:Real
+--             value="30" />
+--         </ssv:Parameter>
+--       </ssv:Parameters>
+--     </ssv:ParameterSet>
+--   </oms:file>
+--   <oms:file
+--     name="resources/signalFilter.xml">
+--     <oms:SignalFilter
+--       version="1.0">
+--       <oms:Variable
+--         name="renameSnapshot.root_1.C1"
+--         type="Real"
+--         kind="input" />
+--       <oms:Variable
+--         name="renameSnapshot.root_1.add_1.u1"
+--         type="Real"
+--         kind="input" />
+--       <oms:Variable
+--         name="renameSnapshot.root_1.add_1.u2"
+--         type="Real"
+--         kind="input" />
+--       <oms:Variable
+--         name="renameSnapshot.root_1.add_1.y"
+--         type="Real"
+--         kind="output" />
+--       <oms:Variable
+--         name="renameSnapshot.root_1.add_1.k1"
+--         type="Real"
+--         kind="parameter" />
+--       <oms:Variable
+--         name="renameSnapshot.root_1.add_1.k2"
+--         type="Real"
+--         kind="parameter" />
+--       <oms:Variable
+--         name="renameSnapshot.root_1.foo_1.Input1"
+--         type="Real"
+--         kind="input" />
+--     </oms:SignalFilter>
+--   </oms:file>
+-- </oms:snapshot>
+--
+-- endResult


### PR DESCRIPTION
### Related Issues

https://github.com/OpenModelica/OpenModelica/pull/7274
https://github.com/OpenModelica/OpenModelica/issues/7111

### Purpose

This PR, fixes the exporting of snapshot when renaming `system, subsystem or submodules`  which will be used by OMEdit text editing of ssp files

### Approach
When renaming `system or subsytem or submodule` , the connector owners are not updated which caused the exportsnapshot to fail, Also the values in ssv files are also updated when renaming.