### PR TITLE
Limit the number of artifacts stored in Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,6 +5,7 @@ pipeline {
   }
   options {
     newContainerPerStage()
+    buildDiscarder(logRotator(numToKeepStr: "100", artifactNumToKeepStr: "5"))
   }
   parameters {
     booleanParam(name: 'MSVC64', defaultValue: true, description: 'Build with MSVC64 (often hangs)')


### PR DESCRIPTION
Artifacts are anyway uploaded to build.openmodelica.org, so they do not
need to be also in Jenkins.

### Purpose

Make backups easier. The artifacts take a lot of space.