### PR TITLE
add support to export and import multipleInstances of same fmu

### DIFF
--- a/src/OMSimulatorLib/ComponentFMUCS.h
+++ b/src/OMSimulatorLib/ComponentFMUCS.h
@@ -56,7 +56,7 @@ namespace oms
   public:
     ~ComponentFMUCS();
 
-    static Component* NewComponent(const ComRef& cref, System* parentSystem, const std::string& fmuPath);
+    static Component* NewComponent(const ComRef& cref, System* parentSystem, const std::string& fmuPath, bool useTempDir = false);
     static Component* NewComponent(const pugi::xml_node& node, System* parentSystem, const std::string& sspVersion, const Snapshot& snapshot);
     const FMUInfo* getFMUInfo() const {return &(this->fmuInfo);}
 

--- a/src/OMSimulatorLib/ComponentFMUME.cpp
+++ b/src/OMSimulatorLib/ComponentFMUME.cpp
@@ -40,6 +40,7 @@
 #include "SystemSC.h"
 #include "SystemTLM.h"
 
+#include <miniunz.h>
 #include <fmilib.h>
 #include <JM/jm_portability.h>
 #include <RegEx.h>
@@ -74,9 +75,38 @@ oms::Component* oms::ComponentFMUME::NewComponent(const oms::ComRef& cref, oms::
     return NULL;
   }
 
+  const char* modelDescription = ::miniunz_onefile_to_memory(fmuPath.c_str(), "modelDescription.xml");
+  Snapshot snapshot;
+  oms_status_enu_t status = snapshot.importResourceMemory("modelDescription.xml", modelDescription);
+  ::miniunz_free(modelDescription);
+
+  if (oms_status_ok != status)
+  {
+    logError("Failed to import modelDescription.xml for fmu " + fmuPath);
+    return NULL;
+  }
+
+  const pugi::xml_node node = snapshot.getResourceNode("modelDescription.xml");
+  if (!node)
+  {
+    logError("Failed to find root node in modelDescription.xml");
+    return NULL;
+  }
+
   filesystem::path temp_root(parentSystem->getModel().getTempDirectory());
   filesystem::path temp_temp = temp_root / "temp";
-  filesystem::path relFMUPath = parentSystem->copyResources() ? (filesystem::path("resources") / (parentSystem->getUniqueID() + "_" + std::string(cref) + ".fmu")) : filesystem::path(fmuPath);
+  filesystem::path relFMUPath;
+
+  std::string guid_ = node.attribute("guid").as_string();
+  auto it = parentSystem->fmuGuid.find(guid_);
+  if (it == parentSystem->fmuGuid.end())
+  {
+    relFMUPath = parentSystem->copyResources() ? (filesystem::path("resources") / (parentSystem->getUniqueID() + "_" + std::string(cref) + ".fmu")) : filesystem::path(fmuPath);
+    parentSystem->fmuGuid[guid_] = relFMUPath;
+  }
+  else
+    relFMUPath = parentSystem->fmuGuid[guid_];
+
   filesystem::path absFMUPath = temp_root / relFMUPath;
 
   ComponentFMUME* component = new ComponentFMUME(cref, parentSystem, relFMUPath.generic_string());
@@ -91,22 +121,33 @@ oms::Component* oms::ComponentFMUME::NewComponent(const oms::ComRef& cref, oms::
 
   // Copy the resource to the temp directory of the model? We don't want have
   // to copy resources if importing an SSP file or snapshot.
-  if (parentSystem->copyResources())
+  if (parentSystem->copyResources() && !filesystem::exists(absFMUPath))
     oms_copy_file(filesystem::path(fmuPath), absFMUPath);
 
   // set temp directory
   filesystem::path tempDir = temp_temp / relFMUPath.stem();
   component->setTempDir(tempDir.string());
-  if (!filesystem::is_directory(tempDir) && !filesystem::create_directory(tempDir))
+
+  bool dirExist = true;
+  if (!filesystem::is_directory(tempDir))
   {
-    logError("Creating temp directory for component \"" + std::string(cref) + "\" failed");
-    return NULL;
+    dirExist = false;
+    if (!filesystem::create_directory(tempDir))
+    {
+      logError("Creating temp directory for component \"" + std::string(cref) + "\" failed");
+      return NULL;
+    }
   }
 
   component->context = fmi_import_allocate_context(&component->callbacks);
 
   // check version of FMU
-  fmi_version_enu_t version = fmi_import_get_fmi_version(component->context, absFMUPath.string().c_str(), component->getTempDir().c_str());
+  fmi_version_enu_t version;
+  if (dirExist)
+    version = fmi_import_get_fmi_version_unzipped(component->context, tempDir.generic_string().c_str());
+  else
+    version = fmi_import_get_fmi_version(component->context, absFMUPath.string().c_str(), component->getTempDir().c_str());
+
   if (fmi_version_2_0_enu != version)
   {
     logError("Unsupported FMI version: " + std::string(fmi_version_to_string(version)));

--- a/src/OMSimulatorLib/ComponentFMUME.h
+++ b/src/OMSimulatorLib/ComponentFMUME.h
@@ -53,7 +53,7 @@ namespace oms
   public:
     ~ComponentFMUME();
 
-    static Component* NewComponent(const oms::ComRef& cref, System* parentSystem, const std::string& fmuPath);
+    static Component* NewComponent(const oms::ComRef& cref, System* parentSystem, const std::string& fmuPath, bool useTempDir = false);
     static Component* NewComponent(const pugi::xml_node& node, System* parentSystem,  const std::string& sspVersion, const Snapshot& snapshot);
     const FMUInfo* getFMUInfo() const {return &(this->fmuInfo);}
 

--- a/src/OMSimulatorLib/Model.cpp
+++ b/src/OMSimulatorLib/Model.cpp
@@ -901,6 +901,13 @@ oms_status_enu_t oms::Model::exportToFile(const std::string& filename) const
   std::vector<std::string> resources;
   writeAllResourcesToFilesystem(resources, snapshot);
 
+  /*
+   * remove duplicates resources which is basically a fmu with multiple instances
+   * eg. tank1 => resources/001_tank1.fmu
+   *     tank2 => resources/001_tank1.fmu
+  */
+  resources.erase(std::unique(resources.begin(), resources.end()), resources.end());
+
   std::string cd = Scope::GetInstance().getWorkingDirectory();
   Scope::GetInstance().setWorkingDirectory(tempDir);
   int argc = 4 + resources.size();

--- a/src/OMSimulatorLib/System.h
+++ b/src/OMSimulatorLib/System.h
@@ -199,6 +199,7 @@ namespace oms
     bool supportsDirectionalDerivatives(int i, DirectedGraph& graph);   ///< returns true if all FMUs support providesDirectionalDerivative
 
     Values& getValues() { return values; }
+    std::map<std::string, filesystem::path> fmuGuid;
 
   protected: // methods
     System(const ComRef& cref, oms_system_enu_t type, Model* parentModel, System* parentSystem, oms_solver_enu_t solverMethod);

--- a/testsuite/simulation/Makefile
+++ b/testsuite/simulation/Makefile
@@ -37,6 +37,7 @@ importStartValues.lua \
 importStartValues1.lua \
 importSuppressUnitConversion.lua \
 multipleConnections.lua \
+multipleInstance.lua \
 nls.py \
 partialSnapshot.lua \
 PI_Controller.lua \

--- a/testsuite/simulation/multipleInstance.lua
+++ b/testsuite/simulation/multipleInstance.lua
@@ -1,0 +1,458 @@
+-- status: correct
+-- teardown_command: rm -rf multiple_instance_lua/
+-- linux: no
+-- mingw32: no
+-- mingw64: yes
+-- win: no
+-- mac: no
+
+oms_setCommandLineOption("--suppressPath=true")
+oms_setTempDirectory("./multiple_instance_lua/")
+
+oms_newModel("model")
+
+oms_addSystem("model.root", oms_system_wc)
+
+oms_addSubModel("model.root.tank1", "../resources/tank1.fmu")
+oms_addSubModel("model.root.tank2", "../resources/tank1.fmu")
+oms_addSubModel("model.root.tank3", "../resources/tank1.fmu")
+oms_addSubModel("model.root.ypipe", "../resources/ypipe.fmu")
+
+oms_setReal("model.root.tank1.inputRate", 0.5)
+oms_setReal("model.root.tank2.inputRate", 0.1)
+
+oms_addConnection("model.root.tank1.outputRate", "model.root.ypipe.inputRate1")
+oms_addConnection("model.root.tank2.outputRate", "model.root.ypipe.inputRate2")
+oms_addConnection("model.root.ypipe.outputRate", "model.root.tank3.inputRate")
+
+
+oms_setResultFile("model", "multiple_instance_res.mat")
+
+oms_setStopTime("model", 1) -- set the stopTime = 100 to match the testing with EDF
+oms_setSolver("model", oms_solver_wc_mav)
+
+oms_setTolerance("model", 1e-5)
+oms_setVariableStepSize("model",  0.01, 1e-6, 1e-1)  -- settings to check for rollbacks
+
+src, status = oms_exportSnapshot("model")
+print(src)
+
+oms_export("model", "multipleinstance.ssp")
+
+oms_instantiate("model")
+oms_initialize("model")
+oms_simulate("model")
+
+oms_terminate("model")
+oms_delete("model")
+
+
+-- Result:
+-- <?xml version="1.0"?>
+-- <oms:snapshot
+--   xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
+--   partial="false">
+--   <oms:file
+--     name="SystemStructure.ssd">
+--     <ssd:SystemStructureDescription
+--       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
+--       xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription"
+--       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
+--       xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping"
+--       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
+--       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
+--       name="model"
+--       version="1.0">
+--       <ssd:System
+--         name="root">
+--         <ssd:Elements>
+--           <ssd:Component
+--             name="ypipe"
+--             type="application/x-fmu-sharedlibrary"
+--             source="resources/0002_ypipe.fmu">
+--             <ssd:Connectors>
+--               <ssd:Connector
+--                 name="inputRate1"
+--                 kind="input">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="0.000000"
+--                   y="0.333333" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="inputRate2"
+--                 kind="input">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="0.000000"
+--                   y="0.666667" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="outputRate"
+--                 kind="output">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="1.000000"
+--                   y="0.500000" />
+--               </ssd:Connector>
+--             </ssd:Connectors>
+--           </ssd:Component>
+--           <ssd:Component
+--             name="tank3"
+--             type="application/x-fmu-sharedlibrary"
+--             source="resources/0001_tank1.fmu">
+--             <ssd:Connectors>
+--               <ssd:Connector
+--                 name="inputRate"
+--                 kind="input">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="0.000000"
+--                   y="0.500000" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="level"
+--                 kind="output">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="1.000000"
+--                   y="0.333333" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="outputRate"
+--                 kind="output">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="1.000000"
+--                   y="0.666667" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="holeSurface"
+--                 kind="parameter">
+--                 <ssc:Real />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="initialLevel"
+--                 kind="parameter">
+--                 <ssc:Real />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="tankSurface"
+--                 kind="parameter">
+--                 <ssc:Real />
+--               </ssd:Connector>
+--             </ssd:Connectors>
+--           </ssd:Component>
+--           <ssd:Component
+--             name="tank2"
+--             type="application/x-fmu-sharedlibrary"
+--             source="resources/0001_tank1.fmu">
+--             <ssd:Connectors>
+--               <ssd:Connector
+--                 name="inputRate"
+--                 kind="input">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="0.000000"
+--                   y="0.500000" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="level"
+--                 kind="output">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="1.000000"
+--                   y="0.333333" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="outputRate"
+--                 kind="output">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="1.000000"
+--                   y="0.666667" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="holeSurface"
+--                 kind="parameter">
+--                 <ssc:Real />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="initialLevel"
+--                 kind="parameter">
+--                 <ssc:Real />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="tankSurface"
+--                 kind="parameter">
+--                 <ssc:Real />
+--               </ssd:Connector>
+--             </ssd:Connectors>
+--             <ssd:ParameterBindings>
+--               <ssd:ParameterBinding>
+--                 <ssd:ParameterValues>
+--                   <ssv:ParameterSet
+--                     version="1.0"
+--                     name="parameters">
+--                     <ssv:Parameters>
+--                       <ssv:Parameter
+--                         name="inputRate">
+--                         <ssv:Real
+--                           value="0.10000000000000001" />
+--                       </ssv:Parameter>
+--                     </ssv:Parameters>
+--                   </ssv:ParameterSet>
+--                 </ssd:ParameterValues>
+--               </ssd:ParameterBinding>
+--             </ssd:ParameterBindings>
+--           </ssd:Component>
+--           <ssd:Component
+--             name="tank1"
+--             type="application/x-fmu-sharedlibrary"
+--             source="resources/0001_tank1.fmu">
+--             <ssd:Connectors>
+--               <ssd:Connector
+--                 name="inputRate"
+--                 kind="input">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="0.000000"
+--                   y="0.500000" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="level"
+--                 kind="output">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="1.000000"
+--                   y="0.333333" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="outputRate"
+--                 kind="output">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="1.000000"
+--                   y="0.666667" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="holeSurface"
+--                 kind="parameter">
+--                 <ssc:Real />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="initialLevel"
+--                 kind="parameter">
+--                 <ssc:Real />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="tankSurface"
+--                 kind="parameter">
+--                 <ssc:Real />
+--               </ssd:Connector>
+--             </ssd:Connectors>
+--             <ssd:ParameterBindings>
+--               <ssd:ParameterBinding>
+--                 <ssd:ParameterValues>
+--                   <ssv:ParameterSet
+--                     version="1.0"
+--                     name="parameters">
+--                     <ssv:Parameters>
+--                       <ssv:Parameter
+--                         name="inputRate">
+--                         <ssv:Real
+--                           value="0.5" />
+--                       </ssv:Parameter>
+--                     </ssv:Parameters>
+--                   </ssv:ParameterSet>
+--                 </ssd:ParameterValues>
+--               </ssd:ParameterBinding>
+--             </ssd:ParameterBindings>
+--           </ssd:Component>
+--         </ssd:Elements>
+--         <ssd:Connections>
+--           <ssd:Connection
+--             startElement="tank1"
+--             startConnector="outputRate"
+--             endElement="ypipe"
+--             endConnector="inputRate1" />
+--           <ssd:Connection
+--             startElement="tank2"
+--             startConnector="outputRate"
+--             endElement="ypipe"
+--             endConnector="inputRate2" />
+--           <ssd:Connection
+--             startElement="ypipe"
+--             startConnector="outputRate"
+--             endElement="tank3"
+--             endConnector="inputRate" />
+--         </ssd:Connections>
+--         <ssd:Annotations>
+--           <ssc:Annotation
+--             type="org.openmodelica">
+--             <oms:Annotations>
+--               <oms:SimulationInformation>
+--                 <oms:VariableStepMaster
+--                   description="oms-mav"
+--                   initialStepSize="0.010000"
+--                   minimumStepSize="0.000001"
+--                   maximumStepSize="0.100000"
+--                   absoluteTolerance="0.000010"
+--                   relativeTolerance="0.000010" />
+--               </oms:SimulationInformation>
+--             </oms:Annotations>
+--           </ssc:Annotation>
+--         </ssd:Annotations>
+--       </ssd:System>
+--       <ssd:DefaultExperiment
+--         startTime="0.000000"
+--         stopTime="1.000000">
+--         <ssd:Annotations>
+--           <ssc:Annotation
+--             type="org.openmodelica">
+--             <oms:Annotations>
+--               <oms:SimulationInformation
+--                 resultFile="multiple_instance_res.mat"
+--                 loggingInterval="0.000000"
+--                 bufferSize="1"
+--                 signalFilter="resources/signalFilter.xml" />
+--             </oms:Annotations>
+--           </ssc:Annotation>
+--         </ssd:Annotations>
+--       </ssd:DefaultExperiment>
+--     </ssd:SystemStructureDescription>
+--   </oms:file>
+--   <oms:file
+--     name="resources/signalFilter.xml">
+--     <oms:SignalFilter
+--       version="1.0">
+--       <oms:Variable
+--         name="model.root.ypipe.der(_D_outputAlias_outputRate)"
+--         type="Real"
+--         kind="unknown" />
+--       <oms:Variable
+--         name="model.root.ypipe.inputRate1"
+--         type="Real"
+--         kind="input" />
+--       <oms:Variable
+--         name="model.root.ypipe.inputRate2"
+--         type="Real"
+--         kind="input" />
+--       <oms:Variable
+--         name="model.root.ypipe.outputRate"
+--         type="Real"
+--         kind="output" />
+--       <oms:Variable
+--         name="model.root.tank3._D_outputAlias_level"
+--         type="Real"
+--         kind="unknown" />
+--       <oms:Variable
+--         name="model.root.tank3.der(_D_outputAlias_level)"
+--         type="Real"
+--         kind="unknown" />
+--       <oms:Variable
+--         name="model.root.tank3.der(_D_outputAlias_outputRate)"
+--         type="Real"
+--         kind="unknown" />
+--       <oms:Variable
+--         name="model.root.tank3.inputRate"
+--         type="Real"
+--         kind="input" />
+--       <oms:Variable
+--         name="model.root.tank3.level"
+--         type="Real"
+--         kind="output" />
+--       <oms:Variable
+--         name="model.root.tank3.outputRate"
+--         type="Real"
+--         kind="output" />
+--       <oms:Variable
+--         name="model.root.tank3.holeSurface"
+--         type="Real"
+--         kind="parameter" />
+--       <oms:Variable
+--         name="model.root.tank3.initialLevel"
+--         type="Real"
+--         kind="parameter" />
+--       <oms:Variable
+--         name="model.root.tank3.tankSurface"
+--         type="Real"
+--         kind="parameter" />
+--       <oms:Variable
+--         name="model.root.tank2._D_outputAlias_level"
+--         type="Real"
+--         kind="unknown" />
+--       <oms:Variable
+--         name="model.root.tank2.der(_D_outputAlias_level)"
+--         type="Real"
+--         kind="unknown" />
+--       <oms:Variable
+--         name="model.root.tank2.der(_D_outputAlias_outputRate)"
+--         type="Real"
+--         kind="unknown" />
+--       <oms:Variable
+--         name="model.root.tank2.inputRate"
+--         type="Real"
+--         kind="input" />
+--       <oms:Variable
+--         name="model.root.tank2.level"
+--         type="Real"
+--         kind="output" />
+--       <oms:Variable
+--         name="model.root.tank2.outputRate"
+--         type="Real"
+--         kind="output" />
+--       <oms:Variable
+--         name="model.root.tank2.holeSurface"
+--         type="Real"
+--         kind="parameter" />
+--       <oms:Variable
+--         name="model.root.tank2.initialLevel"
+--         type="Real"
+--         kind="parameter" />
+--       <oms:Variable
+--         name="model.root.tank2.tankSurface"
+--         type="Real"
+--         kind="parameter" />
+--       <oms:Variable
+--         name="model.root.tank1._D_outputAlias_level"
+--         type="Real"
+--         kind="unknown" />
+--       <oms:Variable
+--         name="model.root.tank1.der(_D_outputAlias_level)"
+--         type="Real"
+--         kind="unknown" />
+--       <oms:Variable
+--         name="model.root.tank1.der(_D_outputAlias_outputRate)"
+--         type="Real"
+--         kind="unknown" />
+--       <oms:Variable
+--         name="model.root.tank1.inputRate"
+--         type="Real"
+--         kind="input" />
+--       <oms:Variable
+--         name="model.root.tank1.level"
+--         type="Real"
+--         kind="output" />
+--       <oms:Variable
+--         name="model.root.tank1.outputRate"
+--         type="Real"
+--         kind="output" />
+--       <oms:Variable
+--         name="model.root.tank1.holeSurface"
+--         type="Real"
+--         kind="parameter" />
+--       <oms:Variable
+--         name="model.root.tank1.initialLevel"
+--         type="Real"
+--         kind="parameter" />
+--       <oms:Variable
+--         name="model.root.tank1.tankSurface"
+--         type="Real"
+--         kind="parameter" />
+--     </oms:SignalFilter>
+--   </oms:file>
+-- </oms:snapshot>
+--
+-- info:    Result file: multiple_instance_res.mat (bufferSize=1)
+-- endResult

--- a/testsuite/simulation/renameValues1.lua
+++ b/testsuite/simulation/renameValues1.lua
@@ -157,7 +157,7 @@ print("info:      renameValues1.root.add_3.u1       : " .. oms_getReal("renameVa
 --           <ssd:Component
 --             name="add_2"
 --             type="application/x-fmu-sharedlibrary"
---             source="resources/0002_add_2.fmu">
+--             source="resources/0001_add_1.fmu">
 --             <ssd:Connectors>
 --               <ssd:Connector
 --                 name="u1"

--- a/testsuite/simulation/renameValues2.lua
+++ b/testsuite/simulation/renameValues2.lua
@@ -195,7 +195,7 @@ print("info:      renameValues2.root.add_3.u1       : " .. oms_getReal("renameVa
 --           <ssd:Component
 --             name="add_2"
 --             type="application/x-fmu-sharedlibrary"
---             source="resources/0002_add_2.fmu">
+--             source="resources/0001_add_1.fmu">
 --             <ssd:Connectors>
 --               <ssd:Connector
 --                 name="u1"


### PR DESCRIPTION
### Purpose

This PR add supports to export and import multiple instances of a single fmu, which reduces the `size` of  `ssp` 

