### PR TITLE
export only referenced entry in ssm to a ssv file

### DIFF
--- a/src/OMSimulatorLib/Model.h
+++ b/src/OMSimulatorLib/Model.h
@@ -38,6 +38,7 @@
 #include "ResultWriter.h"
 #include "Types.h"
 #include "Snapshot.h"
+#include "Values.h"
 #include <assert.h>
 #include <pugixml.hpp>
 
@@ -78,6 +79,7 @@ namespace oms
     oms_status_enu_t deleteReferencesInSSD(const ComRef& cref);
     oms_status_enu_t deleteResourcesInSSP(const std::string& filename);
     oms_status_enu_t referenceResources(const ComRef& cref, const std::string& ssmFile);
+    oms_status_enu_t reduceSSV(const std::string& ssvfile, const std::string& ssmfile, const std::string& filepath);
     oms_status_enu_t exportToSSD(Snapshot& snapshot) const;
     oms_status_enu_t exportSnapshot(const ComRef& cref, char** contents);
     oms_status_enu_t exportSSVTemplate(const ComRef& cref, const std::string& filename);
@@ -161,6 +163,8 @@ namespace oms
     double loggingInterval = 0.0;
     int bufferSize = 10;
     Clock clock;
+
+    Values values;
 
     std::string resultFilename; ///< default <name>_res.mat
     std::string signalFilterFilename = "resources/signalFilter.xml";

--- a/src/OMSimulatorLib/OMSimulator.cpp
+++ b/src/OMSimulatorLib/OMSimulator.cpp
@@ -213,6 +213,15 @@ oms_status_enu_t oms_referenceResources(const char* cref_, const char* ssmFile)
   return model->referenceResources(tail, std::string(ssmFile));
 }
 
+oms_status_enu_t oms_reduceSSV(const char* cref, const char* ssvfile, const char* ssmfile, const char* filepath)
+{
+  oms::Model* model = oms::Scope::GetInstance().getModel(cref);
+  if (!model)
+    return logError_ModelNotInScope(cref);
+
+  return model->reduceSSV(ssvfile, ssmfile, filepath);
+}
+
 oms_status_enu_t oms_export(const char* cref, const char* filename)
 {
   return oms::Scope::GetInstance().exportModel(oms::ComRef(cref), std::string(filename));

--- a/src/OMSimulatorLib/OMSimulator.h
+++ b/src/OMSimulatorLib/OMSimulator.h
@@ -127,6 +127,7 @@ OMSAPI oms_status_enu_t OMSCALL oms_listUnconnectedConnectors(const char* cref, 
 OMSAPI oms_status_enu_t OMSCALL oms_loadSnapshot(const char* cref, const char* snapshot, char** newCref);
 OMSAPI oms_status_enu_t OMSCALL oms_newModel(const char* cref);
 OMSAPI oms_status_enu_t OMSCALL oms_newResources(const char* cref);
+OMSAPI oms_status_enu_t OMSCALL oms_reduceSSV(const char* cref, const char* ssvfile, const char* ssmfile, const char* filepath);
 OMSAPI oms_status_enu_t OMSCALL oms_removeSignalsFromResults(const char* cref, const char* regex);
 OMSAPI oms_status_enu_t OMSCALL oms_rename(const char* cref, const char* newCref);
 OMSAPI oms_status_enu_t OMSCALL oms_reset(const char* cref);

--- a/src/OMSimulatorLib/Values.h
+++ b/src/OMSimulatorLib/Values.h
@@ -96,6 +96,8 @@ namespace oms
     void importUnitDefinitions(const pugi::xml_node& node);
 
     void exportToSSVTemplate(pugi::xml_node& ssvNode, const ComRef& cref);  ///< start values read from modelDescription.xml and creates a ssv template
+    void exportReduceSSV(pugi::xml_node& ssvNode, const ComRef& cref);  ///< reduced SSV file which contains only the referenced crefs in parametermapping
+
     oms_status_enu_t exportToSSMTemplate(pugi::xml_node& ssmNode, const ComRef& cref);  ///< start values read from modelDescription.xml and creates a ssm template
 
     oms_status_enu_t parseModelDescription(const filesystem::path& root); ///< path without the filename, i.e. modelDescription.xml
@@ -116,6 +118,7 @@ namespace oms
 
     void importParameterMapping(const pugi::xml_node& parameterMapping);
     oms::ComRef getMappedCrefEntry(const ComRef& cref) const;
+    bool isEntryReferencedInSSM(const ComRef& cref) const;
     bool empty() const;
 
   public:

--- a/src/OMSimulatorLua/OMSimulatorLua.c
+++ b/src/OMSimulatorLua/OMSimulatorLua.c
@@ -308,6 +308,33 @@ static int OMSimulatorLua_oms_exportSSVTemplate(lua_State *L)
   return 1;
 }
 
+//oms_status_enu_t oms_reduceSSV(const char* ssvfile, const char* ssmfile, const char* filepath);
+static int OMSimulatorLua_oms_reduceSSV(lua_State *L)
+{
+  if (lua_gettop(L) > 4)
+    return luaL_error(L, "expecting exactly 3 or 4 arguments");
+
+  luaL_checktype(L, 1, LUA_TSTRING);
+  luaL_checktype(L, 2, LUA_TSTRING);
+  luaL_checktype(L, 3, LUA_TSTRING);
+
+  const char* cref = lua_tostring(L, 1);
+  const char* ssvfile = lua_tostring(L, 2);
+  const char* ssmfile = lua_tostring(L, 3);
+
+  const char* filepath = "";
+  if (lua_gettop(L) == 4)
+  {
+    luaL_checktype(L, 4, LUA_TSTRING);
+    filepath = lua_tostring(L, 4);
+  }
+
+  oms_status_enu_t status = oms_reduceSSV(cref, ssvfile, ssmfile, filepath);
+
+  lua_pushinteger(L, status);
+  return 1;
+}
+
 //oms_status_enu_t oms_exportSSMTemplate(const char* cref, const char* filename);
 static int OMSimulatorLua_oms_exportSSMTemplate(lua_State *L)
 {
@@ -1445,6 +1472,7 @@ DLLEXPORT int luaopen_OMSimulatorLua(lua_State *L)
   REGISTER_LUA_CALL(oms_rename);
   REGISTER_LUA_CALL(oms_reset);
   REGISTER_LUA_CALL(oms_referenceResources);
+  REGISTER_LUA_CALL(oms_reduceSSV);
   REGISTER_LUA_CALL(oms_setBoolean);
   REGISTER_LUA_CALL(oms_setCommandLineOption);
   REGISTER_LUA_CALL(oms_setFixedStepSize);

--- a/src/OMSimulatorPython/OMSimulator.py
+++ b/src/OMSimulatorPython/OMSimulator.py
@@ -109,6 +109,7 @@ class OMSimulator:
     self.listUnconnectedConnectors = Scope._capi.listUnconnectedConnectors
     self.loadSnapshot = Scope._capi.loadSnapshot
     self.newResources = Scope._capi.newResources
+    self.reduceSSV = Scope._capi.reduceSSV
     self.referenceResources = Scope._capi.referenceResources
     self.removeSignalsFromResults = Scope._capi.removeSignalsFromResults
     self.rename = Scope._capi.rename

--- a/src/OMSimulatorPython/capi.py
+++ b/src/OMSimulatorPython/capi.py
@@ -117,6 +117,8 @@ class capi:
     self.obj.oms_newModel.restype = ctypes.c_int
     self.obj.oms_newResources.argtypes = [ctypes.c_char_p]
     self.obj.oms_newResources.restype = ctypes.c_int
+    self.obj.oms_reduceSSV.argtypes = [ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p]
+    self.obj.oms_reduceSSV.restype = ctypes.c_int
     self.obj.oms_referenceResources.argtypes = [ctypes.c_char_p, ctypes.c_char_p]
     self.obj.oms_referenceResources.restype = ctypes.c_int
     self.obj.oms_removeSignalsFromResults.argtypes = [ctypes.c_char_p, ctypes.c_char_p]
@@ -328,6 +330,8 @@ class capi:
     return self.obj.oms_newModel(cref.encode())
   def newResources(self, crefA):
     return self.obj.oms_newResources(crefA.encode())
+  def reduceSSV(self, crefA, crefB, crefC, crefD=""):
+    return self.obj.oms_reduceSSV(crefA.encode(), crefB.encode(), crefC.encode(), crefD.encode())
   def referenceResources(self, crefA, crefB=""):
     return self.obj.oms_referenceResources(crefA.encode(), crefB.encode())
   def removeSignalsFromResults(self, cref, regex):

--- a/testsuite/api/Makefile
+++ b/testsuite/api/Makefile
@@ -25,6 +25,7 @@ import_export_units2.lua \
 setUnits1.lua \
 setUnits2.lua \
 setUnits3.py \
+reduceSSV.lua \
 test_omsExport.lua \
 test_omsExport.py \
 test01.lua \

--- a/testsuite/api/Makefile
+++ b/testsuite/api/Makefile
@@ -26,6 +26,7 @@ setUnits1.lua \
 setUnits2.lua \
 setUnits3.py \
 reduceSSV.lua \
+reduceSSV.py \
 test_omsExport.lua \
 test_omsExport.py \
 test01.lua \

--- a/testsuite/api/reduceSSV.lua
+++ b/testsuite/api/reduceSSV.lua
@@ -1,0 +1,67 @@
+-- status: correct
+-- teardown_command: rm -rf reducessv_01_lua/
+-- linux: yes
+-- mingw32: yes
+-- mingw64: yes
+-- win: yes
+-- mac: no
+
+
+function readFile(filename)
+    local f = assert(io.open(filename, "r"))
+    local content = f:read("*all")
+    print(content)
+    f:close()
+  end
+
+oms_setCommandLineOption("--suppressPath=true")
+oms_setTempDirectory("./reducessv_01_lua/")
+
+oms_newModel("model")
+
+oms_reduceSSV("model", "../resources/importParameterMapping/resources/import_parameter_mapping.ssv", "../resources/importParameterMapping/resources/import_parameter_mapping.ssm")
+
+readFile("../resources/importParameterMapping/resources/import_parameter_mapping.ssv")
+readFile("reduced.ssv")
+
+
+-- Result:
+-- <?xml version="1.0" encoding="UTF-8"?>
+-- <ssv:ParameterSet xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" version="1.0" name="parameters">
+--     <ssv:Parameters>
+--         <ssv:Parameter name="cosim_input">
+--             <ssv:Real value="20" />
+--         </ssv:Parameter>
+--          <ssv:Parameter name="Input_3">
+--             <ssv:Real value="50" />
+--         </ssv:Parameter>
+--         <ssv:Parameter name="cosim_parameters">
+--             <ssv:Real value="-30" />
+--         </ssv:Parameter>
+--         <ssv:Parameter name="parameter_2">
+--             <ssv:Real value="-40" />
+--         </ssv:Parameter>
+--     </ssv:Parameters>
+-- </ssv:ParameterSet>
+--
+-- <?xml version="1.0" encoding="UTF-8"?>
+-- <ssv:ParameterSet
+--   xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
+--   xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
+--   version="1.0"
+--   name="reducedSSV">
+--   <ssv:Parameters>
+--     <ssv:Parameter
+--       name="cosim_parameters">
+--       <ssv:Real
+--         value="-30" />
+--     </ssv:Parameter>
+--     <ssv:Parameter
+--       name="cosim_input">
+--       <ssv:Real
+--         value="20" />
+--     </ssv:Parameter>
+--   </ssv:Parameters>
+-- </ssv:ParameterSet>
+--
+-- endResult

--- a/testsuite/api/reduceSSV.py
+++ b/testsuite/api/reduceSSV.py
@@ -1,0 +1,70 @@
+## status: correct
+## teardown_command: rm -rf reducessv_01_py/
+## linux: yes
+## mingw32: yes
+## mingw64: yes
+## win: yes
+## mac: no
+
+
+def readFile(filename):
+  f = open(filename, "r")
+  content = f.read()
+  print(content)
+  f:close()
+
+from OMSimulator import OMSimulator
+oms = OMSimulator()
+
+
+oms.setCommandLineOption("--suppressPath=true")
+oms.setTempDirectory("./reducessv_01_py/")
+
+oms.newModel("model")
+
+oms.reduceSSV("model", "../resources/importParameterMapping/resources/import_parameter_mapping.ssv", "../resources/importParameterMapping/resources/import_parameter_mapping.ssm")
+
+readFile("../resources/importParameterMapping/resources/import_parameter_mapping.ssv")
+readFile("reduced.ssv")
+
+
+## Result:
+## <?xml version="1.0" encoding="UTF-8"?>
+## <ssv:ParameterSet xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" version="1.0" name="parameters">
+##     <ssv:Parameters>
+##         <ssv:Parameter name="cosim_input">
+##             <ssv:Real value="20" />
+##         </ssv:Parameter>
+##          <ssv:Parameter name="Input_3">
+##             <ssv:Real value="50" />
+##         </ssv:Parameter>
+##         <ssv:Parameter name="cosim_parameters">
+##             <ssv:Real value="-30" />
+##         </ssv:Parameter>
+##         <ssv:Parameter name="parameter_2">
+##             <ssv:Real value="-40" />
+##         </ssv:Parameter>
+##     </ssv:Parameters>
+## </ssv:ParameterSet>
+##
+## <?xml version="1.0" encoding="UTF-8"?>
+## <ssv:ParameterSet
+##   xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
+##   xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
+##   version="1.0"
+##   name="reducedSSV">
+##   <ssv:Parameters>
+##     <ssv:Parameter
+##       name="cosim_parameters">
+##       <ssv:Real
+##         value="-30" />
+##     </ssv:Parameter>
+##     <ssv:Parameter
+##       name="cosim_input">
+##       <ssv:Real
+##         value="20" />
+##     </ssv:Parameter>
+##   </ssv:Parameters>
+## </ssv:ParameterSet>
+##
+## endResult


### PR DESCRIPTION
### Related Issues
https://github.com/OpenModelica/OMSimulator/issues/1159

### Purpose
This PR exports only the referenced entry in `ssm` file to a `ssv` file through `oms_reduceSSV()`

### TODO

- [x] python support