### PR TITLE
Fix function almostEqualRelativeAndAbs

### DIFF
--- a/src/OMSimulatorLib/Util.h
+++ b/src/OMSimulatorLib/Util.h
@@ -72,7 +72,7 @@ static inline bool almostEqualRelativeAndAbs(double a, double b, double reltol=D
     return true;
 
   if (diff <= fmax(fabs(a), fabs(b)) * reltol)
-    return false;
+    return true;
 
   return false;
 }


### PR DESCRIPTION
It seems that only the absolute value check was implemented correctly, and that the relative value check was basically skipped.