### PR TITLE
Disabling OSX tests for now

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,7 @@ pipeline {
   parameters {
     booleanParam(name: 'MSVC64', defaultValue: true, description: 'Build with MSVC64 (often hangs)')
     booleanParam(name: 'MINGW32', defaultValue: false, description: 'Build with MINGW32')
-    booleanParam(name: 'OSXCROSS', defaultValue: false, description: 'Test on OSX')
+    booleanParam(name: 'OSXCROSS', defaultValue: false, description: 'Test on OSX. Currently offline')
     booleanParam(name: 'SUBMODULE_UPDATE', defaultValue: false, description: 'Allow pull request to update submodules (disabled by default due to common user errors)')
     booleanParam(name: 'UPLOAD_BUILD_OPENMODELICA', defaultValue: false, description: 'Upload install artifacts to build.openmodelica.org/omsimulator. Activates MINGW32 as well.')
     string(name: 'RUNTESTS_FLAG', defaultValue: '', description: 'runtests.pl flag')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,6 +9,7 @@ pipeline {
   parameters {
     booleanParam(name: 'MSVC64', defaultValue: true, description: 'Build with MSVC64 (often hangs)')
     booleanParam(name: 'MINGW32', defaultValue: false, description: 'Build with MINGW32')
+    booleanParam(name: 'OSXCROSS', defaultValue: false, description: 'Test on OSX')
     booleanParam(name: 'SUBMODULE_UPDATE', defaultValue: false, description: 'Allow pull request to update submodules (disabled by default due to common user errors)')
     booleanParam(name: 'UPLOAD_BUILD_OPENMODELICA', defaultValue: false, description: 'Upload install artifacts to build.openmodelica.org/omsimulator. Activates MINGW32 as well.')
     string(name: 'RUNTESTS_FLAG', defaultValue: '', description: 'runtests.pl flag')
@@ -287,10 +288,10 @@ pipeline {
               }
             }
             stage('test') {
-              /* when {
+              when {
                 beforeAgent true
-                expression { return false }
-              } */
+                expression { return params.OSXCROSS }
+              }
               agent {
                 label 'osx'
               }


### PR DESCRIPTION
### Related Issues

The osxcross pipeline is hanging because the OSX server is down.

### Purpose

Adding a parameter `OSXCROSS` to the Jenkins job to disable the testing for now. We still build with the osx cross compilation though

