### PR TITLE
delete references and it's start values

### DIFF
--- a/src/OMSimulatorLib/ComponentFMUCS.cpp
+++ b/src/OMSimulatorLib/ComponentFMUCS.cpp
@@ -697,10 +697,16 @@ oms::ComRef oms::ComponentFMUCS::getValidCref(ComRef cref)
 oms_status_enu_t oms::ComponentFMUCS::newResources(const std::string& ssvFilename, const std::string& ssmFilename, bool externalResources)
 {
   Values resources;
+  if (externalResources) // check of external resources and override the start values with new references
+  {
+    Snapshot snapshot;
+    snapshot.importResourceFile(ssvFilename, getModel().getTempDirectory() + "/resources");
+    if (oms_status_ok != resources.importFromSnapshot(snapshot, ssvFilename, ssmFilename))
+      return logError("referenceResources failed for \"" + std::string(getFullCref()) + ":" + ssvFilename + "\"");
+  }
   if (!values.hasResources())
   {
     resources.allresources["resources/" + ssvFilename] = resources;
-    resources.externalResources = externalResources; // set if resources is "external" or "newResources", if "external" only references will be set in ssd
     if(!ssmFilename.empty())
       resources.ssmFile = "resources/" + ssmFilename;
     values.parameterResources.push_back(resources);
@@ -708,7 +714,6 @@ oms_status_enu_t oms::ComponentFMUCS::newResources(const std::string& ssvFilenam
   else
   {
     // generate empty ssv file, if more resources are added to same level
-    resources.externalResources = externalResources; // set if resources is "external" or "newResources", if "external" only references will be set in ssd
     if(!ssmFilename.empty())
       resources.ssmFile = "resources/" + ssmFilename;;
     values.parameterResources[0].allresources["resources/" + ssvFilename] = resources;

--- a/src/OMSimulatorLib/ComponentFMUCS.cpp
+++ b/src/OMSimulatorLib/ComponentFMUCS.cpp
@@ -569,7 +569,8 @@ oms_status_enu_t oms::ComponentFMUCS::instantiate()
     {
       for (const auto &res : it.allresources)
       {
-        setResourcesHelper1(res.second);
+        if (res.second.linkResources) // set values only if resources are linked in ssd
+          setResourcesHelper1(res.second);
       }
     }
   }
@@ -634,32 +635,41 @@ oms_status_enu_t oms::ComponentFMUCS::setResourcesHelper2(Values values)
     {
       for (const auto &v : res.second.booleanStartValues)
       {
-        oms::ComRef tail(v.first);
-        oms::ComRef head = tail.pop_front();
-        if (head == getCref())
+        if (res.second.linkResources) // set values only if resources are linked in ssd
         {
-          if (oms_status_ok != setBoolean(tail, v.second))
-            return logError("Failed to set start value for " + std::string(v.first));
+          oms::ComRef tail(v.first);
+          oms::ComRef head = tail.pop_front();
+          if (head == getCref())
+          {
+            if (oms_status_ok != setBoolean(tail, v.second))
+              return logError("Failed to set start value for " + std::string(v.first));
+          }
         }
       }
       for (const auto &v : res.second.integerStartValues)
       {
-        oms::ComRef tail(v.first);
-        oms::ComRef head = tail.pop_front();
-        if (head == getCref())
+        if (res.second.linkResources) // set values only if resources are linked in ssd
         {
-          if (oms_status_ok != setInteger(tail, v.second))
-            return logError("Failed to set start value for " + std::string(v.first));
+          oms::ComRef tail(v.first);
+          oms::ComRef head = tail.pop_front();
+          if (head == getCref())
+          {
+            if (oms_status_ok != setInteger(tail, v.second))
+              return logError("Failed to set start value for " + std::string(v.first));
+          }
         }
       }
       for (const auto &v : res.second.realStartValues)
       {
-        oms::ComRef tail(v.first);
-        oms::ComRef head = tail.pop_front();
-        if (head == getCref())
+        if (res.second.linkResources) // set values only if resources are linked in ssd
         {
-          if (oms_status_ok != setReal(tail, v.second))
-            return logError("Failed to set start value for " + std::string(v.first));
+          oms::ComRef tail(v.first);
+          oms::ComRef head = tail.pop_front();
+          if (head == getCref())
+          {
+            if (oms_status_ok != setReal(tail, v.second))
+              return logError("Failed to set start value for " + std::string(v.first));
+          }
         }
       }
     }

--- a/src/OMSimulatorLib/ComponentFMUCS.cpp
+++ b/src/OMSimulatorLib/ComponentFMUCS.cpp
@@ -701,9 +701,15 @@ oms_status_enu_t oms::ComponentFMUCS::newResources(const std::string& ssvFilenam
   {
     Snapshot snapshot;
     snapshot.importResourceFile(ssvFilename, getModel().getTempDirectory() + "/resources");
+
+    // import ssm file, if provided
+    if (!ssmFilename.empty())
+      snapshot.importResourceFile(ssmFilename, getModel().getTempDirectory() + "/resources");
+
     if (oms_status_ok != resources.importFromSnapshot(snapshot, ssvFilename, ssmFilename))
       return logError("referenceResources failed for \"" + std::string(getFullCref()) + ":" + ssvFilename + "\"");
   }
+
   if (!values.hasResources())
   {
     resources.allresources["resources/" + ssvFilename] = resources;

--- a/src/OMSimulatorLib/ComponentFMUME.cpp
+++ b/src/OMSimulatorLib/ComponentFMUME.cpp
@@ -727,9 +727,15 @@ oms_status_enu_t oms::ComponentFMUME::newResources(const std::string& ssvFilenam
   {
     Snapshot snapshot;
     snapshot.importResourceFile(ssvFilename, getModel().getTempDirectory() + "/resources");
+
+    // import ssm file, if provided
+    if (!ssmFilename.empty())
+      snapshot.importResourceFile(ssmFilename, getModel().getTempDirectory() + "/resources");
+
     if (oms_status_ok != resources.importFromSnapshot(snapshot, ssvFilename, ssmFilename))
       return logError("referenceResources failed for \"" + std::string(getFullCref()) + ":" + ssvFilename + "\"");
   }
+
   if (!values.hasResources())
   {
     resources.allresources["resources/" + ssvFilename] = resources;

--- a/src/OMSimulatorLib/ComponentFMUME.cpp
+++ b/src/OMSimulatorLib/ComponentFMUME.cpp
@@ -723,10 +723,16 @@ oms_status_enu_t oms::ComponentFMUME::doEventIteration()
 oms_status_enu_t oms::ComponentFMUME::newResources(const std::string& ssvFilename, const std::string& ssmFilename, bool externalResources)
 {
   Values resources;
+  if (externalResources) // check of external resources and override the start values with new references
+  {
+    Snapshot snapshot;
+    snapshot.importResourceFile(ssvFilename, getModel().getTempDirectory() + "/resources");
+    if (oms_status_ok != resources.importFromSnapshot(snapshot, ssvFilename, ssmFilename))
+      return logError("referenceResources failed for \"" + std::string(getFullCref()) + ":" + ssvFilename + "\"");
+  }
   if (!values.hasResources())
   {
     resources.allresources["resources/" + ssvFilename] = resources;
-    resources.externalResources = externalResources; // set if resources is "external" or "newResources", if "external" only references will be set in ssd
     if(!ssmFilename.empty())
       resources.ssmFile = "resources/" + ssmFilename;
     values.parameterResources.push_back(resources);
@@ -734,7 +740,6 @@ oms_status_enu_t oms::ComponentFMUME::newResources(const std::string& ssvFilenam
   else
   {
     // generate empty ssv file, if more resources are added to same level
-    resources.externalResources = externalResources; // set if resources is "external" or "newResources", if "external" only references will be set in ssd
     if(!ssmFilename.empty())
       resources.ssmFile = "resources/" + ssmFilename;
     values.parameterResources[0].allresources["resources/" + ssvFilename] = resources;

--- a/src/OMSimulatorLib/ComponentFMUME.cpp
+++ b/src/OMSimulatorLib/ComponentFMUME.cpp
@@ -568,7 +568,8 @@ oms_status_enu_t oms::ComponentFMUME::instantiate()
     {
       for (const auto &res : it.allresources)
       {
-        setResourcesHelper1(res.second);
+        if (res.second.linkResources) // set values only if resources are linked in ssd
+          setResourcesHelper1(res.second);
       }
     }
   }
@@ -640,32 +641,41 @@ oms_status_enu_t oms::ComponentFMUME::setResourcesHelper2(Values values)
     {
       for (const auto &v : res.second.booleanStartValues)
       {
-        oms::ComRef tail(v.first);
-        oms::ComRef head = tail.pop_front();
-        if (head == getCref())
+        if (res.second.linkResources) // set values only if resources are linked in ssd
         {
-          if (oms_status_ok != setBoolean(tail, v.second))
-            return logError("Failed to set start value for " + std::string(v.first));
+          oms::ComRef tail(v.first);
+          oms::ComRef head = tail.pop_front();
+          if (head == getCref())
+          {
+            if (oms_status_ok != setBoolean(tail, v.second))
+              return logError("Failed to set start value for " + std::string(v.first));
+          }
         }
       }
       for (const auto &v : res.second.integerStartValues)
       {
-        oms::ComRef tail(v.first);
-        oms::ComRef head = tail.pop_front();
-        if (head == getCref())
+        if (res.second.linkResources) // set values only if resources are linked in ssd
         {
-          if (oms_status_ok != setInteger(tail, v.second))
-            return logError("Failed to set start value for " + std::string(v.first));
+          oms::ComRef tail(v.first);
+          oms::ComRef head = tail.pop_front();
+          if (head == getCref())
+          {
+            if (oms_status_ok != setInteger(tail, v.second))
+              return logError("Failed to set start value for " + std::string(v.first));
+          }
         }
       }
       for (const auto &v : res.second.realStartValues)
       {
-        oms::ComRef tail(v.first);
-        oms::ComRef head = tail.pop_front();
-        if (head == getCref())
+        if (res.second.linkResources) // set values only if resources are linked in ssd
         {
-          if (oms_status_ok != setReal(tail, v.second))
-            return logError("Failed to set start value for " + std::string(v.first));
+          oms::ComRef tail(v.first);
+          oms::ComRef head = tail.pop_front();
+          if (head == getCref())
+          {
+            if (oms_status_ok != setReal(tail, v.second))
+              return logError("Failed to set start value for " + std::string(v.first));
+          }
         }
       }
     }

--- a/src/OMSimulatorLib/Model.cpp
+++ b/src/OMSimulatorLib/Model.cpp
@@ -563,9 +563,9 @@ oms_status_enu_t oms::Model::referenceResources(const oms::ComRef& cref, const s
   {
     std::string ssmExtension = "";
     if (ssmFile.length() > 4)
-      ssmExtension = ssmFile.substr(fileName.length() - 4);
+      ssmExtension = ssmFile.substr(ssmFile.length() - 4);
     if (ssmExtension != ".ssm")
-      return logError("filename extension for \"" + std::string(getCref() + cref) + "\" must be \".ssm\", no other formats are supported");
+      return logError("filename extension for \"" + ssmFile + "\" must be \".ssm\", no other formats are supported");
   }
 
   if (system)

--- a/src/OMSimulatorLib/System.cpp
+++ b/src/OMSimulatorLib/System.cpp
@@ -334,10 +334,17 @@ oms_status_enu_t oms::System::newResources(const ComRef& cref, const std::string
   {
     // top level system and subsystems
     Values resources;
+    if (externalResources) // check of external resources and override the start values with new references
+    {
+      Snapshot snapshot;
+      snapshot.importResourceFile(ssvFilename, getModel().getTempDirectory() + "/resources");
+      //snapshot.debugPrintAll();
+      if (oms_status_ok != resources.importFromSnapshot(snapshot, ssvFilename, ssmFilename))
+        return logError("referenceResources failed for \"" + std::string(getFullCref()) + ":" + ssvFilename + "\"");
+    }
     if (!values.hasResources())
     {
       resources.allresources["resources/" + ssvFilename] = resources;
-      resources.externalResources = externalResources; // set if resources is "external" or "newResources", if "external" only references will be set in ssd
       if (!ssmFilename.empty())
         resources.ssmFile = "resources/"+ ssmFilename;
       values.parameterResources.push_back(resources);
@@ -345,7 +352,6 @@ oms_status_enu_t oms::System::newResources(const ComRef& cref, const std::string
     else
     {
       // generate empty ssv file, if more resources are added to same level
-      resources.externalResources = externalResources; // set if resources is "external" or "newResources", if "external" only references will be set in ssd
       if (!ssmFilename.empty())
         resources.ssmFile = "resources/"+ ssmFilename;
       values.parameterResources[0].allresources["resources/" + ssvFilename] = resources;

--- a/src/OMSimulatorLib/System.cpp
+++ b/src/OMSimulatorLib/System.cpp
@@ -345,7 +345,7 @@ oms_status_enu_t oms::System::newResources(const ComRef& cref, const std::string
 
       //snapshot.debugPrintAll();
       if (oms_status_ok != resources.importFromSnapshot(snapshot, ssvFilename, ssmFilename))
-        return logError("referenceResources failed for \"" + std::string(getFullCref()) + ":" + ssvFilename + "\"");
+        return logError("oms_referenceResources failed for \"" + std::string(getFullCref()) + ":" + ssvFilename + "\"");
     }
 
     if (!values.hasResources())

--- a/src/OMSimulatorLib/System.cpp
+++ b/src/OMSimulatorLib/System.cpp
@@ -338,10 +338,16 @@ oms_status_enu_t oms::System::newResources(const ComRef& cref, const std::string
     {
       Snapshot snapshot;
       snapshot.importResourceFile(ssvFilename, getModel().getTempDirectory() + "/resources");
+
+      // import ssm file, if provided
+      if (!ssmFilename.empty())
+        snapshot.importResourceFile(ssmFilename, getModel().getTempDirectory() + "/resources");
+
       //snapshot.debugPrintAll();
       if (oms_status_ok != resources.importFromSnapshot(snapshot, ssvFilename, ssmFilename))
         return logError("referenceResources failed for \"" + std::string(getFullCref()) + ":" + ssvFilename + "\"");
     }
+
     if (!values.hasResources())
     {
       resources.allresources["resources/" + ssvFilename] = resources;

--- a/src/OMSimulatorLib/Values.cpp
+++ b/src/OMSimulatorLib/Values.cpp
@@ -239,14 +239,20 @@ oms_status_enu_t oms::Values::getRealResources(const ComRef& cref, double& value
     {
       if (externalInput && oms_modelState_simulation == modelState && res.second.realValues[cref] != 0.0)
       {
-        value = res.second.realValues[cref];
-        return oms_status_ok;
+        if (res.second.linkResources)
+        {
+          value = res.second.realValues[cref];
+          return oms_status_ok;
+        }
       }
       auto realValue = res.second.realStartValues.find(cref);
       if (realValue != res.second.realStartValues.end())
       {
-        value = realValue->second;
-        return oms_status_ok;
+        if (res.second.linkResources)
+        {
+          value = realValue->second;
+          return oms_status_ok;
+        }
       }
     }
   }
@@ -262,14 +268,20 @@ oms_status_enu_t oms::Values::getIntegerResources(const ComRef& cref, int& value
     {
       if (externalInput && oms_modelState_simulation == modelState && res.second.integerValues[cref] != 0.0)
       {
-        value = res.second.integerValues[cref];
-        return oms_status_ok;
+        if (res.second.linkResources)
+        {
+          value = res.second.integerValues[cref];
+          return oms_status_ok;
+        }
       }
       auto integerValue = res.second.integerStartValues.find(cref);
       if (integerValue != res.second.integerStartValues.end())
       {
-        value = integerValue->second;
-        return oms_status_ok;
+        if (res.second.linkResources)
+        {
+          value = integerValue->second;
+          return oms_status_ok;
+        }
       }
     }
   }
@@ -285,14 +297,20 @@ oms_status_enu_t oms::Values::getBooleanResources(const ComRef& cref, bool& valu
     {
       if (externalInput && oms_modelState_simulation == modelState && res.second.booleanValues[cref] != 0.0)
       {
-        value = res.second.booleanValues[cref];
-        return oms_status_ok;
+        if (res.second.linkResources)
+        {
+          value = res.second.booleanValues[cref];
+          return oms_status_ok;
+        }
       }
       auto booleanValue = res.second.booleanStartValues.find(cref);
       if (booleanValue != res.second.booleanStartValues.end())
       {
-        value = booleanValue->second;
-        return oms_status_ok;
+        if (res.second.linkResources)
+        {
+          value = booleanValue->second;
+          return oms_status_ok;
+        }
       }
     }
   }

--- a/src/OMSimulatorLib/Values.cpp
+++ b/src/OMSimulatorLib/Values.cpp
@@ -486,8 +486,18 @@ oms_status_enu_t oms::Values::exportToSSD(pugi::xml_node& node) const
 
 oms_status_enu_t oms::Values::importFromSnapshot(const Snapshot &snapshot, const std::string& ssvFilename, const std::string& ssmFilename)
 {
-  pugi::xml_node parameterSet = snapshot.getResourceNode(ssvFilename);
+  // import new ssm references
+  if (!ssmFilename.empty())
+  {
+    pugi::xml_node ssm_parameterMapping = snapshot.getResourceNode(ssmFilename);
+    if (!ssm_parameterMapping)
+      return logError("loading <oms:file> \"" + ssmFilename + "\" from <oms:snapshot> failed");
 
+    importParameterMapping(ssm_parameterMapping);
+  }
+
+  // import new ssv references
+  pugi::xml_node parameterSet = snapshot.getResourceNode(ssvFilename);
   if (!parameterSet)
     return logError("loading <oms:file> \"" + ssvFilename + "\" from <oms:snapshot> failed");
 

--- a/src/OMSimulatorLib/Values.h
+++ b/src/OMSimulatorLib/Values.h
@@ -70,6 +70,7 @@ namespace oms
 
     oms_status_enu_t exportToSSD(pugi::xml_node& node) const;
     oms_status_enu_t importFromSnapshot(const pugi::xml_node& node, const std::string& sspVersion, const Snapshot& snapshot);
+    oms_status_enu_t importFromSnapshot(const Snapshot& snapshot, const std::string& ssvFilePath, const std::string& ssmFilename);
     oms_status_enu_t deleteStartValue(const ComRef& cref);
     oms_status_enu_t deleteStartValueInResources(const ComRef& cref);
 
@@ -117,7 +118,6 @@ namespace oms
     std::map<std::string, Values> allresources; ///< mapped resources either inline or ssv
     std::string ssmFile = ""; ///< mapped ssm files associated with ssv files;
     bool linkResources = true;
-    bool externalResources = false;
   };
 }
 

--- a/testsuite/api/addExternalResources1.lua
+++ b/testsuite/api/addExternalResources1.lua
@@ -453,12 +453,12 @@ print(src)
 --         <ssv:Parameter
 --           name="Input2">
 --           <ssv:Real
---             value="-50" />
+--             value="-500" />
 --         </ssv:Parameter>
 --         <ssv:Parameter
 --           name="Input1">
 --           <ssv:Real
---             value="-10" />
+--             value="-100" />
 --         </ssv:Parameter>
 --       </ssv:Parameters>
 --     </ssv:ParameterSet>
@@ -474,7 +474,7 @@ print(src)
 --         <ssv:Parameter
 --           name="C1">
 --           <ssv:Real
---             value="-10" />
+--             value="-30" />
 --         </ssv:Parameter>
 --       </ssv:Parameters>
 --     </ssv:ParameterSet>

--- a/testsuite/api/addExternalResources3.py
+++ b/testsuite/api/addExternalResources3.py
@@ -456,12 +456,12 @@ print(src)
 ##         <ssv:Parameter
 ##           name="Input2">
 ##           <ssv:Real
-##             value="-50" />
+##             value="-500" />
 ##         </ssv:Parameter>
 ##         <ssv:Parameter
 ##           name="Input1">
 ##           <ssv:Real
-##             value="-10" />
+##             value="-100" />
 ##         </ssv:Parameter>
 ##       </ssv:Parameters>
 ##     </ssv:ParameterSet>
@@ -477,7 +477,7 @@ print(src)
 ##         <ssv:Parameter
 ##           name="C1">
 ##           <ssv:Real
-##             value="-10" />
+##             value="-30" />
 ##         </ssv:Parameter>
 ##       </ssv:Parameters>
 ##     </ssv:ParameterSet>

--- a/testsuite/resources/externalRoot.ssv
+++ b/testsuite/resources/externalRoot.ssv
@@ -8,12 +8,12 @@
     <ssv:Parameter
       name="Input2">
       <ssv:Real
-        value="-50" />
+        value="-500" />
     </ssv:Parameter>
     <ssv:Parameter
       name="Input1">
       <ssv:Real
-        value="-10" />
+        value="-100" />
     </ssv:Parameter>
   </ssv:Parameters>
 </ssv:ParameterSet>

--- a/testsuite/resources/externalSystem1.ssv
+++ b/testsuite/resources/externalSystem1.ssv
@@ -8,7 +8,7 @@
     <ssv:Parameter
       name="C1">
       <ssv:Real
-        value="-10" />
+        value="-30" />
     </ssv:Parameter>
   </ssv:Parameters>
 </ssv:ParameterSet>

--- a/testsuite/resources/importExportAllResources/resources/external_import_parameter_mapping.ssv
+++ b/testsuite/resources/importExportAllResources/resources/external_import_parameter_mapping.ssv
@@ -2,16 +2,16 @@
 <ssv:ParameterSet xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" version="1.0" name="parameters">
     <ssv:Parameters>
         <ssv:Parameter name="cosim_input">
-            <ssv:Real value="20" />
+            <ssv:Real value="-200" />
         </ssv:Parameter>
          <ssv:Parameter name="Input_3">
-            <ssv:Real value="50" />
+            <ssv:Real value="-300" />
         </ssv:Parameter>
         <ssv:Parameter name="cosim_parameters">
-            <ssv:Real value="-30" />
+            <ssv:Real value="-400" />
         </ssv:Parameter>
         <ssv:Parameter name="parameter_2">
-            <ssv:Real value="-40" />
+            <ssv:Real value="-500" />
         </ssv:Parameter>
     </ssv:Parameters>
 </ssv:ParameterSet>

--- a/testsuite/simulation/Makefile
+++ b/testsuite/simulation/Makefile
@@ -7,6 +7,7 @@ deleteStartValues.lua \
 deleteStartValuesInSSV.lua \
 deleteStartValuesInSSV1.lua \
 deleteStartValuesInSSV2.lua \
+deleteReferencesAndStartValues.lua \
 DualMassOscillator.lua \
 Enumeration.lua \
 Enumeration2.lua \

--- a/testsuite/simulation/Makefile
+++ b/testsuite/simulation/Makefile
@@ -37,6 +37,7 @@ partialSnapshot.lua \
 PI_Controller.lua \
 QuarterCarModel.DisplacementDisplacement.lua \
 referenceResources1.lua \
+referenceResources2.lua \
 rename.lua \
 renameValues1.lua \
 renameValues2.lua \

--- a/testsuite/simulation/Makefile
+++ b/testsuite/simulation/Makefile
@@ -36,6 +36,7 @@ multipleConnections.lua \
 partialSnapshot.lua \
 PI_Controller.lua \
 QuarterCarModel.DisplacementDisplacement.lua \
+referenceResources1.lua \
 rename.lua \
 renameValues1.lua \
 renameValues2.lua \

--- a/testsuite/simulation/deleteReferencesAndStartValues.lua
+++ b/testsuite/simulation/deleteReferencesAndStartValues.lua
@@ -1,0 +1,320 @@
+-- status: correct
+-- teardown_command: rm -rf deleteResourcesReferencesAndStartValues_lua/
+-- linux: yes
+-- mingw32: yes
+-- mingw64: yes
+-- win: yes
+-- mac: no
+
+oms_setCommandLineOption("--suppressPath=true")
+oms_setTempDirectory("./deleteResourcesReferencesAndStartValues_lua/")
+oms_setWorkingDirectory("./deleteResourcesReferencesAndStartValues_lua/")
+
+oms_newModel("deleteResources")
+
+oms_addSystem("deleteResources.root", oms_system_wc)
+oms_addConnector("deleteResources.root.Input1", oms_causality_input, oms_signal_type_real)
+oms_addConnector("deleteResources.root.Input2", oms_causality_input, oms_signal_type_real)
+
+-- add Top level resources
+oms_newResources("deleteResources.root:root.ssv")
+
+oms_setReal("deleteResources.root.Input1", 10)
+oms_setReal("deleteResources.root.Input2", 50)
+
+oms_addSystem("deleteResources.root.system1", oms_system_sc)
+oms_addConnector("deleteResources.root.system1.C1", oms_causality_input, oms_signal_type_real)
+oms_addConnector("deleteResources.root.system1.C2", oms_causality_input, oms_signal_type_real)
+
+-- add resources to subsystem
+oms_newResources("deleteResources.root.system1:system1.ssv")
+oms_setReal("deleteResources.root.system1.C1", -10)
+
+oms_addSubModel("deleteResources.root.Gain", "../../resources/Modelica.Blocks.Math.Gain.fmu")
+
+-- add resources to submodule
+oms_newResources("deleteResources.root.Gain:gain.ssv")
+
+oms_setReal("deleteResources.root.Gain.k", 27)
+
+oms_setResultFile("deleteResources", "deleteResources1.mat", 10)
+
+src = oms_exportSnapshot("deleteResources")
+-- print(src)
+
+print("info:    virgin parameter settings:")
+print("info:      deleteResources.root.Input1     : " .. oms_getReal("deleteResources.root.Input1"))
+print("info:      deleteResources.root.Input2     : " .. oms_getReal("deleteResources.root.Input2"))
+print("info:      deleteResources.root.system1.C1 : " .. oms_getReal("deleteResources.root.system1.C1"))
+print("info:      deleteResources.root.system1.C2 : " .. oms_getReal("deleteResources.root.system1.C2"))
+print("info:      deleteResources.root.Gain.k     : " .. oms_getReal("deleteResources.root.Gain.k"))
+
+-- delete only the references
+oms_deleteResources("deleteResources.root:root.ssv")
+-- delete only the references
+oms_deleteResources("deleteResources.root.system1:system1.ssv")
+-- delete only the references
+oms_deleteResources("deleteResources.root.Gain:gain.ssv")
+
+oms_instantiate("deleteResources")
+
+oms_initialize("deleteResources")
+print("info:    Initialization after deleting references and start values")
+print("info:      deleteResources.root.Input1     : " .. oms_getReal("deleteResources.root.Input1"))
+print("info:      deleteResources.root.Input2     : " .. oms_getReal("deleteResources.root.Input2"))
+print("info:      deleteResources.root.system1.C1 : " .. oms_getReal("deleteResources.root.system1.C1"))
+print("info:      deleteResources.root.system1.C2 : " .. oms_getReal("deleteResources.root.system1.C2"))
+print("info:      deleteResources.root.Gain.k     : " .. oms_getReal("deleteResources.root.Gain.k"))
+
+oms_simulate("deleteResources")
+print("info:    Simulation")
+print("info:      deleteResources.root.Input1     : " .. oms_getReal("deleteResources.root.Input1"))
+print("info:      deleteResources.root.Input2     : " .. oms_getReal("deleteResources.root.Input2"))
+print("info:      deleteResources.root.system1.C1 : " .. oms_getReal("deleteResources.root.system1.C1"))
+print("info:      deleteResources.root.system1.C2 : " .. oms_getReal("deleteResources.root.system1.C2"))
+print("info:      deleteResources.root.Gain.k     : " .. oms_getReal("deleteResources.root.Gain.k"))
+
+-- snapshot after deleting references
+src = oms_exportSnapshot("deleteResources")
+print(src)
+
+
+oms_terminate("deleteResources")
+oms_delete("deleteResources")
+
+
+
+-- Result:
+-- info:    virgin parameter settings:
+-- info:      deleteResources.root.Input1     : 10.0
+-- info:      deleteResources.root.Input2     : 50.0
+-- info:      deleteResources.root.system1.C1 : -10.0
+-- info:      deleteResources.root.system1.C2 : 0.0
+-- info:      deleteResources.root.Gain.k     : 27.0
+-- info:    model doesn't contain any continuous state
+-- info:    Result file: deleteResources1.mat (bufferSize=10)
+-- info:    Initialization after deleting references and start values
+-- info:      deleteResources.root.Input1     : 0.0
+-- info:      deleteResources.root.Input2     : 0.0
+-- info:      deleteResources.root.system1.C1 : 0.0
+-- info:      deleteResources.root.system1.C2 : 0.0
+-- info:      deleteResources.root.Gain.k     : 1.0
+-- info:    Simulation
+-- info:      deleteResources.root.Input1     : 0.0
+-- info:      deleteResources.root.Input2     : 0.0
+-- info:      deleteResources.root.system1.C1 : 0.0
+-- info:      deleteResources.root.system1.C2 : 0.0
+-- info:      deleteResources.root.Gain.k     : 1.0
+-- <?xml version="1.0"?>
+-- <oms:snapshot
+--   xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
+--   partial="false">
+--   <oms:file
+--     name="SystemStructure.ssd">
+--     <ssd:SystemStructureDescription
+--       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
+--       xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription"
+--       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
+--       xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping"
+--       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
+--       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
+--       name="deleteResources"
+--       version="1.0">
+--       <ssd:System
+--         name="root">
+--         <ssd:Connectors>
+--           <ssd:Connector
+--             name="Input1"
+--             kind="input">
+--             <ssc:Real />
+--           </ssd:Connector>
+--           <ssd:Connector
+--             name="Input2"
+--             kind="input">
+--             <ssc:Real />
+--           </ssd:Connector>
+--         </ssd:Connectors>
+--         <ssd:Elements>
+--           <ssd:System
+--             name="system1">
+--             <ssd:Connectors>
+--               <ssd:Connector
+--                 name="C1"
+--                 kind="input">
+--                 <ssc:Real />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="C2"
+--                 kind="input">
+--                 <ssc:Real />
+--               </ssd:Connector>
+--             </ssd:Connectors>
+--             <ssd:Annotations>
+--               <ssc:Annotation
+--                 type="org.openmodelica">
+--                 <oms:Annotations>
+--                   <oms:SimulationInformation>
+--                     <oms:VariableStepSolver
+--                       description="euler"
+--                       absoluteTolerance="0.0001"
+--                       relativeTolerance="0.0001"
+--                       minimumStepSize="1e-12"
+--                       maximumStepSize="0.001"
+--                       initialStepSize="1e-06" />
+--                   </oms:SimulationInformation>
+--                 </oms:Annotations>
+--               </ssc:Annotation>
+--             </ssd:Annotations>
+--           </ssd:System>
+--           <ssd:Component
+--             name="Gain"
+--             type="application/x-fmu-sharedlibrary"
+--             source="resources/0001_Gain.fmu">
+--             <ssd:Connectors>
+--               <ssd:Connector
+--                 name="u"
+--                 kind="input">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="0.000000"
+--                   y="0.500000" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="y"
+--                 kind="output">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="1.000000"
+--                   y="0.500000" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="k"
+--                 kind="parameter">
+--                 <ssc:Real />
+--               </ssd:Connector>
+--             </ssd:Connectors>
+--           </ssd:Component>
+--         </ssd:Elements>
+--         <ssd:Annotations>
+--           <ssc:Annotation
+--             type="org.openmodelica">
+--             <oms:Annotations>
+--               <oms:SimulationInformation>
+--                 <oms:FixedStepMaster
+--                   description="oms-ma"
+--                   stepSize="0.001000"
+--                   absoluteTolerance="0.000100"
+--                   relativeTolerance="0.000100" />
+--               </oms:SimulationInformation>
+--             </oms:Annotations>
+--           </ssc:Annotation>
+--         </ssd:Annotations>
+--       </ssd:System>
+--       <ssd:DefaultExperiment
+--         startTime="0.000000"
+--         stopTime="1.000000">
+--         <ssd:Annotations>
+--           <ssc:Annotation
+--             type="org.openmodelica">
+--             <oms:Annotations>
+--               <oms:SimulationInformation
+--                 resultFile="deleteResources1.mat"
+--                 loggingInterval="0.000000"
+--                 bufferSize="10"
+--                 signalFilter="resources/signalFilter.xml" />
+--             </oms:Annotations>
+--           </ssc:Annotation>
+--         </ssd:Annotations>
+--       </ssd:DefaultExperiment>
+--     </ssd:SystemStructureDescription>
+--   </oms:file>
+--   <oms:file
+--     name="resources/root.ssv">
+--     <ssv:ParameterSet
+--       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
+--       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
+--       version="1.0"
+--       name="parameters">
+--       <ssv:Parameters>
+--         <ssv:Parameter
+--           name="Input2">
+--           <ssv:Real
+--             value="50" />
+--         </ssv:Parameter>
+--         <ssv:Parameter
+--           name="Input1">
+--           <ssv:Real
+--             value="10" />
+--         </ssv:Parameter>
+--       </ssv:Parameters>
+--     </ssv:ParameterSet>
+--   </oms:file>
+--   <oms:file
+--     name="resources/system1.ssv">
+--     <ssv:ParameterSet
+--       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
+--       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
+--       version="1.0"
+--       name="parameters">
+--       <ssv:Parameters>
+--         <ssv:Parameter
+--           name="C1">
+--           <ssv:Real
+--             value="-10" />
+--         </ssv:Parameter>
+--       </ssv:Parameters>
+--     </ssv:ParameterSet>
+--   </oms:file>
+--   <oms:file
+--     name="resources/gain.ssv">
+--     <ssv:ParameterSet
+--       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
+--       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
+--       version="1.0"
+--       name="parameters">
+--       <ssv:Parameters>
+--         <ssv:Parameter
+--           name="k">
+--           <ssv:Real
+--             value="27" />
+--         </ssv:Parameter>
+--       </ssv:Parameters>
+--     </ssv:ParameterSet>
+--   </oms:file>
+--   <oms:file
+--     name="resources/signalFilter.xml">
+--     <oms:SignalFilter
+--       version="1.0">
+--       <oms:Variable
+--         name="deleteResources.root.Input1"
+--         type="Real"
+--         kind="input" />
+--       <oms:Variable
+--         name="deleteResources.root.Input2"
+--         type="Real"
+--         kind="input" />
+--       <oms:Variable
+--         name="deleteResources.root.Gain.u"
+--         type="Real"
+--         kind="input" />
+--       <oms:Variable
+--         name="deleteResources.root.Gain.y"
+--         type="Real"
+--         kind="output" />
+--       <oms:Variable
+--         name="deleteResources.root.Gain.k"
+--         type="Real"
+--         kind="parameter" />
+--       <oms:Variable
+--         name="deleteResources.root.system1.C1"
+--         type="Real"
+--         kind="input" />
+--       <oms:Variable
+--         name="deleteResources.root.system1.C2"
+--         type="Real"
+--         kind="input" />
+--     </oms:SignalFilter>
+--   </oms:file>
+-- </oms:snapshot>
+--
+-- endResult

--- a/testsuite/simulation/referenceResources1.lua
+++ b/testsuite/simulation/referenceResources1.lua
@@ -57,7 +57,7 @@ oms_addResources("referenceResources1", "../../resources/externalGain.ssv")
 -- delete references
 oms_deleteResources("referenceResources1.root:root.ssv")
 -- switch with new references
-oms_referenceResources("referenceResources1.root:externalRoot.ssv")
+oms_referenceResources("referenceResources1.root:externalRoot1.ssv")
 
 -- delete only the references
 oms_deleteResources("referenceResources1.root.system1:system1.ssv")
@@ -393,5 +393,5 @@ oms_delete("referenceResources1")
 --     </oms:SignalFilter>
 --   </oms:file>
 -- </oms:snapshot>
--- 
+--
 -- endResult

--- a/testsuite/simulation/referenceResources1.lua
+++ b/testsuite/simulation/referenceResources1.lua
@@ -1,0 +1,397 @@
+-- status: correct
+-- teardown_command: rm -rf referenceResources1_lua/
+-- linux: yes
+-- mingw32: yes
+-- mingw64: yes
+-- win: yes
+-- mac: no
+
+oms_setCommandLineOption("--suppressPath=true")
+oms_setTempDirectory("./referenceResources1_lua/")
+oms_setWorkingDirectory("./referenceResources1_lua/")
+
+oms_newModel("referenceResources1")
+
+oms_addSystem("referenceResources1.root", oms_system_wc)
+oms_addConnector("referenceResources1.root.Input1", oms_causality_input, oms_signal_type_real)
+oms_addConnector("referenceResources1.root.Input2", oms_causality_input, oms_signal_type_real)
+
+-- add Top level resources
+oms_newResources("referenceResources1.root:root.ssv")
+
+oms_setReal("referenceResources1.root.Input1", 10)
+oms_setReal("referenceResources1.root.Input2", 50)
+
+oms_addSystem("referenceResources1.root.system1", oms_system_sc)
+oms_addConnector("referenceResources1.root.system1.C1", oms_causality_input, oms_signal_type_real)
+oms_addConnector("referenceResources1.root.system1.C2", oms_causality_input, oms_signal_type_real)
+
+-- add resources to subsystem
+oms_newResources("referenceResources1.root.system1:system1.ssv")
+oms_setReal("referenceResources1.root.system1.C1", -10)
+
+oms_addSubModel("referenceResources1.root.Gain", "../../resources/Modelica.Blocks.Math.Gain.fmu")
+
+-- add resources to submodule
+oms_newResources("referenceResources1.root.Gain:gain.ssv")
+
+oms_setReal("referenceResources1.root.Gain.k", 27)
+
+oms_setResultFile("referenceResources1", "referenceResources1.mat", 10)
+
+src = oms_exportSnapshot("referenceResources1")
+-- print(src)
+
+print("info:    virgin parameter settings:")
+print("info:      referenceResources1.root.Input1     : " .. oms_getReal("referenceResources1.root.Input1"))
+print("info:      referenceResources1.root.Input2     : " .. oms_getReal("referenceResources1.root.Input2"))
+print("info:      referenceResources1.root.system1.C1 : " .. oms_getReal("referenceResources1.root.system1.C1"))
+print("info:      referenceResources1.root.system1.C2 : " .. oms_getReal("referenceResources1.root.system1.C2"))
+print("info:      referenceResources1.root.Gain.k     : " .. oms_getReal("referenceResources1.root.Gain.k"))
+
+-- add list of external resources from filesystem to ssp
+oms_addResources("referenceResources1", "../../resources/externalRoot.ssv")
+oms_addResources("referenceResources1", "../../resources/externalSystem1.ssv")
+oms_addResources("referenceResources1", "../../resources/externalGain.ssv")
+
+-- delete references
+oms_deleteResources("referenceResources1.root:root.ssv")
+-- switch with new references
+oms_referenceResources("referenceResources1.root:externalRoot.ssv")
+
+-- delete only the references
+oms_deleteResources("referenceResources1.root.system1:system1.ssv")
+-- switch with new references
+oms_referenceResources("referenceResources1.root.system1:externalSystem1.ssv")
+
+-- delete only the references
+oms_deleteResources("referenceResources1.root.Gain:gain.ssv")
+-- switch with new references
+oms_referenceResources("referenceResources1.root.Gain:externalGain.ssv")
+
+oms_instantiate("referenceResources1")
+
+oms_initialize("referenceResources1")
+print("info:    Initialization after switching to new references")
+print("info:      referenceResources1.root.Input1     : " .. oms_getReal("referenceResources1.root.Input1"))
+print("info:      referenceResources1.root.Input2     : " .. oms_getReal("referenceResources1.root.Input2"))
+print("info:      referenceResources1.root.system1.C1 : " .. oms_getReal("referenceResources1.root.system1.C1"))
+print("info:      referenceResources1.root.system1.C2 : " .. oms_getReal("referenceResources1.root.system1.C2"))
+print("info:      referenceResources1.root.Gain.k     : " .. oms_getReal("referenceResources1.root.Gain.k"))
+
+oms_simulate("referenceResources1")
+print("info:    Simulation")
+print("info:      referenceResources1.root.Input1     : " .. oms_getReal("referenceResources1.root.Input1"))
+print("info:      referenceResources1.root.Input2     : " .. oms_getReal("referenceResources1.root.Input2"))
+print("info:      referenceResources1.root.system1.C1 : " .. oms_getReal("referenceResources1.root.system1.C1"))
+print("info:      referenceResources1.root.system1.C2 : " .. oms_getReal("referenceResources1.root.system1.C2"))
+print("info:      referenceResources1.root.Gain.k     : " .. oms_getReal("referenceResources1.root.Gain.k"))
+
+-- snapshot after deleting references
+src = oms_exportSnapshot("referenceResources1")
+print(src)
+
+
+oms_terminate("referenceResources1")
+oms_delete("referenceResources1")
+
+
+-- Result:
+-- info:    virgin parameter settings:
+-- info:      referenceResources1.root.Input1     : 10.0
+-- info:      referenceResources1.root.Input2     : 50.0
+-- info:      referenceResources1.root.system1.C1 : -10.0
+-- info:      referenceResources1.root.system1.C2 : 0.0
+-- info:      referenceResources1.root.Gain.k     : 27.0
+-- info:    model doesn't contain any continuous state
+-- info:    Result file: referenceResources1.mat (bufferSize=10)
+-- info:    Initialization after switching to new references
+-- info:      referenceResources1.root.Input1     : -100.0
+-- info:      referenceResources1.root.Input2     : -500.0
+-- info:      referenceResources1.root.system1.C1 : -30.0
+-- info:      referenceResources1.root.system1.C2 : 0.0
+-- info:      referenceResources1.root.Gain.k     : -35.0
+-- info:    Simulation
+-- info:      referenceResources1.root.Input1     : -100.0
+-- info:      referenceResources1.root.Input2     : -500.0
+-- info:      referenceResources1.root.system1.C1 : -30.0
+-- info:      referenceResources1.root.system1.C2 : 0.0
+-- info:      referenceResources1.root.Gain.k     : -35.0
+-- <?xml version="1.0"?>
+-- <oms:snapshot
+--   xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
+--   partial="false">
+--   <oms:file
+--     name="SystemStructure.ssd">
+--     <ssd:SystemStructureDescription
+--       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
+--       xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription"
+--       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
+--       xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping"
+--       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
+--       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
+--       name="referenceResources1"
+--       version="1.0">
+--       <ssd:System
+--         name="root">
+--         <ssd:Connectors>
+--           <ssd:Connector
+--             name="Input1"
+--             kind="input">
+--             <ssc:Real />
+--           </ssd:Connector>
+--           <ssd:Connector
+--             name="Input2"
+--             kind="input">
+--             <ssc:Real />
+--           </ssd:Connector>
+--         </ssd:Connectors>
+--         <ssd:ParameterBindings>
+--           <ssd:ParameterBinding
+--             source="resources/externalRoot.ssv" />
+--         </ssd:ParameterBindings>
+--         <ssd:Elements>
+--           <ssd:System
+--             name="system1">
+--             <ssd:Connectors>
+--               <ssd:Connector
+--                 name="C1"
+--                 kind="input">
+--                 <ssc:Real />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="C2"
+--                 kind="input">
+--                 <ssc:Real />
+--               </ssd:Connector>
+--             </ssd:Connectors>
+--             <ssd:ParameterBindings>
+--               <ssd:ParameterBinding
+--                 source="resources/externalSystem1.ssv" />
+--             </ssd:ParameterBindings>
+--             <ssd:Annotations>
+--               <ssc:Annotation
+--                 type="org.openmodelica">
+--                 <oms:Annotations>
+--                   <oms:SimulationInformation>
+--                     <oms:VariableStepSolver
+--                       description="euler"
+--                       absoluteTolerance="0.0001"
+--                       relativeTolerance="0.0001"
+--                       minimumStepSize="1e-12"
+--                       maximumStepSize="0.001"
+--                       initialStepSize="1e-06" />
+--                   </oms:SimulationInformation>
+--                 </oms:Annotations>
+--               </ssc:Annotation>
+--             </ssd:Annotations>
+--           </ssd:System>
+--           <ssd:Component
+--             name="Gain"
+--             type="application/x-fmu-sharedlibrary"
+--             source="resources/0001_Gain.fmu">
+--             <ssd:Connectors>
+--               <ssd:Connector
+--                 name="u"
+--                 kind="input">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="0.000000"
+--                   y="0.500000" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="y"
+--                 kind="output">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="1.000000"
+--                   y="0.500000" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="k"
+--                 kind="parameter">
+--                 <ssc:Real />
+--               </ssd:Connector>
+--             </ssd:Connectors>
+--             <ssd:ParameterBindings>
+--               <ssd:ParameterBinding
+--                 source="resources/externalGain.ssv" />
+--             </ssd:ParameterBindings>
+--           </ssd:Component>
+--         </ssd:Elements>
+--         <ssd:Annotations>
+--           <ssc:Annotation
+--             type="org.openmodelica">
+--             <oms:Annotations>
+--               <oms:SimulationInformation>
+--                 <oms:FixedStepMaster
+--                   description="oms-ma"
+--                   stepSize="0.001000"
+--                   absoluteTolerance="0.000100"
+--                   relativeTolerance="0.000100" />
+--               </oms:SimulationInformation>
+--             </oms:Annotations>
+--           </ssc:Annotation>
+--         </ssd:Annotations>
+--       </ssd:System>
+--       <ssd:DefaultExperiment
+--         startTime="0.000000"
+--         stopTime="1.000000">
+--         <ssd:Annotations>
+--           <ssc:Annotation
+--             type="org.openmodelica">
+--             <oms:Annotations>
+--               <oms:SimulationInformation
+--                 resultFile="referenceResources1.mat"
+--                 loggingInterval="0.000000"
+--                 bufferSize="10"
+--                 signalFilter="resources/signalFilter.xml" />
+--             </oms:Annotations>
+--           </ssc:Annotation>
+--         </ssd:Annotations>
+--       </ssd:DefaultExperiment>
+--     </ssd:SystemStructureDescription>
+--   </oms:file>
+--   <oms:file
+--     name="resources/externalRoot.ssv">
+--     <ssv:ParameterSet
+--       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
+--       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
+--       version="1.0"
+--       name="parameters">
+--       <ssv:Parameters>
+--         <ssv:Parameter
+--           name="Input2">
+--           <ssv:Real
+--             value="-500" />
+--         </ssv:Parameter>
+--         <ssv:Parameter
+--           name="Input1">
+--           <ssv:Real
+--             value="-100" />
+--         </ssv:Parameter>
+--       </ssv:Parameters>
+--     </ssv:ParameterSet>
+--   </oms:file>
+--   <oms:file
+--     name="resources/root.ssv">
+--     <ssv:ParameterSet
+--       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
+--       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
+--       version="1.0"
+--       name="parameters">
+--       <ssv:Parameters>
+--         <ssv:Parameter
+--           name="Input2">
+--           <ssv:Real
+--             value="50" />
+--         </ssv:Parameter>
+--         <ssv:Parameter
+--           name="Input1">
+--           <ssv:Real
+--             value="10" />
+--         </ssv:Parameter>
+--       </ssv:Parameters>
+--     </ssv:ParameterSet>
+--   </oms:file>
+--   <oms:file
+--     name="resources/externalSystem1.ssv">
+--     <ssv:ParameterSet
+--       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
+--       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
+--       version="1.0"
+--       name="parameters">
+--       <ssv:Parameters>
+--         <ssv:Parameter
+--           name="C1">
+--           <ssv:Real
+--             value="-30" />
+--         </ssv:Parameter>
+--       </ssv:Parameters>
+--     </ssv:ParameterSet>
+--   </oms:file>
+--   <oms:file
+--     name="resources/system1.ssv">
+--     <ssv:ParameterSet
+--       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
+--       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
+--       version="1.0"
+--       name="parameters">
+--       <ssv:Parameters>
+--         <ssv:Parameter
+--           name="C1">
+--           <ssv:Real
+--             value="-10" />
+--         </ssv:Parameter>
+--       </ssv:Parameters>
+--     </ssv:ParameterSet>
+--   </oms:file>
+--   <oms:file
+--     name="resources/externalGain.ssv">
+--     <ssv:ParameterSet
+--       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
+--       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
+--       version="1.0"
+--       name="parameters">
+--       <ssv:Parameters>
+--         <ssv:Parameter
+--           name="k">
+--           <ssv:Real
+--             value="-35" />
+--         </ssv:Parameter>
+--       </ssv:Parameters>
+--     </ssv:ParameterSet>
+--   </oms:file>
+--   <oms:file
+--     name="resources/gain.ssv">
+--     <ssv:ParameterSet
+--       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
+--       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
+--       version="1.0"
+--       name="parameters">
+--       <ssv:Parameters>
+--         <ssv:Parameter
+--           name="k">
+--           <ssv:Real
+--             value="27" />
+--         </ssv:Parameter>
+--       </ssv:Parameters>
+--     </ssv:ParameterSet>
+--   </oms:file>
+--   <oms:file
+--     name="resources/signalFilter.xml">
+--     <oms:SignalFilter
+--       version="1.0">
+--       <oms:Variable
+--         name="referenceResources1.root.Input1"
+--         type="Real"
+--         kind="input" />
+--       <oms:Variable
+--         name="referenceResources1.root.Input2"
+--         type="Real"
+--         kind="input" />
+--       <oms:Variable
+--         name="referenceResources1.root.Gain.u"
+--         type="Real"
+--         kind="input" />
+--       <oms:Variable
+--         name="referenceResources1.root.Gain.y"
+--         type="Real"
+--         kind="output" />
+--       <oms:Variable
+--         name="referenceResources1.root.Gain.k"
+--         type="Real"
+--         kind="parameter" />
+--       <oms:Variable
+--         name="referenceResources1.root.system1.C1"
+--         type="Real"
+--         kind="input" />
+--       <oms:Variable
+--         name="referenceResources1.root.system1.C2"
+--         type="Real"
+--         kind="input" />
+--     </oms:SignalFilter>
+--   </oms:file>
+-- </oms:snapshot>
+-- 
+-- endResult

--- a/testsuite/simulation/referenceResources1.lua
+++ b/testsuite/simulation/referenceResources1.lua
@@ -57,7 +57,7 @@ oms_addResources("referenceResources1", "../../resources/externalGain.ssv")
 -- delete references
 oms_deleteResources("referenceResources1.root:root.ssv")
 -- switch with new references
-oms_referenceResources("referenceResources1.root:externalRoot1.ssv")
+oms_referenceResources("referenceResources1.root:externalRoot.ssv")
 
 -- delete only the references
 oms_deleteResources("referenceResources1.root.system1:system1.ssv")

--- a/testsuite/simulation/referenceResources2.lua
+++ b/testsuite/simulation/referenceResources2.lua
@@ -1,5 +1,5 @@
 -- status: correct
--- teardown_command: rm -rf importExportAllResources_lua/
+-- teardown_command: rm -rf referenceResources2_lua/
 -- linux: yes
 -- mingw32: yes
 -- mingw64: yes
@@ -7,47 +7,131 @@
 -- mac: no
 
 oms_setCommandLineOption("--suppressPath=true")
-oms_setTempDirectory("./importExportAllResources_lua/")
-oms_setWorkingDirectory("./importExportAllResources_lua/")
+oms_setTempDirectory("./referenceResources2_lua/")
+oms_setWorkingDirectory("./referenceResources2_lua/")
 
 oms_importFile("../../resources/importExportAllResources.ssp");
+
+oms_setResultFile("import_parameter_mapping", "referenceResources2.mat", 10)
+
+print("info:    Virgin Parameter Settings")
+print("info:      import_parameter_mapping.co_sim.Input_1              : " .. oms_getReal("import_parameter_mapping.co_sim.Input_1"))
+print("info:      import_parameter_mapping.co_sim.Input_2              : " .. oms_getReal("import_parameter_mapping.co_sim.Input_2"))
+print("info:      import_parameter_mapping.co_sim.Input_3              : " .. oms_getReal("import_parameter_mapping.co_sim.Input_3"))
+print("info:      import_parameter_mapping.co_sim.parameter_1          : " .. oms_getReal("import_parameter_mapping.co_sim.parameter_1"))
+print("info:      import_parameter_mapping.co_sim.parameter_2          : " .. oms_getReal("import_parameter_mapping.co_sim.parameter_2"))
+
+print("info:      import_parameter_mapping.co_sim.System1.Input_1      : " .. oms_getReal("import_parameter_mapping.co_sim.System1.Input_1"))
+print("info:      import_parameter_mapping.co_sim.System1.Input_2      : " .. oms_getReal("import_parameter_mapping.co_sim.System1.Input_2"))
+print("info:      import_parameter_mapping.co_sim.System1.parameter_1  : " .. oms_getReal("import_parameter_mapping.co_sim.System1.parameter_1"))
+print("info:      import_parameter_mapping.co_sim.System1.parameter_2  : " .. oms_getReal("import_parameter_mapping.co_sim.System1.parameter_2"))
+
+print("info:      import_parameter_mapping.co_sim.System2.Input_1      : " .. oms_getReal("import_parameter_mapping.co_sim.System2.Input_1"))
+print("info:      import_parameter_mapping.co_sim.System2.Input_2      : " .. oms_getReal("import_parameter_mapping.co_sim.System2.Input_2"))
+print("info:      import_parameter_mapping.co_sim.System2.parameter_1  : " .. oms_getReal("import_parameter_mapping.co_sim.System2.parameter_1"))
+print("info:      import_parameter_mapping.co_sim.System2.parameter_2  : " .. oms_getReal("import_parameter_mapping.co_sim.System2.parameter_2"))
+
 
 -- delete the ssv references
 oms_deleteResources("import_parameter_mapping.co_sim:import_parameter_mapping.ssv")
 -- switch with new references, ssv and ssm file
 oms_referenceResources("import_parameter_mapping.co_sim:external_import_parameter_mapping.ssv", "external_import_parameter_mapping.ssm") -- optional second argument for ssm f
 
--- export the file new references
-oms_export("import_parameter_mapping", "importExportAllResources.ssp")
+oms_instantiate("import_parameter_mapping")
 
-oms_terminate("import_parameter_mapping")
-oms_delete("import_parameter_mapping")
+oms_initialize("import_parameter_mapping")
 
-oms_importFile("importExportAllResources.ssp");
+print("info:    Initialization after switching with new references")
+print("info:      import_parameter_mapping.co_sim.Input_1              : " .. oms_getReal("import_parameter_mapping.co_sim.Input_1"))
+print("info:      import_parameter_mapping.co_sim.Input_2              : " .. oms_getReal("import_parameter_mapping.co_sim.Input_2"))
+print("info:      import_parameter_mapping.co_sim.Input_3              : " .. oms_getReal("import_parameter_mapping.co_sim.Input_3"))
+print("info:      import_parameter_mapping.co_sim.parameter_1          : " .. oms_getReal("import_parameter_mapping.co_sim.parameter_1"))
+print("info:      import_parameter_mapping.co_sim.parameter_2          : " .. oms_getReal("import_parameter_mapping.co_sim.parameter_2"))
+
+print("info:      import_parameter_mapping.co_sim.System1.Input_1      : " .. oms_getReal("import_parameter_mapping.co_sim.System1.Input_1"))
+print("info:      import_parameter_mapping.co_sim.System1.Input_2      : " .. oms_getReal("import_parameter_mapping.co_sim.System1.Input_2"))
+print("info:      import_parameter_mapping.co_sim.System1.parameter_1  : " .. oms_getReal("import_parameter_mapping.co_sim.System1.parameter_1"))
+print("info:      import_parameter_mapping.co_sim.System1.parameter_2  : " .. oms_getReal("import_parameter_mapping.co_sim.System1.parameter_2"))
+
+print("info:      import_parameter_mapping.co_sim.System2.Input_1      : " .. oms_getReal("import_parameter_mapping.co_sim.System2.Input_1"))
+print("info:      import_parameter_mapping.co_sim.System2.Input_2      : " .. oms_getReal("import_parameter_mapping.co_sim.System2.Input_2"))
+print("info:      import_parameter_mapping.co_sim.System2.parameter_1  : " .. oms_getReal("import_parameter_mapping.co_sim.System2.parameter_1"))
+print("info:      import_parameter_mapping.co_sim.System2.parameter_2  : " .. oms_getReal("import_parameter_mapping.co_sim.System2.parameter_2"))
+
+oms_simulate("import_parameter_mapping")
+
+print("info:    Simulation")
+print("info:      import_parameter_mapping.co_sim.Input_1              : " .. oms_getReal("import_parameter_mapping.co_sim.Input_1"))
+print("info:      import_parameter_mapping.co_sim.Input_2              : " .. oms_getReal("import_parameter_mapping.co_sim.Input_2"))
+print("info:      import_parameter_mapping.co_sim.Input_3              : " .. oms_getReal("import_parameter_mapping.co_sim.Input_3"))
+print("info:      import_parameter_mapping.co_sim.parameter_1          : " .. oms_getReal("import_parameter_mapping.co_sim.parameter_1"))
+print("info:      import_parameter_mapping.co_sim.parameter_2          : " .. oms_getReal("import_parameter_mapping.co_sim.parameter_2"))
+
+print("info:      import_parameter_mapping.co_sim.System1.Input_1      : " .. oms_getReal("import_parameter_mapping.co_sim.System1.Input_1"))
+print("info:      import_parameter_mapping.co_sim.System1.Input_2      : " .. oms_getReal("import_parameter_mapping.co_sim.System1.Input_2"))
+print("info:      import_parameter_mapping.co_sim.System1.parameter_1  : " .. oms_getReal("import_parameter_mapping.co_sim.System1.parameter_1"))
+print("info:      import_parameter_mapping.co_sim.System1.parameter_2  : " .. oms_getReal("import_parameter_mapping.co_sim.System1.parameter_2"))
+
+print("info:      import_parameter_mapping.co_sim.System2.Input_1      : " .. oms_getReal("import_parameter_mapping.co_sim.System2.Input_1"))
+print("info:      import_parameter_mapping.co_sim.System2.Input_2      : " .. oms_getReal("import_parameter_mapping.co_sim.System2.Input_2"))
+print("info:      import_parameter_mapping.co_sim.System2.parameter_1  : " .. oms_getReal("import_parameter_mapping.co_sim.System2.parameter_1"))
+print("info:      import_parameter_mapping.co_sim.System2.parameter_2  : " .. oms_getReal("import_parameter_mapping.co_sim.System2.parameter_2"))
 
 src = oms_exportSnapshot("import_parameter_mapping");
 print(src)
 
--- delete the external ssv references
-oms_deleteResources("import_parameter_mapping.co_sim:external_import_parameter_mapping.ssv")
--- switch with new references, old ssv and ssm file from resources
-oms_referenceResources("import_parameter_mapping.co_sim:import_parameter_mapping.ssv", "import_parameter_mapping.ssm")
-
--- export the file old references
-oms_export("import_parameter_mapping", "importExportAllResources.ssp")
-
 oms_terminate("import_parameter_mapping")
 oms_delete("import_parameter_mapping")
 
-oms_importFile("importExportAllResources.ssp");
 
-src = oms_exportSnapshot("import_parameter_mapping");
-print(src)
 
-oms_terminate("import_parameter_mapping")
-oms_delete("import_parameter_mapping")
 
 -- Result:
+-- info:    Virgin Parameter Settings
+-- info:      import_parameter_mapping.co_sim.Input_1              : 20.0
+-- info:      import_parameter_mapping.co_sim.Input_2              : 20.0
+-- info:      import_parameter_mapping.co_sim.Input_3              : 50.0
+-- info:      import_parameter_mapping.co_sim.parameter_1          : -30.0
+-- info:      import_parameter_mapping.co_sim.parameter_2          : -40.0
+-- info:      import_parameter_mapping.co_sim.System1.Input_1      : 20.0
+-- info:      import_parameter_mapping.co_sim.System1.Input_2      : 20.0
+-- info:      import_parameter_mapping.co_sim.System1.parameter_1  : -30.0
+-- info:      import_parameter_mapping.co_sim.System1.parameter_2  : 0.0
+-- info:      import_parameter_mapping.co_sim.System2.Input_1      : 20.0
+-- info:      import_parameter_mapping.co_sim.System2.Input_2      : 20.0
+-- info:      import_parameter_mapping.co_sim.System2.parameter_1  : -30.0
+-- info:      import_parameter_mapping.co_sim.System2.parameter_2  : 0.0
+-- info:    model doesn't contain any continuous state
+-- info:    model doesn't contain any continuous state
+-- info:    Result file: referenceResources2.mat (bufferSize=10)
+-- info:    Initialization after switching with new references
+-- info:      import_parameter_mapping.co_sim.Input_1              : -200.0
+-- info:      import_parameter_mapping.co_sim.Input_2              : -200.0
+-- info:      import_parameter_mapping.co_sim.Input_3              : -300.0
+-- info:      import_parameter_mapping.co_sim.parameter_1          : -400.0
+-- info:      import_parameter_mapping.co_sim.parameter_2          : -500.0
+-- info:      import_parameter_mapping.co_sim.System1.Input_1      : -200.0
+-- info:      import_parameter_mapping.co_sim.System1.Input_2      : -200.0
+-- info:      import_parameter_mapping.co_sim.System1.parameter_1  : -400.0
+-- info:      import_parameter_mapping.co_sim.System1.parameter_2  : 0.0
+-- info:      import_parameter_mapping.co_sim.System2.Input_1      : -200.0
+-- info:      import_parameter_mapping.co_sim.System2.Input_2      : -200.0
+-- info:      import_parameter_mapping.co_sim.System2.parameter_1  : -400.0
+-- info:      import_parameter_mapping.co_sim.System2.parameter_2  : 0.0
+-- info:    Simulation
+-- info:      import_parameter_mapping.co_sim.Input_1              : -200.0
+-- info:      import_parameter_mapping.co_sim.Input_2              : -200.0
+-- info:      import_parameter_mapping.co_sim.Input_3              : -300.0
+-- info:      import_parameter_mapping.co_sim.parameter_1          : -400.0
+-- info:      import_parameter_mapping.co_sim.parameter_2          : -500.0
+-- info:      import_parameter_mapping.co_sim.System1.Input_1      : -200.0
+-- info:      import_parameter_mapping.co_sim.System1.Input_2      : -200.0
+-- info:      import_parameter_mapping.co_sim.System1.parameter_1  : -400.0
+-- info:      import_parameter_mapping.co_sim.System1.parameter_2  : 0.0
+-- info:      import_parameter_mapping.co_sim.System2.Input_1      : -200.0
+-- info:      import_parameter_mapping.co_sim.System2.Input_2      : -200.0
+-- info:      import_parameter_mapping.co_sim.System2.parameter_1  : -400.0
+-- info:      import_parameter_mapping.co_sim.System2.parameter_2  : 0.0
 -- <?xml version="1.0"?>
 -- <oms:snapshot
 --   xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
@@ -140,7 +224,7 @@ oms_delete("import_parameter_mapping")
 --                 <oms:Annotations>
 --                   <oms:SimulationInformation>
 --                     <oms:VariableStepSolver
---                       description="cvode"
+--                       description="euler"
 --                       absoluteTolerance="0.0001"
 --                       relativeTolerance="0.0001"
 --                       minimumStepSize="0.0001"
@@ -186,7 +270,7 @@ oms_delete("import_parameter_mapping")
 --                 <oms:Annotations>
 --                   <oms:SimulationInformation>
 --                     <oms:VariableStepSolver
---                       description="cvode"
+--                       description="euler"
 --                       absoluteTolerance="0.0001"
 --                       relativeTolerance="0.0001"
 --                       minimumStepSize="0.0001"
@@ -221,7 +305,7 @@ oms_delete("import_parameter_mapping")
 --             type="org.openmodelica">
 --             <oms:Annotations>
 --               <oms:SimulationInformation
---                 resultFile="import_parameter_mapping_res.mat"
+--                 resultFile="referenceResources2.mat"
 --                 loggingInterval="0.000000"
 --                 bufferSize="10"
 --                 signalFilter="resources/signalFilter.xml" />
@@ -296,261 +380,6 @@ oms_delete("import_parameter_mapping")
 --         source="cosim_input"
 --         target="System2.Input_2" />
 --     </ssm:ParameterMapping>
---   </oms:file>
---   <oms:file
---     name="resources/signalFilter.xml">
---     <oms:SignalFilter
---       version="1.0">
---       <oms:Variable
---         name="import_parameter_mapping.co_sim.Input_1"
---         type="Real"
---         kind="input" />
---       <oms:Variable
---         name="import_parameter_mapping.co_sim.Input_2"
---         type="Real"
---         kind="input" />
---       <oms:Variable
---         name="import_parameter_mapping.co_sim.Input_3"
---         type="Real"
---         kind="input" />
---       <oms:Variable
---         name="import_parameter_mapping.co_sim.Output_cref"
---         type="Real"
---         kind="output" />
---       <oms:Variable
---         name="import_parameter_mapping.co_sim.parameter_1"
---         type="Real"
---         kind="parameter" />
---       <oms:Variable
---         name="import_parameter_mapping.co_sim.parameter_2"
---         type="Real"
---         kind="parameter" />
---       <oms:Variable
---         name="import_parameter_mapping.co_sim.System2.Input_1"
---         type="Real"
---         kind="input" />
---       <oms:Variable
---         name="import_parameter_mapping.co_sim.System2.Input_2"
---         type="Real"
---         kind="input" />
---       <oms:Variable
---         name="import_parameter_mapping.co_sim.System2.parameter_1"
---         type="Real"
---         kind="parameter" />
---       <oms:Variable
---         name="import_parameter_mapping.co_sim.System2.parameter_2"
---         type="Real"
---         kind="parameter" />
---       <oms:Variable
---         name="import_parameter_mapping.co_sim.System2.output"
---         type="Real"
---         kind="output" />
---       <oms:Variable
---         name="import_parameter_mapping.co_sim.System1.Input_1"
---         type="Real"
---         kind="input" />
---       <oms:Variable
---         name="import_parameter_mapping.co_sim.System1.Input_2"
---         type="Real"
---         kind="input" />
---       <oms:Variable
---         name="import_parameter_mapping.co_sim.System1.parameter_1"
---         type="Real"
---         kind="parameter" />
---       <oms:Variable
---         name="import_parameter_mapping.co_sim.System1.parameter_2"
---         type="Real"
---         kind="parameter" />
---       <oms:Variable
---         name="import_parameter_mapping.co_sim.System1.output"
---         type="Real"
---         kind="output" />
---     </oms:SignalFilter>
---   </oms:file>
--- </oms:snapshot>
---
--- <?xml version="1.0"?>
--- <oms:snapshot
---   xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
---   partial="false">
---   <oms:file
---     name="SystemStructure.ssd">
---     <ssd:SystemStructureDescription
---       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
---       xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription"
---       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping"
---       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
---       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
---       name="import_parameter_mapping"
---       version="1.0">
---       <ssd:System
---         name="co_sim">
---         <ssd:Connectors>
---           <ssd:Connector
---             name="Input_1"
---             kind="input">
---             <ssc:Real />
---           </ssd:Connector>
---           <ssd:Connector
---             name="Input_2"
---             kind="input">
---             <ssc:Real />
---           </ssd:Connector>
---           <ssd:Connector
---             name="Input_3"
---             kind="input">
---             <ssc:Real />
---           </ssd:Connector>
---           <ssd:Connector
---             name="Output_cref"
---             kind="output">
---             <ssc:Real />
---           </ssd:Connector>
---           <ssd:Connector
---             name="parameter_1"
---             kind="parameter">
---             <ssc:Real />
---           </ssd:Connector>
---           <ssd:Connector
---             name="parameter_2"
---             kind="parameter">
---             <ssc:Real />
---           </ssd:Connector>
---         </ssd:Connectors>
---         <ssd:ParameterBindings>
---           <ssd:ParameterBinding
---             source="resources/import_parameter_mapping.ssv">
---             <ssd:ParameterMapping
---               source="resources/import_parameter_mapping.ssm" />
---           </ssd:ParameterBinding>
---         </ssd:ParameterBindings>
---         <ssd:Elements>
---           <ssd:System
---             name="System2">
---             <ssd:Connectors>
---               <ssd:Connector
---                 name="Input_1"
---                 kind="input">
---                 <ssc:Real />
---               </ssd:Connector>
---               <ssd:Connector
---                 name="Input_2"
---                 kind="input">
---                 <ssc:Real />
---               </ssd:Connector>
---               <ssd:Connector
---                 name="parameter_1"
---                 kind="parameter">
---                 <ssc:Real />
---               </ssd:Connector>
---               <ssd:Connector
---                 name="parameter_2"
---                 kind="parameter">
---                 <ssc:Real />
---               </ssd:Connector>
---               <ssd:Connector
---                 name="output"
---                 kind="output">
---                 <ssc:Real />
---               </ssd:Connector>
---             </ssd:Connectors>
---             <ssd:Annotations>
---               <ssc:Annotation
---                 type="org.openmodelica">
---                 <oms:Annotations>
---                   <oms:SimulationInformation>
---                     <oms:VariableStepSolver
---                       description="cvode"
---                       absoluteTolerance="0.0001"
---                       relativeTolerance="0.0001"
---                       minimumStepSize="0.0001"
---                       maximumStepSize="0.1"
---                       initialStepSize="0.0001" />
---                   </oms:SimulationInformation>
---                 </oms:Annotations>
---               </ssc:Annotation>
---             </ssd:Annotations>
---           </ssd:System>
---           <ssd:System
---             name="System1">
---             <ssd:Connectors>
---               <ssd:Connector
---                 name="Input_1"
---                 kind="input">
---                 <ssc:Real />
---               </ssd:Connector>
---               <ssd:Connector
---                 name="Input_2"
---                 kind="input">
---                 <ssc:Real />
---               </ssd:Connector>
---               <ssd:Connector
---                 name="parameter_1"
---                 kind="parameter">
---                 <ssc:Real />
---               </ssd:Connector>
---               <ssd:Connector
---                 name="parameter_2"
---                 kind="parameter">
---                 <ssc:Real />
---               </ssd:Connector>
---               <ssd:Connector
---                 name="output"
---                 kind="output">
---                 <ssc:Real />
---               </ssd:Connector>
---             </ssd:Connectors>
---             <ssd:Annotations>
---               <ssc:Annotation
---                 type="org.openmodelica">
---                 <oms:Annotations>
---                   <oms:SimulationInformation>
---                     <oms:VariableStepSolver
---                       description="cvode"
---                       absoluteTolerance="0.0001"
---                       relativeTolerance="0.0001"
---                       minimumStepSize="0.0001"
---                       maximumStepSize="0.1"
---                       initialStepSize="0.0001" />
---                   </oms:SimulationInformation>
---                 </oms:Annotations>
---               </ssc:Annotation>
---             </ssd:Annotations>
---           </ssd:System>
---         </ssd:Elements>
---         <ssd:Annotations>
---           <ssc:Annotation
---             type="org.openmodelica">
---             <oms:Annotations>
---               <oms:SimulationInformation>
---                 <oms:FixedStepMaster
---                   description="oms-ma"
---                   stepSize="0.001000"
---                   absoluteTolerance="0.000100"
---                   relativeTolerance="0.000100" />
---               </oms:SimulationInformation>
---             </oms:Annotations>
---           </ssc:Annotation>
---         </ssd:Annotations>
---       </ssd:System>
---       <ssd:DefaultExperiment
---         startTime="0.000000"
---         stopTime="1.000000">
---         <ssd:Annotations>
---           <ssc:Annotation
---             type="org.openmodelica">
---             <oms:Annotations>
---               <oms:SimulationInformation
---                 resultFile="import_parameter_mapping_res.mat"
---                 loggingInterval="0.000000"
---                 bufferSize="10"
---                 signalFilter="resources/signalFilter.xml" />
---             </oms:Annotations>
---           </ssc:Annotation>
---         </ssd:Annotations>
---       </ssd:DefaultExperiment>
---     </ssd:SystemStructureDescription>
 --   </oms:file>
 --   <oms:file
 --     name="resources/import_parameter_mapping.ssv">


### PR DESCRIPTION
### Related Issues

https://github.com/OpenModelica/OMSimulator/issues/951

### Purpose

This PR deletes the references and it's start values from the system. This PR also makes sure the `ssv` files are exported back to `SSP` resources  

Tasks to Complete
- [x] delete references and its start values
- [x] switch to new references and apply the start values from memory, so that users need not to re export the ssp with new references and then import again.