### PR TITLE
update start values in ssv template

### DIFF
--- a/src/OMSimulatorLib/Values.cpp
+++ b/src/OMSimulatorLib/Values.cpp
@@ -53,18 +53,33 @@ oms::Values::~Values()
 oms_status_enu_t oms::Values::setReal(const ComRef& cref, double value)
 {
   realStartValues[cref] = value;
+  // update start values in ssv template
+  auto realValue = modelDescriptionRealStartValues.find(cref);
+  if (realValue != modelDescriptionRealStartValues.end())
+    modelDescriptionRealStartValues[cref] = value;
+
   return oms_status_ok;
 }
 
 oms_status_enu_t oms::Values::setInteger(const ComRef& cref, int value)
 {
   integerStartValues[cref] = value;
+  // update start values in ssv template
+  auto integerValue = modelDescriptionIntegerStartValues.find(cref);
+  if (integerValue != modelDescriptionIntegerStartValues.end())
+    modelDescriptionIntegerStartValues[cref] = value;
+
   return oms_status_ok;
 }
 
 oms_status_enu_t oms::Values::setBoolean(const ComRef& cref, bool value)
 {
   booleanStartValues[cref] = value;
+  // update start values in ssv template
+  auto boolValue = modelDescriptionBooleanStartValues.find(cref);
+  if (boolValue != modelDescriptionBooleanStartValues.end())
+    modelDescriptionBooleanStartValues[cref] = value;
+
   return oms_status_ok;
 }
 

--- a/testsuite/OMSimulator/exportSSVTemplate.lua
+++ b/testsuite/OMSimulator/exportSSVTemplate.lua
@@ -21,7 +21,10 @@ oms_newModel("test")
 oms_addSystem("test.Root", oms_system_wc)
 
 oms_addSubModel("test.Root.Gain", "../resources/Modelica.Blocks.Math.Gain.fmu")
+oms_setReal("test.Root.Gain.k", 27)
+
 oms_addSubModel("test.Root.add", "../resources/Modelica.Blocks.Math.Add.fmu")
+oms_setReal("test.Root.add.k1", -20)
 
 oms_exportSSVTemplate("test", "template.ssv")
 readFile("template.ssv")
@@ -59,7 +62,7 @@ readFile("gain.ssv")
 --     <ssv:Parameter
 --       name="add.k1">
 --       <ssv:Real
---         value="1" />
+--         value="-20" />
 --     </ssv:Parameter>
 --     <ssv:Parameter
 --       name="Gain.u">
@@ -69,7 +72,7 @@ readFile("gain.ssv")
 --     <ssv:Parameter
 --       name="Gain.k">
 --       <ssv:Real
---         value="1" />
+--         value="27" />
 --     </ssv:Parameter>
 --   </ssv:Parameters>
 -- </ssv:ParameterSet>
@@ -99,7 +102,7 @@ readFile("gain.ssv")
 --     <ssv:Parameter
 --       name="add.k1">
 --       <ssv:Real
---         value="1" />
+--         value="-20" />
 --     </ssv:Parameter>
 --   </ssv:Parameters>
 -- </ssv:ParameterSet>
@@ -119,7 +122,7 @@ readFile("gain.ssv")
 --     <ssv:Parameter
 --       name="Gain.k">
 --       <ssv:Real
---         value="1" />
+--         value="27" />
 --     </ssv:Parameter>
 --   </ssv:Parameters>
 -- </ssv:ParameterSet>

--- a/testsuite/OMSimulator/exportSSVTemplate.py
+++ b/testsuite/OMSimulator/exportSSVTemplate.py
@@ -24,71 +24,110 @@ oms.newModel("test")
 oms.addSystem("test.Root", oms.system_wc)
 
 oms.addSubModel("test.Root.Gain", "../resources/Modelica.Blocks.Math.Gain.fmu")
+oms.setReal("test.Root.Gain.k", 27)
+
 oms.addSubModel("test.Root.add", "../resources/Modelica.Blocks.Math.Add.fmu")
+oms.setReal("test.Root.add.k1", -20)
 
-oms.exportSSVTemplate("test", "template.ssv")
-readFile("template.ssv")
+oms.exportSSVTemplate("test", "template1.ssv")
+readFile("template1.ssv")
 
-oms.exportSSVTemplate("test.Root.add", "add.ssv")
-readFile("add.ssv")
+oms.exportSSVTemplate("test.Root.add", "add1.ssv")
+readFile("add1.ssv")
 
-oms.exportSSVTemplate("test.Root.Gain", "gain.ssv")
-readFile("gain.ssv")
+oms.exportSSVTemplate("test.Root.Gain", "gain1.ssv")
+readFile("gain1.ssv")
 
 
 ## Result:
 ## <?xml version="1.0" encoding="UTF-8"?>
-## <ssv:ParameterSet xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" version="1.0" name="modelDescriptionStartValues">
-## 	<ssv:Parameters>
-## 		<ssv:Parameter name="add.u2">
-## 			<ssv:Real value="0" />
-## 		</ssv:Parameter>
-## 		<ssv:Parameter name="add.u1">
-## 			<ssv:Real value="0" />
-## 		</ssv:Parameter>
-## 		<ssv:Parameter name="add.k2">
-## 			<ssv:Real value="1" />
-## 		</ssv:Parameter>
-## 		<ssv:Parameter name="add.k1">
-## 			<ssv:Real value="1" />
-## 		</ssv:Parameter>
-## 		<ssv:Parameter name="Gain.u">
-## 			<ssv:Real value="0" />
-## 		</ssv:Parameter>
-## 		<ssv:Parameter name="Gain.k">
-## 			<ssv:Real value="1" />
-## 		</ssv:Parameter>
-## 	</ssv:Parameters>
+## <ssv:ParameterSet
+##   xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
+##   xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
+##   version="1.0"
+##   name="modelDescriptionStartValues">
+##   <ssv:Parameters>
+##     <ssv:Parameter
+##       name="add.u2">
+##       <ssv:Real
+##         value="0" />
+##     </ssv:Parameter>
+##     <ssv:Parameter
+##       name="add.u1">
+##       <ssv:Real
+##         value="0" />
+##     </ssv:Parameter>
+##     <ssv:Parameter
+##       name="add.k2">
+##       <ssv:Real
+##         value="1" />
+##     </ssv:Parameter>
+##     <ssv:Parameter
+##       name="add.k1">
+##       <ssv:Real
+##         value="-20" />
+##     </ssv:Parameter>
+##     <ssv:Parameter
+##       name="Gain.u">
+##       <ssv:Real
+##         value="0" />
+##     </ssv:Parameter>
+##     <ssv:Parameter
+##       name="Gain.k">
+##       <ssv:Real
+##         value="27" />
+##     </ssv:Parameter>
+##   </ssv:Parameters>
 ## </ssv:ParameterSet>
 ##
 ## <?xml version="1.0" encoding="UTF-8"?>
-## <ssv:ParameterSet xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" version="1.0" name="modelDescriptionStartValues">
-## 	<ssv:Parameters>
-## 		<ssv:Parameter name="add.u2">
-## 			<ssv:Real value="0" />
-## 		</ssv:Parameter>
-## 		<ssv:Parameter name="add.u1">
-## 			<ssv:Real value="0" />
-## 		</ssv:Parameter>
-## 		<ssv:Parameter name="add.k2">
-## 			<ssv:Real value="1" />
-## 		</ssv:Parameter>
-## 		<ssv:Parameter name="add.k1">
-## 			<ssv:Real value="1" />
-## 		</ssv:Parameter>
-## 	</ssv:Parameters>
+## <ssv:ParameterSet
+##   xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
+##   xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
+##   version="1.0"
+##   name="modelDescriptionStartValues">
+##   <ssv:Parameters>
+##     <ssv:Parameter
+##       name="add.u2">
+##       <ssv:Real
+##         value="0" />
+##     </ssv:Parameter>
+##     <ssv:Parameter
+##       name="add.u1">
+##       <ssv:Real
+##         value="0" />
+##     </ssv:Parameter>
+##     <ssv:Parameter
+##       name="add.k2">
+##       <ssv:Real
+##         value="1" />
+##     </ssv:Parameter>
+##     <ssv:Parameter
+##       name="add.k1">
+##       <ssv:Real
+##         value="-20" />
+##     </ssv:Parameter>
+##   </ssv:Parameters>
 ## </ssv:ParameterSet>
 ##
 ## <?xml version="1.0" encoding="UTF-8"?>
-## <ssv:ParameterSet xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" version="1.0" name="modelDescriptionStartValues">
-## 	<ssv:Parameters>
-## 		<ssv:Parameter name="Gain.u">
-## 			<ssv:Real value="0" />
-## 		</ssv:Parameter>
-## 		<ssv:Parameter name="Gain.k">
-## 			<ssv:Real value="1" />
-## 		</ssv:Parameter>
-## 	</ssv:Parameters>
+## <ssv:ParameterSet
+##   xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
+##   xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
+##   version="1.0"
+##   name="modelDescriptionStartValues">
+##   <ssv:Parameters>
+##     <ssv:Parameter
+##       name="Gain.u">
+##       <ssv:Real
+##         value="0" />
+##     </ssv:Parameter>
+##     <ssv:Parameter
+##       name="Gain.k">
+##       <ssv:Real
+##         value="27" />
+##     </ssv:Parameter>
+##   </ssv:Parameters>
 ## </ssv:ParameterSet>
 ##
 ## endResult


### PR DESCRIPTION
### Related Issues

https://github.com/OpenModelica/OMSimulator/issues/951

### Purpose

This PR updates the new start values for signals exported in `ssv template files` set via `setReal or setInteger or setBoolean`

### example

```
oms_newModel("test")
oms_addSystem("test.Root", oms_system_wc)
oms_addSubModel("test.Root.Gain", "../resources/Modelica.Blocks.Math.Gain.fmu")
oms_setReal("test.Root.Gain.k", 27)
oms_addSubModel("test.Root.add", "../resources/Modelica.Blocks.Math.Add.fmu")
oms_setReal("test.Root.add.k1", -20)
oms_exportSSVTemplate("test", "template.ssv")
```