### PR TITLE
Split mingw into mingw32 and mingw64 for the testsuite

### DIFF
--- a/testsuite/AircraftVehicleDemonstrator/AircraftVehicleDemonstrator.lua
+++ b/testsuite/AircraftVehicleDemonstrator/AircraftVehicleDemonstrator.lua
@@ -1,7 +1,8 @@
 -- status: correct
 -- teardown_command: rm -rf AircraftVehicleDemonstrator_tmp/ AircraftVehicleDemonstrator.log AircraftVehicleDemonstrator*.dot AircraftVehicleDemonstrator_res.mat
 -- linux: no
--- mingw: yes
+-- mingw32: yes
+-- mingw64: yes
 -- win: no
 -- mac: no
 

--- a/testsuite/AircraftVehicleDemonstrator/AircraftVehicleDemonstrator.lua
+++ b/testsuite/AircraftVehicleDemonstrator/AircraftVehicleDemonstrator.lua
@@ -1,7 +1,7 @@
 -- status: correct
 -- teardown_command: rm -rf AircraftVehicleDemonstrator_tmp/ AircraftVehicleDemonstrator.log AircraftVehicleDemonstrator*.dot AircraftVehicleDemonstrator_res.mat
 -- linux: no
--- mingw32: yes
+-- mingw32: no
 -- mingw64: yes
 -- win: no
 -- mac: no

--- a/testsuite/AircraftVehicleDemonstrator/embrace.py
+++ b/testsuite/AircraftVehicleDemonstrator/embrace.py
@@ -1,7 +1,8 @@
 ## status: correct
 ## teardown_command: rm SystemStructure.ssd event.dot init.dot sim_results.mat simulation.dot
 ## linux: yes
-## mingw: no
+## mingw32: no
+-- mingw64: no
 ## win: no
 ## mac: no
 

--- a/testsuite/AircraftVehicleDemonstrator/embrace.py
+++ b/testsuite/AircraftVehicleDemonstrator/embrace.py
@@ -2,7 +2,7 @@
 ## teardown_command: rm SystemStructure.ssd event.dot init.dot sim_results.mat simulation.dot
 ## linux: yes
 ## mingw32: no
--- mingw64: no
+## mingw64: no
 ## win: no
 ## mac: no
 

--- a/testsuite/OMSimulator/DualMassOscillator.lua
+++ b/testsuite/OMSimulator/DualMassOscillator.lua
@@ -1,7 +1,8 @@
 -- status: correct
 -- teardown_command: rm -rf dualmassoscillator-lua/ DualMassOscillator.mat
 -- linux: yes
--- mingw: yes
+-- mingw32: yes
+-- mingw64: yes
 -- win: no
 -- mac: no
 

--- a/testsuite/OMSimulator/Enumeration.lua
+++ b/testsuite/OMSimulator/Enumeration.lua
@@ -1,6 +1,7 @@
 -- status: correct
 -- linux: yes
--- mingw: yes
+-- mingw32: yes
+-- mingw64: yes
 -- win: no
 -- mac: no
 

--- a/testsuite/OMSimulator/Enumeration2.lua
+++ b/testsuite/OMSimulator/Enumeration2.lua
@@ -1,6 +1,7 @@
 -- status: correct
 -- linux: yes
--- mingw: yes
+-- mingw32: yes
+-- mingw64: yes
 -- win: no
 -- mac: no
 

--- a/testsuite/OMSimulator/PI_Controller.lua
+++ b/testsuite/OMSimulator/PI_Controller.lua
@@ -1,7 +1,8 @@
 -- status: correct
 -- teardown_command: rm -rf PI_Controller-lua/ PI_Controller_init.dot PI_Controller_sim.dot PI_Controller_res.mat PI_Controller.ssp
 -- linux: yes
--- mingw: yes
+-- mingw32: yes
+-- mingw64: yes
 -- win: no
 -- mac: no
 

--- a/testsuite/OMSimulator/QuarterCarModel.DisplacementDisplacement.lua
+++ b/testsuite/OMSimulator/QuarterCarModel.DisplacementDisplacement.lua
@@ -1,7 +1,8 @@
 -- status: correct
 -- teardown_command: rm -rf QuarterCarModel/ QuarterCarModel.DisplacementDisplacement.mat
 -- linux: yes
--- mingw: yes
+-- mingw32: yes
+-- mingw64: yes
 -- win: no
 -- mac: no
 

--- a/testsuite/OMSimulator/addResources1.lua
+++ b/testsuite/OMSimulator/addResources1.lua
@@ -1,7 +1,8 @@
 -- status: correct
 -- teardown_command: rm -rf addResources_01_lua/
 -- linux: yes
--- mingw: yes
+-- mingw32: yes
+-- mingw64: yes
 -- win: no
 -- mac: no
 

--- a/testsuite/OMSimulator/addResources2.lua
+++ b/testsuite/OMSimulator/addResources2.lua
@@ -1,7 +1,8 @@
 -- status: correct
 -- teardown_command: rm -rf addResources_02_lua/
 -- linux: yes
--- mingw: yes
+-- mingw32: yes
+-- mingw64: yes
 -- win: no
 -- mac: no
 

--- a/testsuite/OMSimulator/addResources3.lua
+++ b/testsuite/OMSimulator/addResources3.lua
@@ -1,7 +1,8 @@
 -- status: correct
 -- teardown_command: rm -rf addResources_03_lua/
 -- linux: yes
--- mingw: yes
+-- mingw32: yes
+-- mingw64: yes
 -- win: no
 -- mac: no
 
@@ -395,7 +396,7 @@ oms_delete("addResources")
 --     </oms:SignalFilter>
 --   </oms:file>
 -- </oms:snapshot>
--- 
+--
 -- info:    Virgin Parameter settings
 -- info:      addResources.root.system1.C1      : -10.5
 -- info:      addResources.root.system1.C2      : -20.5

--- a/testsuite/OMSimulator/addResources4.lua
+++ b/testsuite/OMSimulator/addResources4.lua
@@ -1,7 +1,8 @@
 -- status: correct
 -- teardown_command: rm -rf addResources_04_lua/
 -- linux: yes
--- mingw: yes
+-- mingw32: yes
+-- mingw64: yes
 -- win: no
 -- mac: no
 
@@ -380,7 +381,7 @@ oms_delete("addResources")
 --     </oms:SignalFilter>
 --   </oms:file>
 -- </oms:snapshot>
--- 
+--
 -- info:    Virgin Parameter settings
 -- info:      addResources.root.system1.C1      : -10.5
 -- info:      addResources.root.system1.C2      : -20.5

--- a/testsuite/OMSimulator/addResources5.lua
+++ b/testsuite/OMSimulator/addResources5.lua
@@ -1,7 +1,8 @@
 -- status: correct
 -- teardown_command: rm -rf addResources_05_lua/
 -- linux: yes
--- mingw: yes
+-- mingw32: yes
+-- mingw64: yes
 -- win: no
 -- mac: no
 

--- a/testsuite/OMSimulator/addResources6.lua
+++ b/testsuite/OMSimulator/addResources6.lua
@@ -1,7 +1,8 @@
 -- status: correct
 -- teardown_command: rm -rf addResources_06_lua/
 -- linux: yes
--- mingw: yes
+-- mingw32: yes
+-- mingw64: yes
 -- win: no
 -- mac: no
 

--- a/testsuite/OMSimulator/addResources7.lua
+++ b/testsuite/OMSimulator/addResources7.lua
@@ -1,7 +1,8 @@
 -- status: correct
 -- teardown_command: rm -rf addResources_07_lua/
 -- linux: yes
--- mingw: yes
+-- mingw32: yes
+-- mingw64: yes
 -- win: no
 -- mac: no
 

--- a/testsuite/OMSimulator/deleteConnector.lua
+++ b/testsuite/OMSimulator/deleteConnector.lua
@@ -1,6 +1,7 @@
 -- status: correct
 -- linux: yes
--- mingw: yes
+-- mingw32: yes
+-- mingw64: yes
 -- win: no
 -- mac: yes
 

--- a/testsuite/OMSimulator/deleteConnector1.lua
+++ b/testsuite/OMSimulator/deleteConnector1.lua
@@ -1,6 +1,7 @@
 -- status: correct
 -- linux: yes
--- mingw: yes
+-- mingw32: yes
+-- mingw64: yes
 -- win: no
 -- mac: yes
 

--- a/testsuite/OMSimulator/deleteStartValues.lua
+++ b/testsuite/OMSimulator/deleteStartValues.lua
@@ -1,6 +1,7 @@
 -- status: correct
 -- linux: yes
--- mingw: yes
+-- mingw32: yes
+-- mingw64: yes
 -- win: no
 -- mac: yes
 

--- a/testsuite/OMSimulator/deleteStartValuesInSSV.lua
+++ b/testsuite/OMSimulator/deleteStartValuesInSSV.lua
@@ -1,6 +1,7 @@
 -- status: correct
 -- linux: yes
--- mingw: yes
+-- mingw32: yes
+-- mingw64: yes
 -- win: no
 -- mac: yes
 

--- a/testsuite/OMSimulator/deleteStartValuesInSSV1.lua
+++ b/testsuite/OMSimulator/deleteStartValuesInSSV1.lua
@@ -1,6 +1,7 @@
 -- status: correct
 -- linux: yes
--- mingw: yes
+-- mingw32: yes
+-- mingw64: yes
 -- win: no
 -- mac: yes
 

--- a/testsuite/OMSimulator/deleteStartValuesInSSV2.lua
+++ b/testsuite/OMSimulator/deleteStartValuesInSSV2.lua
@@ -1,6 +1,7 @@
 -- status: correct
 -- linux: yes
--- mingw: yes
+-- mingw32: yes
+-- mingw64: yes
 -- win: no
 -- mac: yes
 

--- a/testsuite/OMSimulator/exportConnectorsToResultFile.lua
+++ b/testsuite/OMSimulator/exportConnectorsToResultFile.lua
@@ -1,6 +1,7 @@
 -- status: correct
 -- linux: yes
--- mingw: yes
+-- mingw32: yes
+-- mingw64: yes
 -- win: no
 -- mac: no
 

--- a/testsuite/OMSimulator/exportSSMTemplate.lua
+++ b/testsuite/OMSimulator/exportSSMTemplate.lua
@@ -1,7 +1,8 @@
 -- status: correct
 -- teardown_command: rm -rf exportssmtemplate_lua/ add1.ssm gain1.ssm template1.ssm
 -- linux: yes
--- mingw: yes
+-- mingw32: yes
+-- mingw64: yes
 -- win: no
 -- mac: no
 

--- a/testsuite/OMSimulator/exportSSMTemplate.py
+++ b/testsuite/OMSimulator/exportSSMTemplate.py
@@ -2,7 +2,7 @@
 ## teardown_command: rm -rf exportssmtemplate_py/ add2.ssm gain2.ssm template2.ssm
 ## linux: yes
 ## mingw32: yes
--- mingw64: yes
+## mingw64: yes
 ## win: no
 ## mac: no
 

--- a/testsuite/OMSimulator/exportSSMTemplate.py
+++ b/testsuite/OMSimulator/exportSSMTemplate.py
@@ -1,7 +1,8 @@
 ## status: correct
 ## teardown_command: rm -rf exportssmtemplate_py/ add2.ssm gain2.ssm template2.ssm
 ## linux: yes
-## mingw: yes
+## mingw32: yes
+-- mingw64: yes
 ## win: no
 ## mac: no
 

--- a/testsuite/OMSimulator/exportSSVTemplate.lua
+++ b/testsuite/OMSimulator/exportSSVTemplate.lua
@@ -1,6 +1,7 @@
 -- status: correct
 -- linux: yes
--- mingw: yes
+-- mingw32: yes
+-- mingw64: yes
 -- win: no
 -- mac: no
 

--- a/testsuite/OMSimulator/exportSSVTemplate.py
+++ b/testsuite/OMSimulator/exportSSVTemplate.py
@@ -1,6 +1,7 @@
 ## status: correct
 ## linux: yes
-## mingw: yes
+## mingw32: yes
+-- mingw64: yes
 ## win: no
 ## mac: no
 

--- a/testsuite/OMSimulator/exportSSVTemplate.py
+++ b/testsuite/OMSimulator/exportSSVTemplate.py
@@ -1,7 +1,7 @@
 ## status: correct
 ## linux: yes
 ## mingw32: yes
--- mingw64: yes
+## mingw64: yes
 ## win: no
 ## mac: no
 

--- a/testsuite/OMSimulator/exportSnapshotSSP.lua
+++ b/testsuite/OMSimulator/exportSnapshotSSP.lua
@@ -1,7 +1,8 @@
 -- status: correct
 -- teardown_command: rm -rf exportsnapshotssp_lua/
 -- linux: yes
--- mingw: yes
+-- mingw32: yes
+-- mingw64: yes
 -- win: no
 -- mac: no
 

--- a/testsuite/OMSimulator/importPartialSnapshot.lua
+++ b/testsuite/OMSimulator/importPartialSnapshot.lua
@@ -1,6 +1,7 @@
 -- status: correct
 -- linux: yes
--- mingw: yes
+-- mingw32: yes
+-- mingw64: yes
 -- win: no
 -- mac: no
 

--- a/testsuite/OMSimulator/importStartValues.lua
+++ b/testsuite/OMSimulator/importStartValues.lua
@@ -1,7 +1,8 @@
 -- status: correct
 -- teardown_command: rm -rf importStartValues-lua/
 -- linux: yes
--- mingw: yes
+-- mingw32: yes
+-- mingw64: yes
 -- win: no
 -- mac: no
 

--- a/testsuite/OMSimulator/importStartValues1.lua
+++ b/testsuite/OMSimulator/importStartValues1.lua
@@ -1,7 +1,8 @@
 -- status: correct
 -- teardown_command: rm -rf importStartValues_01_lua/
 -- linux: yes
--- mingw: yes
+-- mingw32: yes
+-- mingw64: yes
 -- win: no
 -- mac: no
 
@@ -244,7 +245,7 @@ oms_delete("importStartValues")
 --     </oms:SignalFilter>
 --   </oms:file>
 -- </oms:snapshot>
--- 
+--
 -- info:    model doesn't contain any continuous state
 -- info:    Result file: importStartValues_res.mat (bufferSize=10)
 -- info:    5 warnings

--- a/testsuite/OMSimulator/import_export.lua
+++ b/testsuite/OMSimulator/import_export.lua
@@ -1,7 +1,8 @@
 -- status: correct
 -- teardown_command: rm -rf test.ssp import_export-lua/
 -- linux: yes
--- mingw: yes
+-- mingw32: yes
+-- mingw64: yes
 -- win: no
 -- mac: no
 

--- a/testsuite/OMSimulator/import_export.py
+++ b/testsuite/OMSimulator/import_export.py
@@ -1,7 +1,8 @@
 ## status: correct
 ## teardown_command: rm -rf import_export-py/ test-py.ssp
 ## linux: yes
-## mingw: yes
+## mingw32: yes
+-- mingw64: yes
 ## win: no
 ## mac: no
 

--- a/testsuite/OMSimulator/import_export.py
+++ b/testsuite/OMSimulator/import_export.py
@@ -2,7 +2,7 @@
 ## teardown_command: rm -rf import_export-py/ test-py.ssp
 ## linux: yes
 ## mingw32: yes
--- mingw64: yes
+## mingw64: yes
 ## win: no
 ## mac: no
 

--- a/testsuite/OMSimulator/import_export_parameters1.lua
+++ b/testsuite/OMSimulator/import_export_parameters1.lua
@@ -1,7 +1,8 @@
 -- status: correct
 -- teardown_command: rm -rf import_export_parameters_01_lua/
 -- linux: no
--- mingw: yes
+-- mingw32: yes
+-- mingw64: yes
 -- win: no
 -- mac: no
 

--- a/testsuite/OMSimulator/import_export_parameters2.lua
+++ b/testsuite/OMSimulator/import_export_parameters2.lua
@@ -1,7 +1,8 @@
 -- status: correct
 -- teardown_command: rm -rf import_export_parameters_02_lua/
 -- linux: no
--- mingw: yes
+-- mingw32: yes
+-- mingw64: yes
 -- win: no
 -- mac: no
 

--- a/testsuite/OMSimulator/import_export_parameters3.lua
+++ b/testsuite/OMSimulator/import_export_parameters3.lua
@@ -1,7 +1,8 @@
 -- status: correct
 -- teardown_command: rm -rf import_export_parameters_03_lua/
 -- linux: no
--- mingw: yes
+-- mingw32: yes
+-- mingw64: yes
 -- win: no
 -- mac: no
 

--- a/testsuite/OMSimulator/import_export_parameters4.lua
+++ b/testsuite/OMSimulator/import_export_parameters4.lua
@@ -1,7 +1,8 @@
 -- status: correct
 -- teardown_command: rm -rf import_export_parameters_04_lua/
 -- linux: yes
--- mingw: yes
+-- mingw32: yes
+-- mingw64: yes
 -- win: no
 -- mac: no
 

--- a/testsuite/OMSimulator/import_export_parameters_inline.lua
+++ b/testsuite/OMSimulator/import_export_parameters_inline.lua
@@ -1,7 +1,8 @@
 -- status: correct
 -- teardown_command: rm -rf import_export_parameters_inline_lua/
 -- linux: yes
--- mingw: yes
+-- mingw32: yes
+-- mingw64: yes
 -- win: no
 -- mac: no
 

--- a/testsuite/OMSimulator/import_export_parameters_to_ssv.lua
+++ b/testsuite/OMSimulator/import_export_parameters_to_ssv.lua
@@ -1,7 +1,8 @@
 -- status: correct
 -- teardown_command: rm -rf import_export_parameters_lua/
 -- linux: yes
--- mingw: yes
+-- mingw32: yes
+-- mingw64: yes
 -- win: no
 -- mac: no
 

--- a/testsuite/OMSimulator/import_export_signalFilter.lua
+++ b/testsuite/OMSimulator/import_export_signalFilter.lua
@@ -2,7 +2,8 @@
 -- teardown_command: rm -rf import_export_signalFilter-lua/ model_res.csv
 -- linux: yes
 -- linux32: yes
--- mingw: yes
+-- mingw32: yes
+-- mingw64: yes
 -- win: no
 -- mac: no
 

--- a/testsuite/OMSimulator/import_export_snapshot.lua
+++ b/testsuite/OMSimulator/import_export_snapshot.lua
@@ -1,7 +1,8 @@
 -- status: correct
 -- teardown_command: rm -rf import_export_snapshot_lua/ import_export_snapshot.ssp
 -- linux: yes
--- mingw: yes
+-- mingw32: yes
+-- mingw64: yes
 -- win: no
 -- mac: no
 

--- a/testsuite/OMSimulator/import_hierarchical_ssv_sources.lua
+++ b/testsuite/OMSimulator/import_hierarchical_ssv_sources.lua
@@ -1,7 +1,8 @@
 -- status: correct
 -- teardown_command: rm -rf import_hierarchical_ssv_sources_lua/
 -- linux: yes
--- mingw: yes
+-- mingw32: yes
+-- mingw64: yes
 -- win: no
 -- mac: no
 

--- a/testsuite/OMSimulator/import_hierarchical_ssv_sources1.lua
+++ b/testsuite/OMSimulator/import_hierarchical_ssv_sources1.lua
@@ -1,7 +1,8 @@
 -- status: correct
 -- teardown_command: rm -rf import_hierarchical_ssv_sources_01_lua/
 -- linux: yes
--- mingw: yes
+-- mingw32: yes
+-- mingw64: yes
 -- win: no
 -- mac: no
 

--- a/testsuite/OMSimulator/import_parameter_mapping_from_ssm.lua
+++ b/testsuite/OMSimulator/import_parameter_mapping_from_ssm.lua
@@ -1,7 +1,8 @@
 -- status: correct
 -- teardown_command: rm -rf import_parameter_mapping_ssm_lua/
 -- linux: yes
--- mingw: yes
+-- mingw32: yes
+-- mingw64: yes
 -- win: no
 -- mac: no
 

--- a/testsuite/OMSimulator/import_parameter_mapping_inline.lua
+++ b/testsuite/OMSimulator/import_parameter_mapping_inline.lua
@@ -1,7 +1,8 @@
 -- status: correct
 -- teardown_command: rm -rf import_parameter_mapping_inline_lua/
 -- linux: yes
--- mingw: yes
+-- mingw32: yes
+-- mingw64: yes
 -- win: no
 -- mac: no
 

--- a/testsuite/OMSimulator/multipleConnections.lua
+++ b/testsuite/OMSimulator/multipleConnections.lua
@@ -1,6 +1,7 @@
 -- status: correct
 -- linux: yes
--- mingw: yes
+-- mingw32: yes
+-- mingw64: yes
 -- win: no
 -- mac: no
 

--- a/testsuite/OMSimulator/partialSnapshot.lua
+++ b/testsuite/OMSimulator/partialSnapshot.lua
@@ -1,6 +1,7 @@
 -- status: correct
 -- linux: yes
--- mingw: yes
+-- mingw32: yes
+-- mingw64: yes
 -- win: no
 -- mac: no
 

--- a/testsuite/OMSimulator/rename.lua
+++ b/testsuite/OMSimulator/rename.lua
@@ -1,6 +1,7 @@
 -- status: correct
 -- linux: yes
--- mingw: yes
+-- mingw32: yes
+-- mingw64: yes
 -- win: no
 -- mac: no
 

--- a/testsuite/OMSimulator/renameModel.lua
+++ b/testsuite/OMSimulator/renameModel.lua
@@ -1,7 +1,8 @@
 -- status: correct
 -- teardown_command: rm -rf rename_model
 -- linux: yes
--- mingw: yes
+-- mingw32: yes
+-- mingw64: yes
 -- win: no
 -- mac: no
 

--- a/testsuite/OMSimulator/renameNewCref.lua
+++ b/testsuite/OMSimulator/renameNewCref.lua
@@ -1,6 +1,7 @@
 -- status: correct
 -- linux: yes
--- mingw: yes
+-- mingw32: yes
+-- mingw64: yes
 -- win: no
 -- mac: no
 

--- a/testsuite/OMSimulator/renameNewCref_1.lua
+++ b/testsuite/OMSimulator/renameNewCref_1.lua
@@ -1,6 +1,7 @@
 -- status: correct
 -- linux: yes
--- mingw: yes
+-- mingw32: yes
+-- mingw64: yes
 -- win: no
 -- mac: no
 

--- a/testsuite/OMSimulator/renameNewCref_2.lua
+++ b/testsuite/OMSimulator/renameNewCref_2.lua
@@ -1,6 +1,7 @@
 -- status: correct
 -- linux: yes
--- mingw: yes
+-- mingw32: yes
+-- mingw64: yes
 -- win: no
 -- mac: no
 

--- a/testsuite/OMSimulator/renameSnapshot.lua
+++ b/testsuite/OMSimulator/renameSnapshot.lua
@@ -1,7 +1,8 @@
 -- status: correct
 -- teardown_command: rm -rf rename_snapshot_lua/ renameSnapshot.ssp
 -- linux: yes
--- mingw: yes
+-- mingw32: yes
+-- mingw64: yes
 -- win: no
 -- mac: no
 

--- a/testsuite/OMSimulator/renameValues1.lua
+++ b/testsuite/OMSimulator/renameValues1.lua
@@ -1,7 +1,8 @@
 -- status: correct
 -- teardown_command: rm -rf rename_values_01_lua/
 -- linux: yes
--- mingw: yes
+-- mingw32: yes
+-- mingw64: yes
 -- win: no
 -- mac: no
 

--- a/testsuite/OMSimulator/renameValues2.lua
+++ b/testsuite/OMSimulator/renameValues2.lua
@@ -1,7 +1,8 @@
 -- status: correct
 -- teardown_command: rm -rf rename_values_02_lua/
 -- linux: yes
--- mingw: yes
+-- mingw32: yes
+-- mingw64: yes
 -- win: no
 -- mac: no
 

--- a/testsuite/OMSimulator/setExternalInputs.lua
+++ b/testsuite/OMSimulator/setExternalInputs.lua
@@ -1,6 +1,7 @@
 -- status: correct
 -- linux: yes
--- mingw: yes
+-- mingw32: yes
+-- mingw64: yes
 -- win: no
 -- mac: no
 

--- a/testsuite/OMSimulator/simulation.lua
+++ b/testsuite/OMSimulator/simulation.lua
@@ -1,7 +1,8 @@
 -- status: correct
 -- teardown_command: rm -rf simulation-lua/ test_init2.dot test_event2.dot test_sim2.dot test_res.mat
 -- linux: yes
--- mingw: no
+-- mingw32: no
+-- mingw64: no
 -- win: no
 -- mac: no
 

--- a/testsuite/OMSimulator/simulation.py
+++ b/testsuite/OMSimulator/simulation.py
@@ -1,7 +1,8 @@
 ## status: correct
 ## teardown_command: rm -rf simulation-py/ test_init1.dot test_sim1.dot test_event1.dot test.mat
 ## linux: yes
-## mingw: no
+## mingw32: no
+-- mingw64: no
 ## win: no
 ## mac: no
 

--- a/testsuite/OMSimulator/simulation.py
+++ b/testsuite/OMSimulator/simulation.py
@@ -2,7 +2,7 @@
 ## teardown_command: rm -rf simulation-py/ test_init1.dot test_sim1.dot test_event1.dot test.mat
 ## linux: yes
 ## mingw32: no
--- mingw64: no
+## mingw64: no
 ## win: no
 ## mac: no
 

--- a/testsuite/OMSimulator/snapshot.lua
+++ b/testsuite/OMSimulator/snapshot.lua
@@ -1,6 +1,7 @@
 -- status: correct
 -- linux: yes
--- mingw: yes
+-- mingw32: yes
+-- mingw64: yes
 -- win: no
 -- mac: no
 

--- a/testsuite/OMSimulator/snapshot.py
+++ b/testsuite/OMSimulator/snapshot.py
@@ -1,6 +1,7 @@
 ## status: correct
 ## linux: yes
-## mingw: yes
+## mingw32: yes
+-- mingw64: yes
 ## win: no
 ## mac: no
 

--- a/testsuite/OMSimulator/snapshot.py
+++ b/testsuite/OMSimulator/snapshot.py
@@ -1,7 +1,7 @@
 ## status: correct
 ## linux: yes
 ## mingw32: yes
--- mingw64: yes
+## mingw64: yes
 ## win: no
 ## mac: no
 

--- a/testsuite/OMSimulator/table.lua
+++ b/testsuite/OMSimulator/table.lua
@@ -1,7 +1,8 @@
 -- status: correct
 -- teardown_command: rm -rf table-lua/ table_res.mat
 -- linux: yes
--- mingw: yes
+-- mingw32: yes
+-- mingw64: yes
 -- win: no
 -- mac: yes
 

--- a/testsuite/api/buses.lua
+++ b/testsuite/api/buses.lua
@@ -1,7 +1,8 @@
 -- status: correct
 -- teardown_command: rm -rf buses-lua/
 -- linux: yes
--- mingw: yes
+-- mingw32: yes
+-- mingw64: yes
 -- win: no
 -- mac: no
 

--- a/testsuite/api/buses.py
+++ b/testsuite/api/buses.py
@@ -1,7 +1,8 @@
 ## status: correct
 ## teardown_command: rm -rf buses-py/
 ## linux: yes
-## mingw: yes
+## mingw32: yes
+-- mingw64: yes
 ## win: no
 ## mac: no
 

--- a/testsuite/api/buses.py
+++ b/testsuite/api/buses.py
@@ -2,7 +2,7 @@
 ## teardown_command: rm -rf buses-py/
 ## linux: yes
 ## mingw32: yes
--- mingw64: yes
+## mingw64: yes
 ## win: no
 ## mac: no
 

--- a/testsuite/api/connections.lua
+++ b/testsuite/api/connections.lua
@@ -1,7 +1,8 @@
 -- status: correct
 -- teardown_command: rm -rf connections-lua/
 -- linux: yes
--- mingw: yes
+-- mingw32: yes
+-- mingw64: yes
 -- win: no
 -- mac: yes
 

--- a/testsuite/api/connections.py
+++ b/testsuite/api/connections.py
@@ -1,7 +1,8 @@
 ## status: correct
 ## teardown_command: rm -rf connections-py/
 ## linux: yes
-## mingw: yes
+## mingw32: yes
+-- mingw64: yes
 ## win: no
 ## mac: no
 

--- a/testsuite/api/connections.py
+++ b/testsuite/api/connections.py
@@ -2,7 +2,7 @@
 ## teardown_command: rm -rf connections-py/
 ## linux: yes
 ## mingw32: yes
--- mingw64: yes
+## mingw64: yes
 ## win: no
 ## mac: no
 

--- a/testsuite/api/test01.lua
+++ b/testsuite/api/test01.lua
@@ -2,7 +2,8 @@
 -- teardown_command: rm -rf test01-lua/
 -- linux: yes
 -- linux32: yes
--- mingw: yes
+-- mingw32: yes
+-- mingw64: yes
 -- win: no
 -- mac: yes
 

--- a/testsuite/api/test01.py
+++ b/testsuite/api/test01.py
@@ -1,7 +1,8 @@
 ## status: correct
 ## teardown_command: rm -rf test01-py/
 ## linux: yes
-## mingw: yes
+## mingw32: yes
+-- mingw64: yes
 ## win: no
 ## mac: no
 

--- a/testsuite/api/test01.py
+++ b/testsuite/api/test01.py
@@ -2,7 +2,7 @@
 ## teardown_command: rm -rf test01-py/
 ## linux: yes
 ## mingw32: yes
--- mingw64: yes
+## mingw64: yes
 ## win: no
 ## mac: no
 

--- a/testsuite/api/test02.lua
+++ b/testsuite/api/test02.lua
@@ -1,7 +1,8 @@
 -- status: correct
 -- teardown_command: rm -rf test02-lua/
 -- linux: yes
--- mingw: yes
+-- mingw32: yes
+-- mingw64: yes
 -- win: no
 -- mac: no
 

--- a/testsuite/api/test02.py
+++ b/testsuite/api/test02.py
@@ -2,7 +2,7 @@
 ## teardown_command: rm -rf test02-py/
 ## linux: yes
 ## mingw32: yes
--- mingw64: yes
+## mingw64: yes
 ## win: no
 ## mac: no
 

--- a/testsuite/api/test02.py
+++ b/testsuite/api/test02.py
@@ -1,7 +1,8 @@
 ## status: correct
 ## teardown_command: rm -rf test02-py/
 ## linux: yes
-## mingw: yes
+## mingw32: yes
+-- mingw64: yes
 ## win: no
 ## mac: no
 

--- a/testsuite/api/test03.lua
+++ b/testsuite/api/test03.lua
@@ -1,7 +1,8 @@
 -- status: correct
 -- teardown_command: rm -rf test03-lua/ test_res.mat
 -- linux: yes
--- mingw: yes
+-- mingw32: yes
+-- mingw64: yes
 -- win: no
 -- mac: no
 

--- a/testsuite/api/test03.py
+++ b/testsuite/api/test03.py
@@ -1,7 +1,8 @@
 ## status: correct
 ## teardown_command: rm -rf test03-py/ test_res.mat
 ## linux: yes
-## mingw: yes
+## mingw32: yes
+-- mingw64: yes
 ## win: no
 ## mac: no
 

--- a/testsuite/api/test03.py
+++ b/testsuite/api/test03.py
@@ -2,7 +2,7 @@
 ## teardown_command: rm -rf test03-py/ test_res.mat
 ## linux: yes
 ## mingw32: yes
--- mingw64: yes
+## mingw64: yes
 ## win: no
 ## mac: no
 

--- a/testsuite/api/test_omsExport.lua
+++ b/testsuite/api/test_omsExport.lua
@@ -2,7 +2,8 @@
 -- teardown_command: rm -rf test_omsExport-lua/
 -- linux: yes
 -- linux32: yes
--- mingw: yes
+-- mingw32: yes
+-- mingw64: yes
 -- win: no
 -- mac: yes
 

--- a/testsuite/api/test_omsExport.py
+++ b/testsuite/api/test_omsExport.py
@@ -2,7 +2,8 @@
 ## teardown_command: rm -rf test_omsExport-py/
 ## linux: yes
 ## linux32: yes
-## mingw: yes
+## mingw32: yes
+-- mingw64: yes
 ## win: no
 ## mac: no
 

--- a/testsuite/api/test_omsExport.py
+++ b/testsuite/api/test_omsExport.py
@@ -3,7 +3,7 @@
 ## linux: yes
 ## linux32: yes
 ## mingw32: yes
--- mingw64: yes
+## mingw64: yes
 ## win: no
 ## mac: no
 

--- a/testsuite/assc/ASSCExample.lua
+++ b/testsuite/assc/ASSCExample.lua
@@ -1,7 +1,8 @@
 -- status: correct
 -- teardown_command: rm -rf Example_res.mat Example.log
 -- linux: yes
--- mingw: yes
+-- mingw32: yes
+-- mingw64: yes
 -- win: no
 
 oms_setCommandLineOption("--suppressPath=true --stripRoot=true")

--- a/testsuite/rtest
+++ b/testsuite/rtest
@@ -16,22 +16,24 @@ if ($cwd =~ m/(.*)testsuite\/(.+)$/) {
   $os = `uname`;
   if ($os =~ /MINGW/) {
     if ($os =~ /MINGW64/) {
-      $PLATFORM = "mingw64";
+      $PLATFORM = "mingw";
+      $TEST_PLATFORM = "mingw64";
     }
     else {
-      $PLATFORM = "mingw32";
+      $PLATFORM = "mingw";
+      $TEST_PLATFORM = "mingw32";
     }
   }
   else {
     if ($os =~ /Darwin/) {
       $PLATFORM = "mac";
+      $TEST_PLATFORM = $PLATFORM;
     }
     else {
       $PLATFORM = "linux";
+      $TEST_PLATFORM = $PLATFORM;
     }
   }
-
-  $TEST_PLATFORM = $PLATFORM;
 
   if ($SUPERPROJECT) {
     $OMCDIFF = "$prefix/../build/bin/omc-diff";

--- a/testsuite/rtest
+++ b/testsuite/rtest
@@ -15,7 +15,12 @@ if ($cwd =~ m/(.*)testsuite\/(.+)$/) {
   $dirname = $2;
   $os = `uname`;
   if ($os =~ /MINGW/) {
-    $PLATFORM = "mingw";
+    if ($os =~ /MINGW64/) {
+      $PLATFORM = "mingw64";
+    }
+    else {
+      $PLATFORM = "mingw32";
+    }
   }
   else {
     if ($os =~ /Darwin/) {
@@ -300,7 +305,8 @@ sub dofile
         "linux"   => "yes",
         "linux32" => "",
         "win"     => "",
-        "mingw"   => "",
+        "mingw32" => "",
+        "mingw64" => "",
         "mac"     => "");
     $expected = $expectedPrefix . "tmp_expected-" . $f;
     $got = $gotPrefix . "_tmp_got-" . $f;

--- a/testsuite/tlm/externalmodels.lua
+++ b/testsuite/tlm/externalmodels.lua
@@ -1,7 +1,8 @@
 -- status: correct
 -- teardown_command: rm -rf externalmodels-lua/
 -- linux: yes
--- mingw: yes
+-- mingw32: yes
+-- mingw64: yes
 -- win: no
 -- mac: no
 

--- a/testsuite/tlm/externalmodels.py
+++ b/testsuite/tlm/externalmodels.py
@@ -1,7 +1,8 @@
 ## status: correct
 ## teardown_command: rm -rf externalmodels-py
 ## linux: yes
-## mingw: yes
+## mingw32: yes
+-- mingw64: yes
 ## win: no
 ## mac: no
 

--- a/testsuite/tlm/externalmodels.py
+++ b/testsuite/tlm/externalmodels.py
@@ -2,7 +2,7 @@
 ## teardown_command: rm -rf externalmodels-py
 ## linux: yes
 ## mingw32: yes
--- mingw64: yes
+## mingw64: yes
 ## win: no
 ## mac: no
 

--- a/testsuite/tlm/tlm1d.lua
+++ b/testsuite/tlm/tlm1d.lua
@@ -1,7 +1,8 @@
 -- status: correct
 -- teardown_command: rm -rf tlm1d.log tlm1d-lua/ tlm1d.csv tlm1d.run tlm1d_res.mat
 -- linux: yes
--- mingw: no
+-- mingw32: no
+-- mingw64: no
 -- mac: no
 
 oms_setLogFile("tlm1d.log")

--- a/testsuite/tlm/tlm1dfg.lua
+++ b/testsuite/tlm/tlm1dfg.lua
@@ -1,7 +1,8 @@
 -- status: correct
 -- teardown_command: rm -rf tlm1dfg.log tlm1dfg-lua/ tlm1dfg.csv tlm1dfg.run tlm1dfg_res.mat
 -- linux: yes
--- mingw: no
+-- mingw32: no
+-- mingw64: no
 -- mac: no
 
 oms_setLogFile("tlm1dfg.log")

--- a/testsuite/tlm/tlm3d.lua
+++ b/testsuite/tlm/tlm3d.lua
@@ -1,7 +1,8 @@
 -- status: correct
 -- teardown_command: rm -rf tlm3d.log tlm3d-lua/ tlm3d.csv tlm3d.run tlm3d_all.csv
 -- linux: yes
--- mingw: no
+-- mingw32: no
+-- mingw64: no
 -- mac: no
 
 oms_setLogFile("tlm3d.log")

--- a/testsuite/tlm/tlmbuses.lua
+++ b/testsuite/tlm/tlmbuses.lua
@@ -1,7 +1,8 @@
 -- status: correct
 -- teardown_command: rm -rf tlmbuses-lua/
 -- linux: yes
--- mingw: yes
+-- mingw32: yes
+-- mingw64: yes
 -- win: no
 -- mac: no
 

--- a/testsuite/tlm/tlmbuses.py
+++ b/testsuite/tlm/tlmbuses.py
@@ -1,7 +1,8 @@
 ## status: correct
 ## teardown_command: rm -rf tlmbuses-py/
 ## linux: yes
-## mingw: yes
+## mingw32: yes
+-- mingw64: yes
 ## win: no
 ## mac: no
 

--- a/testsuite/tlm/tlmbuses.py
+++ b/testsuite/tlm/tlmbuses.py
@@ -2,7 +2,7 @@
 ## teardown_command: rm -rf tlmbuses-py/
 ## linux: yes
 ## mingw32: yes
--- mingw64: yes
+## mingw64: yes
 ## win: no
 ## mac: no
 

--- a/testsuite/tlm/tlmexternal.lua
+++ b/testsuite/tlm/tlmexternal.lua
@@ -1,7 +1,8 @@
 -- status: correct
 -- teardown_command: rm -rf tlmexternal.log tlmexternal-lua/ tlmexternal.csv tlmexternal.run tlmexternal_res.mat
 -- linux: yes
--- mingw: no
+-- mingw32: no
+-- mingw64: no
 -- mac: no
 
 oms_setLogFile("tlmexternal.log")

--- a/testsuite/tlm/tlmsignals.lua
+++ b/testsuite/tlm/tlmsignals.lua
@@ -1,7 +1,8 @@
 -- status: correct
 -- teardown_command: rm -rf tlmsignals.log tlmsignals-lua/ tlmsignals.run tlmsignals.csv tlmsignals_res.mat
 -- linux: yes
--- mingw: no
+-- mingw32: no
+-- mingw64: no
 -- mac: no
 
 oms_setLogFile("tlmsignals.log")


### PR DESCRIPTION
### Purpose

The AircraftVehicleDemonstrator test only provides FMUs for mingw64 and is therefore failing in the 32bit jenkins test. With this changes, we can enable a test case specifically for mingw32 or mingw64.

I didn't test it though, becuase I have no Windows setup on my computer. But I guess running the pull request with the CI/MINGW32 flag should test it.