### PR TITLE
Only consider continuous variables for derivatives

### DIFF
--- a/src/OMSimulatorLib/Variable.cpp
+++ b/src/OMSimulatorLib/Variable.cpp
@@ -45,6 +45,7 @@ oms::Variable::Variable(fmi2_import_variable_t* var)
   trim(description);
   vr = fmi2_import_get_variable_vr(var);
   causality = fmi2_import_get_causality(var);
+  variability = fmi2_import_get_variability(var);
   initialProperty = fmi2_import_get_initial(var);
 
   switch (fmi2_import_get_variable_base_type(var))
@@ -71,7 +72,7 @@ oms::Variable::Variable(fmi2_import_variable_t* var)
   }
 
   // mark derivatives
-  if (oms_signal_type_real == type)
+  if (oms_signal_type_real == type && variability == fmi2_variability_enu_continuous)
   {
     fmi2_import_real_variable_t* varReal = fmi2_import_get_variable_as_real(var);
     fmi2_import_variable_t* varState = (fmi2_import_variable_t*)fmi2_import_get_real_variable_derivative_of(varReal);

--- a/src/OMSimulatorLib/Variable.h
+++ b/src/OMSimulatorLib/Variable.h
@@ -95,6 +95,7 @@ namespace oms
     std::string description;
     fmi2_value_reference_t vr;
     fmi2_causality_enu_t causality;
+    fmi2_variability_enu_t variability;
     fmi2_initial_enu_t initialProperty;
     bool is_state;
     bool is_der;


### PR DESCRIPTION
### Purpose

E.g., a derivative could be a parameter. Those variables shouldn't be considered for the derivatives.