### PR TITLE
Remove hints for finding libatomic

### DIFF
--- a/config.cmake/FindGccAtomic.cmake
+++ b/config.cmake/FindGccAtomic.cmake
@@ -23,19 +23,7 @@
 
 # I'm also putting "atomic.so.1" because at least FC19 and Ubuntu's repo don't create
 # "libatomic.so" symlink. They only have libatomic.so.1.0.0 and libatomic.so.1 symlink. No idea why.
-FIND_LIBRARY(GCCLIBATOMIC_LIBRARY NAMES atomic atomic.so.1 libatomic.so.1
-  HINTS
-  $ENV{HOME}/local/lib64
-  $ENV{HOME}/local/lib
-  /usr/local/lib64
-  /usr/local/lib
-  /opt/local/lib64
-  /opt/local/lib
-  /usr/lib64
-  /usr/lib
-  /lib64
-  /lib
-)
+FIND_LIBRARY(GCCLIBATOMIC_LIBRARY NAMES atomic atomic.so.1 libatomic.so.1)
 
 IF (GCCLIBATOMIC_LIBRARY)
     SET(GCCLIBATOMIC_FOUND TRUE)


### PR DESCRIPTION
The hints gave lib64 also for 32-bit platforms and preferred the 64-bit
library also on 32-bit platforms (Debian Buster's clang installs 64-bit
libraries and then fails to link).

### Related Issues

#1032 