### PR TITLE
Use cmake3 on CentOS7.

### DIFF
--- a/.CI/centos7/Dockerfile
+++ b/.CI/centos7/Dockerfile
@@ -1,3 +1,5 @@
 FROM centos:7
 
+RUN yum -y install epel-release
+
 RUN yum -y install libtool automake gcc-c++ libstdc++-static boost-devel git make cmake3 readline-devel lua-devel

--- a/.CI/centos7/Dockerfile
+++ b/.CI/centos7/Dockerfile
@@ -1,3 +1,3 @@
 FROM centos:7
 
-RUN yum -y install libtool automake gcc-c++ libstdc++-static boost-devel git make cmake readline-devel lua-devel
+RUN yum -y install libtool automake gcc-c++ libstdc++-static boost-devel git make cmake3 readline-devel lua-devel

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -127,7 +127,7 @@ pipeline {
             }
           }
           environment {
-            OMSFLAGS = "OMTLM=OFF"
+            OMSFLAGS = "CMAKE=cmake3 OMTLM=OFF"
           }
           steps {
             buildOMS()


### PR DESCRIPTION
### Related Issues
None

### Purpose

Change CI builds on CentOS7 to use cmake3 (CMake versions > 3) 

### Approach

 We now have cmake3 installed on OpenModelica's CentOS7 docker images. However, OMSimulator does not actually use those and uses the clean base centos:7 image. So just install cmake3 on that one as well.

### Commits

@mahge
Use cmake3 on CentOS7. 
71710a0
  - We now have cmake3 installed on our CentOS images. Use that when
    building OMSimulator.

@mahge
OMSimulator uses its own clean CentOS7 image. 
2b53541
  - So we can just install cmake3 on it.

  - If this was not done intentionally, it should probably use the one
    used by OpenModelica CI as well, i.e,
       `docker.openmodelica.org/build-deps:el7.amd64`

@mahge
Add epel repo for cmake3 package.
b18cd34