### PR TITLE
export start values in subsystem to SSV template

### DIFF
--- a/src/OMSimulatorLib/ComponentFMUCS.h
+++ b/src/OMSimulatorLib/ComponentFMUCS.h
@@ -123,6 +123,7 @@ namespace oms
 
     oms_status_enu_t deleteReferencesInSSD(const std::string& filename);
     oms_status_enu_t deleteResourcesInSSP(const std::string& filename);
+    void copyModelDescriptionUnit(Values& value);
 
   protected:
     ComponentFMUCS(const ComRef& cref, System* parentSystem, const std::string& fmuPath);

--- a/src/OMSimulatorLib/ComponentFMUME.cpp
+++ b/src/OMSimulatorLib/ComponentFMUME.cpp
@@ -1453,6 +1453,8 @@ oms_status_enu_t oms::ComponentFMUME::setBoolean(const ComRef& cref, bool value)
 
   if (oms_modelState_virgin == getModel().getModelState())
   {
+    // update start values in top level Modeldescription.xml to be exported in ssv templates
+    values.updateModelDescriptionBooleanStartValue(cref, value);
     // check for local resources available
     if (values.hasResources())
     {
@@ -1503,6 +1505,8 @@ oms_status_enu_t oms::ComponentFMUME::setInteger(const ComRef& cref, int value)
 
   if (oms_modelState_virgin == getModel().getModelState())
   {
+    // update start values in top level Modeldescription.xml to be exported in ssv templates
+    values.updateModelDescriptionIntegerStartValue(cref, value);
     // check for local resources available
     if (values.hasResources())
     {
@@ -1581,19 +1585,24 @@ oms_status_enu_t oms::ComponentFMUME::setReal(const ComRef& cref, double value)
 
   if (oms_modelState_virgin == getModel().getModelState())
   {
+    // update start values in top level Modeldescription.xml to be exported in ssv templates
+    values.updateModelDescriptionRealStartValue(cref, value);
     // check for local resources available
     if (values.hasResources())
     {
+      values.copyModelDescriptionUnitToResources(values);
       return values.setRealResources(cref, value, getFullCref(), false, oms_modelState_virgin);
     }
     // check for resources in root
     else if (getParentSystem() && getParentSystem()->getValues().hasResources())
     {
+      getParentSystem()->getValues().copyModelDescriptionUnitToResources(values);
       return getParentSystem()->getValues().setRealResources(getCref()+cref, value, getParentSystem()->getFullCref(), false, oms_modelState_virgin);
     }
     // check for resources in top level root
     else if (getParentSystem()->getParentSystem() && getParentSystem()->getParentSystem()->getValues().hasResources())
     {
+      getParentSystem()->getParentSystem()->getValues().copyModelDescriptionUnitToResources(values);
       return getParentSystem()->getParentSystem()->getValues().setRealResources(getCref()+cref, value, getParentSystem()->getParentSystem()->getFullCref(), false, oms_modelState_virgin);
     }
     else
@@ -1634,6 +1643,8 @@ oms_status_enu_t oms::ComponentFMUME::setString(const ComRef& cref, const std::s
 
   if (oms_modelState_virgin == getModel().getModelState())
   {
+    // update start values in top level Modeldescription.xml to be exported in ssv templates
+    values.updateModelDescriptionStringStartValue(cref, value);
     // check for local resources available
     if (values.hasResources())
     {
@@ -1680,6 +1691,10 @@ oms_status_enu_t oms::ComponentFMUME::setUnit(const ComRef &cref, const std::str
       }
     }
   }
+
+  // set unit in top level modeldescription.xml
+  values.updateModelDescriptionVariableUnit(cref, value);
+
   // check for local resources available
   if (values.hasResources())
   {

--- a/src/OMSimulatorLib/Model.cpp
+++ b/src/OMSimulatorLib/Model.cpp
@@ -408,11 +408,30 @@ oms_status_enu_t oms::Model::exportSSVTemplate(const oms::ComRef& cref, const st
 
   for (const auto& component : system->getComponents())
   {
-    if(component.first == tail || cref.isEmpty()) // allow querying single component or whole model
+    if(component.first == tail || cref.isEmpty() || cref.isValidIdent()) // allow querying single component or whole model
     {
       if (oms_status_ok != component.second->exportToSSVTemplate(ssvNode, snapshot))
       {
         return logError("export of ssv template failed for component " + std::string(system->getFullCref()+std::string(component.first)));
+      }
+    }
+  }
+
+  // check in subsystems
+  ComRef tailA(tail);
+  ComRef frontA = tailA.pop_front();
+
+  //std::cout <<"\n subsystem: " << tailA.c_str() << "==>" << frontA.c_str() << "==>" << cref.c_str();
+  for (const auto &subsytem : system->getSubSystems())
+  {
+    for (const auto &component : subsytem.second->getComponents())
+    {
+      if (component.first == tailA || cref.isEmpty() || (system->getSystem(frontA) && tailA.isEmpty()))
+      {
+        if (oms_status_ok != component.second->exportToSSVTemplate(ssvNode, snapshot))
+        {
+          return logError("export of ssv template failed for component " + std::string(system->getFullCref() + std::string(component.first)));
+        }
       }
     }
   }

--- a/src/OMSimulatorLib/Values.cpp
+++ b/src/OMSimulatorLib/Values.cpp
@@ -54,12 +54,6 @@ oms::Values::~Values()
 oms_status_enu_t oms::Values::setReal(const ComRef& cref, double value)
 {
   realStartValues[cref] = value;
-
-  // update start values in ssv template
-  auto realValue = modelDescriptionRealStartValues.find(cref);
-  if (realValue != modelDescriptionRealStartValues.end())
-    modelDescriptionRealStartValues[cref] = value;
-
   setUnitDefinitions(cref);
 
   return oms_status_ok;
@@ -105,22 +99,12 @@ oms_status_enu_t oms::Values::setInteger(const ComRef& cref, int value)
 {
   integerStartValues[cref] = value;
 
-  // update start values in ssv template
-  auto integerValue = modelDescriptionIntegerStartValues.find(cref);
-  if (integerValue != modelDescriptionIntegerStartValues.end())
-    modelDescriptionIntegerStartValues[cref] = value;
-
   return oms_status_ok;
 }
 
 oms_status_enu_t oms::Values::setBoolean(const ComRef& cref, bool value)
 {
   booleanStartValues[cref] = value;
-
-  // update start values in ssv template
-  auto boolValue = modelDescriptionBooleanStartValues.find(cref);
-  if (boolValue != modelDescriptionBooleanStartValues.end())
-    modelDescriptionBooleanStartValues[cref] = value;
 
   return oms_status_ok;
 }
@@ -129,19 +113,65 @@ oms_status_enu_t oms::Values::setString(const ComRef& cref, const std::string& v
 {
   stringStartValues[cref] = value;
 
+  return oms_status_ok;
+}
+
+void oms::Values::updateModelDescriptionRealStartValue(const ComRef& cref, double value)
+{
+  // update start values in ssv template
+  auto realValue = modelDescriptionRealStartValues.find(cref);
+  if (realValue != modelDescriptionRealStartValues.end())
+    modelDescriptionRealStartValues[cref] = value;
+}
+
+void oms::Values::updateModelDescriptionIntegerStartValue(const ComRef& cref, int value)
+{
+  // update start values in ssv template
+  auto integerValue = modelDescriptionIntegerStartValues.find(cref);
+  if (integerValue != modelDescriptionIntegerStartValues.end())
+    modelDescriptionIntegerStartValues[cref] = value;
+}
+
+void oms::Values::updateModelDescriptionBooleanStartValue(const ComRef& cref, bool value)
+{
+  // update start values in ssv template
+  auto boolValue = modelDescriptionBooleanStartValues.find(cref);
+  if (boolValue != modelDescriptionBooleanStartValues.end())
+    modelDescriptionBooleanStartValues[cref] = value;
+}
+
+void oms::Values::updateModelDescriptionStringStartValue(const ComRef& cref, std::string value)
+{
   // update start values in ssv template
   auto stringValue = modelDescriptionStringStartValues.find(cref);
   if (stringValue != modelDescriptionStringStartValues.end())
     modelDescriptionStringStartValues[cref] = value;
+}
 
-  return oms_status_ok;
+void oms::Values::updateModelDescriptionVariableUnit(const ComRef& cref, const std::string& value)
+{
+  modelDescriptionVariableUnits[cref] = value; // override if exists otherwise make a new entry
+  // update unit Definitions
+  for (const auto & it:modeldescriptionUnitDefinitions)
+    if (it.first == cref.c_str())
+      modeldescriptionUnitDefinitions[it.first] = {}; // make the baseUnit empty, as we do not calculate base units
+}
+
+void oms::Values::copyModelDescriptionUnitToResources(Values& value)
+{
+  for (auto &it: parameterResources)
+  {
+    for (auto &res: it.allresources)
+    {
+      res.second.modelDescriptionVariableUnits = value.modelDescriptionVariableUnits;
+      res.second.modeldescriptionUnitDefinitions = value.modeldescriptionUnitDefinitions;
+    }
+  }
 }
 
 oms_status_enu_t oms::Values::setUnit(const ComRef& cref, const std::string& value)
 {
   variableUnits[cref] = value;
-  // update unit values in ssv template
-  modelDescriptionVariableUnits[cref] = value; // override if exists otherwise make a new entry
   // update unit Definitions
   for (auto & it : unitDefinitionsToExportInSSP)
   {

--- a/src/OMSimulatorLib/Values.h
+++ b/src/OMSimulatorLib/Values.h
@@ -55,6 +55,13 @@ namespace oms
     oms_status_enu_t setUnit(const ComRef& cref, const std::string& value);
     void setUnitDefinitions(const ComRef& cref);
     void getFilteredUnitDefinitionsToSSD(std::map<std::string, std::map<std::string, std::string>>& unitDefinitions);
+    void updateModelDescriptionRealStartValue(const ComRef& cref, double value);
+    void updateModelDescriptionIntegerStartValue(const ComRef& cref, int value);
+    void updateModelDescriptionBooleanStartValue(const ComRef& cref, bool value);
+    void updateModelDescriptionStringStartValue(const ComRef& cref, std::string value);
+
+    void updateModelDescriptionVariableUnit(const ComRef& cref, const std::string& value);
+    void copyModelDescriptionUnitToResources(Values& value);
 
     oms_status_enu_t getBoolean(const ComRef& cref, bool& value);
     oms_status_enu_t getInteger(const ComRef& cref, int& value);

--- a/testsuite/export/Makefile
+++ b/testsuite/export/Makefile
@@ -1,8 +1,9 @@
 TEST = ../rtest -v
 
 TESTFILES = \
-exportSSVTemplate.lua \
-exportSSVTemplate.py \
+exportSSVTemplate1.lua \
+exportSSVTemplate2.py \
+exportSSVTemplate3.lua \
 
 # Run make failingtest
 FAILINGTESTFILES = \

--- a/testsuite/export/exportSSVTemplate1.lua
+++ b/testsuite/export/exportSSVTemplate1.lua
@@ -1,5 +1,5 @@
 -- status: correct
--- teardown_command: rm -rf exportSSVTemplate_lua/
+-- teardown_command: rm -rf exportSSVTemplate_01_lua/
 -- linux: yes
 -- mingw32: yes
 -- mingw64: yes
@@ -7,8 +7,8 @@
 -- mac: yes
 
 oms_setCommandLineOption("--suppressPath=true")
-oms_setTempDirectory("./exportSSVTemplate_lua/")
-oms_setWorkingDirectory("./exportSSVTemplate_lua/")
+oms_setTempDirectory("./exportSSVTemplate_01_lua/")
+oms_setWorkingDirectory("./exportSSVTemplate_01_lua/")
 
 function readFile(filename)
   local f = assert(io.open(filename, "r"))

--- a/testsuite/export/exportSSVTemplate2.py
+++ b/testsuite/export/exportSSVTemplate2.py
@@ -1,5 +1,5 @@
 ## status: correct
-## teardown_command: rm -rf exportSSVTemplate_py/
+## teardown_command: rm -rf exportSSVTemplate_02_py/
 ## linux: yes
 ## mac: no
 ## mingw32: yes
@@ -9,8 +9,8 @@
 import OMSimulator as oms
 
 oms.setCommandLineOption("--suppressPath=true")
-oms.setTempDirectory("./exportSSVTemplate_py/")
-oms.setWorkingDirectory("./exportSSVTemplate_py/")
+oms.setTempDirectory("./exportSSVTemplate_02_py/")
+oms.setWorkingDirectory("./exportSSVTemplate_02_py/")
 
 model = oms.newModel("exportSSVTemplate")
 root = model.addSystem("root", oms.Types.System.WC)

--- a/testsuite/export/exportSSVTemplate3.lua
+++ b/testsuite/export/exportSSVTemplate3.lua
@@ -1,0 +1,420 @@
+-- status: correct
+-- teardown_command: rm -rf exportSSVTemplate_03_lua/
+-- linux: yes
+-- mingw32: yes
+-- mingw64: yes
+-- win: yes
+-- mac: no
+
+function readFile(filename)
+    local f = assert(io.open(filename, "r"))
+    local content = f:read("*all")
+    print(content)
+    f:close()
+end
+
+
+oms_setCommandLineOption("--suppressPath=true")
+oms_setTempDirectory("./exportSSVTemplate_03_lua/")
+oms_setWorkingDirectory("./exportSSVTemplate_03_lua/")
+
+oms_newModel("model")
+
+oms_addSystem("model.root", oms_system_wc)
+
+oms_addSubModel("model.root.sine", "../../resources/Modelica.Blocks.Sources.Sine.fmu")
+oms_addSubModel("model.root.gain", "../../resources/Modelica.Blocks.Math.Gain.fmu")
+
+-- add resources to submodule
+oms_newResources("model.root.sine:sine.ssv")
+oms_newResources("model.root.gain:gain.ssv")
+
+oms_setReal("model.root.sine.phase", 27)
+oms_setReal("model.root.sine.amplitude", -100)
+oms_setReal("model.root.sine.freqHz", -300)
+oms_setReal("model.root.gain.k", -200)
+
+oms_addSystem("model.root.subsystem", oms_system_sc)
+
+oms_addSubModel("model.root.subsystem.sine1", "../../resources/Modelica.Blocks.Sources.Sine.fmu")
+oms_addSubModel("model.root.subsystem.gain1", "../../resources/Modelica.Blocks.Math.Gain.fmu")
+
+oms_newResources("model.root.subsystem.sine1:sine1.ssv")
+oms_newResources("model.root.subsystem.gain1:gain1.ssv")
+
+oms_setReal("model.root.subsystem.sine1.phase", 50)
+oms_setReal("model.root.subsystem.sine1.amplitude", 60)
+oms_setReal("model.root.subsystem.sine1.freqHz", 70)
+oms_setReal("model.root.subsystem.gain1.k", -150)
+
+oms_setResultFile("model", "")
+
+-- query whole model or top level system (e.g) model or model.root
+oms_exportSSVTemplate("model", "root.ssv")
+readFile("root.ssv")
+
+-- query single component in top level system
+oms_exportSSVTemplate("model.root.sine", "sine.ssv")
+readFile("sine.ssv")
+
+-- query single component in top level system
+oms_exportSSVTemplate("model.root.gain", "gain.ssv")
+readFile("gain.ssv")
+
+-- query entire subsystem
+oms_exportSSVTemplate("model.root.subsystem", "subsytem.ssv")
+readFile("subsytem.ssv")
+
+-- query single component in subsystem
+oms_exportSSVTemplate("model.root.subsystem.sine1", "sine1.ssv")
+readFile("sine1.ssv")
+
+-- query single component in subsystem
+oms_exportSSVTemplate("model.root.subsystem.gain1", "gain1.ssv")
+readFile("gain1.ssv")
+
+oms_terminate("model")
+oms_delete("model")
+
+
+-- Result:
+-- <?xml version="1.0" encoding="UTF-8"?>
+-- <ssv:ParameterSet
+--   xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
+--   xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
+--   version="1.0"
+--   name="modelDescriptionStartValues">
+--   <ssv:Parameters>
+--     <ssv:Parameter
+--       name="sine.startTime">
+--       <ssv:Real
+--         value="0"
+--         unit="s" />
+--     </ssv:Parameter>
+--     <ssv:Parameter
+--       name="sine.phase">
+--       <ssv:Real
+--         value="27"
+--         unit="rad" />
+--     </ssv:Parameter>
+--     <ssv:Parameter
+--       name="sine.offset">
+--       <ssv:Real
+--         value="0" />
+--     </ssv:Parameter>
+--     <ssv:Parameter
+--       name="sine.freqHz">
+--       <ssv:Real
+--         value="-300"
+--         unit="Hz" />
+--     </ssv:Parameter>
+--     <ssv:Parameter
+--       name="sine.amplitude">
+--       <ssv:Real
+--         value="-100" />
+--     </ssv:Parameter>
+--     <ssv:Parameter
+--       name="gain.u">
+--       <ssv:Real
+--         value="0" />
+--     </ssv:Parameter>
+--     <ssv:Parameter
+--       name="gain.k">
+--       <ssv:Real
+--         value="-200"
+--         unit="1" />
+--     </ssv:Parameter>
+--     <ssv:Parameter
+--       name="sine1.startTime">
+--       <ssv:Real
+--         value="0"
+--         unit="s" />
+--     </ssv:Parameter>
+--     <ssv:Parameter
+--       name="sine1.phase">
+--       <ssv:Real
+--         value="50"
+--         unit="rad" />
+--     </ssv:Parameter>
+--     <ssv:Parameter
+--       name="sine1.offset">
+--       <ssv:Real
+--         value="0" />
+--     </ssv:Parameter>
+--     <ssv:Parameter
+--       name="sine1.freqHz">
+--       <ssv:Real
+--         value="70"
+--         unit="Hz" />
+--     </ssv:Parameter>
+--     <ssv:Parameter
+--       name="sine1.amplitude">
+--       <ssv:Real
+--         value="60" />
+--     </ssv:Parameter>
+--     <ssv:Parameter
+--       name="gain1.u">
+--       <ssv:Real
+--         value="0" />
+--     </ssv:Parameter>
+--     <ssv:Parameter
+--       name="gain1.k">
+--       <ssv:Real
+--         value="-150"
+--         unit="1" />
+--     </ssv:Parameter>
+--   </ssv:Parameters>
+--   <ssv:Units>
+--     <ssc:Unit
+--       name="s">
+--       <ssc:BaseUnit
+--         s="1" />
+--     </ssc:Unit>
+--     <ssc:Unit
+--       name="rad">
+--       <ssc:BaseUnit />
+--     </ssc:Unit>
+--     <ssc:Unit
+--       name="Hz">
+--       <ssc:BaseUnit
+--         s="-1" />
+--     </ssc:Unit>
+--     <ssc:Unit
+--       name="1">
+--       <ssc:BaseUnit />
+--     </ssc:Unit>
+--   </ssv:Units>
+-- </ssv:ParameterSet>
+-- 
+-- <?xml version="1.0" encoding="UTF-8"?>
+-- <ssv:ParameterSet
+--   xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
+--   xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
+--   version="1.0"
+--   name="modelDescriptionStartValues">
+--   <ssv:Parameters>
+--     <ssv:Parameter
+--       name="sine.startTime">
+--       <ssv:Real
+--         value="0"
+--         unit="s" />
+--     </ssv:Parameter>
+--     <ssv:Parameter
+--       name="sine.phase">
+--       <ssv:Real
+--         value="27"
+--         unit="rad" />
+--     </ssv:Parameter>
+--     <ssv:Parameter
+--       name="sine.offset">
+--       <ssv:Real
+--         value="0" />
+--     </ssv:Parameter>
+--     <ssv:Parameter
+--       name="sine.freqHz">
+--       <ssv:Real
+--         value="-300"
+--         unit="Hz" />
+--     </ssv:Parameter>
+--     <ssv:Parameter
+--       name="sine.amplitude">
+--       <ssv:Real
+--         value="-100" />
+--     </ssv:Parameter>
+--   </ssv:Parameters>
+--   <ssv:Units>
+--     <ssc:Unit
+--       name="s">
+--       <ssc:BaseUnit
+--         s="1" />
+--     </ssc:Unit>
+--     <ssc:Unit
+--       name="rad">
+--       <ssc:BaseUnit />
+--     </ssc:Unit>
+--     <ssc:Unit
+--       name="Hz">
+--       <ssc:BaseUnit
+--         s="-1" />
+--     </ssc:Unit>
+--   </ssv:Units>
+-- </ssv:ParameterSet>
+-- 
+-- <?xml version="1.0" encoding="UTF-8"?>
+-- <ssv:ParameterSet
+--   xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
+--   xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
+--   version="1.0"
+--   name="modelDescriptionStartValues">
+--   <ssv:Parameters>
+--     <ssv:Parameter
+--       name="gain.u">
+--       <ssv:Real
+--         value="0" />
+--     </ssv:Parameter>
+--     <ssv:Parameter
+--       name="gain.k">
+--       <ssv:Real
+--         value="-200"
+--         unit="1" />
+--     </ssv:Parameter>
+--   </ssv:Parameters>
+--   <ssv:Units>
+--     <ssc:Unit
+--       name="1">
+--       <ssc:BaseUnit />
+--     </ssc:Unit>
+--   </ssv:Units>
+-- </ssv:ParameterSet>
+-- 
+-- <?xml version="1.0" encoding="UTF-8"?>
+-- <ssv:ParameterSet
+--   xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
+--   xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
+--   version="1.0"
+--   name="modelDescriptionStartValues">
+--   <ssv:Parameters>
+--     <ssv:Parameter
+--       name="sine1.startTime">
+--       <ssv:Real
+--         value="0"
+--         unit="s" />
+--     </ssv:Parameter>
+--     <ssv:Parameter
+--       name="sine1.phase">
+--       <ssv:Real
+--         value="50"
+--         unit="rad" />
+--     </ssv:Parameter>
+--     <ssv:Parameter
+--       name="sine1.offset">
+--       <ssv:Real
+--         value="0" />
+--     </ssv:Parameter>
+--     <ssv:Parameter
+--       name="sine1.freqHz">
+--       <ssv:Real
+--         value="70"
+--         unit="Hz" />
+--     </ssv:Parameter>
+--     <ssv:Parameter
+--       name="sine1.amplitude">
+--       <ssv:Real
+--         value="60" />
+--     </ssv:Parameter>
+--     <ssv:Parameter
+--       name="gain1.u">
+--       <ssv:Real
+--         value="0" />
+--     </ssv:Parameter>
+--     <ssv:Parameter
+--       name="gain1.k">
+--       <ssv:Real
+--         value="-150"
+--         unit="1" />
+--     </ssv:Parameter>
+--   </ssv:Parameters>
+--   <ssv:Units>
+--     <ssc:Unit
+--       name="s">
+--       <ssc:BaseUnit
+--         s="1" />
+--     </ssc:Unit>
+--     <ssc:Unit
+--       name="rad">
+--       <ssc:BaseUnit />
+--     </ssc:Unit>
+--     <ssc:Unit
+--       name="Hz">
+--       <ssc:BaseUnit
+--         s="-1" />
+--     </ssc:Unit>
+--     <ssc:Unit
+--       name="1">
+--       <ssc:BaseUnit />
+--     </ssc:Unit>
+--   </ssv:Units>
+-- </ssv:ParameterSet>
+-- 
+-- <?xml version="1.0" encoding="UTF-8"?>
+-- <ssv:ParameterSet
+--   xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
+--   xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
+--   version="1.0"
+--   name="modelDescriptionStartValues">
+--   <ssv:Parameters>
+--     <ssv:Parameter
+--       name="sine1.startTime">
+--       <ssv:Real
+--         value="0"
+--         unit="s" />
+--     </ssv:Parameter>
+--     <ssv:Parameter
+--       name="sine1.phase">
+--       <ssv:Real
+--         value="50"
+--         unit="rad" />
+--     </ssv:Parameter>
+--     <ssv:Parameter
+--       name="sine1.offset">
+--       <ssv:Real
+--         value="0" />
+--     </ssv:Parameter>
+--     <ssv:Parameter
+--       name="sine1.freqHz">
+--       <ssv:Real
+--         value="70"
+--         unit="Hz" />
+--     </ssv:Parameter>
+--     <ssv:Parameter
+--       name="sine1.amplitude">
+--       <ssv:Real
+--         value="60" />
+--     </ssv:Parameter>
+--   </ssv:Parameters>
+--   <ssv:Units>
+--     <ssc:Unit
+--       name="s">
+--       <ssc:BaseUnit
+--         s="1" />
+--     </ssc:Unit>
+--     <ssc:Unit
+--       name="rad">
+--       <ssc:BaseUnit />
+--     </ssc:Unit>
+--     <ssc:Unit
+--       name="Hz">
+--       <ssc:BaseUnit
+--         s="-1" />
+--     </ssc:Unit>
+--   </ssv:Units>
+-- </ssv:ParameterSet>
+-- 
+-- <?xml version="1.0" encoding="UTF-8"?>
+-- <ssv:ParameterSet
+--   xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
+--   xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
+--   version="1.0"
+--   name="modelDescriptionStartValues">
+--   <ssv:Parameters>
+--     <ssv:Parameter
+--       name="gain1.u">
+--       <ssv:Real
+--         value="0" />
+--     </ssv:Parameter>
+--     <ssv:Parameter
+--       name="gain1.k">
+--       <ssv:Real
+--         value="-150"
+--         unit="1" />
+--     </ssv:Parameter>
+--   </ssv:Parameters>
+--   <ssv:Units>
+--     <ssc:Unit
+--       name="1">
+--       <ssc:BaseUnit />
+--     </ssc:Unit>
+--   </ssv:Units>
+-- </ssv:ParameterSet>
+-- 
+-- endResult


### PR DESCRIPTION
### Related Issues

#1172 

### Purpose

This PR exports SSV template from `subsystems`  and also fixes bug when updating start values and units in `modeldescription.xml ` when exporting to `SSV` templates


