### PR TITLE
fix connectors when renaming model

### DIFF
--- a/src/OMSimulatorLib/Model.cpp
+++ b/src/OMSimulatorLib/Model.cpp
@@ -121,9 +121,11 @@ oms_status_enu_t oms::Model::rename(const oms::ComRef& cref)
   this->cref = cref;
 
   if (system)
+  {
     system->renameConnectors();
     for (const auto & it:system->getSubSystems())
       it.second->renameConnectors();
+  }
 
   return oms_status_ok;
 }

--- a/src/OMSimulatorLib/Model.cpp
+++ b/src/OMSimulatorLib/Model.cpp
@@ -119,6 +119,7 @@ oms_status_enu_t oms::Model::rename(const oms::ComRef& cref)
     return logError(std::string(cref) + " is not a valid ident");
 
   this->cref = cref;
+  system->renameConnectors();
   return oms_status_ok;
 }
 

--- a/src/OMSimulatorLib/Model.cpp
+++ b/src/OMSimulatorLib/Model.cpp
@@ -119,7 +119,12 @@ oms_status_enu_t oms::Model::rename(const oms::ComRef& cref)
     return logError(std::string(cref) + " is not a valid ident");
 
   this->cref = cref;
-  system->renameConnectors();
+
+  if (system)
+    system->renameConnectors();
+    for (const auto & it:system->getSubSystems())
+      it.second->renameConnectors();
+
   return oms_status_ok;
 }
 

--- a/testsuite/OMSimulator/Makefile
+++ b/testsuite/OMSimulator/Makefile
@@ -27,6 +27,7 @@ partialSnapshot.lua \
 PI_Controller.lua \
 QuarterCarModel.DisplacementDisplacement.lua \
 rename.lua \
+renameModel.lua \
 renameSnapshot.lua \
 renameNewCref.lua \
 setExternalInputs.lua \

--- a/testsuite/OMSimulator/renameModel.lua
+++ b/testsuite/OMSimulator/renameModel.lua
@@ -14,6 +14,11 @@ oms_addSystem("model.root", oms_system_wc)
 oms_addConnector("model.root.input1", oms_causality_input, oms_signal_type_real)
 oms_addConnector("model.root.output", oms_causality_output, oms_signal_type_real)
 
+oms_addSystem("model.root.System1", oms_system_sc)
+oms_addConnector("model.root.System1.input1", oms_causality_input, oms_signal_type_real)
+
+oms_addSubModel("model.root.add", "../resources/Modelica.Blocks.Math.Add.fmu")
+
 oms_rename("model", "model_3")
 
 src = oms_exportSnapshot("model_3")
@@ -50,6 +55,75 @@ print(src)
 --             <ssc:Real />
 --           </ssd:Connector>
 --         </ssd:Connectors>
+--         <ssd:Elements>
+--           <ssd:System
+--             name="System1">
+--             <ssd:Connectors>
+--               <ssd:Connector
+--                 name="input1"
+--                 kind="input">
+--                 <ssc:Real />
+--               </ssd:Connector>
+--             </ssd:Connectors>
+--             <ssd:Annotations>
+--               <ssc:Annotation
+--                 type="org.openmodelica">
+--                 <oms:Annotations>
+--                   <oms:SimulationInformation>
+--                     <oms:VariableStepSolver
+--                       description="cvode"
+--                       absoluteTolerance="0.000100"
+--                       relativeTolerance="0.000100"
+--                       minimumStepSize="0.000100"
+--                       maximumStepSize="0.100000"
+--                       initialStepSize="0.000100" />
+--                   </oms:SimulationInformation>
+--                 </oms:Annotations>
+--               </ssc:Annotation>
+--             </ssd:Annotations>
+--           </ssd:System>
+--           <ssd:Component
+--             name="add"
+--             type="application/x-fmu-sharedlibrary"
+--             source="resources/0001_add.fmu">
+--             <ssd:Connectors>
+--               <ssd:Connector
+--                 name="u1"
+--                 kind="input">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="0.000000"
+--                   y="0.333333" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="u2"
+--                 kind="input">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="0.000000"
+--                   y="0.666667" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="y"
+--                 kind="output">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="1.000000"
+--                   y="0.500000" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="k1"
+--                 kind="parameter">
+--                 <ssc:Real />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="k2"
+--                 kind="parameter">
+--                 <ssc:Real />
+--               </ssd:Connector>
+--             </ssd:Connectors>
+--           </ssd:Component>
+--         </ssd:Elements>
 --         <ssd:Annotations>
 --           <ssc:Annotation
 --             type="org.openmodelica">
@@ -95,6 +169,30 @@ print(src)
 --         name="model_3.root.output"
 --         type="Real"
 --         kind="output" />
+--       <oms:Variable
+--         name="model_3.root.add.u1"
+--         type="Real"
+--         kind="input" />
+--       <oms:Variable
+--         name="model_3.root.add.u2"
+--         type="Real"
+--         kind="input" />
+--       <oms:Variable
+--         name="model_3.root.add.y"
+--         type="Real"
+--         kind="output" />
+--       <oms:Variable
+--         name="model_3.root.add.k1"
+--         type="Real"
+--         kind="parameter" />
+--       <oms:Variable
+--         name="model_3.root.add.k2"
+--         type="Real"
+--         kind="parameter" />
+--       <oms:Variable
+--         name="model_3.root.System1.input1"
+--         type="Real"
+--         kind="input" />
 --     </oms:SignalFilter>
 --   </oms:file>
 -- </oms:snapshot>

--- a/testsuite/OMSimulator/renameModel.lua
+++ b/testsuite/OMSimulator/renameModel.lua
@@ -1,0 +1,102 @@
+-- status: correct
+-- teardown_command: rm -rf rename_model
+-- linux: yes
+-- mingw: yes
+-- win: no
+-- mac: no
+
+oms_setCommandLineOption("--suppressPath=true")
+oms_setTempDirectory("./rename_model/")
+
+oms_newModel("model")
+
+oms_addSystem("model.root", oms_system_wc)
+oms_addConnector("model.root.input1", oms_causality_input, oms_signal_type_real)
+oms_addConnector("model.root.output", oms_causality_output, oms_signal_type_real)
+
+oms_rename("model", "model_3")
+
+src = oms_exportSnapshot("model_3")
+print(src)
+
+
+-- Result:
+-- <?xml version="1.0"?>
+-- <oms:snapshot
+--   xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
+--   partial="false">
+--   <oms:file
+--     name="SystemStructure.ssd">
+--     <ssd:SystemStructureDescription
+--       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
+--       xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription"
+--       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
+--       xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping"
+--       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
+--       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
+--       name="model_3"
+--       version="1.0">
+--       <ssd:System
+--         name="root">
+--         <ssd:Connectors>
+--           <ssd:Connector
+--             name="input1"
+--             kind="input">
+--             <ssc:Real />
+--           </ssd:Connector>
+--           <ssd:Connector
+--             name="output"
+--             kind="output">
+--             <ssc:Real />
+--           </ssd:Connector>
+--         </ssd:Connectors>
+--         <ssd:Annotations>
+--           <ssc:Annotation
+--             type="org.openmodelica">
+--             <oms:Annotations>
+--               <oms:SimulationInformation>
+--                 <oms:FixedStepMaster
+--                   description="oms-ma"
+--                   stepSize="0.100000"
+--                   absoluteTolerance="0.000100"
+--                   relativeTolerance="0.000100" />
+--               </oms:SimulationInformation>
+--             </oms:Annotations>
+--           </ssc:Annotation>
+--         </ssd:Annotations>
+--       </ssd:System>
+--       <ssd:DefaultExperiment
+--         startTime="0.000000"
+--         stopTime="1.000000">
+--         <ssd:Annotations>
+--           <ssc:Annotation
+--             type="org.openmodelica">
+--             <oms:Annotations>
+--               <oms:SimulationInformation
+--                 resultFile="model_res.mat"
+--                 loggingInterval="0.000000"
+--                 bufferSize="10"
+--                 signalFilter="resources/signalFilter.xml" />
+--             </oms:Annotations>
+--           </ssc:Annotation>
+--         </ssd:Annotations>
+--       </ssd:DefaultExperiment>
+--     </ssd:SystemStructureDescription>
+--   </oms:file>
+--   <oms:file
+--     name="resources/signalFilter.xml">
+--     <oms:SignalFilter
+--       version="1.0">
+--       <oms:Variable
+--         name="model_3.root.input1"
+--         type="Real"
+--         kind="input" />
+--       <oms:Variable
+--         name="model_3.root.output"
+--         type="Real"
+--         kind="output" />
+--     </oms:SignalFilter>
+--   </oms:file>
+-- </oms:snapshot>
+--
+-- endResult


### PR DESCRIPTION
### Related Issues

https://github.com/OpenModelica/OMSimulator/issues/1008

### Purpose

This PR fixes the `connectors` when renaming the `model` 

