### PR TITLE
fix #8163 search for the libOMSimulator library in two places

### DIFF
--- a/src/OMSimulatorPython/capi.py
+++ b/src/OMSimulatorPython/capi.py
@@ -5,6 +5,9 @@ class capi:
   def __init__(self):
     dirname = os.path.dirname(__file__)
     omslib = os.path.join(dirname, "@OMSIMULATORLIB_DIR_STRING@", "@OMSIMULATORLIB_STRING@")
+    # attempt to fix #8163 on Linux
+    if not os.path.exists(omslib):
+      omslib = os.path.join(dirname, "..", "@OMSIMULATORLIB_DIR_STRING@", "@OMSIMULATORLIB_STRING@")
 
     if os.name == 'nt': # Windows
       dllDir = os.add_dll_directory(os.path.dirname(omslib))


### PR DESCRIPTION
### Related Issues

https://github.com/OpenModelica/OpenModelica/issues/8163

### Purpose

OMSimulator library is installed in `/usr/lib/x86_64-linux-gnu/` and OMSimulator.py searches for it in `/usr/lib/OMSimulator/x86_64-linux-gnu/`. The fix is detailed below.

### Approach

If you can't find the lib in `/usr/lib/OMSimulator/x86_64-linux-gnu/` use the one in `/usr/lib/OMSimulator/../x86_64-linux-gnu/`
