### PR TITLE
fix bug in renaming values

### DIFF
--- a/src/OMSimulatorLib/Component.cpp
+++ b/src/OMSimulatorLib/Component.cpp
@@ -232,7 +232,8 @@ oms_status_enu_t oms::Component::deleteConnector(const ComRef& cref)
 
 oms_status_enu_t oms::Component::rename(const oms::ComRef& newCref)
 {
+  ComRef oldCref = this->cref;
   this->cref = newCref;
-  this->renameValues(newCref); // rename values in ssv files (only for FMUs)
+  this->renameValues(oldCref, newCref); // rename values in ssv files (only for FMUs)
   return oms_status_ok;
 }

--- a/src/OMSimulatorLib/Component.h
+++ b/src/OMSimulatorLib/Component.h
@@ -130,7 +130,7 @@ namespace oms
     Component(Component const&);            ///< not implemented
     Component& operator=(Component const&); ///< not implemented
 
-    virtual oms_status_enu_t renameValues(const ComRef& newCref) { return oms_status_ok; }
+    virtual oms_status_enu_t renameValues(const ComRef& oldCref, const ComRef& newCref) { return oms_status_ok; }
 
   protected:
     DirectedGraph initialUnknownsGraph;

--- a/src/OMSimulatorLib/ComponentFMUCS.cpp
+++ b/src/OMSimulatorLib/ComponentFMUCS.cpp
@@ -1250,7 +1250,7 @@ void oms::ComponentFMUCS::getFilteredSignals(std::vector<Connector>& filteredSig
   }
 }
 
-oms_status_enu_t oms::ComponentFMUCS::renameValues(const ComRef& newCref)
+oms_status_enu_t oms::ComponentFMUCS::renameValues(const ComRef& oldCref, const ComRef& newCref)
 {
-  return values.rename(newCref);
+  return values.rename(oldCref, newCref);
 }

--- a/src/OMSimulatorLib/ComponentFMUCS.h
+++ b/src/OMSimulatorLib/ComponentFMUCS.h
@@ -117,7 +117,7 @@ namespace oms
     ComponentFMUCS(ComponentFMUCS const& copy);            ///< not implemented
     ComponentFMUCS& operator=(ComponentFMUCS const& copy); ///< not implemented
 
-    oms_status_enu_t renameValues(const ComRef& newCref);
+    oms_status_enu_t renameValues(const ComRef& oldCref, const ComRef& newCref);
 
   private:
     jm_callbacks callbacks;

--- a/src/OMSimulatorLib/ComponentFMUME.cpp
+++ b/src/OMSimulatorLib/ComponentFMUME.cpp
@@ -1209,7 +1209,7 @@ void oms::ComponentFMUME::getFilteredSignals(std::vector<Connector>& filteredSig
   }
 }
 
-oms_status_enu_t oms::ComponentFMUME::renameValues(const ComRef& newCref)
+oms_status_enu_t oms::ComponentFMUME::renameValues(const ComRef& oldCref, const ComRef& newCref)
 {
-  return values.rename(newCref);
+  return values.rename(oldCref, newCref);
 }

--- a/src/OMSimulatorLib/ComponentFMUME.h
+++ b/src/OMSimulatorLib/ComponentFMUME.h
@@ -114,7 +114,7 @@ namespace oms
     ComponentFMUME(ComponentFMUME const& copy);            ///< not implemented
     ComponentFMUME& operator=(ComponentFMUME const& copy); ///< not implemented
 
-    oms_status_enu_t renameValues(const ComRef& newCref);
+    oms_status_enu_t renameValues(const ComRef& oldCref, const ComRef& newCref);
 
   private:
     jm_callbacks callbacks;

--- a/src/OMSimulatorLib/System.cpp
+++ b/src/OMSimulatorLib/System.cpp
@@ -2579,7 +2579,7 @@ oms_status_enu_t oms::System::rename(const ComRef& cref, const ComRef& newCref)
   if (subsystem != subsystems.end())
   {
     subsystem->second->rename(tail, newCref);
-    subsystem->second->values.rename(newCref);
+    subsystem->second->values.rename(cref, newCref);
     this->renameConnections(cref, newCref);
     subsystems[newCref] = subsystem->second;
     subsystems.erase(subsystem);  // delete the old cref from the lookup

--- a/src/OMSimulatorLib/Values.cpp
+++ b/src/OMSimulatorLib/Values.cpp
@@ -503,30 +503,39 @@ void oms::Values::importParameterMapping(const pugi::xml_node& parameterMapping)
   }
 }
 
-oms_status_enu_t oms::Values::rename(const oms::ComRef& newCref)
+oms_status_enu_t oms::Values::rename(const oms::ComRef& oldCref, const oms::ComRef& newCref)
 {
   for (const auto &r : realStartValues)
   {
     ComRef tail(r.first);
     ComRef front = tail.pop_front();
-    realStartValues[newCref + tail] = r.second; // update the newCref
-    realStartValues.erase(r.first); // delete the old cref
+    if (oldCref == front)
+    {
+      realStartValues[newCref + tail] = r.second; // update the newCref
+      realStartValues.erase(r.first); // delete the old cref
+    }
   }
 
   for (const auto &i : integerStartValues)
   {
     ComRef tail(i.first);
     ComRef front = tail.pop_front();
-    integerStartValues[newCref + tail] = i.second; // update the newCref
-    integerStartValues.erase(i.first); // delete the old cref
+    if (oldCref == front)
+    {
+      integerStartValues[newCref + tail] = i.second; // update the newCref
+      integerStartValues.erase(i.first);             // delete the old cref
+    }
   }
 
   for (const auto &b : booleanStartValues)
   {
     ComRef tail(b.first);
     ComRef front = tail.pop_front();
-    integerStartValues[newCref + tail] = b.second; // update the newCref
-    integerStartValues.erase(b.first); // delete the old cref
+    if (oldCref == front)
+    {
+      booleanStartValues[newCref + tail] = b.second; // update the newCref
+      booleanStartValues.erase(b.first);             // delete the old cref
+    }
   }
 
   return oms_status_ok;

--- a/src/OMSimulatorLib/Values.h
+++ b/src/OMSimulatorLib/Values.h
@@ -61,7 +61,7 @@ namespace oms
     oms_status_enu_t exportToSSMTemplate(pugi::xml_node& ssmNode, const ComRef& cref);  ///< start values read from modelDescription.xml and creates a ssm template
 
     oms_status_enu_t parseModelDescription(const filesystem::path& root); ///< path without the filename, i.e. modelDescription.xml
-    oms_status_enu_t rename(const oms::ComRef& newCref);
+    oms_status_enu_t rename(const oms::ComRef& oldCref, const oms::ComRef& newCref);
 
     void exportParameterBindings(pugi::xml_node& node, const oms::ComRef& Cref) const;
 

--- a/testsuite/OMSimulator/Makefile
+++ b/testsuite/OMSimulator/Makefile
@@ -28,6 +28,8 @@ partialSnapshot.lua \
 PI_Controller.lua \
 QuarterCarModel.DisplacementDisplacement.lua \
 rename.lua \
+renameValues1.lua \
+renameValues2.lua \
 renameModel.lua \
 renameSnapshot.lua \
 renameNewCref.lua \

--- a/testsuite/OMSimulator/renameSnapshot.lua
+++ b/testsuite/OMSimulator/renameSnapshot.lua
@@ -797,6 +797,11 @@ print(snapshot)
 --             value="-20" />
 --         </ssv:Parameter>
 --         <ssv:Parameter
+--           name="add_1.u1">
+--           <ssv:Real
+--             value="10" />
+--         </ssv:Parameter>
+--         <ssv:Parameter
 --           name="add_1.k1">
 --           <ssv:Real
 --             value="30" />

--- a/testsuite/OMSimulator/renameValues1.lua
+++ b/testsuite/OMSimulator/renameValues1.lua
@@ -1,0 +1,336 @@
+-- status: correct
+-- teardown_command: rm -rf rename_values_01_lua/
+-- linux: yes
+-- mingw: yes
+-- win: no
+-- mac: no
+
+
+oms_setCommandLineOption("--suppressPath=true --exportParametersInline=false")
+oms_setTempDirectory("./rename_values_01_lua/")
+
+oms_newModel("renamevalues")
+oms_addSystem("renamevalues.root", oms_system_wc)
+
+oms_addSystem("renamevalues.root.system1", oms_system_sc)
+
+oms_addConnector("renamevalues.root.system1.k1", oms_causality_parameter, oms_signal_type_real)
+oms_setReal("renamevalues.root.system1.k1", -10)
+
+oms_addSubModel("renamevalues.root.add_1", "../resources/Modelica.Blocks.Math.Add.fmu")
+oms_setReal("renamevalues.root.add_1.k1", 10)
+oms_setReal("renamevalues.root.add_1.k2", 20)
+oms_setReal("renamevalues.root.add_1.u1", 40)
+
+oms_addSubModel("renamevalues.root.add_2", "../resources/Modelica.Blocks.Math.Add.fmu")
+
+oms_addConnection("renamevalues.root.add_1.y", "renamevalues.root.add_2.u1")
+
+oms_export("renamevalues", "renamevalues1.ssp")
+
+oms_terminate("renamevalues")
+oms_delete("renamevalues")
+
+oms_importFile("renamevalues1.ssp")
+
+oms_rename("renamevalues.root.add_1", "add_3")
+oms_rename("renamevalues.root.system1", "system2")
+
+src = oms_exportSnapshot("renamevalues")
+print(src)
+
+oms_instantiate("renamevalues")
+print("info:      Instantiation")
+print("info:      renamevalues.root.system2.k1     : " .. oms_getReal("renamevalues.root.system2.k1"))
+print("info:      renamevalues.root.add_3.k1       : " .. oms_getReal("renamevalues.root.add_3.k1"))
+print("info:      renamevalues.root.add_3.k2       : " .. oms_getReal("renamevalues.root.add_3.k2"))
+print("info:      renamevalues.root.add_3.u1       : " .. oms_getReal("renamevalues.root.add_3.u1"))
+
+oms_initialize("renamevalues")
+print("info:      Initialization")
+print("info:      renamevalues.root.system2.k1     : " .. oms_getReal("renamevalues.root.system2.k1"))
+print("info:      renamevalues.root.add_3.k1       : " .. oms_getReal("renamevalues.root.add_3.k1"))
+print("info:      renamevalues.root.add_3.k2       : " .. oms_getReal("renamevalues.root.add_3.k2"))
+print("info:      renamevalues.root.add_3.u1       : " .. oms_getReal("renamevalues.root.add_3.u1"))
+
+oms_simulate("renamevalues")
+print("info:      Simulation")
+print("info:      renamevalues.root.system2.k1     : " .. oms_getReal("renamevalues.root.system2.k1"))
+print("info:      renamevalues.root.add_3.k1       : " .. oms_getReal("renamevalues.root.add_3.k1"))
+print("info:      renamevalues.root.add_3.k2       : " .. oms_getReal("renamevalues.root.add_3.k2"))
+print("info:      renamevalues.root.add_3.u1       : " .. oms_getReal("renamevalues.root.add_3.u1"))
+
+
+-- Result:
+-- <?xml version="1.0"?>
+-- <oms:snapshot
+--   xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
+--   partial="false">
+--   <oms:file
+--     name="SystemStructure.ssd">
+--     <ssd:SystemStructureDescription
+--       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
+--       xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription"
+--       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
+--       xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping"
+--       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
+--       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
+--       name="renamevalues"
+--       version="1.0">
+--       <ssd:System
+--         name="root">
+--         <ssd:ParameterBindings>
+--           <ssd:ParameterBinding
+--             source="resources/renamevalues.ssv" />
+--         </ssd:ParameterBindings>
+--         <ssd:Elements>
+--           <ssd:System
+--             name="system2">
+--             <ssd:Connectors>
+--               <ssd:Connector
+--                 name="k1"
+--                 kind="parameter">
+--                 <ssc:Real />
+--               </ssd:Connector>
+--             </ssd:Connectors>
+--             <ssd:Annotations>
+--               <ssc:Annotation
+--                 type="org.openmodelica">
+--                 <oms:Annotations>
+--                   <oms:SimulationInformation>
+--                     <oms:VariableStepSolver
+--                       description="cvode"
+--                       absoluteTolerance="0.000100"
+--                       relativeTolerance="0.000100"
+--                       minimumStepSize="0.000100"
+--                       maximumStepSize="0.100000"
+--                       initialStepSize="0.000100" />
+--                   </oms:SimulationInformation>
+--                 </oms:Annotations>
+--               </ssc:Annotation>
+--             </ssd:Annotations>
+--           </ssd:System>
+--           <ssd:Component
+--             name="add_3"
+--             type="application/x-fmu-sharedlibrary"
+--             source="resources/0001_add_1.fmu">
+--             <ssd:Connectors>
+--               <ssd:Connector
+--                 name="u1"
+--                 kind="input">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="0.000000"
+--                   y="0.333333" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="u2"
+--                 kind="input">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="0.000000"
+--                   y="0.666667" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="y"
+--                 kind="output">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="1.000000"
+--                   y="0.500000" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="k1"
+--                 kind="parameter">
+--                 <ssc:Real />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="k2"
+--                 kind="parameter">
+--                 <ssc:Real />
+--               </ssd:Connector>
+--             </ssd:Connectors>
+--           </ssd:Component>
+--           <ssd:Component
+--             name="add_2"
+--             type="application/x-fmu-sharedlibrary"
+--             source="resources/0002_add_2.fmu">
+--             <ssd:Connectors>
+--               <ssd:Connector
+--                 name="u1"
+--                 kind="input">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="0.000000"
+--                   y="0.333333" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="u2"
+--                 kind="input">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="0.000000"
+--                   y="0.666667" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="y"
+--                 kind="output">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="1.000000"
+--                   y="0.500000" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="k1"
+--                 kind="parameter">
+--                 <ssc:Real />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="k2"
+--                 kind="parameter">
+--                 <ssc:Real />
+--               </ssd:Connector>
+--             </ssd:Connectors>
+--           </ssd:Component>
+--         </ssd:Elements>
+--         <ssd:Connections>
+--           <ssd:Connection
+--             startElement="add_3"
+--             startConnector="y"
+--             endElement="add_2"
+--             endConnector="u1" />
+--         </ssd:Connections>
+--         <ssd:Annotations>
+--           <ssc:Annotation
+--             type="org.openmodelica">
+--             <oms:Annotations>
+--               <oms:SimulationInformation>
+--                 <oms:FixedStepMaster
+--                   description="oms-ma"
+--                   stepSize="0.100000"
+--                   absoluteTolerance="0.000100"
+--                   relativeTolerance="0.000100" />
+--               </oms:SimulationInformation>
+--             </oms:Annotations>
+--           </ssc:Annotation>
+--         </ssd:Annotations>
+--       </ssd:System>
+--       <ssd:DefaultExperiment
+--         startTime="0.000000"
+--         stopTime="1.000000">
+--         <ssd:Annotations>
+--           <ssc:Annotation
+--             type="org.openmodelica">
+--             <oms:Annotations>
+--               <oms:SimulationInformation
+--                 resultFile="renamevalues_res.mat"
+--                 loggingInterval="0.000000"
+--                 bufferSize="10"
+--                 signalFilter="resources/signalFilter.xml" />
+--             </oms:Annotations>
+--           </ssc:Annotation>
+--         </ssd:Annotations>
+--       </ssd:DefaultExperiment>
+--     </ssd:SystemStructureDescription>
+--   </oms:file>
+--   <oms:file
+--     name="resources/renamevalues.ssv">
+--     <ssv:ParameterSet
+--       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
+--       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
+--       version="1.0"
+--       name="parameters">
+--       <ssv:Parameters>
+--         <ssv:Parameter
+--           name="system2.k1">
+--           <ssv:Real
+--             value="-10" />
+--         </ssv:Parameter>
+--         <ssv:Parameter
+--           name="add_3.u1">
+--           <ssv:Real
+--             value="40" />
+--         </ssv:Parameter>
+--         <ssv:Parameter
+--           name="add_3.k2">
+--           <ssv:Real
+--             value="20" />
+--         </ssv:Parameter>
+--         <ssv:Parameter
+--           name="add_3.k1">
+--           <ssv:Real
+--             value="10" />
+--         </ssv:Parameter>
+--       </ssv:Parameters>
+--     </ssv:ParameterSet>
+--   </oms:file>
+--   <oms:file
+--     name="resources/signalFilter.xml">
+--     <oms:SignalFilter
+--       version="1.0">
+--       <oms:Variable
+--         name="renamevalues.root.add_3.u1"
+--         type="Real"
+--         kind="input" />
+--       <oms:Variable
+--         name="renamevalues.root.add_3.u2"
+--         type="Real"
+--         kind="input" />
+--       <oms:Variable
+--         name="renamevalues.root.add_3.y"
+--         type="Real"
+--         kind="output" />
+--       <oms:Variable
+--         name="renamevalues.root.add_3.k1"
+--         type="Real"
+--         kind="parameter" />
+--       <oms:Variable
+--         name="renamevalues.root.add_3.k2"
+--         type="Real"
+--         kind="parameter" />
+--       <oms:Variable
+--         name="renamevalues.root.add_2.u1"
+--         type="Real"
+--         kind="input" />
+--       <oms:Variable
+--         name="renamevalues.root.add_2.u2"
+--         type="Real"
+--         kind="input" />
+--       <oms:Variable
+--         name="renamevalues.root.add_2.y"
+--         type="Real"
+--         kind="output" />
+--       <oms:Variable
+--         name="renamevalues.root.add_2.k1"
+--         type="Real"
+--         kind="parameter" />
+--       <oms:Variable
+--         name="renamevalues.root.add_2.k2"
+--         type="Real"
+--         kind="parameter" />
+--       <oms:Variable
+--         name="renamevalues.root.system2.k1"
+--         type="Real"
+--         kind="parameter" />
+--     </oms:SignalFilter>
+--   </oms:file>
+-- </oms:snapshot>
+--
+-- info:    model doesn't contain any continuous state
+-- info:      Instantiation
+-- info:      renamevalues.root.system2.k1     : -10.0
+-- info:      renamevalues.root.add_3.k1       : 10.0
+-- info:      renamevalues.root.add_3.k2       : 20.0
+-- info:      renamevalues.root.add_3.u1       : 40.0
+-- info:    Result file: renamevalues_res.mat (bufferSize=10)
+-- info:      Initialization
+-- info:      renamevalues.root.system2.k1     : -10.0
+-- info:      renamevalues.root.add_3.k1       : 10.0
+-- info:      renamevalues.root.add_3.k2       : 20.0
+-- info:      renamevalues.root.add_3.u1       : 40.0
+-- info:      Simulation
+-- info:      renamevalues.root.system2.k1     : -10.0
+-- info:      renamevalues.root.add_3.k1       : 10.0
+-- info:      renamevalues.root.add_3.k2       : 20.0
+-- info:      renamevalues.root.add_3.u1       : 40.0
+-- endResult

--- a/testsuite/OMSimulator/renameValues2.lua
+++ b/testsuite/OMSimulator/renameValues2.lua
@@ -1,0 +1,345 @@
+-- status: correct
+-- teardown_command: rm -rf rename_values_02_lua/
+-- linux: yes
+-- mingw: yes
+-- win: no
+-- mac: no
+
+
+oms_setCommandLineOption("--suppressPath=true")
+oms_setTempDirectory("./rename_values_02_lua/")
+
+oms_newModel("renamevalues")
+oms_addSystem("renamevalues.root", oms_system_wc)
+
+oms_addSystem("renamevalues.root.system1", oms_system_sc)
+
+oms_addConnector("renamevalues.root.system1.k1", oms_causality_parameter, oms_signal_type_real)
+oms_setReal("renamevalues.root.system1.k1", -10)
+
+oms_addSubModel("renamevalues.root.add_1", "../resources/Modelica.Blocks.Math.Add.fmu")
+oms_setReal("renamevalues.root.add_1.k1", 10)
+oms_setReal("renamevalues.root.add_1.k2", 20)
+oms_setReal("renamevalues.root.add_1.u1", 40)
+
+oms_addSubModel("renamevalues.root.add_2", "../resources/Modelica.Blocks.Math.Add.fmu")
+
+oms_addConnection("renamevalues.root.add_1.y", "renamevalues.root.add_2.u1")
+
+oms_export("renamevalues", "renamevalues2.ssp")
+
+oms_terminate("renamevalues")
+oms_delete("renamevalues")
+
+oms_importFile("renamevalues2.ssp")
+
+oms_rename("renamevalues.root.add_1", "add_3")
+oms_rename("renamevalues.root.system1", "system2")
+
+src = oms_exportSnapshot("renamevalues")
+print(src)
+
+oms_instantiate("renamevalues")
+print("info:      Instantiation")
+print("info:      renamevalues.root.system2.k1     : " .. oms_getReal("renamevalues.root.system2.k1"))
+print("info:      renamevalues.root.add_3.k1       : " .. oms_getReal("renamevalues.root.add_3.k1"))
+print("info:      renamevalues.root.add_3.k2       : " .. oms_getReal("renamevalues.root.add_3.k2"))
+print("info:      renamevalues.root.add_3.u1       : " .. oms_getReal("renamevalues.root.add_3.u1"))
+
+oms_initialize("renamevalues")
+print("info:      Initialization")
+print("info:      renamevalues.root.system2.k1     : " .. oms_getReal("renamevalues.root.system2.k1"))
+print("info:      renamevalues.root.add_3.k1       : " .. oms_getReal("renamevalues.root.add_3.k1"))
+print("info:      renamevalues.root.add_3.k2       : " .. oms_getReal("renamevalues.root.add_3.k2"))
+print("info:      renamevalues.root.add_3.u1       : " .. oms_getReal("renamevalues.root.add_3.u1"))
+
+oms_simulate("renamevalues")
+print("info:      Simulation")
+print("info:      renamevalues.root.system2.k1     : " .. oms_getReal("renamevalues.root.system2.k1"))
+print("info:      renamevalues.root.add_3.k1       : " .. oms_getReal("renamevalues.root.add_3.k1"))
+print("info:      renamevalues.root.add_3.k2       : " .. oms_getReal("renamevalues.root.add_3.k2"))
+print("info:      renamevalues.root.add_3.u1       : " .. oms_getReal("renamevalues.root.add_3.u1"))
+
+
+-- Result:
+-- <?xml version="1.0"?>
+-- <oms:snapshot
+--   xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
+--   partial="false">
+--   <oms:file
+--     name="SystemStructure.ssd">
+--     <ssd:SystemStructureDescription
+--       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
+--       xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription"
+--       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
+--       xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping"
+--       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
+--       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
+--       name="renamevalues"
+--       version="1.0">
+--       <ssd:System
+--         name="root">
+--         <ssd:Elements>
+--           <ssd:System
+--             name="system2">
+--             <ssd:Connectors>
+--               <ssd:Connector
+--                 name="k1"
+--                 kind="parameter">
+--                 <ssc:Real />
+--               </ssd:Connector>
+--             </ssd:Connectors>
+--             <ssd:ParameterBindings>
+--               <ssd:ParameterBinding>
+--                 <ssd:ParameterValues>
+--                   <ssv:ParameterSet
+--                     version="1.0"
+--                     name="parameters">
+--                     <ssv:Parameters>
+--                       <ssv:Parameter
+--                         name="k1">
+--                         <ssv:Real
+--                           value="-10" />
+--                       </ssv:Parameter>
+--                     </ssv:Parameters>
+--                   </ssv:ParameterSet>
+--                 </ssd:ParameterValues>
+--               </ssd:ParameterBinding>
+--             </ssd:ParameterBindings>
+--             <ssd:Annotations>
+--               <ssc:Annotation
+--                 type="org.openmodelica">
+--                 <oms:Annotations>
+--                   <oms:SimulationInformation>
+--                     <oms:VariableStepSolver
+--                       description="cvode"
+--                       absoluteTolerance="0.000100"
+--                       relativeTolerance="0.000100"
+--                       minimumStepSize="0.000100"
+--                       maximumStepSize="0.100000"
+--                       initialStepSize="0.000100" />
+--                   </oms:SimulationInformation>
+--                 </oms:Annotations>
+--               </ssc:Annotation>
+--             </ssd:Annotations>
+--           </ssd:System>
+--           <ssd:Component
+--             name="add_3"
+--             type="application/x-fmu-sharedlibrary"
+--             source="resources/0001_add_1.fmu">
+--             <ssd:Connectors>
+--               <ssd:Connector
+--                 name="u1"
+--                 kind="input">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="0.000000"
+--                   y="0.333333" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="u2"
+--                 kind="input">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="0.000000"
+--                   y="0.666667" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="y"
+--                 kind="output">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="1.000000"
+--                   y="0.500000" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="k1"
+--                 kind="parameter">
+--                 <ssc:Real />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="k2"
+--                 kind="parameter">
+--                 <ssc:Real />
+--               </ssd:Connector>
+--             </ssd:Connectors>
+--             <ssd:ParameterBindings>
+--               <ssd:ParameterBinding>
+--                 <ssd:ParameterValues>
+--                   <ssv:ParameterSet
+--                     version="1.0"
+--                     name="parameters">
+--                     <ssv:Parameters>
+--                       <ssv:Parameter
+--                         name="u1">
+--                         <ssv:Real
+--                           value="40" />
+--                       </ssv:Parameter>
+--                       <ssv:Parameter
+--                         name="k2">
+--                         <ssv:Real
+--                           value="20" />
+--                       </ssv:Parameter>
+--                       <ssv:Parameter
+--                         name="k1">
+--                         <ssv:Real
+--                           value="10" />
+--                       </ssv:Parameter>
+--                     </ssv:Parameters>
+--                   </ssv:ParameterSet>
+--                 </ssd:ParameterValues>
+--               </ssd:ParameterBinding>
+--             </ssd:ParameterBindings>
+--           </ssd:Component>
+--           <ssd:Component
+--             name="add_2"
+--             type="application/x-fmu-sharedlibrary"
+--             source="resources/0002_add_2.fmu">
+--             <ssd:Connectors>
+--               <ssd:Connector
+--                 name="u1"
+--                 kind="input">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="0.000000"
+--                   y="0.333333" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="u2"
+--                 kind="input">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="0.000000"
+--                   y="0.666667" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="y"
+--                 kind="output">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="1.000000"
+--                   y="0.500000" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="k1"
+--                 kind="parameter">
+--                 <ssc:Real />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="k2"
+--                 kind="parameter">
+--                 <ssc:Real />
+--               </ssd:Connector>
+--             </ssd:Connectors>
+--           </ssd:Component>
+--         </ssd:Elements>
+--         <ssd:Connections>
+--           <ssd:Connection
+--             startElement="add_3"
+--             startConnector="y"
+--             endElement="add_2"
+--             endConnector="u1" />
+--         </ssd:Connections>
+--         <ssd:Annotations>
+--           <ssc:Annotation
+--             type="org.openmodelica">
+--             <oms:Annotations>
+--               <oms:SimulationInformation>
+--                 <oms:FixedStepMaster
+--                   description="oms-ma"
+--                   stepSize="0.100000"
+--                   absoluteTolerance="0.000100"
+--                   relativeTolerance="0.000100" />
+--               </oms:SimulationInformation>
+--             </oms:Annotations>
+--           </ssc:Annotation>
+--         </ssd:Annotations>
+--       </ssd:System>
+--       <ssd:DefaultExperiment
+--         startTime="0.000000"
+--         stopTime="1.000000">
+--         <ssd:Annotations>
+--           <ssc:Annotation
+--             type="org.openmodelica">
+--             <oms:Annotations>
+--               <oms:SimulationInformation
+--                 resultFile="renamevalues_res.mat"
+--                 loggingInterval="0.000000"
+--                 bufferSize="10"
+--                 signalFilter="resources/signalFilter.xml" />
+--             </oms:Annotations>
+--           </ssc:Annotation>
+--         </ssd:Annotations>
+--       </ssd:DefaultExperiment>
+--     </ssd:SystemStructureDescription>
+--   </oms:file>
+--   <oms:file
+--     name="resources/signalFilter.xml">
+--     <oms:SignalFilter
+--       version="1.0">
+--       <oms:Variable
+--         name="renamevalues.root.add_3.u1"
+--         type="Real"
+--         kind="input" />
+--       <oms:Variable
+--         name="renamevalues.root.add_3.u2"
+--         type="Real"
+--         kind="input" />
+--       <oms:Variable
+--         name="renamevalues.root.add_3.y"
+--         type="Real"
+--         kind="output" />
+--       <oms:Variable
+--         name="renamevalues.root.add_3.k1"
+--         type="Real"
+--         kind="parameter" />
+--       <oms:Variable
+--         name="renamevalues.root.add_3.k2"
+--         type="Real"
+--         kind="parameter" />
+--       <oms:Variable
+--         name="renamevalues.root.add_2.u1"
+--         type="Real"
+--         kind="input" />
+--       <oms:Variable
+--         name="renamevalues.root.add_2.u2"
+--         type="Real"
+--         kind="input" />
+--       <oms:Variable
+--         name="renamevalues.root.add_2.y"
+--         type="Real"
+--         kind="output" />
+--       <oms:Variable
+--         name="renamevalues.root.add_2.k1"
+--         type="Real"
+--         kind="parameter" />
+--       <oms:Variable
+--         name="renamevalues.root.add_2.k2"
+--         type="Real"
+--         kind="parameter" />
+--       <oms:Variable
+--         name="renamevalues.root.system2.k1"
+--         type="Real"
+--         kind="parameter" />
+--     </oms:SignalFilter>
+--   </oms:file>
+-- </oms:snapshot>
+--
+-- info:    model doesn't contain any continuous state
+-- info:      Instantiation
+-- info:      renamevalues.root.system2.k1     : -10.0
+-- info:      renamevalues.root.add_3.k1       : 10.0
+-- info:      renamevalues.root.add_3.k2       : 20.0
+-- info:      renamevalues.root.add_3.u1       : 40.0
+-- info:    Result file: renamevalues_res.mat (bufferSize=10)
+-- info:      Initialization
+-- info:      renamevalues.root.system2.k1     : -10.0
+-- info:      renamevalues.root.add_3.k1       : 10.0
+-- info:      renamevalues.root.add_3.k2       : 20.0
+-- info:      renamevalues.root.add_3.u1       : 40.0
+-- info:      Simulation
+-- info:      renamevalues.root.system2.k1     : -10.0
+-- info:      renamevalues.root.add_3.k1       : 10.0
+-- info:      renamevalues.root.add_3.k2       : 20.0
+-- info:      renamevalues.root.add_3.u1       : 40.0
+-- endResult


### PR DESCRIPTION
### Related Issues

https://github.com/OpenModelica/OMSimulator/issues/1020
https://github.com/OpenModelica/OMSimulator/issues/1021

### Purpose

This PR fixes the bug in `renaming` values in `ssv files` or `inline` when `renaming` a `Subsystem` or `Submodule`

