### PR TITLE
Include cmath explicitly.

### DIFF
--- a/src/OMSimulatorLib/ComponentFMUCS.cpp
+++ b/src/OMSimulatorLib/ComponentFMUCS.cpp
@@ -44,6 +44,8 @@
 #include <JM/jm_portability.h>
 #include <RegEx.h>
 #include <unordered_set>
+#include <cmath>
+
 
 oms::ComponentFMUCS::ComponentFMUCS(const ComRef& cref, System* parentSystem, const std::string& fmuPath)
   : oms::Component(cref, oms_component_fmu, parentSystem, fmuPath), fmuInfo(fmuPath)

--- a/src/OMSimulatorLib/ComponentFMUME.cpp
+++ b/src/OMSimulatorLib/ComponentFMUME.cpp
@@ -44,6 +44,8 @@
 #include <JM/jm_portability.h>
 #include <RegEx.h>
 #include <unordered_set>
+#include <cmath>
+
 
 oms::ComponentFMUME::ComponentFMUME(const ComRef& cref, System* parentSystem, const std::string& fmuPath)
   : oms::Component(cref, oms_component_fmu, parentSystem, fmuPath), fmuInfo(fmuPath)


### PR DESCRIPTION

### Purpose

`cmath` is not included directly.

  - The files use `std::isnan` and `std::isinf` from `cmath`.
  - It breaks on old compilers (e.g. gcc-5) because the header might not
    be included indirectly.

### Approach
Include `cmath` explicitly. 
