### PR TITLE
Include cmath explicitly.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -728,6 +728,7 @@ void partest(cache=true, extraArgs='') {
 
   sh ("""#!/bin/bash -x
   ulimit -t 1500
+  ulimit -v 6291456 # Max 6GB per process
 
   cd testsuite/partest
   ./runtests.pl ${env.ASAN ? "-asan": ""} ${env.ASAN ? "-j1": "-j${numPhysicalCPU()}"} -nocolour ${env.BRANCH_NAME == "master" ? "-notlm" : ""} -with-xml ${params.RUNTESTS_FLAG} ${extraArgs}

--- a/src/OMSimulatorLib/ComponentFMUCS.cpp
+++ b/src/OMSimulatorLib/ComponentFMUCS.cpp
@@ -44,6 +44,8 @@
 #include <JM/jm_portability.h>
 #include <RegEx.h>
 #include <unordered_set>
+#include <cmath>
+
 
 oms::ComponentFMUCS::ComponentFMUCS(const ComRef& cref, System* parentSystem, const std::string& fmuPath)
   : oms::Component(cref, oms_component_fmu, parentSystem, fmuPath), fmuInfo(fmuPath)

--- a/src/OMSimulatorLib/ComponentFMUCS.cpp
+++ b/src/OMSimulatorLib/ComponentFMUCS.cpp
@@ -44,7 +44,6 @@
 #include <JM/jm_portability.h>
 #include <RegEx.h>
 #include <unordered_set>
-#include <cmath>
 
 
 oms::ComponentFMUCS::ComponentFMUCS(const ComRef& cref, System* parentSystem, const std::string& fmuPath)

--- a/src/OMSimulatorLib/ComponentFMUME.cpp
+++ b/src/OMSimulatorLib/ComponentFMUME.cpp
@@ -44,7 +44,7 @@
 #include <JM/jm_portability.h>
 #include <RegEx.h>
 #include <unordered_set>
-#include <cmath>
+
 
 
 oms::ComponentFMUME::ComponentFMUME(const ComRef& cref, System* parentSystem, const std::string& fmuPath)

--- a/src/OMSimulatorLib/ComponentFMUME.cpp
+++ b/src/OMSimulatorLib/ComponentFMUME.cpp
@@ -44,6 +44,8 @@
 #include <JM/jm_portability.h>
 #include <RegEx.h>
 #include <unordered_set>
+#include <cmath>
+
 
 oms::ComponentFMUME::ComponentFMUME(const ComRef& cref, System* parentSystem, const std::string& fmuPath)
   : oms::Component(cref, oms_component_fmu, parentSystem, fmuPath), fmuInfo(fmuPath)

--- a/src/OMSimulatorLib/ResultWriter.cpp
+++ b/src/OMSimulatorLib/ResultWriter.cpp
@@ -99,6 +99,7 @@ bool oms::ResultWriter::create(const std::string& filename, double startTime, do
     return false;
 
   data_2 = new double[bufferSize*(signals.size() + 1)];
+  memset (data_2, 0, sizeof(double)*bufferSize*(signals.size() + 1));
   nEmits = 0;
   return true;
 }


### PR DESCRIPTION
This is a "retry" of #1097. To see if there is some transient issue with the PR itself.

### Purpose

`cmath` is not included directly.

  - The files use `std::isnan` and `std::isinf` from `cmath`.
  - It breaks on old compilers (e.g. gcc-5) because the header might not
    be included indirectly.

### Approach
Include `cmath` explicitly. 
