### PR TITLE
export units to connectors

### DIFF
--- a/src/OMSimulatorLib/ComponentFMUCS.cpp
+++ b/src/OMSimulatorLib/ComponentFMUCS.cpp
@@ -277,10 +277,20 @@ oms::Component* oms::ComponentFMUCS::NewComponent(const pugi::xml_node& node, om
     std::string name = it->name();
     if(name == oms::ssp::Draft20180219::ssd::connectors)
     {
+      // get the ssdNode to parse UnitDefinitions in "SystemStructure.ssd"
+      pugi::xml_node ssdNode = snapshot.getResourceNode("SystemStructure.ssd");
+      component->values.importUnitDefinitions(ssdNode);
       // import connectors
       for(pugi::xml_node_iterator itConnectors = (*it).begin(); itConnectors != (*it).end(); ++itConnectors)
       {
         component->connectors.push_back(oms::Connector::NewConnector(*itConnectors, sspVersion, component->getFullCref()));
+        // set units to connector
+        if ((*itConnectors).child(oms::ssp::Version1_0::ssc::real_type))
+        {
+          std::string unitName = (*itConnectors).child(oms::ssp::Version1_0::ssc::real_type).attribute("unit").as_string();
+          if (!unitName.empty())
+            component->connectors.back()->connectorUnits[unitName] = component->values.modeldescriptionUnitDefinitions[unitName];
+        }
       }
     }
     else if(name == oms::ssp::Draft20180219::ssd::element_geometry)

--- a/src/OMSimulatorLib/ComponentFMUCS.cpp
+++ b/src/OMSimulatorLib/ComponentFMUCS.cpp
@@ -238,6 +238,17 @@ oms::Component* oms::ComponentFMUCS::NewComponent(const oms::ComRef& cref, oms::
   // parse modelDescription.xml to get start values before instantiating fmu's
   component->values.parseModelDescription(tempDir);
 
+  // set units to connector
+  for (auto &connector : component->connectors)
+  {
+    if (connector)
+    {
+      oms::ComRef connectorCref = connector->getName();
+      std::string unitName = component->values.getUnitFromModeldescription(connectorCref);
+      if (!unitName.empty())
+        connector->connectorUnits[unitName] = component->values.modeldescriptionUnitDefinitions[unitName];
+    }
+  }
   return component;
 }
 
@@ -335,6 +346,23 @@ oms_status_enu_t oms::ComponentFMUCS::exportToSSD(pugi::xml_node& node, Snapshot
 
 void oms::ComponentFMUCS::getFilteredUnitDefinitionsToSSD(std::map<std::string, std::map<std::string, std::string>>& unitDefinitions)
 {
+  // get units from connectors
+  for (const auto &connector : connectors)
+  {
+    if (connector)
+    {
+      if (!connector->connectorUnits.empty())
+      {
+        for (auto &con : connector->connectorUnits)
+        {
+          auto unitvalue = unitDefinitions.find(con.first);
+          if (unitvalue == unitDefinitions.end())
+            unitDefinitions[con.first] = con.second;
+        }
+      }
+    }
+  }
+
   return values.getFilteredUnitDefinitionsToSSD(unitDefinitions);
 }
 

--- a/src/OMSimulatorLib/ComponentFMUCS.cpp
+++ b/src/OMSimulatorLib/ComponentFMUCS.cpp
@@ -1653,6 +1653,18 @@ oms_status_enu_t oms::ComponentFMUCS::setString(const ComRef& cref, const std::s
 
 oms_status_enu_t oms::ComponentFMUCS::setUnit(const ComRef &cref, const std::string &value)
 {
+  // set units to connectors
+  for (auto &connector : connectors)
+  {
+    if (connector)
+    {
+      if (connector->getName() == cref)
+      {
+        connector->connectorUnits.clear();
+        connector->connectorUnits[value] = {};
+      }
+    }
+  }
   // check for local resources available
   if (values.hasResources())
   {

--- a/src/OMSimulatorLib/ComponentFMUME.cpp
+++ b/src/OMSimulatorLib/ComponentFMUME.cpp
@@ -240,6 +240,18 @@ oms::Component* oms::ComponentFMUME::NewComponent(const oms::ComRef& cref, oms::
   // parse modelDescription.xml to get start values before instantiating fmu's
   component->values.parseModelDescription(tempDir);
 
+  // set units to connector
+  for (auto &connector : component->connectors)
+  {
+    if (connector)
+    {
+      oms::ComRef connectorCref = connector->getName();
+      std::string unitName = component->values.getUnitFromModeldescription(connectorCref);
+      if (!unitName.empty())
+        connector->connectorUnits[unitName] = component->values.modeldescriptionUnitDefinitions[unitName];
+    }
+  }
+
   return component;
 }
 
@@ -337,6 +349,23 @@ oms_status_enu_t oms::ComponentFMUME::exportToSSD(pugi::xml_node& node, Snapshot
 
 void oms::ComponentFMUME::getFilteredUnitDefinitionsToSSD(std::map<std::string, std::map<std::string, std::string>>& unitDefinitions)
 {
+  // get units from connectors
+  for (const auto &connector : connectors)
+  {
+    if (connector)
+    {
+      if (!connector->connectorUnits.empty())
+      {
+        for (auto &con : connector->connectorUnits)
+        {
+          auto unitvalue = unitDefinitions.find(con.first);
+          if (unitvalue == unitDefinitions.end())
+            unitDefinitions[con.first] = con.second;
+        }
+      }
+    }
+  }
+
   return values.getFilteredUnitDefinitionsToSSD(unitDefinitions);
 }
 

--- a/src/OMSimulatorLib/ComponentFMUME.cpp
+++ b/src/OMSimulatorLib/ComponentFMUME.cpp
@@ -1617,6 +1617,18 @@ oms_status_enu_t oms::ComponentFMUME::setString(const ComRef& cref, const std::s
 
 oms_status_enu_t oms::ComponentFMUME::setUnit(const ComRef &cref, const std::string &value)
 {
+  // set units to connectors
+  for (auto &connector : connectors)
+  {
+    if (connector)
+    {
+      if (connector->getName() == cref)
+      {
+        connector->connectorUnits.clear();
+        connector->connectorUnits[value] = {};
+      }
+    }
+  }
   // check for local resources available
   if (values.hasResources())
   {

--- a/src/OMSimulatorLib/ComponentFMUME.cpp
+++ b/src/OMSimulatorLib/ComponentFMUME.cpp
@@ -280,10 +280,20 @@ oms::Component* oms::ComponentFMUME::NewComponent(const pugi::xml_node& node, om
     std::string name = it->name();
     if(name == oms::ssp::Draft20180219::ssd::connectors)
     {
+      // get the ssdNode to parse UnitDefinitions in "SystemStructure.ssd"
+      pugi::xml_node ssdNode = snapshot.getResourceNode("SystemStructure.ssd");
+      component->values.importUnitDefinitions(ssdNode);
       // import connectors
       for(pugi::xml_node_iterator itConnectors = (*it).begin(); itConnectors != (*it).end(); ++itConnectors)
       {
         component->connectors.push_back(oms::Connector::NewConnector(*itConnectors, sspVersion, component->getFullCref()));
+        // set units to connector
+        if ((*itConnectors).child(oms::ssp::Version1_0::ssc::real_type))
+        {
+          std::string unitName = (*itConnectors).child(oms::ssp::Version1_0::ssc::real_type).attribute("unit").as_string();
+          if (!unitName.empty())
+            component->connectors.back()->connectorUnits[unitName] = component->values.modeldescriptionUnitDefinitions[unitName];
+        }
       }
     }
     else if(name == oms::ssp::Draft20180219::ssd::element_geometry)

--- a/src/OMSimulatorLib/Connector.cpp
+++ b/src/OMSimulatorLib/Connector.cpp
@@ -240,6 +240,9 @@ oms_status_enu_t oms::Connector::exportToSSD(pugi::xml_node &root) const
     break;
   case oms_signal_type_real:
     node.append_child(oms::ssp::Version1_0::ssc::real_type);
+    if (!this->connectorUnits.empty())
+      for (const auto & it : this->connectorUnits)
+        node.child(oms::ssp::Version1_0::ssc::real_type).append_attribute("unit") = it.first.c_str();
     break;
   case oms_signal_type_string:
     node.append_child(oms::ssp::Version1_0::ssc::string_type);

--- a/src/OMSimulatorLib/Connector.h
+++ b/src/OMSimulatorLib/Connector.h
@@ -71,7 +71,7 @@ namespace oms
     void setOwner(const oms::ComRef& owner);
     void setGeometry(const oms::ssd::ConnectorGeometry* newGeometry);
 
-    std::map<std::string, std::map<std::string, std::string>> connectorUnits;  ///< <UnitDefinitions> list from modeldescription.xml
+    std::map<std::string, std::map<std::string, std::string>> connectorUnits;  ///< single entry map which contains unit as key and BaseUnits as value for a connector
 
     const oms_causality_enu_t getCausality() const {return causality;}
     const oms_signal_type_enu_t getType() const {return type;}

--- a/src/OMSimulatorLib/Connector.h
+++ b/src/OMSimulatorLib/Connector.h
@@ -37,6 +37,7 @@
 #include "Types.h"
 
 #include <string>
+#include <map>
 
 #include <pugixml.hpp>
 
@@ -69,6 +70,8 @@ namespace oms
     void setName(const oms::ComRef& name);
     void setOwner(const oms::ComRef& owner);
     void setGeometry(const oms::ssd::ConnectorGeometry* newGeometry);
+
+    std::map<std::string, std::map<std::string, std::string>> connectorUnits;  ///< <UnitDefinitions> list from modeldescription.xml
 
     const oms_causality_enu_t getCausality() const {return causality;}
     const oms_signal_type_enu_t getType() const {return type;}

--- a/testsuite/api/addExternalResources1.lua
+++ b/testsuite/api/addExternalResources1.lua
@@ -176,7 +176,8 @@ print(src)
 --               <ssd:Connector
 --                 name="k"
 --                 kind="parameter">
---                 <ssc:Real />
+--                 <ssc:Real
+--                   unit="1" />
 --               </ssd:Connector>
 --             </ssd:Connectors>
 --             <ssd:ParameterBindings>
@@ -200,6 +201,12 @@ print(src)
 --           </ssc:Annotation>
 --         </ssd:Annotations>
 --       </ssd:System>
+--       <ssd:Units>
+--         <ssc:Unit
+--           name="1">
+--           <ssc:BaseUnit />
+--         </ssc:Unit>
+--       </ssd:Units>
 --       <ssd:DefaultExperiment
 --         startTime="0.000000"
 --         stopTime="1.000000">
@@ -407,7 +414,8 @@ print(src)
 --               <ssd:Connector
 --                 name="k"
 --                 kind="parameter">
---                 <ssc:Real />
+--                 <ssc:Real
+--                   unit="1" />
 --               </ssd:Connector>
 --             </ssd:Connectors>
 --             <ssd:ParameterBindings>
@@ -431,6 +439,12 @@ print(src)
 --           </ssc:Annotation>
 --         </ssd:Annotations>
 --       </ssd:System>
+--       <ssd:Units>
+--         <ssc:Unit
+--           name="1">
+--           <ssc:BaseUnit />
+--         </ssc:Unit>
+--       </ssd:Units>
 --       <ssd:DefaultExperiment
 --         startTime="0.000000"
 --         stopTime="1.000000">

--- a/testsuite/api/addExternalResources3.py
+++ b/testsuite/api/addExternalResources3.py
@@ -179,7 +179,8 @@ print(src)
 ##               <ssd:Connector
 ##                 name="k"
 ##                 kind="parameter">
-##                 <ssc:Real />
+##                 <ssc:Real
+##                   unit="1" />
 ##               </ssd:Connector>
 ##             </ssd:Connectors>
 ##             <ssd:ParameterBindings>
@@ -203,6 +204,12 @@ print(src)
 ##           </ssc:Annotation>
 ##         </ssd:Annotations>
 ##       </ssd:System>
+##       <ssd:Units>
+##         <ssc:Unit
+##           name="1">
+##           <ssc:BaseUnit />
+##         </ssc:Unit>
+##       </ssd:Units>
 ##       <ssd:DefaultExperiment
 ##         startTime="0.000000"
 ##         stopTime="1.000000">
@@ -410,7 +417,8 @@ print(src)
 ##               <ssd:Connector
 ##                 name="k"
 ##                 kind="parameter">
-##                 <ssc:Real />
+##                 <ssc:Real
+##                   unit="1" />
 ##               </ssd:Connector>
 ##             </ssd:Connectors>
 ##             <ssd:ParameterBindings>
@@ -434,6 +442,12 @@ print(src)
 ##           </ssc:Annotation>
 ##         </ssd:Annotations>
 ##       </ssd:System>
+##       <ssd:Units>
+##         <ssc:Unit
+##           name="1">
+##           <ssc:BaseUnit />
+##         </ssc:Unit>
+##       </ssd:Units>
 ##       <ssd:DefaultExperiment
 ##         startTime="0.000000"
 ##         stopTime="1.000000">

--- a/testsuite/api/deleteReferencesInSSD1.lua
+++ b/testsuite/api/deleteReferencesInSSD1.lua
@@ -161,7 +161,8 @@ oms_delete("deleteResources")
 --               <ssd:Connector
 --                 name="k"
 --                 kind="parameter">
---                 <ssc:Real />
+--                 <ssc:Real
+--                   unit="1" />
 --               </ssd:Connector>
 --             </ssd:Connectors>
 --             <ssd:ParameterBindings>
@@ -185,6 +186,12 @@ oms_delete("deleteResources")
 --           </ssc:Annotation>
 --         </ssd:Annotations>
 --       </ssd:System>
+--       <ssd:Units>
+--         <ssc:Unit
+--           name="1">
+--           <ssc:BaseUnit />
+--         </ssc:Unit>
+--       </ssd:Units>
 --       <ssd:DefaultExperiment
 --         startTime="0.000000"
 --         stopTime="1.000000">
@@ -298,7 +305,7 @@ oms_delete("deleteResources")
 --     </oms:SignalFilter>
 --   </oms:file>
 -- </oms:snapshot>
--- 
+--
 -- <?xml version="1.0"?>
 -- <oms:snapshot
 --   xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
@@ -384,7 +391,8 @@ oms_delete("deleteResources")
 --               <ssd:Connector
 --                 name="k"
 --                 kind="parameter">
---                 <ssc:Real />
+--                 <ssc:Real
+--                   unit="1" />
 --               </ssd:Connector>
 --             </ssd:Connectors>
 --           </ssd:Component>
@@ -404,6 +412,12 @@ oms_delete("deleteResources")
 --           </ssc:Annotation>
 --         </ssd:Annotations>
 --       </ssd:System>
+--       <ssd:Units>
+--         <ssc:Unit
+--           name="1">
+--           <ssc:BaseUnit />
+--         </ssc:Unit>
+--       </ssd:Units>
 --       <ssd:DefaultExperiment
 --         startTime="0.000000"
 --         stopTime="1.000000">
@@ -517,5 +531,5 @@ oms_delete("deleteResources")
 --     </oms:SignalFilter>
 --   </oms:file>
 -- </oms:snapshot>
--- 
+--
 -- endResult

--- a/testsuite/api/deleteResourcesInSSP1.lua
+++ b/testsuite/api/deleteResourcesInSSP1.lua
@@ -158,7 +158,8 @@ oms_delete("deleteResources")
 --               <ssd:Connector
 --                 name="k"
 --                 kind="parameter">
---                 <ssc:Real />
+--                 <ssc:Real
+--                   unit="1" />
 --               </ssd:Connector>
 --             </ssd:Connectors>
 --             <ssd:ParameterBindings>
@@ -182,6 +183,12 @@ oms_delete("deleteResources")
 --           </ssc:Annotation>
 --         </ssd:Annotations>
 --       </ssd:System>
+--       <ssd:Units>
+--         <ssc:Unit
+--           name="1">
+--           <ssc:BaseUnit />
+--         </ssc:Unit>
+--       </ssd:Units>
 --       <ssd:DefaultExperiment
 --         startTime="0.000000"
 --         stopTime="1.000000">
@@ -381,7 +388,8 @@ oms_delete("deleteResources")
 --               <ssd:Connector
 --                 name="k"
 --                 kind="parameter">
---                 <ssc:Real />
+--                 <ssc:Real
+--                   unit="1" />
 --               </ssd:Connector>
 --             </ssd:Connectors>
 --           </ssd:Component>
@@ -401,6 +409,12 @@ oms_delete("deleteResources")
 --           </ssc:Annotation>
 --         </ssd:Annotations>
 --       </ssd:System>
+--       <ssd:Units>
+--         <ssc:Unit
+--           name="1">
+--           <ssc:BaseUnit />
+--         </ssc:Unit>
+--       </ssd:Units>
 --       <ssd:DefaultExperiment
 --         startTime="0.000000"
 --         stopTime="1.000000">

--- a/testsuite/api/import_export_units2.lua
+++ b/testsuite/api/import_export_units2.lua
@@ -36,7 +36,9 @@ src, status = oms_exportSnapshot("model")
 print(src)
 
 -- Result:
--- <?xml version="1.0"?>
+--
+--  baseunits: s=-1
+--  baseunits: s=1<?xml version="1.0"?>
 -- <oms:snapshot
 --   xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --   partial="false">
@@ -75,7 +77,8 @@ print(src)
 --               <ssd:Connector
 --                 name="freqHz"
 --                 kind="parameter">
---                 <ssc:Real />
+--                 <ssc:Real
+--                   unit="Hz" />
 --               </ssd:Connector>
 --               <ssd:Connector
 --                 name="offset"
@@ -85,12 +88,14 @@ print(src)
 --               <ssd:Connector
 --                 name="phase"
 --                 kind="parameter">
---                 <ssc:Real />
+--                 <ssc:Real
+--                   unit="rad" />
 --               </ssd:Connector>
 --               <ssd:Connector
 --                 name="startTime"
 --                 kind="parameter">
---                 <ssc:Real />
+--                 <ssc:Real
+--                   unit="s" />
 --               </ssd:Connector>
 --             </ssd:Connectors>
 --             <ssd:ParameterBindings>
@@ -148,6 +153,11 @@ print(src)
 --         <ssc:Unit
 --           name="rad">
 --           <ssc:BaseUnit />
+--         </ssc:Unit>
+--         <ssc:Unit
+--           name="s">
+--           <ssc:BaseUnit
+--             s="1" />
 --         </ssc:Unit>
 --       </ssd:Units>
 --       <ssd:DefaultExperiment
@@ -200,7 +210,11 @@ print(src)
 --   </oms:file>
 -- </oms:snapshot>
 --
--- <?xml version="1.0"?>
+--
+--  baseunits: s=-1
+--  baseunits: s=1
+--  baseunits: s=-1
+--  baseunits: s=1<?xml version="1.0"?>
 -- <oms:snapshot
 --   xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --   partial="false">
@@ -239,7 +253,8 @@ print(src)
 --               <ssd:Connector
 --                 name="freqHz"
 --                 kind="parameter">
---                 <ssc:Real />
+--                 <ssc:Real
+--                   unit="Hz" />
 --               </ssd:Connector>
 --               <ssd:Connector
 --                 name="offset"
@@ -249,12 +264,14 @@ print(src)
 --               <ssd:Connector
 --                 name="phase"
 --                 kind="parameter">
---                 <ssc:Real />
+--                 <ssc:Real
+--                   unit="rad" />
 --               </ssd:Connector>
 --               <ssd:Connector
 --                 name="startTime"
 --                 kind="parameter">
---                 <ssc:Real />
+--                 <ssc:Real
+--                   unit="s" />
 --               </ssd:Connector>
 --             </ssd:Connectors>
 --             <ssd:ParameterBindings>
@@ -312,6 +329,22 @@ print(src)
 --           name="Hz">
 --           <ssc:BaseUnit
 --             s="-1" />
+--         </ssc:Unit>
+--       </ssd:Units>
+--       <ssd:Units>
+--         <ssc:Unit
+--           name="Hz">
+--           <ssc:BaseUnit
+--             s="-1" />
+--         </ssc:Unit>
+--         <ssc:Unit
+--           name="rad">
+--           <ssc:BaseUnit />
+--         </ssc:Unit>
+--         <ssc:Unit
+--           name="s">
+--           <ssc:BaseUnit
+--             s="1" />
 --         </ssc:Unit>
 --       </ssd:Units>
 --       <ssd:DefaultExperiment

--- a/testsuite/api/import_export_units2.lua
+++ b/testsuite/api/import_export_units2.lua
@@ -36,9 +36,7 @@ src, status = oms_exportSnapshot("model")
 print(src)
 
 -- Result:
---
---  baseunits: s=-1
---  baseunits: s=1<?xml version="1.0"?>
+-- <?xml version="1.0"?>
 -- <oms:snapshot
 --   xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --   partial="false">
@@ -210,11 +208,7 @@ print(src)
 --   </oms:file>
 -- </oms:snapshot>
 --
---
---  baseunits: s=-1
---  baseunits: s=1
---  baseunits: s=-1
---  baseunits: s=1<?xml version="1.0"?>
+-- <?xml version="1.0"?>
 -- <oms:snapshot
 --   xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --   partial="false">

--- a/testsuite/api/setUnits2.lua
+++ b/testsuite/api/setUnits2.lua
@@ -37,7 +37,9 @@ oms_delete("model")
 
 
 -- Result:
--- <?xml version="1.0"?>
+--
+--  baseunits: s=-1
+--  baseunits: s=1<?xml version="1.0"?>
 -- <oms:snapshot
 --   xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --   partial="false">
@@ -76,7 +78,8 @@ oms_delete("model")
 --               <ssd:Connector
 --                 name="freqHz"
 --                 kind="parameter">
---                 <ssc:Real />
+--                 <ssc:Real
+--                   unit="Hz" />
 --               </ssd:Connector>
 --               <ssd:Connector
 --                 name="offset"
@@ -86,12 +89,14 @@ oms_delete("model")
 --               <ssd:Connector
 --                 name="phase"
 --                 kind="parameter">
---                 <ssc:Real />
+--                 <ssc:Real
+--                   unit="rad" />
 --               </ssd:Connector>
 --               <ssd:Connector
 --                 name="startTime"
 --                 kind="parameter">
---                 <ssc:Real />
+--                 <ssc:Real
+--                   unit="s" />
 --               </ssd:Connector>
 --             </ssd:Connectors>
 --             <ssd:ParameterBindings>
@@ -150,6 +155,11 @@ oms_delete("model")
 --           name="rad">
 --           <ssc:BaseUnit />
 --         </ssc:Unit>
+--         <ssc:Unit
+--           name="s">
+--           <ssc:BaseUnit
+--             s="1" />
+--         </ssc:Unit>
 --       </ssd:Units>
 --       <ssd:DefaultExperiment
 --         startTime="0.000000"
@@ -201,7 +211,9 @@ oms_delete("model")
 --   </oms:file>
 -- </oms:snapshot>
 --
--- <?xml version="1.0"?>
+--
+--  baseunits: s=-1
+--  baseunits: s=1<?xml version="1.0"?>
 -- <oms:snapshot
 --   xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --   partial="false">
@@ -235,12 +247,14 @@ oms_delete("model")
 --               <ssd:Connector
 --                 name="amplitude"
 --                 kind="parameter">
---                 <ssc:Real />
+--                 <ssc:Real
+--                   unit="m" />
 --               </ssd:Connector>
 --               <ssd:Connector
 --                 name="freqHz"
 --                 kind="parameter">
---                 <ssc:Real />
+--                 <ssc:Real
+--                   unit="Hz" />
 --               </ssd:Connector>
 --               <ssd:Connector
 --                 name="offset"
@@ -250,12 +264,14 @@ oms_delete("model")
 --               <ssd:Connector
 --                 name="phase"
 --                 kind="parameter">
---                 <ssc:Real />
+--                 <ssc:Real
+--                   unit="m" />
 --               </ssd:Connector>
 --               <ssd:Connector
 --                 name="startTime"
 --                 kind="parameter">
---                 <ssc:Real />
+--                 <ssc:Real
+--                   unit="s" />
 --               </ssd:Connector>
 --             </ssd:Connectors>
 --             <ssd:ParameterBindings>
@@ -314,6 +330,11 @@ oms_delete("model")
 --         <ssc:Unit
 --           name="m">
 --           <ssc:BaseUnit />
+--         </ssc:Unit>
+--         <ssc:Unit
+--           name="s">
+--           <ssc:BaseUnit
+--             s="1" />
 --         </ssc:Unit>
 --       </ssd:Units>
 --       <ssd:DefaultExperiment

--- a/testsuite/api/setUnits2.lua
+++ b/testsuite/api/setUnits2.lua
@@ -37,9 +37,7 @@ oms_delete("model")
 
 
 -- Result:
---
---  baseunits: s=-1
---  baseunits: s=1<?xml version="1.0"?>
+-- <?xml version="1.0"?>
 -- <oms:snapshot
 --   xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --   partial="false">
@@ -211,9 +209,7 @@ oms_delete("model")
 --   </oms:file>
 -- </oms:snapshot>
 --
---
---  baseunits: s=-1
---  baseunits: s=1<?xml version="1.0"?>
+-- <?xml version="1.0"?>
 -- <oms:snapshot
 --   xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --   partial="false">

--- a/testsuite/api/test03.lua
+++ b/testsuite/api/test03.lua
@@ -67,7 +67,9 @@ oms_terminate("test03lua")
 oms_delete("test03lua")
 
 -- Result:
--- <?xml version="1.0"?>
+--
+--  baseunits: s=-1
+--  baseunits: s=1<?xml version="1.0"?>
 -- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="test03lua" version="1.0">
 -- 	<ssd:System name="eoo">
 -- 		<ssd:Elements>
@@ -81,16 +83,16 @@ oms_delete("test03lua")
 -- 						<ssc:Real />
 -- 					</ssd:Connector>
 -- 					<ssd:Connector name="freqHz" kind="parameter">
--- 						<ssc:Real />
+-- 						<ssc:Real unit="Hz" />
 -- 					</ssd:Connector>
 -- 					<ssd:Connector name="offset" kind="parameter">
 -- 						<ssc:Real />
 -- 					</ssd:Connector>
 -- 					<ssd:Connector name="phase" kind="parameter">
--- 						<ssc:Real />
+-- 						<ssc:Real unit="rad" />
 -- 					</ssd:Connector>
 -- 					<ssd:Connector name="startTime" kind="parameter">
--- 						<ssc:Real />
+-- 						<ssc:Real unit="s" />
 -- 					</ssd:Connector>
 -- 				</ssd:Connectors>
 -- 			</ssd:Component>
@@ -105,6 +107,17 @@ oms_delete("test03lua")
 -- 			</ssc:Annotation>
 -- 		</ssd:Annotations>
 -- 	</ssd:System>
+-- 	<ssd:Units>
+-- 		<ssc:Unit name="Hz">
+-- 			<ssc:BaseUnit s="-1" />
+-- 		</ssc:Unit>
+-- 		<ssc:Unit name="rad">
+-- 			<ssc:BaseUnit />
+-- 		</ssc:Unit>
+-- 		<ssc:Unit name="s">
+-- 			<ssc:BaseUnit s="1" />
+-- 		</ssc:Unit>
+-- 	</ssd:Units>
 -- 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
 -- 		<ssd:Annotations>
 -- 			<ssc:Annotation type="org.openmodelica">
@@ -118,7 +131,9 @@ oms_delete("test03lua")
 --
 -- error:   [getResourceNode] Failed to find node "resources/signalFilter.xml"
 -- status:  [correct] ok
--- <?xml version="1.0"?>
+--
+--  baseunits: s=-1
+--  baseunits: s=1<?xml version="1.0"?>
 -- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="test03lua" version="1.0">
 -- 	<ssd:System name="eoo">
 -- 		<ssd:Elements>
@@ -132,16 +147,16 @@ oms_delete("test03lua")
 -- 						<ssc:Real />
 -- 					</ssd:Connector>
 -- 					<ssd:Connector name="freqHz" kind="parameter">
--- 						<ssc:Real />
+-- 						<ssc:Real unit="Hz" />
 -- 					</ssd:Connector>
 -- 					<ssd:Connector name="offset" kind="parameter">
 -- 						<ssc:Real />
 -- 					</ssd:Connector>
 -- 					<ssd:Connector name="phase" kind="parameter">
--- 						<ssc:Real />
+-- 						<ssc:Real unit="rad" />
 -- 					</ssd:Connector>
 -- 					<ssd:Connector name="startTime" kind="parameter">
--- 						<ssc:Real />
+-- 						<ssc:Real unit="s" />
 -- 					</ssd:Connector>
 -- 				</ssd:Connectors>
 -- 			</ssd:Component>
@@ -156,6 +171,17 @@ oms_delete("test03lua")
 -- 			</ssc:Annotation>
 -- 		</ssd:Annotations>
 -- 	</ssd:System>
+-- 	<ssd:Units>
+-- 		<ssc:Unit name="Hz">
+-- 			<ssc:BaseUnit s="-1" />
+-- 		</ssc:Unit>
+-- 		<ssc:Unit name="rad">
+-- 			<ssc:BaseUnit />
+-- 		</ssc:Unit>
+-- 		<ssc:Unit name="s">
+-- 			<ssc:BaseUnit s="1" />
+-- 		</ssc:Unit>
+-- 	</ssd:Units>
 -- 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
 -- 		<ssd:Annotations>
 -- 			<ssc:Annotation type="org.openmodelica">

--- a/testsuite/api/test03.lua
+++ b/testsuite/api/test03.lua
@@ -67,9 +67,7 @@ oms_terminate("test03lua")
 oms_delete("test03lua")
 
 -- Result:
---
---  baseunits: s=-1
---  baseunits: s=1<?xml version="1.0"?>
+-- <?xml version="1.0"?>
 -- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="test03lua" version="1.0">
 -- 	<ssd:System name="eoo">
 -- 		<ssd:Elements>
@@ -131,9 +129,7 @@ oms_delete("test03lua")
 --
 -- error:   [getResourceNode] Failed to find node "resources/signalFilter.xml"
 -- status:  [correct] ok
---
---  baseunits: s=-1
---  baseunits: s=1<?xml version="1.0"?>
+-- <?xml version="1.0"?>
 -- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="test03lua" version="1.0">
 -- 	<ssd:System name="eoo">
 -- 		<ssd:Elements>

--- a/testsuite/api/test03.py
+++ b/testsuite/api/test03.py
@@ -73,16 +73,16 @@ oms.delete("test03py")
 ## 						<ssc:Real />
 ## 					</ssd:Connector>
 ## 					<ssd:Connector name="freqHz" kind="parameter">
-## 						<ssc:Real />
+## 						<ssc:Real unit="Hz" />
 ## 					</ssd:Connector>
 ## 					<ssd:Connector name="offset" kind="parameter">
 ## 						<ssc:Real />
 ## 					</ssd:Connector>
 ## 					<ssd:Connector name="phase" kind="parameter">
-## 						<ssc:Real />
+## 						<ssc:Real unit="rad" />
 ## 					</ssd:Connector>
 ## 					<ssd:Connector name="startTime" kind="parameter">
-## 						<ssc:Real />
+## 						<ssc:Real unit="s" />
 ## 					</ssd:Connector>
 ## 				</ssd:Connectors>
 ## 			</ssd:Component>
@@ -97,6 +97,17 @@ oms.delete("test03py")
 ## 			</ssc:Annotation>
 ## 		</ssd:Annotations>
 ## 	</ssd:System>
+## 	<ssd:Units>
+## 		<ssc:Unit name="Hz">
+## 			<ssc:BaseUnit s="-1" />
+## 		</ssc:Unit>
+## 		<ssc:Unit name="rad">
+## 			<ssc:BaseUnit />
+## 		</ssc:Unit>
+## 		<ssc:Unit name="s">
+## 			<ssc:BaseUnit s="1" />
+## 		</ssc:Unit>
+## 	</ssd:Units>
 ## 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
 ## 		<ssd:Annotations>
 ## 			<ssc:Annotation type="org.openmodelica">
@@ -108,7 +119,9 @@ oms.delete("test03py")
 ## 	</ssd:DefaultExperiment>
 ## </ssd:SystemStructureDescription>
 ##
-## error:   [getResourceNode] Failed to find node "resources/signalFilter.xml"
+##
+##  baseunits: s=-1
+##  baseunits: s=1error:   [getResourceNode] Failed to find node "resources/signalFilter.xml"
 ## status:  [correct] ok
 ## <?xml version="1.0"?>
 ## <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="test03py" version="1.0">
@@ -124,16 +137,16 @@ oms.delete("test03py")
 ## 						<ssc:Real />
 ## 					</ssd:Connector>
 ## 					<ssd:Connector name="freqHz" kind="parameter">
-## 						<ssc:Real />
+## 						<ssc:Real unit="Hz" />
 ## 					</ssd:Connector>
 ## 					<ssd:Connector name="offset" kind="parameter">
 ## 						<ssc:Real />
 ## 					</ssd:Connector>
 ## 					<ssd:Connector name="phase" kind="parameter">
-## 						<ssc:Real />
+## 						<ssc:Real unit="rad" />
 ## 					</ssd:Connector>
 ## 					<ssd:Connector name="startTime" kind="parameter">
-## 						<ssc:Real />
+## 						<ssc:Real unit="s" />
 ## 					</ssd:Connector>
 ## 				</ssd:Connectors>
 ## 			</ssd:Component>
@@ -148,6 +161,17 @@ oms.delete("test03py")
 ## 			</ssc:Annotation>
 ## 		</ssd:Annotations>
 ## 	</ssd:System>
+## 	<ssd:Units>
+## 		<ssc:Unit name="Hz">
+## 			<ssc:BaseUnit s="-1" />
+## 		</ssc:Unit>
+## 		<ssc:Unit name="rad">
+## 			<ssc:BaseUnit />
+## 		</ssc:Unit>
+## 		<ssc:Unit name="s">
+## 			<ssc:BaseUnit s="1" />
+## 		</ssc:Unit>
+## 	</ssd:Units>
 ## 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
 ## 		<ssd:Annotations>
 ## 			<ssc:Annotation type="org.openmodelica">
@@ -159,7 +183,9 @@ oms.delete("test03py")
 ## 	</ssd:DefaultExperiment>
 ## </ssd:SystemStructureDescription>
 ##
-## info:    Result file: test03py_res.mat (bufferSize=10)
+##
+##  baseunits: s=-1
+##  baseunits: s=1info:    Result file: test03py_res.mat (bufferSize=10)
 ## info:    0 warnings
 ## info:    1 errors
 ## endResult

--- a/testsuite/api/test03.py
+++ b/testsuite/api/test03.py
@@ -119,9 +119,7 @@ oms.delete("test03py")
 ## 	</ssd:DefaultExperiment>
 ## </ssd:SystemStructureDescription>
 ##
-##
-##  baseunits: s=-1
-##  baseunits: s=1error:   [getResourceNode] Failed to find node "resources/signalFilter.xml"
+## error:   [getResourceNode] Failed to find node "resources/signalFilter.xml"
 ## status:  [correct] ok
 ## <?xml version="1.0"?>
 ## <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="test03py" version="1.0">
@@ -183,9 +181,7 @@ oms.delete("test03py")
 ## 	</ssd:DefaultExperiment>
 ## </ssd:SystemStructureDescription>
 ##
-##
-##  baseunits: s=-1
-##  baseunits: s=1info:    Result file: test03py_res.mat (bufferSize=10)
+## info:    Result file: test03py_res.mat (bufferSize=10)
 ## info:    0 warnings
 ## info:    1 errors
 ## endResult

--- a/testsuite/simulation/deleteConnector.lua
+++ b/testsuite/simulation/deleteConnector.lua
@@ -124,7 +124,7 @@ print(src)
 -- 								<ssd:ConnectorGeometry x="1.000000" y="0.500000" />
 -- 							</ssd:Connector>
 -- 							<ssd:Connector name="k" kind="parameter">
--- 								<ssc:Real />
+-- 								<ssc:Real unit="1" />
 -- 							</ssd:Connector>
 -- 						</ssd:Connectors>
 -- 						<ssd:ParameterBindings>

--- a/testsuite/simulation/deleteConnector1.lua
+++ b/testsuite/simulation/deleteConnector1.lua
@@ -170,7 +170,8 @@ oms_delete("deleteConnector")
 --                   <ssd:Connector
 --                     name="k"
 --                     kind="parameter">
---                     <ssc:Real />
+--                     <ssc:Real
+--                       unit="1" />
 --                   </ssd:Connector>
 --                 </ssd:Connectors>
 --               </ssd:Component>

--- a/testsuite/simulation/deleteReferencesAndStartValues.lua
+++ b/testsuite/simulation/deleteReferencesAndStartValues.lua
@@ -190,7 +190,8 @@ oms_delete("deleteResources")
 --               <ssd:Connector
 --                 name="k"
 --                 kind="parameter">
---                 <ssc:Real />
+--                 <ssc:Real
+--                   unit="1" />
 --               </ssd:Connector>
 --             </ssd:Connectors>
 --           </ssd:Component>
@@ -210,6 +211,12 @@ oms_delete("deleteResources")
 --           </ssc:Annotation>
 --         </ssd:Annotations>
 --       </ssd:System>
+--       <ssd:Units>
+--         <ssc:Unit
+--           name="1">
+--           <ssc:BaseUnit />
+--         </ssc:Unit>
+--       </ssd:Units>
 --       <ssd:DefaultExperiment
 --         startTime="0.000000"
 --         stopTime="1.000000">

--- a/testsuite/simulation/deleteStartValues.lua
+++ b/testsuite/simulation/deleteStartValues.lua
@@ -155,7 +155,7 @@ print(src)
 -- 								<ssd:ConnectorGeometry x="1.000000" y="0.500000" />
 -- 							</ssd:Connector>
 -- 							<ssd:Connector name="k" kind="parameter">
--- 								<ssc:Real />
+-- 								<ssc:Real unit="1" />
 -- 							</ssd:Connector>
 -- 						</ssd:Connectors>
 -- 					</ssd:Component>
@@ -249,7 +249,7 @@ print(src)
 -- 								<ssd:ConnectorGeometry x="1.000000" y="0.500000" />
 -- 							</ssd:Connector>
 -- 							<ssd:Connector name="k" kind="parameter">
--- 								<ssc:Real />
+-- 								<ssc:Real unit="1" />
 -- 							</ssd:Connector>
 -- 						</ssd:Connectors>
 -- 					</ssd:Component>

--- a/testsuite/simulation/deleteStartValuesInSSV.lua
+++ b/testsuite/simulation/deleteStartValuesInSSV.lua
@@ -95,7 +95,7 @@ oms_delete("deleteStartValuesInSSV")
 -- 								<ssd:ConnectorGeometry x="1.000000" y="0.500000" />
 -- 							</ssd:Connector>
 -- 							<ssd:Connector name="k" kind="parameter">
--- 								<ssc:Real />
+-- 								<ssc:Real unit="1" />
 -- 							</ssd:Connector>
 -- 						</ssd:Connectors>
 -- 					</ssd:Component>

--- a/testsuite/simulation/deleteStartValuesInSSV1.lua
+++ b/testsuite/simulation/deleteStartValuesInSSV1.lua
@@ -137,7 +137,8 @@ oms_delete("deleteStartValuesInSSV")
 --                   <ssd:Connector
 --                     name="k"
 --                     kind="parameter">
---                     <ssc:Real />
+--                     <ssc:Real
+--                       unit="1" />
 --                   </ssd:Connector>
 --                 </ssd:Connectors>
 --               </ssd:Component>

--- a/testsuite/simulation/deleteStartValuesInSSV2.lua
+++ b/testsuite/simulation/deleteStartValuesInSSV2.lua
@@ -162,7 +162,8 @@ oms_delete("deleteStartValuesInSSV")
 --               <ssd:Connector
 --                 name="k"
 --                 kind="parameter">
---                 <ssc:Real />
+--                 <ssc:Real
+--                   unit="1" />
 --               </ssd:Connector>
 --             </ssd:Connectors>
 --             <ssd:ParameterBindings>
@@ -186,6 +187,12 @@ oms_delete("deleteStartValuesInSSV")
 --           </ssc:Annotation>
 --         </ssd:Annotations>
 --       </ssd:System>
+--       <ssd:Units>
+--         <ssc:Unit
+--           name="1">
+--           <ssc:BaseUnit />
+--         </ssc:Unit>
+--       </ssd:Units>
 --       <ssd:DefaultExperiment
 --         startTime="0.000000"
 --         stopTime="1.000000">

--- a/testsuite/simulation/exportConnectorsToResultFile.lua
+++ b/testsuite/simulation/exportConnectorsToResultFile.lua
@@ -131,7 +131,7 @@ oms_delete("exportConnectors")
 -- 						<ssd:ConnectorGeometry x="1.000000" y="0.500000" />
 -- 					</ssd:Connector>
 -- 					<ssd:Connector name="k" kind="parameter">
--- 						<ssc:Real />
+-- 						<ssc:Real unit="1" />
 -- 					</ssd:Connector>
 -- 				</ssd:Connectors>
 -- 				<ssd:ParameterBindings>
@@ -159,6 +159,11 @@ oms_delete("exportConnectors")
 -- 			</ssc:Annotation>
 -- 		</ssd:Annotations>
 -- 	</ssd:System>
+-- 	<ssd:Units>
+-- 		<ssc:Unit name="1">
+-- 			<ssc:BaseUnit />
+-- 		</ssc:Unit>
+-- 	</ssd:Units>
 -- 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
 -- 		<ssd:Annotations>
 -- 			<ssc:Annotation type="org.openmodelica">

--- a/testsuite/simulation/exportSnapshotSSP.lua
+++ b/testsuite/simulation/exportSnapshotSSP.lua
@@ -90,7 +90,8 @@ print(src)
 --               <ssd:Connector
 --                 name="k"
 --                 kind="parameter">
---                 <ssc:Real />
+--                 <ssc:Real
+--                   unit="1" />
 --               </ssd:Connector>
 --             </ssd:Connectors>
 --           </ssd:Component>
@@ -110,6 +111,12 @@ print(src)
 --           </ssc:Annotation>
 --         </ssd:Annotations>
 --       </ssd:System>
+--       <ssd:Units>
+--         <ssc:Unit
+--           name="1">
+--           <ssc:BaseUnit />
+--         </ssc:Unit>
+--       </ssd:Units>
 --       <ssd:DefaultExperiment
 --         startTime="0.000000"
 --         stopTime="1.000000">

--- a/testsuite/simulation/import_export_parameters_inline.lua
+++ b/testsuite/simulation/import_export_parameters_inline.lua
@@ -278,7 +278,7 @@ oms_delete("import_export_parameters")
 -- 						<ssd:ConnectorGeometry x="1.000000" y="0.500000" />
 -- 					</ssd:Connector>
 -- 					<ssd:Connector name="k" kind="parameter">
--- 						<ssc:Real />
+-- 						<ssc:Real unit="1" />
 -- 					</ssd:Connector>
 -- 				</ssd:Connectors>
 -- 			</ssd:Component>
@@ -299,6 +299,11 @@ oms_delete("import_export_parameters")
 -- 			</ssc:Annotation>
 -- 		</ssd:Annotations>
 -- 	</ssd:System>
+-- 	<ssd:Units>
+-- 		<ssc:Unit name="1">
+-- 			<ssc:BaseUnit />
+-- 		</ssc:Unit>
+-- 	</ssd:Units>
 -- 	<ssd:DefaultExperiment startTime="0.000000" stopTime="4.000000">
 -- 		<ssd:Annotations>
 -- 			<ssc:Annotation type="org.openmodelica">

--- a/testsuite/simulation/import_export_parameters_to_ssv.lua
+++ b/testsuite/simulation/import_export_parameters_to_ssv.lua
@@ -223,7 +223,7 @@ oms_delete("import_export_parameters")
 -- 						<ssd:ConnectorGeometry x="1.000000" y="0.500000" />
 -- 					</ssd:Connector>
 -- 					<ssd:Connector name="k" kind="parameter">
--- 						<ssc:Real />
+-- 						<ssc:Real unit="1" />
 -- 					</ssd:Connector>
 -- 				</ssd:Connectors>
 -- 			</ssd:Component>
@@ -244,6 +244,11 @@ oms_delete("import_export_parameters")
 -- 			</ssc:Annotation>
 -- 		</ssd:Annotations>
 -- 	</ssd:System>
+-- 	<ssd:Units>
+-- 		<ssc:Unit name="1">
+-- 			<ssc:BaseUnit />
+-- 		</ssc:Unit>
+-- 	</ssd:Units>
 -- 	<ssd:DefaultExperiment startTime="0.000000" stopTime="4.000000">
 -- 		<ssd:Annotations>
 -- 			<ssc:Annotation type="org.openmodelica">

--- a/testsuite/simulation/import_export_signalFilter.lua
+++ b/testsuite/simulation/import_export_signalFilter.lua
@@ -184,7 +184,8 @@ oms_delete("model")
 --               <ssd:Connector
 --                 name="k"
 --                 kind="parameter">
---                 <ssc:Real />
+--                 <ssc:Real
+--                   unit="1" />
 --               </ssd:Connector>
 --             </ssd:Connectors>
 --           </ssd:Component>
@@ -204,6 +205,12 @@ oms_delete("model")
 --           </ssc:Annotation>
 --         </ssd:Annotations>
 --       </ssd:System>
+--       <ssd:Units>
+--         <ssc:Unit
+--           name="1">
+--           <ssc:BaseUnit />
+--         </ssc:Unit>
+--       </ssd:Units>
 --       <ssd:DefaultExperiment
 --         startTime="0.000000"
 --         stopTime="1.000000">

--- a/testsuite/simulation/referenceResources1.lua
+++ b/testsuite/simulation/referenceResources1.lua
@@ -210,7 +210,8 @@ oms_delete("referenceResources1")
 --               <ssd:Connector
 --                 name="k"
 --                 kind="parameter">
---                 <ssc:Real />
+--                 <ssc:Real
+--                   unit="1" />
 --               </ssd:Connector>
 --             </ssd:Connectors>
 --             <ssd:ParameterBindings>
@@ -234,6 +235,12 @@ oms_delete("referenceResources1")
 --           </ssc:Annotation>
 --         </ssd:Annotations>
 --       </ssd:System>
+--       <ssd:Units>
+--         <ssc:Unit
+--           name="1">
+--           <ssc:BaseUnit />
+--         </ssc:Unit>
+--       </ssd:Units>
 --       <ssd:DefaultExperiment
 --         startTime="0.000000"
 --         stopTime="1.000000">

--- a/testsuite/simulation/setExternalInputs.lua
+++ b/testsuite/simulation/setExternalInputs.lua
@@ -62,7 +62,7 @@ oms_delete("setExternalInputs")
 -- 						<ssd:ConnectorGeometry x="1.000000" y="0.500000" />
 -- 					</ssd:Connector>
 -- 					<ssd:Connector name="k" kind="parameter">
--- 						<ssc:Real />
+-- 						<ssc:Real unit="1" />
 -- 					</ssd:Connector>
 -- 				</ssd:Connectors>
 -- 			</ssd:Component>
@@ -77,6 +77,11 @@ oms_delete("setExternalInputs")
 -- 			</ssc:Annotation>
 -- 		</ssd:Annotations>
 -- 	</ssd:System>
+-- 	<ssd:Units>
+-- 		<ssc:Unit name="1">
+-- 			<ssc:BaseUnit />
+-- 		</ssc:Unit>
+-- 	</ssd:Units>
 -- 	<ssd:DefaultExperiment startTime="0.000000" stopTime="5.000000">
 -- 		<ssd:Annotations>
 -- 			<ssc:Annotation type="org.openmodelica">


### PR DESCRIPTION
### Related Issues

https://github.com/OpenModelica/OMSimulator/issues/942

### Purpose

This PR exports units to connectors, which will be used to check the units when making `connections` between the `connectors` 

### TODO

- [x] export units to connectors
- [x] import units from connectors
- [x] set units to connectors