### PR TITLE
attempt to fix perl hangs and print some info

### DIFF
--- a/testsuite/partest/runtests.pl
+++ b/testsuite/partest/runtests.pl
@@ -294,6 +294,9 @@ foreach(@test_list) {
   $test_queue->enqueue($_);
 }
 
+# Signal that there is no more work to be sent
+$test_queue->end();
+
 # Check if we can open /proc/cpuinfo to see how many cores are available, and
 # use that many threads instead.
 if ($check_proc_cpu) {
@@ -330,6 +333,7 @@ for(my $i = 0; $i < $thread_count; $i++) {
 # Wait for the tests to finish.
 foreach my $thr (threads->list()) {
   $thr->join();
+  print "{joined thread: " . $thr->tid() . "}"
 }
 
 # Print out the list of tests that failed, and a summary of how many failed.


### PR DESCRIPTION
### Purpose

Attempt to fix random perl hangs when running the testsuite.

### Approach

Signal the queue that there is no more work.
