### PR TITLE
restructure exporting SSP to snapshot interface

### DIFF
--- a/src/OMSimulatorLib/Component.h
+++ b/src/OMSimulatorLib/Component.h
@@ -62,7 +62,8 @@ namespace oms
     virtual ~Component();
 
     virtual oms_status_enu_t addSignalsToResults(const char* regex) = 0;
-    virtual oms_status_enu_t exportToSSD(pugi::xml_node& node, pugi::xml_node& ssvNode, Snapshot& snapshot) const = 0;
+    virtual oms_status_enu_t exportToSSD(pugi::xml_node& node, Snapshot& snapshot) const = 0;
+    virtual oms_status_enu_t exportToSSV(pugi::xml_node& ssvNode) { return logError_NotImplemented; }
     virtual oms_status_enu_t initialize() = 0;
     virtual oms_status_enu_t instantiate() = 0;
     virtual oms_status_enu_t registerSignalsForResultFile(ResultWriter& resultFile) = 0;

--- a/src/OMSimulatorLib/ComponentFMUCS.cpp
+++ b/src/OMSimulatorLib/ComponentFMUCS.cpp
@@ -300,7 +300,7 @@ oms::Component* oms::ComponentFMUCS::NewComponent(const pugi::xml_node& node, om
   return component;
 }
 
-oms_status_enu_t oms::ComponentFMUCS::exportToSSD(pugi::xml_node& node, pugi::xml_node& ssvNode, Snapshot& snapshot) const
+oms_status_enu_t oms::ComponentFMUCS::exportToSSD(pugi::xml_node& node, Snapshot& snapshot) const
 {
 #if !defined(NO_TLM)
   if (tlmbusconnectors[0])
@@ -332,12 +332,13 @@ oms_status_enu_t oms::ComponentFMUCS::exportToSSD(pugi::xml_node& node, pugi::xm
   {
     values.exportToSSD(node);
   }
-  else
-  {
-    values.exportToSSV(ssvNode); // export to ssv file
-  }
 
   return oms_status_ok;
+}
+
+oms_status_enu_t oms::ComponentFMUCS::exportToSSV(pugi::xml_node& ssvNode)
+{
+  return values.exportToSSV(ssvNode);
 }
 
 oms_status_enu_t oms::ComponentFMUCS::exportToSSVTemplate(pugi::xml_node& ssvNode)

--- a/src/OMSimulatorLib/ComponentFMUCS.h
+++ b/src/OMSimulatorLib/ComponentFMUCS.h
@@ -59,7 +59,8 @@ namespace oms
     static Component* NewComponent(const pugi::xml_node& node, System* parentSystem, const std::string& sspVersion, const Snapshot& snapshot);
     const FMUInfo* getFMUInfo() const {return &(this->fmuInfo);}
 
-    oms_status_enu_t exportToSSD(pugi::xml_node& node, pugi::xml_node& ssvNode, Snapshot& snapshot) const;
+    oms_status_enu_t exportToSSD(pugi::xml_node& node, Snapshot& snapshot) const;
+    oms_status_enu_t exportToSSV(pugi::xml_node& ssvNode);
     oms_status_enu_t exportToSSVTemplate(pugi::xml_node& ssvNode);
     oms_status_enu_t exportToSSMTemplate(pugi::xml_node& ssmNode);
     oms_status_enu_t instantiate();

--- a/src/OMSimulatorLib/ComponentFMUME.cpp
+++ b/src/OMSimulatorLib/ComponentFMUME.cpp
@@ -302,7 +302,7 @@ oms::Component* oms::ComponentFMUME::NewComponent(const pugi::xml_node& node, om
   return component;
 }
 
-oms_status_enu_t oms::ComponentFMUME::exportToSSD(pugi::xml_node& node, pugi::xml_node& ssvNode, Snapshot& snapshot) const
+oms_status_enu_t oms::ComponentFMUME::exportToSSD(pugi::xml_node& node, Snapshot& snapshot) const
 {
 #if !defined(NO_TLM)
   if (tlmbusconnectors[0])
@@ -334,12 +334,13 @@ oms_status_enu_t oms::ComponentFMUME::exportToSSD(pugi::xml_node& node, pugi::xm
   {
     values.exportToSSD(node);
   }
-  else
-  {
-    values.exportToSSV(ssvNode); // export to ssv file
-  }
 
   return oms_status_ok;
+}
+
+oms_status_enu_t oms::ComponentFMUME::exportToSSV(pugi::xml_node& ssvNode)
+{
+  return values.exportToSSV(ssvNode);
 }
 
 oms_status_enu_t oms::ComponentFMUME::exportToSSVTemplate(pugi::xml_node& ssvNode)

--- a/src/OMSimulatorLib/ComponentFMUME.h
+++ b/src/OMSimulatorLib/ComponentFMUME.h
@@ -57,7 +57,8 @@ namespace oms
     static Component* NewComponent(const pugi::xml_node& node, System* parentSystem,  const std::string& sspVersion, const Snapshot& snapshot);
     const FMUInfo* getFMUInfo() const {return &(this->fmuInfo);}
 
-    oms_status_enu_t exportToSSD(pugi::xml_node& node, pugi::xml_node& ssvNode, Snapshot& snapshot) const;
+    oms_status_enu_t exportToSSD(pugi::xml_node& node, Snapshot& snapshot) const;
+    oms_status_enu_t exportToSSV(pugi::xml_node& ssvNode);
     oms_status_enu_t exportToSSVTemplate(pugi::xml_node& ssvNode);
     oms_status_enu_t exportToSSMTemplate(pugi::xml_node& ssmNode);
     oms_status_enu_t instantiate();

--- a/src/OMSimulatorLib/ComponentTable.cpp
+++ b/src/OMSimulatorLib/ComponentTable.cpp
@@ -161,7 +161,7 @@ oms::Component* oms::ComponentTable::NewComponent(const pugi::xml_node& node, om
   return component;
 }
 
-oms_status_enu_t oms::ComponentTable::exportToSSD(pugi::xml_node& node, pugi::xml_node& ssvNode, Snapshot& snapshot) const
+oms_status_enu_t oms::ComponentTable::exportToSSD(pugi::xml_node& node, Snapshot& snapshot) const
 {
   node.append_attribute("name") = this->getCref().c_str();
   node.append_attribute("type") = "application/table";

--- a/src/OMSimulatorLib/ComponentTable.h
+++ b/src/OMSimulatorLib/ComponentTable.h
@@ -55,7 +55,7 @@ namespace oms
     static Component* NewComponent(const oms::ComRef& cref, System* parentSystem, const std::string& path);
     static Component* NewComponent(const pugi::xml_node& node, System* parentSystem, const std::string& sspVersion, const Snapshot& snapshot);
 
-    oms_status_enu_t exportToSSD(pugi::xml_node& node, pugi::xml_node& ssvNode, Snapshot& snapshot) const;
+    oms_status_enu_t exportToSSD(pugi::xml_node& node, Snapshot& snapshot) const;
     oms_status_enu_t exportToSSVTemplate(pugi::xml_node& ssvNode) {return oms_status_ok;}
     oms_status_enu_t exportToSSMTemplate(pugi::xml_node& ssmNode) {return oms_status_ok;}
     oms_status_enu_t instantiate();

--- a/src/OMSimulatorLib/Model.cpp
+++ b/src/OMSimulatorLib/Model.cpp
@@ -312,14 +312,6 @@ oms_status_enu_t oms::Model::list(const oms::ComRef& cref, char** contents)
   {
     isTopSystemOrModel = true;
     exportToSSD(snapshot);
-    // update parameterBindings in ssd
-    if (!Flags::ExportParametersInline())
-    {
-      pugi::xml_node ssdNode = snapshot.getResourceNode("SystemStructure.ssd");
-      pugi::xml_node system_node = ssdNode.child(oms::ssp::Draft20180219::ssd::system);
-      updateParameterBindingsToSSD(system_node, true);
-      // TODO ssm file
-    }
     doc.append_copy(snapshot.getResourceNode("SystemStructure.ssd"));
   }
   else
@@ -339,12 +331,6 @@ oms_status_enu_t oms::Model::list(const oms::ComRef& cref, char** contents)
       pugi::xml_node system_node = ssdNode.append_child(oms::ssp::Draft20180219::ssd::system);
 
       subsystem->exportToSSD(system_node, snapshot);
-      // update parameterBindings in ssd
-      if (!Flags::ExportParametersInline())
-      {
-        updateParameterBindingsToSSD(system_node, true);
-        // TODO ssm file
-      }
       doc.append_copy(snapshot.getResourceNode("SystemStructure.ssd").first_child());
     }
     else
@@ -380,10 +366,6 @@ oms_status_enu_t oms::Model::exportSnapshot(const oms::ComRef& cref, char** cont
   if (!Flags::ExportParametersInline())
   {
     system->exportToSSV(snapshot);
-    // update parameterBindings in ssd
-    pugi::xml_node ssdNode = snapshot.getResourceNode("SystemStructure.ssd");
-    pugi::xml_node system_node = ssdNode.child(oms::ssp::Draft20180219::ssd::system);
-    updateParameterBindingsToSSD(system_node, true);
     // TODO ssm file
   }
 
@@ -739,10 +721,6 @@ oms_status_enu_t oms::Model::exportToFile(const std::string& filename) const
   if (!Flags::ExportParametersInline())
   {
     system->exportToSSV(snapshot);
-    // update parameterBindings in ssd
-    pugi::xml_node ssdNode = snapshot.getResourceNode("SystemStructure.ssd");
-    pugi::xml_node system_node = ssdNode.child(oms::ssp::Draft20180219::ssd::system);
-    updateParameterBindingsToSSD(system_node, true);
     // TODO ssm file
   }
 

--- a/src/OMSimulatorLib/Model.cpp
+++ b/src/OMSimulatorLib/Model.cpp
@@ -302,31 +302,25 @@ oms_status_enu_t oms::Model::list(const oms::ComRef& cref, char** contents)
 
   xmlStringWriter writer;
   pugi::xml_document doc;
-  pugi::xml_document ssvdoc;
 
   Snapshot snapshot;
   // check for toplevelSystem or Model to update parameterbindings in ssd
   bool isTopSystemOrModel = false;
 
-  // generate XML declaration for ssv file
-  pugi::xml_node ssvDeclarationNode = ssvdoc.append_child(pugi::node_declaration);
-  ssvDeclarationNode.append_attribute("version") = "1.0";
-  ssvDeclarationNode.append_attribute("encoding") = "UTF-8";
-
-  pugi::xml_node node_parameterset = ssvdoc.append_child(oms::ssp::Version1_0::ssv::parameter_set);
-  node_parameterset.append_attribute("version") = "1.0";
-  node_parameterset.append_attribute("name") = "parameters";
-  pugi::xml_node node_parameters = node_parameterset.append_child(oms::ssp::Version1_0::ssv::parameters);
-
   // list model
   if (cref.isEmpty())
   {
     isTopSystemOrModel = true;
-    pugi::xml_node node = doc.append_child(oms::ssp::Draft20180219::ssd::system_structure_description);
-    exportToSSD(node, node_parameters, snapshot);
+    exportToSSD(snapshot);
     // update parameterBindings in ssd
-    pugi::xml_node system_node = node.child(oms::ssp::Draft20180219::ssd::system);
-    updateParameterBindingsToSSD(system_node, node_parameters, isTopSystemOrModel);
+    if (!Flags::ExportParametersInline())
+    {
+      pugi::xml_node ssdNode = snapshot.getResourceNode("SystemStructure.ssd");
+      pugi::xml_node system_node = ssdNode.child(oms::ssp::Draft20180219::ssd::system);
+      updateParameterBindingsToSSD(system_node, true);
+      // TODO ssm file
+    }
+    doc.append_copy(snapshot.getResourceNode("SystemStructure.ssd"));
   }
   else
   {
@@ -341,10 +335,17 @@ oms_status_enu_t oms::Model::list(const oms::ComRef& cref, char** contents)
 
     if (subsystem)
     {
-      pugi::xml_node node = doc.append_child(oms::ssp::Draft20180219::ssd::system);
-      subsystem->exportToSSD(node, node_parameters, snapshot);
+      pugi::xml_node ssdNode = snapshot.getTemplateResourceNodeSSD("SystemStructure.ssd", this->getCref());
+      pugi::xml_node system_node = ssdNode.append_child(oms::ssp::Draft20180219::ssd::system);
+
+      subsystem->exportToSSD(system_node, snapshot);
       // update parameterBindings in ssd
-      updateParameterBindingsToSSD(node, node_parameters, isTopSystemOrModel);
+      if (!Flags::ExportParametersInline())
+      {
+        updateParameterBindingsToSSD(system_node, true);
+        // TODO ssm file
+      }
+      doc.append_copy(snapshot.getResourceNode("SystemStructure.ssd").first_child());
     }
     else
     {
@@ -353,8 +354,11 @@ oms_status_enu_t oms::Model::list(const oms::ComRef& cref, char** contents)
       if (!component)
         return logError("error");
 
-      pugi::xml_node node = doc.append_child(oms::ssp::Draft20180219::ssd::system);
-      component->exportToSSD(node, node_parameters, snapshot);
+      pugi::xml_node ssdNode = snapshot.getTemplateResourceNodeSSD("SystemStructure.ssd", this->getCref());
+      pugi::xml_node system_node = ssdNode.append_child(oms::ssp::Draft20180219::ssd::system);
+
+      component->exportToSSD(system_node, snapshot);
+      doc.append_copy(snapshot.getResourceNode("SystemStructure.ssd").first_child());
     }
   }
 
@@ -362,6 +366,7 @@ oms_status_enu_t oms::Model::list(const oms::ComRef& cref, char** contents)
   *contents = mallocAndCopyString(writer.result);
   if (!*contents)
     return oms_status_fatal;
+
   return oms_status_ok;
 }
 
@@ -369,29 +374,20 @@ oms_status_enu_t oms::Model::exportSnapshot(const oms::ComRef& cref, char** cont
 {
   Snapshot snapshot;
 
-  pugi::xml_node oms_ssd = snapshot.newResourceNode("SystemStructure.ssd");
-  pugi::xml_node ssdNode = oms_ssd.append_child(oms::ssp::Draft20180219::ssd::system_structure_description);
+  exportToSSD(snapshot);
 
-  pugi::xml_node ssvNode = snapshot.getTemplateResourceNodeSSV("resources/" + std::string(this->getCref()) + ".ssv");
-
-  exportToSSD(ssdNode, ssvNode, snapshot);
-
-  pugi::xml_node oms_signalFilter = snapshot.getTemplateResourceNodeSignalFilter(signalFilterFilename);
-  exportSignalFilter(oms_signalFilter);
-
-  // update ssv file if exist
+  // export to ssv file if Flag set
   if (!Flags::ExportParametersInline())
   {
+    system->exportToSSV(snapshot);
     // update parameterBindings in ssd
+    pugi::xml_node ssdNode = snapshot.getResourceNode("SystemStructure.ssd");
     pugi::xml_node system_node = ssdNode.child(oms::ssp::Draft20180219::ssd::system);
-    updateParameterBindingsToSSD(system_node, ssvNode, true);
+    updateParameterBindingsToSSD(system_node, true);
     // TODO ssm file
   }
-  else
-  {
-    // delete ssv node from <oms:snapshot> if flag not set
-    snapshot.deleteResourceNode("resources/" + std::string(this->getCref()) + ".ssv");
-  }
+
+  exportSignalFilter(snapshot);
 
   if (cref.isEmpty())
     return snapshot.writeDocument(contents);
@@ -408,6 +404,10 @@ oms_status_enu_t oms::Model::exportSSVTemplate(const oms::ComRef& cref, const st
   oms::ComRef front = tail.pop_front();
 
   pugi::xml_document ssvdoc;
+  // generate XML declaration for ssm file
+  pugi::xml_node ssvDeclarationNode = ssvdoc.append_child(pugi::node_declaration);
+  ssvDeclarationNode.append_attribute("version") = "1.0";
+  ssvDeclarationNode.append_attribute("encoding") = "UTF-8";
 
   std::string extension = "";
   if (filename.length() > 4)
@@ -416,24 +416,14 @@ oms_status_enu_t oms::Model::exportSSVTemplate(const oms::ComRef& cref, const st
   if (extension != ".ssv")
     return logError("filename extension must be \".ssv\"; no other formats are supported");
 
-  // generate XML declaration for ssv file
-  pugi::xml_node ssvDeclarationNode = ssvdoc.append_child(pugi::node_declaration);
-  ssvDeclarationNode.append_attribute("version") = "1.0";
-  ssvDeclarationNode.append_attribute("encoding") = "UTF-8";
-
-  pugi::xml_node node_parameterset = ssvdoc.append_child(oms::ssp::Version1_0::ssv::parameter_set);
-  node_parameterset.append_attribute("xmlns:ssc") = "http://ssp-standard.org/SSP1/SystemStructureCommon";
-  node_parameterset.append_attribute("xmlns:ssv") = "http://ssp-standard.org/SSP1/SystemStructureParameterValues";
-
-  node_parameterset.append_attribute("version") = "1.0";
-  node_parameterset.append_attribute("name") = "modelDescriptionStartValues";
-  pugi::xml_node node_parameters = node_parameterset.append_child(oms::ssp::Version1_0::ssv::parameters);
+  Snapshot snapshot;
+  pugi::xml_node ssvNode = snapshot.getTemplateResourceNodeSSV("template.ssv", "modelDescriptionStartValues");
 
   for (const auto& component : system->getComponents())
   {
     if(component.first == tail || cref.isEmpty()) // allow querying single component or whole model
     {
-      if (oms_status_ok != component.second->exportToSSVTemplate(node_parameters))
+      if (oms_status_ok != component.second->exportToSSVTemplate(ssvNode))
       {
         return logError("export of ssv template failed for component " + std::string(system->getFullCref()+std::string(component.first)));
       }
@@ -441,6 +431,7 @@ oms_status_enu_t oms::Model::exportSSVTemplate(const oms::ComRef& cref, const st
   }
 
   //ssvdoc.save(std::cout);
+  ssvdoc.append_copy(snapshot.getResourceNode("template.ssv"));
 
   if (!ssvdoc.save_file(filename.c_str()))
     return logError("failed to export  \"" + filename + "\" (for model \"" + std::string(this->getCref()) + "\")");
@@ -454,6 +445,10 @@ oms_status_enu_t oms::Model::exportSSMTemplate(const oms::ComRef& cref, const st
   oms::ComRef front = tail.pop_front();
 
   pugi::xml_document ssmdoc;
+  // generate XML declaration for ssm file
+  pugi::xml_node ssmDeclarationNode = ssmdoc.append_child(pugi::node_declaration);
+  ssmDeclarationNode.append_attribute("version") = "1.0";
+  ssmDeclarationNode.append_attribute("encoding") = "UTF-8";
 
   std::string extension = "";
   if (filename.length() > 4)
@@ -462,22 +457,14 @@ oms_status_enu_t oms::Model::exportSSMTemplate(const oms::ComRef& cref, const st
   if (extension != ".ssm")
     return logError("filename extension must be \".ssm\"; no other formats are supported");
 
-  // generate XML declaration for ssv file
-  pugi::xml_node ssmDeclarationNode = ssmdoc.append_child(pugi::node_declaration);
-  ssmDeclarationNode.append_attribute("version") = "1.0";
-  ssmDeclarationNode.append_attribute("encoding") = "UTF-8";
-
-  pugi::xml_node node_parameterMapping = ssmdoc.append_child(oms::ssp::Version1_0::ssm::parameter_mapping);
-  node_parameterMapping.append_attribute("xmlns:ssc") = "http://ssp-standard.org/SSP1/SystemStructureCommon";
-  node_parameterMapping.append_attribute("xmlns:ssm") = "http://ssp-standard.org/SSP1/SystemStructureParameterMapping";
-
-  node_parameterMapping.append_attribute("version") = "1.0";
+  Snapshot snapshot;
+  pugi::xml_node ssmNode = snapshot.getTemplateResourceNodeSSM("template.ssm");
 
   for (const auto& component : system->getComponents())
   {
     if(component.first == tail || cref.isEmpty()) // allow querying single component or whole model
     {
-      if (oms_status_ok != component.second->exportToSSMTemplate(node_parameterMapping))
+      if (oms_status_ok != component.second->exportToSSMTemplate(ssmNode))
       {
         return logError("export of ssm template failed for component " + std::string(system->getFullCref()+std::string(component.first)));
       }
@@ -485,6 +472,7 @@ oms_status_enu_t oms::Model::exportSSMTemplate(const oms::ComRef& cref, const st
   }
 
   //ssmdoc.save(std::cout);
+  ssmdoc.append_copy(snapshot.getResourceNode("template.ssm"));
 
   if (!ssmdoc.save_file(filename.c_str()))
     return logError("failed to export  \"" + filename + "\" (for model \"" + std::string(this->getCref()) + "\")");
@@ -498,12 +486,10 @@ oms_status_enu_t oms::Model::exportSSMTemplate(const oms::ComRef& cref, const st
  *     <ssd:ParameterBinding source="resources/import_export_parameters.ssv" />
  * </ssd:ParameterBindings>
  */
-oms_status_enu_t oms::Model::updateParameterBindingsToSSD(pugi::xml_node& node, pugi::xml_node& ssvNode, bool isTopSystemOrModel) const
+oms_status_enu_t oms::Model::updateParameterBindingsToSSD(pugi::xml_node& node, bool isTopSystemOrModel) const
 {
-  int parameterNodeCount = std::distance(ssvNode.begin(), ssvNode.end());
-
   // check parameter bindings exist and export to ssv file and also update the ssd file with parameterBindings at the top level
-  if (parameterNodeCount > 0 && isTopSystemOrModel)
+  if (isTopSystemOrModel)
   {
     // update the ssd with the top level parameterBindings (e.g)  <ParameterBinding source="resources/ControlledTemperature.ssv">
     for(pugi::xml_node_iterator it = node.begin(); it != node.end(); ++it)
@@ -548,26 +534,18 @@ oms_status_enu_t oms::Model::addSystem(const oms::ComRef& cref, oms_system_enu_t
   return logError("wrong input \"" + std::string(front) + "\" != \"" + std::string(system->getCref()) + "\"");
 }
 
-oms_status_enu_t oms::Model::exportToSSD(pugi::xml_node& node, pugi::xml_node& ssvNode, Snapshot& snapshot) const
+oms_status_enu_t oms::Model::exportToSSD(Snapshot& snapshot) const
 {
-  node.append_attribute("xmlns:ssc") = "http://ssp-standard.org/SSP1/SystemStructureCommon";
-  node.append_attribute("xmlns:ssd") = "http://ssp-standard.org/SSP1/SystemStructureDescription";
-  node.append_attribute("xmlns:ssv") = "http://ssp-standard.org/SSP1/SystemStructureParameterValues";
-  node.append_attribute("xmlns:ssm") = "http://ssp-standard.org/SSP1/SystemStructureParameterMapping";
-  node.append_attribute("xmlns:ssb") = "http://ssp-standard.org/SSP1/SystemStructureSignalDictionary";
-  node.append_attribute("xmlns:oms") = "https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd";
-
-  node.append_attribute("name") = this->getCref().c_str();
-  node.append_attribute("version") = "1.0";
+  pugi::xml_node ssdNode = snapshot.getTemplateResourceNodeSSD("SystemStructure.ssd", this->getCref());
 
   if (system)
   {
-    pugi::xml_node system_node = node.append_child(oms::ssp::Draft20180219::ssd::system);
-    if (oms_status_ok != system->exportToSSD(system_node, ssvNode, snapshot))
+    pugi::xml_node system_node = ssdNode.append_child(oms::ssp::Draft20180219::ssd::system);
+    if (oms_status_ok != system->exportToSSD(system_node, snapshot))
       return logError("export of system failed");
   }
 
-  pugi::xml_node default_experiment = node.append_child(oms::ssp::Draft20180219::ssd::default_experiment);
+  pugi::xml_node default_experiment = ssdNode.append_child(oms::ssp::Draft20180219::ssd::default_experiment);
   default_experiment.append_attribute("startTime") = std::to_string(startTime).c_str();
   default_experiment.append_attribute("stopTime") = std::to_string(stopTime).c_str();
 
@@ -745,8 +723,6 @@ oms_system_enu_t oms::Model::getSystemTypeHelper(const pugi::xml_node& node, con
 
 oms_status_enu_t oms::Model::exportToFile(const std::string& filename) const
 {
-  pugi::xml_document doc;
-  pugi::xml_document ssvdoc;
 
   Snapshot snapshot;
 
@@ -757,79 +733,20 @@ oms_status_enu_t oms::Model::exportToFile(const std::string& filename) const
   if (extension != ".ssp")
     return logError("filename extension must be \".ssp\"; no other formats are supported");
 
-  // generate XML declaration
-  pugi::xml_node declarationNode = doc.append_child(pugi::node_declaration);
-  declarationNode.append_attribute("version") = "1.0";
-  declarationNode.append_attribute("encoding") = "UTF-8";
+  exportToSSD(snapshot);
 
-  pugi::xml_node node = doc.append_child(oms::ssp::Draft20180219::ssd::system_structure_description);
-
-  // generate XML declaration for ssv file
-  pugi::xml_node ssvDeclarationNode = ssvdoc.append_child(pugi::node_declaration);
-  ssvDeclarationNode.append_attribute("version") = "1.0";
-  ssvDeclarationNode.append_attribute("encoding") = "UTF-8";
-
-  pugi::xml_node node_parameterset = ssvdoc.append_child(oms::ssp::Version1_0::ssv::parameter_set);
-  node_parameterset.append_attribute("xmlns:ssc") = "http://ssp-standard.org/SSP1/SystemStructureCommon";
-  node_parameterset.append_attribute("xmlns:ssv") = "http://ssp-standard.org/SSP1/SystemStructureParameterValues";
-
-  node_parameterset.append_attribute("version") = "1.0";
-  node_parameterset.append_attribute("name") = "parameters";
-  pugi::xml_node node_parameters = node_parameterset.append_child(oms::ssp::Version1_0::ssv::parameters);
-
-  exportToSSD(node, node_parameters, snapshot);
-
-  filesystem::path ssdPath = filesystem::path(tempDir) / "SystemStructure.ssd";
-
-  // check for parameter-bindings are defined, (i.e) count the child nodes node_parameters in ssvdoc
-  int parameterNodeCount = std::distance(node_parameters.begin(), node_parameters.end());
-  std::string ssvFileName = "";
-
-  std::vector<std::string> resources;
-
-  // check parameter bindings exist and export to ssv file and also update the ssd file with parameterBindings at the top level
-  if (parameterNodeCount > 0)
+  // export to ssv if flag set
+  if (!Flags::ExportParametersInline())
   {
-    ssvFileName = "resources/" + std::string(this->getCref()) + ".ssv";
-    resources.push_back(ssvFileName);
-
-    filesystem::path ssvPath = filesystem::path(tempDir) /  ssvFileName;
-    //std::cout << "\n ssvPath  : " << ssvPath << " filename : " << ssvFileName;
-    ssvdoc.save_file(ssvPath.string().c_str());
-
-    // update the ssd with the top level parameterBindings (e.g)  <ParameterBinding source="resources/ControlledTemperature.ssv">
-    for(pugi::xml_node_iterator it = node.begin(); it != node.end(); ++it)
-    {
-      pugi::xml_node node_elements = it->child(oms::ssp::Draft20180219::ssd::elements);
-      if (node_elements) // insert the parameter bindings before <ssd:Elements>
-      {
-        pugi::xml_node node_parameters_bindings = it->insert_child_before(oms::ssp::Version1_0::ssd::parameter_bindings, node_elements);
-        pugi::xml_node node_parameter_binding  = node_parameters_bindings.append_child(oms::ssp::Version1_0::ssd::parameter_binding);
-        node_parameter_binding.append_attribute("source") = ssvFileName.c_str();
-        break;
-      }
-    }
+    system->exportToSSV(snapshot);
+    // update parameterBindings in ssd
+    pugi::xml_node ssdNode = snapshot.getResourceNode("SystemStructure.ssd");
+    pugi::xml_node system_node = ssdNode.child(oms::ssp::Draft20180219::ssd::system);
+    updateParameterBindingsToSSD(system_node, true);
+    // TODO ssm file
   }
 
-  // signal Filter
-  pugi::xml_document signalFilterdoc;
-  // generate XML declaration for signal filter
-  pugi::xml_node signalFilterNode = signalFilterdoc.append_child(pugi::node_declaration);
-  signalFilterNode.append_attribute("version") = "1.0";
-  signalFilterNode.append_attribute("encoding") = "UTF-8";
-
-  pugi::xml_node oms_signalFilter = signalFilterdoc.append_child(oms::ssp::Version1_0::oms_signalFilter);
-  oms_signalFilter.append_attribute("version") = "1.0";
-
-  exportSignalFilter(oms_signalFilter);
-
-  filesystem::path signalFilterFilePath = filesystem::path(tempDir) / signalFilterFilename;
-  signalFilterdoc.save_file(signalFilterFilePath.string().c_str());
-
-  //doc.save(std::cout);
-
-  if (!doc.save_file(ssdPath.string().c_str()))
-    return logError("failed to export \"" + ssdPath.string() + "\" (for model \"" + std::string(this->getCref()) + "\")");
+  exportSignalFilter(snapshot);
 
   // Usage: minizip [-o] [-a] [-0 to -9] [-p password] [-j] file.zip [files_to_add]
   //        -o  Overwrite existing file.zip
@@ -839,7 +756,8 @@ oms_status_enu_t oms::Model::exportToFile(const std::string& filename) const
   //        -9  Compress better
   //        -j  exclude path. store only the file name
 
-  getAllResources(resources);
+  std::vector<std::string> resources;
+  getAllResources(resources, snapshot);
 
   std::string cd = Scope::GetInstance().getWorkingDirectory();
   Scope::GetInstance().setWorkingDirectory(tempDir);
@@ -862,10 +780,19 @@ oms_status_enu_t oms::Model::exportToFile(const std::string& filename) const
   return oms_status_ok;
 }
 
-void oms::Model::getAllResources(std::vector<std::string>& resources) const
+void oms::Model::getAllResources(std::vector<std::string>& resources, Snapshot& snapshot) const
 {
-  resources.push_back("SystemStructure.ssd");
-  resources.push_back(signalFilterFilename);
+  // get all files from snapshot and save the document (eg.) ssd, ssv and signalFilter
+  snapshot.getResources(resources);
+  for (auto const &filename : resources)
+  {
+    //std::cout << "\n resources Nodes : " << filename;
+    pugi::xml_document doc;
+    doc.append_copy(snapshot.getResourceNode(filename));
+    filesystem::path filepath = filesystem::path(tempDir) /  filename;
+    if (!doc.save_file(filepath.string().c_str()))
+      logError("failed to export \"" + filepath.string() + "\" (for file \"" + filename + "\")");
+  }
 
   if (system)
     system->getAllResources(resources);
@@ -1218,17 +1145,19 @@ oms_status_enu_t oms::Model::removeSignalsFromResults(const char* regex)
   return oms_status_ok;
 }
 
-void oms::Model::exportSignalFilter(pugi::xml_node &node) const
+void oms::Model::exportSignalFilter(Snapshot& snapshot) const
 {
   if (!system)
     return;
+
+  pugi::xml_node oms_signalFilter = snapshot.getTemplateResourceNodeSignalFilter(signalFilterFilename);
 
   std::vector<oms::Connector> filteredSignals;
   system->getFilteredSignals(filteredSignals);
 
   for (auto const& signal : filteredSignals)
   {
-    pugi::xml_node oms_variable = node.append_child(oms::ssp::Version1_0::oms_Variable);
+    pugi::xml_node oms_variable = oms_signalFilter.append_child(oms::ssp::Version1_0::oms_Variable);
     oms_variable.append_attribute("name") = signal.getFullName().c_str();
     oms_variable.append_attribute("type") = signal.getTypeString().c_str();
     oms_variable.append_attribute("kind") = signal.getCausalityString().c_str();

--- a/src/OMSimulatorLib/Model.h
+++ b/src/OMSimulatorLib/Model.h
@@ -73,23 +73,23 @@ namespace oms
     oms_status_enu_t rename(const ComRef& cref, const ComRef& newCref);
     oms_status_enu_t list(const ComRef& cref, char** contents);
     oms_status_enu_t addSystem(const ComRef& cref, oms_system_enu_t type);
-    oms_status_enu_t exportToSSD(pugi::xml_node& node, pugi::xml_node& ssvNode, Snapshot& snapshot) const;
+    oms_status_enu_t exportToSSD(Snapshot& snapshot) const;
     oms_status_enu_t exportSnapshot(const ComRef& cref, char** contents);
     oms_status_enu_t exportSSVTemplate(const ComRef& cref, const std::string& filename);
     oms_status_enu_t exportSSMTemplate(const ComRef& cref, const std::string& filename);
-    void exportSignalFilter(pugi::xml_node &signalfilter) const;
+    void exportSignalFilter(Snapshot& snapshot) const;
     oms_status_enu_t importFromSnapshot(const Snapshot& snapshot);
     oms_status_enu_t importSnapshot(const char* snapshot, char** newCref);
     oms_status_enu_t importSignalFilter(const std::string& filename, const Snapshot& snapshot);
     oms_status_enu_t exportToFile(const std::string& filename) const;
     oms_system_enu_t getSystemType(const pugi::xml_node& node, const std::string& sspVersion);
     oms_system_enu_t getSystemTypeHelper(const pugi::xml_node& node, const std::string& sspVersion);
-    oms_status_enu_t updateParameterBindingsToSSD(pugi::xml_node& node, pugi::xml_node& ssvNode, bool isTopSystemOrModel) const;
+    oms_status_enu_t updateParameterBindingsToSSD(pugi::xml_node& node, bool isTopSystemOrModel) const;
     void copyResources(bool copy_resources) {this->copy_resources = copy_resources;}
     bool copyResources() {return copy_resources;}
 
     oms::Element** getElements() {return &elements[0];}
-    void getAllResources(std::vector<std::string>& resources) const;
+    void getAllResources(std::vector<std::string>& resources, Snapshot& snapshot) const;
 
     oms_status_enu_t instantiate();
     oms_status_enu_t initialize();

--- a/src/OMSimulatorLib/Snapshot.cpp
+++ b/src/OMSimulatorLib/Snapshot.cpp
@@ -179,32 +179,44 @@ void oms::Snapshot::debugPrintAll() const
   doc.save(std::cout, "  ", pugi::format_indent|pugi::format_indent_attributes, pugi::encoding_utf8);
 }
 
-pugi::xml_node oms::Snapshot::getTemplateResourceNodeSSD(const filesystem::path& filename)
+pugi::xml_node oms::Snapshot::getTemplateResourceNodeSSD(const filesystem::path& filename, const ComRef& cref)
 {
   pugi::xml_node new_node = newResourceNode(filename);
-  new_node.append_attribute("xmlns:ssc") = "http://ssp-standard.org/SSP1/SystemStructureCommon";
-  new_node.append_attribute("xmlns:ssd") = "http://ssp-standard.org/SSP1/SystemStructureDescription";
-  new_node.append_attribute("xmlns:ssv") = "http://ssp-standard.org/SSP1/SystemStructureParameterValues";
-  new_node.append_attribute("xmlns:ssm") = "http://ssp-standard.org/SSP1/SystemStructureParameterMapping";
-  new_node.append_attribute("xmlns:ssb") = "http://ssp-standard.org/SSP1/SystemStructureSignalDictionary";
-  new_node.append_attribute("xmlns:oms") = "https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd";
-  // new_node.append_attribute("name") = this->getCref().c_str();
-  new_node.append_attribute("version") = "1.0";
+  pugi::xml_node ssdNode = new_node.append_child(oms::ssp::Draft20180219::ssd::system_structure_description);
+  ssdNode.append_attribute("xmlns:ssc") = "http://ssp-standard.org/SSP1/SystemStructureCommon";
+  ssdNode.append_attribute("xmlns:ssd") = "http://ssp-standard.org/SSP1/SystemStructureDescription";
+  ssdNode.append_attribute("xmlns:ssv") = "http://ssp-standard.org/SSP1/SystemStructureParameterValues";
+  ssdNode.append_attribute("xmlns:ssm") = "http://ssp-standard.org/SSP1/SystemStructureParameterMapping";
+  ssdNode.append_attribute("xmlns:ssb") = "http://ssp-standard.org/SSP1/SystemStructureSignalDictionary";
+  ssdNode.append_attribute("xmlns:oms") = "https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd";
+  ssdNode.append_attribute("name") = cref.c_str();
+  ssdNode.append_attribute("version") = "1.0";
 
-  return new_node;
+  return ssdNode;
 }
 
-pugi::xml_node oms::Snapshot::getTemplateResourceNodeSSV(const filesystem::path& filename)
+pugi::xml_node oms::Snapshot::getTemplateResourceNodeSSV(const filesystem::path& filename, const std::string& cref)
 {
   pugi::xml_node new_node = newResourceNode(filename);
   pugi::xml_node node_parameterset = new_node.append_child(oms::ssp::Version1_0::ssv::parameter_set);
   node_parameterset.append_attribute("xmlns:ssc") = "http://ssp-standard.org/SSP1/SystemStructureCommon";
   node_parameterset.append_attribute("xmlns:ssv") = "http://ssp-standard.org/SSP1/SystemStructureParameterValues";
   node_parameterset.append_attribute("version") = "1.0";
-  node_parameterset.append_attribute("name") = "parameters";
+  node_parameterset.append_attribute("name") = cref.c_str();
   pugi::xml_node node_parameters = node_parameterset.append_child(oms::ssp::Version1_0::ssv::parameters);
 
   return node_parameters;
+}
+
+pugi::xml_node oms::Snapshot::getTemplateResourceNodeSSM(const filesystem::path& filename)
+{
+  pugi::xml_node new_node = newResourceNode(filename);
+  pugi::xml_node node_parameterMapping = new_node.append_child(oms::ssp::Version1_0::ssm::parameter_mapping);
+  node_parameterMapping.append_attribute("xmlns:ssc") = "http://ssp-standard.org/SSP1/SystemStructureCommon";
+  node_parameterMapping.append_attribute("xmlns:ssm") = "http://ssp-standard.org/SSP1/SystemStructureParameterMapping";
+  node_parameterMapping.append_attribute("version") = "1.0";
+
+  return node_parameterMapping;
 }
 
 pugi::xml_node oms::Snapshot::getTemplateResourceNodeSignalFilter(const filesystem::path& filename)

--- a/src/OMSimulatorLib/Snapshot.h
+++ b/src/OMSimulatorLib/Snapshot.h
@@ -62,8 +62,9 @@ namespace oms
     void getResources(std::vector<std::string>& resources) const;
     pugi::xml_node getResourceNode(const filesystem::path& filename) const;
 
-    pugi::xml_node getTemplateResourceNodeSSD(const filesystem::path& filename);
-    pugi::xml_node getTemplateResourceNodeSSV(const filesystem::path& filename);
+    pugi::xml_node getTemplateResourceNodeSSD(const filesystem::path& filename, const ComRef& cref);
+    pugi::xml_node getTemplateResourceNodeSSV(const filesystem::path& filename, const std::string& cref);
+    pugi::xml_node getTemplateResourceNodeSSM(const filesystem::path& filename);
     pugi::xml_node getTemplateResourceNodeSignalFilter(const filesystem::path& filename);
     oms_status_enu_t exportPartialSnapshot(const ComRef& cref, Snapshot& partialSnapshot);
     oms_status_enu_t importPartialSnapshot(const char* fullsnapshot);

--- a/src/OMSimulatorLib/System.cpp
+++ b/src/OMSimulatorLib/System.cpp
@@ -419,6 +419,11 @@ oms_status_enu_t oms::System::exportToSSD(pugi::xml_node& node, Snapshot& snapsh
   {
     values.exportToSSD(node);
   }
+  // export top level parameterBindings in ssv file
+  else if (std::string(node.parent().name()) == oms::ssp::Draft20180219::ssd::system_structure_description)
+  {
+    values.exportParameterBindings(node, parentModel->getCref());
+  }
 
   if (subelements.size() > 1)
   {

--- a/src/OMSimulatorLib/System.h
+++ b/src/OMSimulatorLib/System.h
@@ -96,7 +96,8 @@ namespace oms
     oms_status_enu_t addSubSystem(const ComRef& cref, oms_system_enu_t type);
     oms_status_enu_t addSubModel(const ComRef& cref, const std::string& fmuPath);
     bool validCref(const ComRef& cref);
-    oms_status_enu_t exportToSSD(pugi::xml_node& node, pugi::xml_node& ssvNode, Snapshot& snapshot) const;
+    oms_status_enu_t exportToSSD(pugi::xml_node& node, Snapshot& snapshot) const;
+    oms_status_enu_t exportToSSV(Snapshot& snapshot) const;
     oms_status_enu_t importFromSnapshot(const pugi::xml_node& node, const std::string& sspVersion, const Snapshot& snapshot);
     void setGeometry(const ssd::ElementGeometry& geometry) {element.setGeometry(&geometry);}
     oms_status_enu_t addConnector(const ComRef& cref, oms_causality_enu_t causality, oms_signal_type_enu_t type);

--- a/src/OMSimulatorLib/TLM/ExternalModel.cpp
+++ b/src/OMSimulatorLib/TLM/ExternalModel.cpp
@@ -87,7 +87,7 @@ oms_status_enu_t oms::ExternalModel::getRealParameter(const std::string& var, do
   return oms_status_error;
 }
 
-oms_status_enu_t oms::ExternalModel::exportToSSD(pugi::xml_node& node, pugi::xml_node& ssvNode, Snapshot& snapshot) const
+oms_status_enu_t oms::ExternalModel::exportToSSD(pugi::xml_node& node, Snapshot& snapshot) const
 {
   pugi::xml_node annotations_node = node.append_child(oms::ssp::Draft20180219::ssd::annotations);
   pugi::xml_node annotation_node = annotations_node.append_child(oms::ssp::Version1_0::ssc::annotation);

--- a/src/OMSimulatorLib/TLM/ExternalModel.h
+++ b/src/OMSimulatorLib/TLM/ExternalModel.h
@@ -60,7 +60,7 @@ namespace oms
     const std::string getStartScript() const {return externalModelInfo.getStartScript();}
     const std::map<std::string, oms::Option<double>>& getRealParameters() const {return realParameters;}
 
-    oms_status_enu_t exportToSSD(pugi::xml_node& node, pugi::xml_node& ssvNode, Snapshot& snapshot) const;
+    oms_status_enu_t exportToSSD(pugi::xml_node& node, Snapshot& snapshot) const;
     oms_status_enu_t instantiate();
     oms_status_enu_t initialize();
     oms_status_enu_t terminate();

--- a/src/OMSimulatorLib/Values.cpp
+++ b/src/OMSimulatorLib/Values.cpp
@@ -251,6 +251,14 @@ oms_status_enu_t oms::Values::exportStartValuesHelper(pugi::xml_node& node) cons
   return oms_status_ok;
 }
 
+void oms::Values::exportParameterBindings(pugi::xml_node &node, const ComRef &cref) const
+{
+  pugi::xml_node node_parameters_bindings = node.append_child(oms::ssp::Version1_0::ssd::parameter_bindings);
+  pugi::xml_node node_parameter_binding = node_parameters_bindings.append_child(oms::ssp::Version1_0::ssd::parameter_binding);
+  std::string ssvFileName = "resources/" + std::string(cref) + ".ssv";
+  node_parameter_binding.append_attribute("source") = ssvFileName.c_str();
+}
+
 /*
  * returns mapped cref if entry found associated with parameter mapping,
  * otherwise return the default cref

--- a/src/OMSimulatorLib/Values.h
+++ b/src/OMSimulatorLib/Values.h
@@ -63,6 +63,8 @@ namespace oms
     oms_status_enu_t parseModelDescription(const filesystem::path& root); ///< path without the filename, i.e. modelDescription.xml
     oms_status_enu_t rename(const oms::ComRef& newCref);
 
+    void exportParameterBindings(pugi::xml_node& node, const oms::ComRef& Cref) const;
+
   private:
     oms_status_enu_t exportStartValuesHelper(pugi::xml_node& node) const;
     void exportParameterMappingInline(pugi::xml_node& node) const;

--- a/testsuite/OMSimulator/Makefile
+++ b/testsuite/OMSimulator/Makefile
@@ -10,6 +10,7 @@ exportConnectorsToResultFile.lua \
 exportSSMTemplate.lua \
 exportSSMTemplate.py \
 exportSSVTemplate.lua \
+exportSnapshotSSP.lua \
 import_export_parameters_inline.lua \
 import_export_parameters_to_ssv.lua \
 import_export_signalFilter.lua \

--- a/testsuite/OMSimulator/exportSnapshotSSP.lua
+++ b/testsuite/OMSimulator/exportSnapshotSSP.lua
@@ -1,0 +1,171 @@
+-- status: correct
+-- teardown_command: rm -rf exportsnapshotssp_lua/
+-- linux: yes
+-- mingw: yes
+-- win: no
+-- mac: no
+
+oms_setCommandLineOption("--suppressPath=true --exportParametersInline=false")
+oms_setTempDirectory("./exportsnapshotssp_lua/")
+
+oms_newModel("exportSnapshotSSP")
+
+oms_addSystem("exportSnapshotSSP.root", oms_system_wc)
+oms_addConnector("exportSnapshotSSP.root.Input1", oms_causality_input, oms_signal_type_real)
+oms_setReal("exportSnapshotSSP.root.Input1", 10)
+
+oms_addSubModel("exportSnapshotSSP.root.Gain", "../resources/Modelica.Blocks.Math.Gain.fmu")
+oms_setReal("exportSnapshotSSP.root.Gain.k", 27)
+
+-- snapshot = oms_exportSnapshot("exportSnapshotSSP")
+-- print(snapshot)
+
+oms_export("exportSnapshotSSP", "exportSnapshotSSP.ssp")
+
+oms_terminate("exportSnapshotSSP")
+oms_delete("exportSnapshotSSP")
+
+oms_importFile("exportSnapshotSSP.ssp")
+
+src, status = oms_exportSnapshot("exportSnapshotSSP")
+print(src)
+
+
+-- Result:
+-- <?xml version="1.0"?>
+-- <oms:snapshot
+--   xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
+--   partial="false">
+--   <oms:file
+--     name="SystemStructure.ssd">
+--     <ssd:SystemStructureDescription
+--       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
+--       xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription"
+--       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
+--       xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping"
+--       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
+--       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
+--       name="exportSnapshotSSP"
+--       version="1.0">
+--       <ssd:System
+--         name="root">
+--         <ssd:Connectors>
+--           <ssd:Connector
+--             name="Input1"
+--             kind="input">
+--             <ssc:Real />
+--           </ssd:Connector>
+--         </ssd:Connectors>
+--         <ssd:ParameterBindings>
+--           <ssd:ParameterBinding
+--             source="resources/exportSnapshotSSP.ssv" />
+--         </ssd:ParameterBindings>
+--         <ssd:Elements>
+--           <ssd:Component
+--             name="Gain"
+--             type="application/x-fmu-sharedlibrary"
+--             source="resources/0001_Gain.fmu">
+--             <ssd:Connectors>
+--               <ssd:Connector
+--                 name="u"
+--                 kind="input">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="0.000000"
+--                   y="0.500000" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="y"
+--                 kind="output">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="1.000000"
+--                   y="0.500000" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="k"
+--                 kind="parameter">
+--                 <ssc:Real />
+--               </ssd:Connector>
+--             </ssd:Connectors>
+--           </ssd:Component>
+--         </ssd:Elements>
+--         <ssd:Annotations>
+--           <ssc:Annotation
+--             type="org.openmodelica">
+--             <oms:Annotations>
+--               <oms:SimulationInformation>
+--                 <oms:FixedStepMaster
+--                   description="oms-ma"
+--                   stepSize="0.100000"
+--                   absoluteTolerance="0.000100"
+--                   relativeTolerance="0.000100" />
+--               </oms:SimulationInformation>
+--             </oms:Annotations>
+--           </ssc:Annotation>
+--         </ssd:Annotations>
+--       </ssd:System>
+--       <ssd:DefaultExperiment
+--         startTime="0.000000"
+--         stopTime="1.000000">
+--         <ssd:Annotations>
+--           <ssc:Annotation
+--             type="org.openmodelica">
+--             <oms:Annotations>
+--               <oms:SimulationInformation
+--                 resultFile="exportSnapshotSSP_res.mat"
+--                 loggingInterval="0.000000"
+--                 bufferSize="10"
+--                 signalFilter="resources/signalFilter.xml" />
+--             </oms:Annotations>
+--           </ssc:Annotation>
+--         </ssd:Annotations>
+--       </ssd:DefaultExperiment>
+--     </ssd:SystemStructureDescription>
+--   </oms:file>
+--   <oms:file
+--     name="resources/exportSnapshotSSP.ssv">
+--     <ssv:ParameterSet
+--       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
+--       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
+--       version="1.0"
+--       name="parameters">
+--       <ssv:Parameters>
+--         <ssv:Parameter
+--           name="Input1">
+--           <ssv:Real
+--             value="10" />
+--         </ssv:Parameter>
+--         <ssv:Parameter
+--           name="Gain.k">
+--           <ssv:Real
+--             value="27" />
+--         </ssv:Parameter>
+--       </ssv:Parameters>
+--     </ssv:ParameterSet>
+--   </oms:file>
+--   <oms:file
+--     name="resources/signalFilter.xml">
+--     <oms:SignalFilter
+--       version="1.0">
+--       <oms:Variable
+--         name="exportSnapshotSSP.root.Input1"
+--         type="Real"
+--         kind="input" />
+--       <oms:Variable
+--         name="exportSnapshotSSP.root.Gain.u"
+--         type="Real"
+--         kind="input" />
+--       <oms:Variable
+--         name="exportSnapshotSSP.root.Gain.y"
+--         type="Real"
+--         kind="output" />
+--       <oms:Variable
+--         name="exportSnapshotSSP.root.Gain.k"
+--         type="Real"
+--         kind="parameter" />
+--     </oms:SignalFilter>
+--   </oms:file>
+-- </oms:snapshot>
+--
+-- endResult


### PR DESCRIPTION
### Purpose

The PR implements the exporting of `SSPs` and `snapshots` to fully use the `snapshot class interface` which simplifies the code. Also this PR simplifies the exporting of SSV files.

### Multiple SSV files 
Currently we generate one top level `SSV` file for the whole model, This could be extended to generate multiple `SSV` files at different level.