### PR TITLE
Update libxml2 to version 2.9.11.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -268,14 +268,14 @@ config-libxml2:
 	@echo
 else
 config-libxml2: 3rdParty/libxml2/$(INSTALL_DIR)/lib/libxml2.a
-3rdParty/libxml2/$(INSTALL_DIR)/lib/libxml2.a: 3rdParty/libxml2/Makefile
-	$(MAKE) -C 3rdParty/libxml2/ && $(MAKE) -C 3rdParty/libxml2/ install
-3rdParty/libxml2/Makefile:
+3rdParty/libxml2/$(INSTALL_DIR)/lib/libxml2.a: 3rdParty/libxml2/$(BUILD_DIR)/Makefile
+	$(MAKE) -C 3rdParty/libxml2/$(BUILD_DIR)/ install
+3rdParty/libxml2/$(BUILD_DIR)/Makefile: 3rdParty/libxml2/CMakeLists.txt
 	@echo
 	@echo "# config libxml2"
 	@echo
-	$(MKDIR) 3rdParty/libxml2/$(INSTALL_DIR)
-	cd 3rdParty/libxml2 && $(FPIC) ./autogen.sh --prefix="$(ROOT_DIR)/3rdParty/libxml2/$(INSTALL_DIR)" $(DISABLE_SHARED) --without-python --without-zlib --without-lzma $(HOST_CROSS_TRIPLE)
+	$(MKDIR) 3rdParty/libxml2/$(BUILD_DIR)
+	cd 3rdParty/libxml2/$(BUILD_DIR) && $(CMAKE) $(CMAKE_TARGET) ../.. -DCMAKE_INSTALL_PREFIX=../../$(INSTALL_DIR) -DBUILD_SHARED_LIBS=OFF -DLIBXML2_WITH_PYTHON=OFF -DLIBXML2_WITH_ZLIB=OFF -DLIBXML2_WITH_LZMA=OFF -DLIBXML2_WITH_TESTS=OFF
 endif
 
 distclean:
@@ -295,6 +295,8 @@ distclean:
 	$(RM) 3rdParty/kinsol/$(INSTALL_DIR)
 	$(RM) 3rdParty/xerces/$(BUILD_DIR)
 	$(RM) 3rdParty/xerces/$(INSTALL_DIR)
+	$(RM) 3rdParty/libxml2/$(BUILD_DIR)
+	$(RM) 3rdParty/libxml2/$(INSTALL_DIR)
 
 testsuite:
 	@echo

--- a/configWinVS.bat
+++ b/configWinVS.bat
@@ -200,18 +200,21 @@ EXIT /B 0
 :: -- pthread -------------------------
 
 
-:: -- config libxml2 ------------------
+:: -- config libxml2 -------------------
 :libxml2
 ECHO # config libxml2
-CD 3rdParty\libxml2
-START /B /WAIT CMD /C "buildWinVS.bat %OMS_VS_TARGET%"
+IF EXIST "3rdParty\libxml2\build\win\" RMDIR /S /Q 3rdParty\libxml2\build\win
+IF EXIST "3rdParty\libxml2\install\win\" RMDIR /S /Q 3rdParty\libxml2\install\win
+MKDIR 3rdParty\libxml2\build\win
+CD 3rdParty\libxml2\build\win
+cmake.exe -G %OMS_VS_VERSION% ..\.. -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -DCMAKE_INSTALL_PREFIX=..\..\install\win -DBUILD_SHARED_LIBS=OFF -DLIBXML2_WITH_PYTHON=OFF -DLIBXML2_WITH_ZLIB=OFF -DLIBXML2_WITH_LZMA=OFF -DLIBXML2_WITH_TESTS=OFF
 IF NOT ["%ERRORLEVEL%"]==["0"] GOTO fail
-CD ..\..
-ECHO # copy libxml2
-IF NOT EXIST "install\win\bin" MKDIR install\win\bin
-XCOPY /Y /F 3rdParty\libxml2\install\win\bin\libxml2.dll install\win\bin
+CD ..\..\..\..
+ECHO # build libxml2
+msbuild.exe "3rdParty\libxml2\build\win\INSTALL.vcxproj" /t:Build /p:configuration=Release /maxcpucount
+IF NOT ["%ERRORLEVEL%"]==["0"] GOTO fail
 EXIT /B 0
-:: -- config libxml2 ------------------
+:: -- config libxml2 -------------------
 
 
 :: -- copy boost ----------------------


### PR DESCRIPTION
  - This version comes, of course, with a lot of fixes and improvements
    as well as CMake support.

   - The CMake support allows OMSimulator to move one step closer to complete
     CMake based build.

