### PR TITLE
Include cstring header for strcmp function.

### DIFF
--- a/src/OMSimulatorLib/ComRef.cpp
+++ b/src/OMSimulatorLib/ComRef.cpp
@@ -35,6 +35,7 @@
 
 #include <assert.h>
 #include <RegEx.h>
+#include <cstring>
 
 const oms_regex re_ident("^[a-zA-Z][a-zA-Z0-9_]*$");
 


### PR DESCRIPTION
  - This works fine on most systems but it breaks on the new Fedora Core 36.
    
 - Failing Build: https://test.openmodelica.org/jenkins/blue/organizations/jenkins/LINUX_BUILDS/detail/LINUX_BUILDS/1745/pipeline/1137
 - Log: https://test.openmodelica.org/jenkins/blue/rest/organizations/jenkins/pipelines/LINUX_BUILDS/runs/1745/nodes/1137/steps/1573/log/?start=0