### PR TITLE
add suppressUnitConversion to connections

### DIFF
--- a/doc/UsersGuide/source/api/addConnection.rst
+++ b/doc/UsersGuide/source/api/addConnection.rst
@@ -9,31 +9,33 @@ specified as fully qualified component references, e.g., `"model.system.componen
 #LUA#
 .. code-block:: lua
 
-  status = oms_addConnection(crefA, crefB)
+  status = oms_addConnection(crefA, crefB, suppressUnitConversion)
 
 #END#
 
 #PYTHON#
 .. code-block:: python
 
-  status = oms.addConnection(crefA, crefB)
+  status = oms.addConnection(crefA, crefB, suppressUnitConversion)
 
 #END#
 
 #CAPI#
 .. code-block:: c
 
-  oms_status_enu_t oms_addConnection(const char* crefA, const char* crefB);
+  oms_status_enu_t oms_addConnection(const char* crefA, const char* crefB, bool suppressUnitConversion);
 
 #END#
 
 #OMC#
 .. code-block:: modelica
 
-  status := oms_addConnection(crefA, crefB);
+  status := oms_addConnection(crefA, crefB, suppressUnitConversion);
 
 #END#
 
 #DESCRIPTION#
-The two arguments `crefA` and `crefB` get swapped automatically if necessary.
+The two arguments `crefA` and `crefB` get swapped automatically if necessary. The third argument suppressUnitConversion is
+optional and the default value is `false` which allows automatic unit conversion between connections, if set to `true` then
+automatic unit conversion will be disabled.
 #END#

--- a/src/OMSimulatorLib/Connection.cpp
+++ b/src/OMSimulatorLib/Connection.cpp
@@ -134,6 +134,9 @@ oms_status_enu_t oms::Connection::exportToSSD(pugi::xml_node &root) const
   node.append_attribute("endElement") = endConnectorRef.isEmpty() ? "" : endElementRef.c_str();
   node.append_attribute("endConnector") = endConnectorRef.isEmpty() ? endElementRef.c_str() : endConnectorRef.c_str();
 
+  if (suppressUnitConversion)
+    node.append_attribute("suppressUnitConversion") = suppressUnitConversion;
+
   if(type == oms_connection_tlm)
   {
     node.append_attribute("delay") = std::to_string(tlmparameters->delay).c_str();

--- a/src/OMSimulatorLib/Connection.cpp
+++ b/src/OMSimulatorLib/Connection.cpp
@@ -39,7 +39,7 @@
 #include <vector>
 #include <string>
 
-oms::Connection::Connection(const oms::ComRef& conA, const oms::ComRef& conB, oms_connection_type_enu_t type)
+oms::Connection::Connection(const oms::ComRef& conA, const oms::ComRef& conB, bool suppressUnitConversion, oms_connection_type_enu_t type)
 {
   std::string str;
 
@@ -56,6 +56,8 @@ oms::Connection::Connection(const oms::ComRef& conA, const oms::ComRef& conB, om
   this->geometry = reinterpret_cast<ssd_connection_geometry_t*>(new oms::ssd::ConnectionGeometry());
 
   tlmparameters = NULL;
+
+  this->suppressUnitConversion = suppressUnitConversion;
 }
 
 oms::Connection::~Connection()
@@ -81,6 +83,8 @@ oms::Connection::Connection(const oms::Connection& rhs)
   this->geometry = reinterpret_cast<ssd_connection_geometry_t*>(geometry_);
 
   tlmparameters = NULL;
+
+  this->suppressUnitConversion = rhs.suppressUnitConversion;
 }
 
 oms::Connection& oms::Connection::operator=(const oms::Connection& rhs)
@@ -106,6 +110,8 @@ oms::Connection& oms::Connection::operator=(const oms::Connection& rhs)
   this->geometry = reinterpret_cast<ssd_connection_geometry_t*>(geometry_);
 
   setTLMParameters(rhs.tlmparameters);
+
+  this->suppressUnitConversion = rhs.suppressUnitConversion;
 
   return *this;
 }

--- a/src/OMSimulatorLib/Connection.h
+++ b/src/OMSimulatorLib/Connection.h
@@ -47,7 +47,7 @@ namespace oms
   class Connection : protected oms_connection_t
   {
   public:
-    Connection(const oms::ComRef& conA, const oms::ComRef& conB, oms_connection_type_enu_t type=oms_connection_single);
+    Connection(const oms::ComRef& conA, const oms::ComRef& conB, bool suppressUnitConversion=false, oms_connection_type_enu_t type=oms_connection_single);
     ~Connection();
 
     // methods to copy the object
@@ -73,6 +73,7 @@ namespace oms
     bool containsSignal(const oms::ComRef& signal) const;
     bool containsSignalB(const oms::ComRef& signal) const;
 
+    bool getSuppressUnitConversion() {return suppressUnitConversion;}
     /**
     * \brief Checks a connection based on SSP-1.0 connection table
     */

--- a/src/OMSimulatorLib/DirectedGraph.cpp
+++ b/src/OMSimulatorLib/DirectedGraph.cpp
@@ -296,6 +296,17 @@ void oms::DirectedGraph::calculateSortedConnections()
           }
           // factor = output_Connector_Factor/ input_Connector_Factor
           scc.factor = (factorA/factorB);
+
+          // set suppressUnitConversion = true or false
+          scc.suppressUnitConversion = false;
+          for (const auto &it : unitConversion)
+          {
+            if (it.conA == conA.getName() && it.conB == conB.getName())
+            {
+              scc.suppressUnitConversion = it.unitConversion;
+              break;
+            }
+          }
         }
       }
     }
@@ -324,7 +335,7 @@ void oms::DirectedGraph::calculateSortedConnections()
   sortedConnectionsAreValid = true;
 }
 
-void oms::DirectedGraph::setUnits(Connector* conA, Connector* conB)
+void oms::DirectedGraph::setUnits(Connector* conA, Connector* conB, bool suppressUnitConversion)
 {
   /* get the full cref to check the connector owner with nodes
      (e.g) model.root.A.y1 ==> A.y1
@@ -336,6 +347,8 @@ void oms::DirectedGraph::setUnits(Connector* conA, Connector* conB)
   ComRef crefB(conB->getOwner() + conB->getName());
   ComRef tailA1 = crefB.pop_front();
   ComRef tailB1 = crefB.pop_front();
+
+  unitConversion.push_back({crefA, crefB, suppressUnitConversion});
 
   for (auto &it : nodes)
   {

--- a/src/OMSimulatorLib/DirectedGraph.h
+++ b/src/OMSimulatorLib/DirectedGraph.h
@@ -59,6 +59,7 @@ namespace oms
     unsigned int size_including_internal;
     std::set<oms::ComRef> component_names;
     double factor;
+    bool suppressUnitConversion;
   };
 
   class DirectedGraph
@@ -81,7 +82,7 @@ namespace oms
     const std::vector<Connector>& getNodes() const {return nodes;}
     const scc_t& getEdges() const {return edges;}
 
-    void setUnits(Connector* conA, Connector* conB);
+    void setUnits(Connector* conA, Connector* conB, bool suppressUnitConversion);
     void dumpNodes() const;
 
   private:
@@ -98,6 +99,15 @@ namespace oms
     std::vector< std::vector<int> > G;
     std::vector< scc_t > sortedConnections;
     bool sortedConnectionsAreValid;
+
+    struct suppressUnitConversion
+    {
+      oms::ComRef conA;
+      oms::ComRef conB;
+      bool unitConversion;
+    };
+
+    std::vector<suppressUnitConversion> unitConversion;
   };
 }
 

--- a/src/OMSimulatorLib/OMSimulator.cpp
+++ b/src/OMSimulatorLib/OMSimulator.cpp
@@ -501,7 +501,7 @@ oms_status_enu_t oms_getSystemType(const char* cref, oms_system_enu_t* type)
   return oms_status_ok;
 }
 
-oms_status_enu_t oms_addConnection(const char *crefA, const char *crefB)
+oms_status_enu_t oms_addConnection(const char *crefA, const char *crefB, bool suppressUnitConversion)
 {
   oms::ComRef tailA(crefA);
   oms::ComRef modelCref = tailA.pop_front();
@@ -521,7 +521,7 @@ oms_status_enu_t oms_addConnection(const char *crefA, const char *crefB)
     return logError_SystemNotInModel(modelCref, systemCref);
   }
 
-  return system->addConnection(tailA,tailB);
+  return system->addConnection(tailA, tailB, suppressUnitConversion);
 }
 
 oms_status_enu_t oms_deleteConnection(const char *crefA, const char *crefB)

--- a/src/OMSimulatorLib/OMSimulator.h
+++ b/src/OMSimulatorLib/OMSimulator.h
@@ -59,7 +59,7 @@ extern "C"
 #endif
 
 OMSAPI oms_status_enu_t OMSCALL oms_addBus(const char* cref);
-OMSAPI oms_status_enu_t OMSCALL oms_addConnection(const char* crefA, const char* crefB);
+OMSAPI oms_status_enu_t OMSCALL oms_addConnection(const char* crefA, const char* crefB, bool suppressUnitConversion);
 OMSAPI oms_status_enu_t OMSCALL oms_addConnector(const char* cref, oms_causality_enu_t causality, oms_signal_type_enu_t type);
 OMSAPI oms_status_enu_t OMSCALL oms_addConnectorToBus(const char* busCref, const char* connectorCref);
 OMSAPI oms_status_enu_t OMSCALL oms_addConnectorToTLMBus(const char* busCref, const char* connectorCref, const char *type);

--- a/src/OMSimulatorLib/System.cpp
+++ b/src/OMSimulatorLib/System.cpp
@@ -642,8 +642,6 @@ oms_status_enu_t oms::System::exportToSSV(Snapshot& snapshot) const
 
 oms_status_enu_t oms::System::importFromSnapshot(const pugi::xml_node& node, const std::string& sspVersion, const Snapshot& snapshot)
 {
-  std::map<std::string, std::string> startValuesFileSources;  ///< ssvFileSource mapped with ssmFilesource if mapping is provided, otherwise only ssvFilesource entry is made
-
   for(pugi::xml_node_iterator it = node.begin(); it != node.end(); ++it)
   {
     std::string name = it->name();

--- a/src/OMSimulatorLib/System.h
+++ b/src/OMSimulatorLib/System.h
@@ -117,7 +117,7 @@ namespace oms
 #endif
     Connection* getConnection(const ComRef& crefA, const ComRef& crefB);
     Connection** getConnections(const ComRef &cref);
-    oms_status_enu_t addConnection(const ComRef& crefA, const ComRef& crefB);
+    oms_status_enu_t addConnection(const ComRef& crefA, const ComRef& crefB, bool suppressUnitConversion = false);
     oms_status_enu_t deleteConnection(const ComRef& crefA, const ComRef& crefB);
     oms_status_enu_t setConnectorGeometry(const ComRef& cref, const oms::ssd::ConnectorGeometry* geometry);
     oms_status_enu_t setConnectionGeometry(const ComRef &crefA, const ComRef &crefB, const oms::ssd::ConnectionGeometry* geometry);

--- a/src/OMSimulatorLib/SystemSC.cpp
+++ b/src/OMSimulatorLib/SystemSC.cpp
@@ -708,10 +708,15 @@ oms_status_enu_t oms::SystemSC::updateInputs(DirectedGraph& graph)
       {
         double value = 0.0;
         if (oms_status_ok != getReal(graph.getNodes()[output].getName(), value)) return oms_status_error;
-        /* check for unit conversion and set the value multiplied by factor,
+        /* check for unit conversion and suppressUnitConversion and set the value multiplied by factor,
          * by default, factor = 1.0, (e.g) mm to m will be (factor*value) => (10^-3 * value)
         */
-        if (oms_status_ok != setReal(graph.getNodes()[input].getName(), sortedConnections[i].factor*value)) return oms_status_error;
+        if (sortedConnections[i].suppressUnitConversion)
+          value = value;
+        else
+          value = sortedConnections[i].factor*value;
+
+        if (oms_status_ok != setReal(graph.getNodes()[input].getName(), value)) return oms_status_error;
       }
       else if (graph.getNodes()[input].getType() == oms_signal_type_integer || graph.getNodes()[input].getType() == oms_signal_type_enum)
       {

--- a/src/OMSimulatorLib/SystemWC.cpp
+++ b/src/OMSimulatorLib/SystemWC.cpp
@@ -1006,10 +1006,15 @@ oms_status_enu_t oms::SystemWC::updateInputs(oms::DirectedGraph& graph)
       {
         double value = 0.0;
         if (oms_status_ok != getReal(graph.getNodes()[output].getName(), value)) return oms_status_error;
-        /* check for unit conversion and set the value multiplied by factor,
+        /* check for unit conversion and suppressUnitConversion and set the value multiplied by factor,
          * by default, factor = 1.0, (e.g) mm to m will be (factor*value) => (10^-3 * value)
         */
-        if (oms_status_ok != setReal(graph.getNodes()[input].getName(), sortedConnections[i].factor*value)) return oms_status_error;
+        if (sortedConnections[i].suppressUnitConversion)
+          value = value;
+        else
+          value = sortedConnections[i].factor*value;
+
+        if (oms_status_ok != setReal(graph.getNodes()[input].getName(), value)) return oms_status_error;
 
         // derivatives
         if (Flags::InputExtrapolation() && getModel().validState(oms_modelState_simulation))

--- a/src/OMSimulatorLib/Types.h
+++ b/src/OMSimulatorLib/Types.h
@@ -349,6 +349,7 @@ typedef struct {
   char* conB;                                      ///< Name of connector B
   ssd_connection_geometry_t* geometry;             ///< Geometry information of the connection
   oms_tlm_connection_parameters_t* tlmparameters;  ///< TLM parameters (only for TLM connections)
+  bool suppressUnitConversion;                     ///< boolean to specify automatic unit coversion between connections
 } oms_connection_t;
 
 /**

--- a/src/OMSimulatorLua/OMSimulatorLua.c
+++ b/src/OMSimulatorLua/OMSimulatorLua.c
@@ -850,14 +850,22 @@ static int OMSimulatorLua_oms_addConnector(lua_State *L)
 //oms_status_enu_t oms_addConnection(const char *crefA, const char *crefB);
 static int OMSimulatorLua_oms_addConnection(lua_State *L)
 {
-  if (lua_gettop(L) != 2)
-    return luaL_error(L, "expecting exactly 2 arguments");
+  if (lua_gettop(L) > 3)
+    return luaL_error(L, "expecting exactly 2 or 3 arguments");
   luaL_checktype(L, 1, LUA_TSTRING);
   luaL_checktype(L, 2, LUA_TSTRING);
 
   const char* crefA = lua_tostring(L, 1);
   const char* crefB = lua_tostring(L, 2);
-  oms_status_enu_t status = oms_addConnection(crefA, crefB);
+
+  bool suppressUnitConversion = false;
+  if (lua_gettop(L) == 3)
+  {
+    luaL_checktype(L, 3, LUA_TBOOLEAN);
+    suppressUnitConversion = lua_toboolean(L, 3);
+  }
+
+  oms_status_enu_t status = oms_addConnection(crefA, crefB, suppressUnitConversion);
 
   lua_pushinteger(L, status);
 

--- a/src/OMSimulatorLua/OMSimulatorLua.c
+++ b/src/OMSimulatorLua/OMSimulatorLua.c
@@ -311,7 +311,7 @@ static int OMSimulatorLua_oms_exportSSVTemplate(lua_State *L)
 //oms_status_enu_t oms_reduceSSV(const char* ssvfile, const char* ssmfile, const char* filepath);
 static int OMSimulatorLua_oms_reduceSSV(lua_State *L)
 {
-  if (lua_gettop(L) > 4)
+  if (lua_gettop(L) != 3 && lua_gettop(L) != 4)
     return luaL_error(L, "expecting exactly 3 or 4 arguments");
 
   luaL_checktype(L, 1, LUA_TSTRING);
@@ -850,7 +850,7 @@ static int OMSimulatorLua_oms_addConnector(lua_State *L)
 //oms_status_enu_t oms_addConnection(const char *crefA, const char *crefB);
 static int OMSimulatorLua_oms_addConnection(lua_State *L)
 {
-  if (lua_gettop(L) > 3)
+  if (lua_gettop(L) != 2 && lua_gettop(L) != 3)
     return luaL_error(L, "expecting exactly 2 or 3 arguments");
   luaL_checktype(L, 1, LUA_TSTRING);
   luaL_checktype(L, 2, LUA_TSTRING);

--- a/src/OMSimulatorPython/capi.py
+++ b/src/OMSimulatorPython/capi.py
@@ -17,7 +17,7 @@ class capi:
 
     self.obj.oms_addBus.argtypes = [ctypes.c_char_p]
     self.obj.oms_addBus.restype = ctypes.c_int
-    self.obj.oms_addConnection.argtypes = [ctypes.c_char_p, ctypes.c_char_p]
+    self.obj.oms_addConnection.argtypes = [ctypes.c_char_p, ctypes.c_char_p, ctypes.c_bool]
     self.obj.oms_addConnection.restype = ctypes.c_int
     self.obj.oms_addConnector.argtypes = [ctypes.c_char_p, ctypes.c_int, ctypes.c_int]
     self.obj.oms_addConnector.restype = ctypes.c_int
@@ -181,8 +181,8 @@ class capi:
 
   def addBus(self, crefA):
     return self.obj.oms_addBus(crefA.encode())
-  def addConnection(self, crefA, crefB):
-    return self.obj.oms_addConnection(crefA.encode(), crefB.encode())
+  def addConnection(self, crefA, crefB, suppressUnit=False):
+    return self.obj.oms_addConnection(crefA.encode(), crefB.encode(), suppressUnit)
   def addConnector(self, cref, causality, type_):
     return self.obj.oms_addConnector(cref.encode(), causality, type_)
   def addConnectorToBus(self, busCref, connectorCref):

--- a/testsuite/simulation/Makefile
+++ b/testsuite/simulation/Makefile
@@ -35,6 +35,7 @@ import_parameter_mapping_inline.lua \
 importPartialSnapshot.lua \
 importStartValues.lua \
 importStartValues1.lua \
+importSuppressUnitConversion.lua \
 multipleConnections.lua \
 nls.py \
 partialSnapshot.lua \

--- a/testsuite/simulation/Makefile
+++ b/testsuite/simulation/Makefile
@@ -57,6 +57,7 @@ snapshot.lua \
 snapshot.py \
 str_hello_world.lua \
 str_hello_world.py \
+suppressUnitConversion.lua \
 table.lua \
 
 # Run make failingtest

--- a/testsuite/simulation/importSuppressUnitConversion.lua
+++ b/testsuite/simulation/importSuppressUnitConversion.lua
@@ -1,0 +1,301 @@
+-- status: correct
+-- teardown_command: rm -rf importsuppressunit_lua/
+-- linux: no
+-- mingw32: no
+-- mingw64: yes
+-- win: yes
+-- mac: no
+
+oms_setCommandLineOption("--suppressPath=true")
+oms_setTempDirectory("./importsuppressunit_lua/")
+
+oms_newModel("model")
+
+oms_addSystem("model.root", oms_system_wc)
+
+oms_addSubModel("model.root.A", "../resources/A.fmu")
+oms_addSubModel("model.root.B", "../resources/B.fmu")
+
+-- invalid connection with different unit
+oms_addConnection("model.root.A.y", "model.root.B.u")
+-- valid connection mm to m
+oms_addConnection("model.root.A.y1", "model.root.B.u1", true)
+oms_addConnection("model.root.A.y2", "model.root.B.u2", true)
+
+oms_setResultFile("model", "importsuppressunits.mat")
+
+oms_export("model", "importsuppressunitConversion.ssp")
+
+oms_terminate("model")
+oms_delete("model")
+
+oms_importFile("importsuppressunitConversion.ssp")
+
+src, status = oms_exportSnapshot("model")
+print(src)
+
+oms_instantiate("model")
+oms_initialize("model")
+print("info:    Initialization")
+print("info:      model.root.A.y1     : " .. oms_getReal("model.root.A.y1"))
+print("info:      model.root.B.u1     : " .. oms_getReal("model.root.B.u1"))
+print("info:      model.root.A.y2     : " .. oms_getReal("model.root.A.y2"))
+print("info:      model.root.B.u2     : " .. oms_getReal("model.root.B.u2"))
+
+oms_simulate("model")
+print("info:    Simulation")
+print("info:      model.root.A.y1     : " .. oms_getReal("model.root.A.y1"))
+print("info:      model.root.B.u1     : " .. oms_getReal("model.root.B.u1"))
+print("info:      model.root.A.y2     : " .. oms_getReal("model.root.A.y2"))
+print("info:      model.root.B.u2     : " .. oms_getReal("model.root.B.u2"))
+
+oms_terminate("model")
+oms_delete("model")
+
+
+
+-- Result:
+-- error:   [addConnection] Unit mismatch in connection: A.y -> B.u
+-- <?xml version="1.0"?>
+-- <oms:snapshot
+--   xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
+--   partial="false">
+--   <oms:file
+--     name="SystemStructure.ssd">
+--     <ssd:SystemStructureDescription
+--       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
+--       xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription"
+--       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
+--       xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping"
+--       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
+--       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
+--       name="model"
+--       version="1.0">
+--       <ssd:System
+--         name="root">
+--         <ssd:Elements>
+--           <ssd:Component
+--             name="B"
+--             type="application/x-fmu-sharedlibrary"
+--             source="resources/0002_B.fmu">
+--             <ssd:Connectors>
+--               <ssd:Connector
+--                 name="u"
+--                 kind="input">
+--                 <ssc:Real
+--                   unit="m/s" />
+--                 <ssd:ConnectorGeometry
+--                   x="0.000000"
+--                   y="0.250000" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="u1"
+--                 kind="input">
+--                 <ssc:Real
+--                   unit="m" />
+--                 <ssd:ConnectorGeometry
+--                   x="0.000000"
+--                   y="0.500000" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="u2"
+--                 kind="input">
+--                 <ssc:Real
+--                   unit="m/ms" />
+--                 <ssd:ConnectorGeometry
+--                   x="0.000000"
+--                   y="0.750000" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="y"
+--                 kind="output">
+--                 <ssc:Real
+--                   unit="m" />
+--                 <ssd:ConnectorGeometry
+--                   x="1.000000"
+--                   y="0.500000" />
+--               </ssd:Connector>
+--             </ssd:Connectors>
+--           </ssd:Component>
+--           <ssd:Component
+--             name="A"
+--             type="application/x-fmu-sharedlibrary"
+--             source="resources/0001_A.fmu">
+--             <ssd:Connectors>
+--               <ssd:Connector
+--                 name="u"
+--                 kind="input">
+--                 <ssc:Real
+--                   unit="m/s" />
+--                 <ssd:ConnectorGeometry
+--                   x="0.000000"
+--                   y="0.500000" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="y"
+--                 kind="output">
+--                 <ssc:Real
+--                   unit="m" />
+--                 <ssd:ConnectorGeometry
+--                   x="1.000000"
+--                   y="0.250000" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="y1"
+--                 kind="output">
+--                 <ssc:Real
+--                   unit="mm" />
+--                 <ssd:ConnectorGeometry
+--                   x="1.000000"
+--                   y="0.500000" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="y2"
+--                 kind="output">
+--                 <ssc:Real
+--                   unit="mm/s" />
+--                 <ssd:ConnectorGeometry
+--                   x="1.000000"
+--                   y="0.750000" />
+--               </ssd:Connector>
+--             </ssd:Connectors>
+--           </ssd:Component>
+--         </ssd:Elements>
+--         <ssd:Connections>
+--           <ssd:Connection
+--             startElement="A"
+--             startConnector="y1"
+--             endElement="B"
+--             endConnector="u1"
+--             importsuppressunitConversion="true" />
+--           <ssd:Connection
+--             startElement="A"
+--             startConnector="y2"
+--             endElement="B"
+--             endConnector="u2"
+--             importsuppressunitConversion="true" />
+--         </ssd:Connections>
+--         <ssd:Annotations>
+--           <ssc:Annotation
+--             type="org.openmodelica">
+--             <oms:Annotations>
+--               <oms:SimulationInformation>
+--                 <oms:FixedStepMaster
+--                   description="oms-ma"
+--                   stepSize="0.001000"
+--                   absoluteTolerance="0.000100"
+--                   relativeTolerance="0.000100" />
+--               </oms:SimulationInformation>
+--             </oms:Annotations>
+--           </ssc:Annotation>
+--         </ssd:Annotations>
+--       </ssd:System>
+--       <ssd:Units>
+--         <ssc:Unit
+--           name="m">
+--           <ssc:BaseUnit
+--             m="1" />
+--         </ssc:Unit>
+--         <ssc:Unit
+--           name="m/ms">
+--           <ssc:BaseUnit
+--             factor="1000.0"
+--             m="1"
+--             s="-1" />
+--         </ssc:Unit>
+--         <ssc:Unit
+--           name="m/s">
+--           <ssc:BaseUnit
+--             m="1"
+--             s="-1" />
+--         </ssc:Unit>
+--         <ssc:Unit
+--           name="mm">
+--           <ssc:BaseUnit
+--             factor="0.001"
+--             m="1" />
+--         </ssc:Unit>
+--         <ssc:Unit
+--           name="mm/s">
+--           <ssc:BaseUnit
+--             factor="0.001"
+--             m="1"
+--             s="-1" />
+--         </ssc:Unit>
+--       </ssd:Units>
+--       <ssd:DefaultExperiment
+--         startTime="0.000000"
+--         stopTime="1.000000">
+--         <ssd:Annotations>
+--           <ssc:Annotation
+--             type="org.openmodelica">
+--             <oms:Annotations>
+--               <oms:SimulationInformation
+--                 resultFile="importsuppressunits.mat"
+--                 loggingInterval="0.000000"
+--                 bufferSize="1"
+--                 signalFilter="resources/signalFilter.xml" />
+--             </oms:Annotations>
+--           </ssc:Annotation>
+--         </ssd:Annotations>
+--       </ssd:DefaultExperiment>
+--     </ssd:SystemStructureDescription>
+--   </oms:file>
+--   <oms:file
+--     name="resources/signalFilter.xml">
+--     <oms:SignalFilter
+--       version="1.0">
+--       <oms:Variable
+--         name="model.root.B.u"
+--         type="Real"
+--         kind="input" />
+--       <oms:Variable
+--         name="model.root.B.u1"
+--         type="Real"
+--         kind="input" />
+--       <oms:Variable
+--         name="model.root.B.u2"
+--         type="Real"
+--         kind="input" />
+--       <oms:Variable
+--         name="model.root.B.y"
+--         type="Real"
+--         kind="output" />
+--       <oms:Variable
+--         name="model.root.A.x"
+--         type="Real"
+--         kind="unknown" />
+--       <oms:Variable
+--         name="model.root.A.u"
+--         type="Real"
+--         kind="input" />
+--       <oms:Variable
+--         name="model.root.A.y"
+--         type="Real"
+--         kind="output" />
+--       <oms:Variable
+--         name="model.root.A.y1"
+--         type="Real"
+--         kind="output" />
+--       <oms:Variable
+--         name="model.root.A.y2"
+--         type="Real"
+--         kind="output" />
+--     </oms:SignalFilter>
+--   </oms:file>
+-- </oms:snapshot>
+--
+-- info:    Result file: importsuppressunits.mat (bufferSize=1)
+-- info:    Initialization
+-- info:      model.root.A.y1     : 5.0
+-- info:      model.root.B.u1     : 5.0
+-- info:      model.root.A.y2     : 5.0
+-- info:      model.root.B.u2     : 5.0
+-- info:    Simulation
+-- info:      model.root.A.y1     : 5.0
+-- info:      model.root.B.u1     : 5.0
+-- info:      model.root.A.y2     : 5.0
+-- info:      model.root.B.u2     : 5.0
+-- info:    0 warnings
+-- info:    1 errors
+-- endResult

--- a/testsuite/simulation/importSuppressUnitConversion.lua
+++ b/testsuite/simulation/importSuppressUnitConversion.lua
@@ -167,13 +167,13 @@ oms_delete("model")
 --             startConnector="y1"
 --             endElement="B"
 --             endConnector="u1"
---             importsuppressunitConversion="true" />
+--             suppressUnitConversion="true" />
 --           <ssd:Connection
 --             startElement="A"
 --             startConnector="y2"
 --             endElement="B"
 --             endConnector="u2"
---             importsuppressunitConversion="true" />
+--             suppressUnitConversion="true" />
 --         </ssd:Connections>
 --         <ssd:Annotations>
 --           <ssc:Annotation

--- a/testsuite/simulation/suppressUnitConversion.lua
+++ b/testsuite/simulation/suppressUnitConversion.lua
@@ -25,7 +25,7 @@ oms_addConnection("model.root.A.y2", "model.root.B.u2", true)
 oms_setResultFile("model", "suppressunits.mat")
 
 src, status = oms_exportSnapshot("model")
--- print(src)
+print(src)
 
 oms_instantiate("model")
 oms_initialize("model")
@@ -49,6 +49,239 @@ oms_delete("model")
 
 -- Result:
 -- error:   [addConnection] Unit mismatch in connection: A.y -> B.u
+-- <?xml version="1.0"?>
+-- <oms:snapshot
+--   xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
+--   partial="false">
+--   <oms:file
+--     name="SystemStructure.ssd">
+--     <ssd:SystemStructureDescription
+--       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
+--       xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription"
+--       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
+--       xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping"
+--       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
+--       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
+--       name="model"
+--       version="1.0">
+--       <ssd:System
+--         name="root">
+--         <ssd:Elements>
+--           <ssd:Component
+--             name="B"
+--             type="application/x-fmu-sharedlibrary"
+--             source="resources/0002_B.fmu">
+--             <ssd:Connectors>
+--               <ssd:Connector
+--                 name="u"
+--                 kind="input">
+--                 <ssc:Real
+--                   unit="m/s" />
+--                 <ssd:ConnectorGeometry
+--                   x="0.000000"
+--                   y="0.250000" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="u1"
+--                 kind="input">
+--                 <ssc:Real
+--                   unit="m" />
+--                 <ssd:ConnectorGeometry
+--                   x="0.000000"
+--                   y="0.500000" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="u2"
+--                 kind="input">
+--                 <ssc:Real
+--                   unit="m/ms" />
+--                 <ssd:ConnectorGeometry
+--                   x="0.000000"
+--                   y="0.750000" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="y"
+--                 kind="output">
+--                 <ssc:Real
+--                   unit="m" />
+--                 <ssd:ConnectorGeometry
+--                   x="1.000000"
+--                   y="0.500000" />
+--               </ssd:Connector>
+--             </ssd:Connectors>
+--           </ssd:Component>
+--           <ssd:Component
+--             name="A"
+--             type="application/x-fmu-sharedlibrary"
+--             source="resources/0001_A.fmu">
+--             <ssd:Connectors>
+--               <ssd:Connector
+--                 name="u"
+--                 kind="input">
+--                 <ssc:Real
+--                   unit="m/s" />
+--                 <ssd:ConnectorGeometry
+--                   x="0.000000"
+--                   y="0.500000" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="y"
+--                 kind="output">
+--                 <ssc:Real
+--                   unit="m" />
+--                 <ssd:ConnectorGeometry
+--                   x="1.000000"
+--                   y="0.250000" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="y1"
+--                 kind="output">
+--                 <ssc:Real
+--                   unit="mm" />
+--                 <ssd:ConnectorGeometry
+--                   x="1.000000"
+--                   y="0.500000" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="y2"
+--                 kind="output">
+--                 <ssc:Real
+--                   unit="mm/s" />
+--                 <ssd:ConnectorGeometry
+--                   x="1.000000"
+--                   y="0.750000" />
+--               </ssd:Connector>
+--             </ssd:Connectors>
+--           </ssd:Component>
+--         </ssd:Elements>
+--         <ssd:Connections>
+--           <ssd:Connection
+--             startElement="A"
+--             startConnector="y1"
+--             endElement="B"
+--             endConnector="u1"
+--             suppressUnitConversion="true" />
+--           <ssd:Connection
+--             startElement="A"
+--             startConnector="y2"
+--             endElement="B"
+--             endConnector="u2"
+--             suppressUnitConversion="true" />
+--         </ssd:Connections>
+--         <ssd:Annotations>
+--           <ssc:Annotation
+--             type="org.openmodelica">
+--             <oms:Annotations>
+--               <oms:SimulationInformation>
+--                 <oms:FixedStepMaster
+--                   description="oms-ma"
+--                   stepSize="0.001000"
+--                   absoluteTolerance="0.000100"
+--                   relativeTolerance="0.000100" />
+--               </oms:SimulationInformation>
+--             </oms:Annotations>
+--           </ssc:Annotation>
+--         </ssd:Annotations>
+--       </ssd:System>
+--       <ssd:Units>
+--         <ssc:Unit
+--           name="m">
+--           <ssc:BaseUnit
+--             m="1" />
+--         </ssc:Unit>
+--         <ssc:Unit
+--           name="m/ms">
+--           <ssc:BaseUnit
+--             factor="1000.0"
+--             m="1"
+--             s="-1" />
+--         </ssc:Unit>
+--         <ssc:Unit
+--           name="m/s">
+--           <ssc:BaseUnit
+--             m="1"
+--             s="-1" />
+--         </ssc:Unit>
+--         <ssc:Unit
+--           name="mm">
+--           <ssc:BaseUnit
+--             factor="0.001"
+--             m="1" />
+--         </ssc:Unit>
+--         <ssc:Unit
+--           name="mm/s">
+--           <ssc:BaseUnit
+--             factor="0.001"
+--             m="1"
+--             s="-1" />
+--         </ssc:Unit>
+--       </ssd:Units>
+--       <ssd:DefaultExperiment
+--         startTime="0.000000"
+--         stopTime="1.000000">
+--         <ssd:Annotations>
+--           <ssc:Annotation
+--             type="org.openmodelica">
+--             <oms:Annotations>
+--               <oms:SimulationInformation
+--                 resultFile="suppressunits.mat"
+--                 loggingInterval="0.000000"
+--                 bufferSize="1"
+--                 signalFilter="resources/signalFilter.xml" />
+--             </oms:Annotations>
+--           </ssc:Annotation>
+--         </ssd:Annotations>
+--       </ssd:DefaultExperiment>
+--     </ssd:SystemStructureDescription>
+--   </oms:file>
+--   <oms:file
+--     name="resources/signalFilter.xml">
+--     <oms:SignalFilter
+--       version="1.0">
+--       <oms:Variable
+--         name="model.root.B.u"
+--         type="Real"
+--         kind="input" />
+--       <oms:Variable
+--         name="model.root.B.u1"
+--         type="Real"
+--         kind="input" />
+--       <oms:Variable
+--         name="model.root.B.u2"
+--         type="Real"
+--         kind="input" />
+--       <oms:Variable
+--         name="model.root.B.y"
+--         type="Real"
+--         kind="output" />
+--       <oms:Variable
+--         name="model.root.A.x"
+--         type="Real"
+--         kind="unknown" />
+--       <oms:Variable
+--         name="model.root.A.der(x)"
+--         type="Real"
+--         kind="unknown" />
+--       <oms:Variable
+--         name="model.root.A.u"
+--         type="Real"
+--         kind="input" />
+--       <oms:Variable
+--         name="model.root.A.y"
+--         type="Real"
+--         kind="output" />
+--       <oms:Variable
+--         name="model.root.A.y1"
+--         type="Real"
+--         kind="output" />
+--       <oms:Variable
+--         name="model.root.A.y2"
+--         type="Real"
+--         kind="output" />
+--     </oms:SignalFilter>
+--   </oms:file>
+-- </oms:snapshot>
+--
 -- info:    Result file: suppressunits.mat (bufferSize=1)
 -- info:    Initialization
 -- info:      model.root.A.y1     : 5.0

--- a/testsuite/simulation/suppressUnitConversion.lua
+++ b/testsuite/simulation/suppressUnitConversion.lua
@@ -1,0 +1,65 @@
+-- status: correct
+-- teardown_command: rm -rf suppressunit_lua/
+-- linux: no
+-- mingw32: no
+-- mingw64: yes
+-- win: yes
+-- mac: no
+
+oms_setCommandLineOption("--suppressPath=true")
+oms_setTempDirectory("./suppressunit_lua/")
+
+oms_newModel("model")
+
+oms_addSystem("model.root", oms_system_wc)
+
+oms_addSubModel("model.root.A", "../resources/A.fmu")
+oms_addSubModel("model.root.B", "../resources/B.fmu")
+
+-- invalid connection with different unit
+oms_addConnection("model.root.A.y", "model.root.B.u")
+-- valid connection mm to m
+oms_addConnection("model.root.A.y1", "model.root.B.u1", true)
+oms_addConnection("model.root.A.y2", "model.root.B.u2", true)
+
+oms_setResultFile("model", "suppressunits.mat")
+
+src, status = oms_exportSnapshot("model")
+-- print(src)
+
+oms_instantiate("model")
+oms_initialize("model")
+print("info:    Initialization")
+print("info:      model.root.A.y1     : " .. oms_getReal("model.root.A.y1"))
+print("info:      model.root.B.u1     : " .. oms_getReal("model.root.B.u1"))
+print("info:      model.root.A.y2     : " .. oms_getReal("model.root.A.y2"))
+print("info:      model.root.B.u2     : " .. oms_getReal("model.root.B.u2"))
+
+oms_simulate("model")
+print("info:    Simulation")
+print("info:      model.root.A.y1     : " .. oms_getReal("model.root.A.y1"))
+print("info:      model.root.B.u1     : " .. oms_getReal("model.root.B.u1"))
+print("info:      model.root.A.y2     : " .. oms_getReal("model.root.A.y2"))
+print("info:      model.root.B.u2     : " .. oms_getReal("model.root.B.u2"))
+
+oms_terminate("model")
+oms_delete("model")
+
+
+
+-- Result:
+-- error:   [addConnection] Unit mismatch in connection: A.y -> B.u
+-- info:    Result file: suppressunits.mat (bufferSize=1)
+-- info:    Initialization
+-- info:      model.root.A.y1     : 5.0
+-- info:      model.root.B.u1     : 5.0
+-- info:      model.root.A.y2     : 5.0
+-- info:      model.root.B.u2     : 5.0
+-- info:    Simulation
+-- info:      model.root.A.y1     : 5.0
+-- info:      model.root.B.u1     : 5.0
+-- info:      model.root.A.y2     : 5.0
+-- info:      model.root.B.u2     : 5.0
+-- info:    0 warnings
+-- info:    1 errors
+-- endResult


### PR DESCRIPTION
### Purpose
This PR checks if `suppressUnitConversion` is provided by user in `connections` and disables `automatic unit conversion` if `suppressUnitConversion=true`, the default is `suppressUnitConversion=false`

TODO

- [x] export suppressUnitConversion to ssp
- [x] import suppressUnitConversion to ssp
