### PR TITLE
Use CC variable for OMTLMSimulator make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,7 +128,7 @@ OMSimulator:
 	@echo LIBXML2: $(LIBXML2)
 	@echo "# make OMSimulator"
 	@echo
-	@$(MAKE) CC="$(CXX)" CXX="$(CXX)" OMTLMSimulator
+	@$(MAKE) CC="$(CC)" CXX="$(CXX)" OMTLMSimulator
 	@$(MAKE) OMSimulatorCore
 	test ! -z "$(DISABLE_RUN_OMSIMULATOR_VERSION)" || $(TOP_INSTALL_DIR)/bin/OMSimulator --version
 


### PR DESCRIPTION
### Related Issues

https://github.com/OpenModelica/OMTLMSimulator/issues/132

### Purpose

Resolve warnings like
```
clang: warning: treating 'c' input as 'c++' when in C++ mode, this behavior is deprecated [-Wdeprecated]
```

in OMTLMSimulator sub-project.
