### PR TITLE
Remove deprecated flag --setInputDerivatives

### DIFF
--- a/src/OMSimulatorLib/Flags.cpp
+++ b/src/OMSimulatorLib/Flags.cpp
@@ -374,12 +374,6 @@ oms_status_enu_t oms::Flags::ResultFile(const std::string& value)
   return oms_status_ok;
 }
 
-oms_status_enu_t oms::Flags::SetInputDerivatives(const std::string& value)
-{
-  logWarning("--setInputDerivatives is deprecated; use --inputExtrapolation instead");
-  return InputExtrapolation(value);
-}
-
 oms_status_enu_t oms::Flags::SkipCSVHeader(const std::string& value)
 {
   GetInstance().skipCSVHeader = (value == "true");

--- a/src/OMSimulatorLib/Flags.h
+++ b/src/OMSimulatorLib/Flags.h
@@ -166,7 +166,6 @@ namespace oms
       {"--progressBar", "", "Shows a progress bar for the simulation progress in the terminal (true, [false])", re_bool, Flags::ProgressBar, false},
       {"--realTime", "", "Experimental feature for (soft) real-time co-simulation (true, [false])", re_bool, Flags::RealTime, false},
       {"--resultFile", "-r", "Specifies the name of the output result file", re_default, Flags::ResultFile, false},
-      {"--setInputDerivatives", "", "Deprecated; see '--inputExtrapolation'", re_bool, Flags::SetInputDerivatives, false},
       {"--skipCSVHeader", "", "Skip exporting the scv delimiter in the header ([true], false), ", re_default, Flags::SkipCSVHeader, false},
       {"--solver", "", "Specifies the integration method (euler, [cvode])", re_default, Flags::Solver, false},
       {"--solverStats", "", "Adds solver stats to the result file, e.g. step size; not supported for all solvers (true, [false])", re_bool, Flags::SolverStats, false},
@@ -206,7 +205,6 @@ namespace oms
     static oms_status_enu_t ProgressBar(const std::string& value);
     static oms_status_enu_t RealTime(const std::string& value);
     static oms_status_enu_t ResultFile(const std::string& value);
-    static oms_status_enu_t SetInputDerivatives(const std::string& value);
     static oms_status_enu_t SkipCSVHeader(const std::string& value);
     static oms_status_enu_t Solver(const std::string& value);
     static oms_status_enu_t SolverStats(const std::string& value);


### PR DESCRIPTION
`--setInputDerivatives` is deprecated and was replaced with the flag `--inputExtrapolation` long time ago. Now it's time to remove the deprecated flag in preparation for the next release.