### PR TITLE
copy libxml2.so to lib for linux32

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,8 @@ STATIC ?= OFF
 BUILD_TYPE ?= Release
 
 detected_OS ?= $(shell uname -s)
+# check architecture type 32 or 64 bit
+detected_arch ?= $(shell uname -m)
 
 ifeq ($(detected_OS),Darwin)
 	BUILD_DIR := build/mac
@@ -58,7 +60,8 @@ else
 	INSTALL_DIR := install/linux
 	CMAKE_TARGET=-DCMAKE_SYSTEM_NAME=$(detected_OS)
 # if empty is LINUX64, else LINUX32
-ifneq (,$(filter i386% i486% i586% i686%,$(host_short)))
+# ifneq (,$(filter i386% i486% i586% i686%,$(host_short)))
+ifneq (,$(filter $(detected_arch),i386 i486 i586 i686))
 	export ABI := LINUX32
 else
 	export ABI := LINUX64

--- a/src/OMSimulatorLib/CMakeLists.txt
+++ b/src/OMSimulatorLib/CMakeLists.txt
@@ -171,7 +171,7 @@ ELSE ()
 ENDIF ()
 
 ## Copy libxml2 libraries to lib for linux32
-IF ("${ABI}" MATCHES "LINUX32")
+IF ("${ABI}" MATCHES "LINUX")
  install(DIRECTORY ../../3rdParty/libxml2/install/linux/lib/ DESTINATION lib FILES_MATCHING PATTERN "*xml2.so*" PATTERN "cmake" EXCLUDE PATTERN "pkgconfig" EXCLUDE PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ)
 ENDIF()
 

--- a/src/OMSimulatorLib/CMakeLists.txt
+++ b/src/OMSimulatorLib/CMakeLists.txt
@@ -170,10 +170,10 @@ ELSE ()
   install(TARGETS OMSimulatorLib DESTINATION lib/${HOST_SHORT})
 ENDIF ()
 
-## Copy libxml2 libraries to lib for linux32
-IF ("${ABI}" MATCHES "LINUX")
- install(DIRECTORY ../../3rdParty/libxml2/install/linux/lib/ DESTINATION lib FILES_MATCHING PATTERN "*xml2.so*" PATTERN "cmake" EXCLUDE PATTERN "pkgconfig" EXCLUDE PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ)
-ENDIF()
+## Copy libxml2 libraries to lib, this is needed only for linux32, but as a workaround we copy the libs for all platforms
+## IF ("${ABI}" MATCHES "LINUX")
+ ##install(DIRECTORY ../../3rdParty/libxml2/install/linux/lib/ DESTINATION lib FILES_MATCHING PATTERN "*xml2.so*" PATTERN "cmake" EXCLUDE PATTERN "pkgconfig" EXCLUDE PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ)
+##ENDIF()
 
 install(TARGETS OMSimulatorLib_static DESTINATION lib/${HOST_SHORT})
 install(FILES OMSimulator.h Types.h DESTINATION include)

--- a/src/OMSimulatorLib/CMakeLists.txt
+++ b/src/OMSimulatorLib/CMakeLists.txt
@@ -170,5 +170,10 @@ ELSE ()
   install(TARGETS OMSimulatorLib DESTINATION lib/${HOST_SHORT})
 ENDIF ()
 
+## Copy libxml2 libraries to lib for linux32
+IF ("${ABI}" MATCHES "LINUX32")
+ install(DIRECTORY ../../3rdParty/libxml2/install/linux/lib/ DESTINATION lib FILES_MATCHING PATTERN "*xml2.so*" PATTERN "cmake" EXCLUDE PATTERN "pkgconfig" EXCLUDE PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ)
+ENDIF()
+
 install(TARGETS OMSimulatorLib_static DESTINATION lib/${HOST_SHORT})
 install(FILES OMSimulator.h Types.h DESTINATION include)


### PR DESCRIPTION
### Purpose

This PR copies the `libxml2` libraries to `lib` folder to fix `linux32` 
