### PR TITLE
display warnings when replacing SubModel

### DIFF
--- a/src/OMSimulatorLib/Component.h
+++ b/src/OMSimulatorLib/Component.h
@@ -81,7 +81,7 @@ namespace oms
     virtual oms_status_enu_t deleteStartValue(const ComRef& cref) { return oms_status_ok; }
     virtual std::vector<Values> getValuesResources() { return{}; }
     virtual oms_status_enu_t setValuesResources(std::vector<Values>& allResources) { return oms_status_ok; }
-    virtual oms_status_enu_t updateOrDeleteStartValueInReplacedComponent() { return oms_status_ok; }
+    virtual oms_status_enu_t updateOrDeleteStartValueInReplacedComponent(std::vector<std::string>& warningList) { return oms_status_ok; }
     virtual oms_status_enu_t exportToSSMTemplate(pugi::xml_node& ssmNode) { return logError_NotImplemented; }
     virtual oms_status_enu_t exportToSSVTemplate(pugi::xml_node& ssvNode, Snapshot& snapshot) { return logError_NotImplemented; }
     virtual oms_status_enu_t freeState() { return logError_NotImplemented; }

--- a/src/OMSimulatorLib/ComponentFMUCS.cpp
+++ b/src/OMSimulatorLib/ComponentFMUCS.cpp
@@ -1794,22 +1794,22 @@ std::vector<oms::Values> oms::ComponentFMUCS::getValuesResources()
   return this->values.parameterResources;
 }
 
-oms_status_enu_t oms::ComponentFMUCS::updateOrDeleteStartValueInReplacedComponent()
+oms_status_enu_t oms::ComponentFMUCS::updateOrDeleteStartValueInReplacedComponent(std::vector<std::string>& warningList)
 {
   // check for local resources available
   if (values.hasResources())
   {
-    return values.updateOrDeleteStartValueInReplacedComponent(values, this->getCref());
+    return values.updateOrDeleteStartValueInReplacedComponent(values, this->getCref(), warningList);
   }
   // check for resources in root
   else if (getParentSystem() && getParentSystem()->getValues().hasResources())
   {
-    return getParentSystem()->getValues().updateOrDeleteStartValueInReplacedComponent(values, this->getCref());
+    return getParentSystem()->getValues().updateOrDeleteStartValueInReplacedComponent(values, this->getCref(), warningList);
   }
   // check for resources in top level root
   else if (getParentSystem()->getParentSystem() && getParentSystem()->getParentSystem()->getValues().hasResources())
   {
-    return getParentSystem()->getParentSystem()->getValues().updateOrDeleteStartValueInReplacedComponent(values, this->getCref());
+    return getParentSystem()->getParentSystem()->getValues().updateOrDeleteStartValueInReplacedComponent(values, this->getCref(), warningList);
   }
   else
   {

--- a/src/OMSimulatorLib/ComponentFMUCS.h
+++ b/src/OMSimulatorLib/ComponentFMUCS.h
@@ -95,7 +95,7 @@ namespace oms
     oms_status_enu_t getDirectionalDerivativeHeper(const int unknownIndex, const int knownindex, const std::vector<int>& dependencyList, double& value);
 
     oms_status_enu_t deleteStartValue(const ComRef& cref);
-    oms_status_enu_t updateOrDeleteStartValueInReplacedComponent();
+    oms_status_enu_t updateOrDeleteStartValueInReplacedComponent(std::vector<std::string>& warningList);
     oms_status_enu_t setValuesResources(std::vector<Values>& allValuesResources);
     std::vector<Values> getValuesResources();
 

--- a/src/OMSimulatorLib/ComponentFMUME.cpp
+++ b/src/OMSimulatorLib/ComponentFMUME.cpp
@@ -1576,22 +1576,22 @@ std::vector<oms::Values> oms::ComponentFMUME::getValuesResources()
   return this->values.parameterResources;
 }
 
-oms_status_enu_t oms::ComponentFMUME::updateOrDeleteStartValueInReplacedComponent()
+oms_status_enu_t oms::ComponentFMUME::updateOrDeleteStartValueInReplacedComponent(std::vector<std::string>& warningList)
 {
   // check for local resources available
   if (values.hasResources())
   {
-    return values.updateOrDeleteStartValueInReplacedComponent(values, this->getCref());
+    return values.updateOrDeleteStartValueInReplacedComponent(values, this->getCref(), warningList);
   }
   // check for resources in root
   else if (getParentSystem() && getParentSystem()->getValues().hasResources())
   {
-    return getParentSystem()->getValues().updateOrDeleteStartValueInReplacedComponent(values, this->getCref());
+    return getParentSystem()->getValues().updateOrDeleteStartValueInReplacedComponent(values, this->getCref(), warningList);
   }
   // check for resources in top level root
   else if (getParentSystem()->getParentSystem() && getParentSystem()->getParentSystem()->getValues().hasResources())
   {
-    return getParentSystem()->getParentSystem()->getValues().updateOrDeleteStartValueInReplacedComponent(values, this->getCref());
+    return getParentSystem()->getParentSystem()->getValues().updateOrDeleteStartValueInReplacedComponent(values, this->getCref(), warningList);
   }
   else
   {

--- a/src/OMSimulatorLib/ComponentFMUME.h
+++ b/src/OMSimulatorLib/ComponentFMUME.h
@@ -90,7 +90,7 @@ namespace oms
     oms_status_enu_t getDirectionalDerivativeHeper(const int unknownIndex, const int knownIndex, const std::vector<int>& dependencyList, double& value);
 
     oms_status_enu_t deleteStartValue(const ComRef& cref);
-    oms_status_enu_t updateOrDeleteStartValueInReplacedComponent();
+    oms_status_enu_t updateOrDeleteStartValueInReplacedComponent(std::vector<std::string>& warningList);
     oms_status_enu_t setValuesResources(std::vector<Values>& allValuesResources);
     std::vector<Values> getValuesResources();
 

--- a/src/OMSimulatorLib/OMSimulator.cpp
+++ b/src/OMSimulatorLib/OMSimulator.cpp
@@ -916,7 +916,7 @@ oms_status_enu_t oms_addSubModel(const char* cref, const char* fmuPath)
   return system->addSubModel(tail, fmuPath);
 }
 
-oms_status_enu_t oms_replaceSubModel(const char* cref, const char* fmuPath)
+oms_status_enu_t oms_replaceSubModel(const char* cref, const char* fmuPath, bool replaceSubModel)
 {
   oms::ComRef tail(cref);
   oms::ComRef front = tail.pop_front();
@@ -929,7 +929,7 @@ oms_status_enu_t oms_replaceSubModel(const char* cref, const char* fmuPath)
   if (!system)
     return logError_SystemNotInModel(model->getCref(), front);
 
-  return system->replaceSubModel(tail, fmuPath);
+  return system->replaceSubModel(tail, fmuPath, replaceSubModel);
 }
 
 oms_status_enu_t oms_getComponentType(const char* cref, oms_component_enu_t* type)

--- a/src/OMSimulatorLib/OMSimulator.cpp
+++ b/src/OMSimulatorLib/OMSimulator.cpp
@@ -916,7 +916,7 @@ oms_status_enu_t oms_addSubModel(const char* cref, const char* fmuPath)
   return system->addSubModel(tail, fmuPath);
 }
 
-oms_status_enu_t oms_replaceSubModel(const char* cref, const char* fmuPath, bool dryRun)
+oms_status_enu_t oms_replaceSubModel(const char* cref, const char* fmuPath, bool dryRun, int* warningCount)
 {
   oms::ComRef tail(cref);
   oms::ComRef front = tail.pop_front();
@@ -929,7 +929,7 @@ oms_status_enu_t oms_replaceSubModel(const char* cref, const char* fmuPath, bool
   if (!system)
     return logError_SystemNotInModel(model->getCref(), front);
 
-  return system->replaceSubModel(tail, fmuPath, dryRun);
+  return system->replaceSubModel(tail, fmuPath, dryRun, *warningCount);
 }
 
 oms_status_enu_t oms_getComponentType(const char* cref, oms_component_enu_t* type)

--- a/src/OMSimulatorLib/OMSimulator.cpp
+++ b/src/OMSimulatorLib/OMSimulator.cpp
@@ -916,7 +916,7 @@ oms_status_enu_t oms_addSubModel(const char* cref, const char* fmuPath)
   return system->addSubModel(tail, fmuPath);
 }
 
-oms_status_enu_t oms_replaceSubModel(const char* cref, const char* fmuPath, bool replaceSubModel)
+oms_status_enu_t oms_replaceSubModel(const char* cref, const char* fmuPath, bool dryRun)
 {
   oms::ComRef tail(cref);
   oms::ComRef front = tail.pop_front();
@@ -929,7 +929,7 @@ oms_status_enu_t oms_replaceSubModel(const char* cref, const char* fmuPath, bool
   if (!system)
     return logError_SystemNotInModel(model->getCref(), front);
 
-  return system->replaceSubModel(tail, fmuPath, replaceSubModel);
+  return system->replaceSubModel(tail, fmuPath, dryRun);
 }
 
 oms_status_enu_t oms_getComponentType(const char* cref, oms_component_enu_t* type)

--- a/src/OMSimulatorLib/OMSimulator.h
+++ b/src/OMSimulatorLib/OMSimulator.h
@@ -130,7 +130,7 @@ OMSAPI oms_status_enu_t OMSCALL oms_newResources(const char* cref);
 OMSAPI oms_status_enu_t OMSCALL oms_reduceSSV(const char* cref, const char* ssvfile, const char* ssmfile, const char* filepath);
 OMSAPI oms_status_enu_t OMSCALL oms_removeSignalsFromResults(const char* cref, const char* regex);
 OMSAPI oms_status_enu_t OMSCALL oms_rename(const char* cref, const char* newCref);
-OMSAPI oms_status_enu_t OMSCALL oms_replaceSubModel(const char* cref, const char* fmuPath, bool replaceSubModel);
+OMSAPI oms_status_enu_t OMSCALL oms_replaceSubModel(const char* cref, const char* fmuPath, bool dryRun);
 OMSAPI oms_status_enu_t OMSCALL oms_reset(const char* cref);
 OMSAPI oms_status_enu_t OMSCALL oms_referenceResources(const char* cref, const char* ssmFile);
 OMSAPI oms_status_enu_t OMSCALL oms_RunFile(const char* filename);

--- a/src/OMSimulatorLib/OMSimulator.h
+++ b/src/OMSimulatorLib/OMSimulator.h
@@ -130,7 +130,7 @@ OMSAPI oms_status_enu_t OMSCALL oms_newResources(const char* cref);
 OMSAPI oms_status_enu_t OMSCALL oms_reduceSSV(const char* cref, const char* ssvfile, const char* ssmfile, const char* filepath);
 OMSAPI oms_status_enu_t OMSCALL oms_removeSignalsFromResults(const char* cref, const char* regex);
 OMSAPI oms_status_enu_t OMSCALL oms_rename(const char* cref, const char* newCref);
-OMSAPI oms_status_enu_t OMSCALL oms_replaceSubModel(const char* cref, const char* fmuPath);
+OMSAPI oms_status_enu_t OMSCALL oms_replaceSubModel(const char* cref, const char* fmuPath, bool replaceSubModel);
 OMSAPI oms_status_enu_t OMSCALL oms_reset(const char* cref);
 OMSAPI oms_status_enu_t OMSCALL oms_referenceResources(const char* cref, const char* ssmFile);
 OMSAPI oms_status_enu_t OMSCALL oms_RunFile(const char* filename);

--- a/src/OMSimulatorLib/OMSimulator.h
+++ b/src/OMSimulatorLib/OMSimulator.h
@@ -130,7 +130,7 @@ OMSAPI oms_status_enu_t OMSCALL oms_newResources(const char* cref);
 OMSAPI oms_status_enu_t OMSCALL oms_reduceSSV(const char* cref, const char* ssvfile, const char* ssmfile, const char* filepath);
 OMSAPI oms_status_enu_t OMSCALL oms_removeSignalsFromResults(const char* cref, const char* regex);
 OMSAPI oms_status_enu_t OMSCALL oms_rename(const char* cref, const char* newCref);
-OMSAPI oms_status_enu_t OMSCALL oms_replaceSubModel(const char* cref, const char* fmuPath, bool dryRun);
+OMSAPI oms_status_enu_t OMSCALL oms_replaceSubModel(const char* cref, const char* fmuPath, bool dryRun, int* warningCount);
 OMSAPI oms_status_enu_t OMSCALL oms_reset(const char* cref);
 OMSAPI oms_status_enu_t OMSCALL oms_referenceResources(const char* cref, const char* ssmFile);
 OMSAPI oms_status_enu_t OMSCALL oms_RunFile(const char* filename);

--- a/src/OMSimulatorLib/System.cpp
+++ b/src/OMSimulatorLib/System.cpp
@@ -325,11 +325,11 @@ oms_status_enu_t oms::System::addSubModel(const oms::ComRef& cref, const std::st
   return system->addSubModel(tail, path);
 }
 
-oms_status_enu_t oms::System::replaceSubModel(const oms::ComRef& cref, const std::string& path, bool replaceSubModel)
+oms_status_enu_t oms::System::replaceSubModel(const oms::ComRef& cref, const std::string& path, bool dryRun)
 {
   /*
     take the snapshot of entire ssd before replacing,
-    if (replaceSubModel==true)
+    if (dryRun==true)
       showwarnings, reimport the snapshot and replacing is not done
     else
       show warnings and replace is done
@@ -398,7 +398,7 @@ oms_status_enu_t oms::System::replaceSubModel(const oms::ComRef& cref, const std
       // update or delete the start value in ssv of with the replaced component
       replaceComponent->updateOrDeleteStartValueInReplacedComponent();
 
-      if (replaceSubModel)
+      if (dryRun)
       {
         char * newCref = NULL;
         getModel().importSnapshot(fullsnapshot, &newCref);

--- a/src/OMSimulatorLib/System.cpp
+++ b/src/OMSimulatorLib/System.cpp
@@ -325,8 +325,20 @@ oms_status_enu_t oms::System::addSubModel(const oms::ComRef& cref, const std::st
   return system->addSubModel(tail, path);
 }
 
-oms_status_enu_t oms::System::replaceSubModel(const oms::ComRef& cref, const std::string& path)
+oms_status_enu_t oms::System::replaceSubModel(const oms::ComRef& cref, const std::string& path, bool replaceSubModel)
 {
+  /*
+    take the snapshot of entire ssd before replacing,
+    if (replaceSubModel==true)
+      showwarnings, reimport the snapshot and replacing is not done
+    else
+      show warnings and replace is done
+  */
+
+   // get full snapshot
+  char* fullsnapshot = NULL;
+  getModel().exportSnapshot("", &fullsnapshot);
+
   if (cref.isValidIdent())
   {
     if (validCref(cref))
@@ -378,12 +390,20 @@ oms_status_enu_t oms::System::replaceSubModel(const oms::ComRef& cref, const std
           }
         }
       }
+
       // copy all the resources from old component to replacing component
       std::vector<Values> allResources = component->second->getValuesResources();
       replaceComponent->setValuesResources(allResources);
 
       // update or delete the start value in ssv of with the replaced component
       replaceComponent->updateOrDeleteStartValueInReplacedComponent();
+
+      if (replaceSubModel)
+      {
+        char * newCref = NULL;
+        getModel().importSnapshot(fullsnapshot, &newCref);
+        return oms_status_ok;
+      }
 
       //delete component
       delete component->second;

--- a/src/OMSimulatorLib/System.h
+++ b/src/OMSimulatorLib/System.h
@@ -95,7 +95,7 @@ namespace oms
     oms_system_enu_t getType() const {return type;}
     oms_status_enu_t addSubSystem(const ComRef& cref, oms_system_enu_t type);
     oms_status_enu_t addSubModel(const ComRef& cref, const std::string& fmuPath);
-    oms_status_enu_t replaceSubModel(const ComRef& cref, const std::string& fmuPath);
+    oms_status_enu_t replaceSubModel(const ComRef& cref, const std::string& fmuPath, bool replaceSubModel);
     bool isValidScalarVariable(Component* referenceComponent, Component* replacingComponent, Connection* connection, const ComRef& crefA, const ComRef& crefB, const ComRef& signalName, const std::string& path);
     bool validCref(const ComRef& cref);
     oms_status_enu_t exportToSSD(pugi::xml_node& node, Snapshot& snapshot) const;

--- a/src/OMSimulatorLib/System.h
+++ b/src/OMSimulatorLib/System.h
@@ -95,7 +95,7 @@ namespace oms
     oms_system_enu_t getType() const {return type;}
     oms_status_enu_t addSubSystem(const ComRef& cref, oms_system_enu_t type);
     oms_status_enu_t addSubModel(const ComRef& cref, const std::string& fmuPath);
-    oms_status_enu_t replaceSubModel(const ComRef& cref, const std::string& fmuPath, bool replaceSubModel);
+    oms_status_enu_t replaceSubModel(const ComRef& cref, const std::string& fmuPath, bool dryRun);
     bool isValidScalarVariable(Component* referenceComponent, Component* replacingComponent, Connection* connection, const ComRef& crefA, const ComRef& crefB, const ComRef& signalName, const std::string& path);
     bool validCref(const ComRef& cref);
     oms_status_enu_t exportToSSD(pugi::xml_node& node, Snapshot& snapshot) const;

--- a/src/OMSimulatorLib/System.h
+++ b/src/OMSimulatorLib/System.h
@@ -95,8 +95,8 @@ namespace oms
     oms_system_enu_t getType() const {return type;}
     oms_status_enu_t addSubSystem(const ComRef& cref, oms_system_enu_t type);
     oms_status_enu_t addSubModel(const ComRef& cref, const std::string& fmuPath);
-    oms_status_enu_t replaceSubModel(const ComRef& cref, const std::string& fmuPath, bool dryRun);
-    bool isValidScalarVariable(Component* referenceComponent, Component* replacingComponent, Connection* connection, const ComRef& crefA, const ComRef& crefB, const ComRef& signalName, const std::string& path);
+    oms_status_enu_t replaceSubModel(const ComRef& cref, const std::string& fmuPath, bool dryRun, int& warningCount);
+    bool isValidScalarVariable(Component* referenceComponent, Component* replacingComponent, Connection* connection, const ComRef& crefA, const ComRef& crefB, const ComRef& signalName, const std::string& path, std::vector<std::string>& warningList);
     bool validCref(const ComRef& cref);
     oms_status_enu_t exportToSSD(pugi::xml_node& node, Snapshot& snapshot) const;
     oms_status_enu_t exportToSSV(Snapshot& snapshot) const;

--- a/src/OMSimulatorLib/Values.cpp
+++ b/src/OMSimulatorLib/Values.cpp
@@ -656,6 +656,7 @@ oms_status_enu_t oms::Values::updateOrDeleteStartValueInReplacedComponent(Values
             {
               //res.second.realStartValues.erase(mappedCref->second); // NOTE: should we keep unreferenced signals in ssm and ssv when importing ?
               mappedCref = res.second.mappedEntry.erase(mappedCref);
+              logWarning("deleting start value \"" + std::string(owner + front) + "\"" + " in \"" + std::string(res.second.ssmFile) + "\""  + " resources, because the identifier couldn't be resolved to any system signal in the replacing model");
             }
           }
           ++ mappedCref;
@@ -695,6 +696,7 @@ oms_status_enu_t oms::Values::updateOrDeleteStartValueInReplacedComponent(Values
             {
               // if (res.second.ssmFile.empty()) should we keep the unreferenced signals in ssv which does not have any reference in ssm when importing?
               res.second.realStartValues.erase(name.first); // delete the start value as signal does not exist in replaced component
+              logWarning("deleting start value \"" + std::string(owner + front) + "\"" + " in \"" + std::string(res.first) + "\""  + " resources, because the identifier couldn't be resolved to any system signal in the replacing model");
             }
           }
         }

--- a/src/OMSimulatorLib/Values.cpp
+++ b/src/OMSimulatorLib/Values.cpp
@@ -632,7 +632,7 @@ oms_status_enu_t oms::Values::deleteStartValue(const ComRef& cref)
   return oms_status_error;
 }
 
-oms_status_enu_t oms::Values::updateOrDeleteStartValueInReplacedComponent(Values& value, const ComRef& owner)
+oms_status_enu_t oms::Values::updateOrDeleteStartValueInReplacedComponent(Values& value, const ComRef& owner, std::vector<std::string>& warningList)
 {
   for (auto &it : parameterResources)
   {
@@ -656,7 +656,9 @@ oms_status_enu_t oms::Values::updateOrDeleteStartValueInReplacedComponent(Values
             {
               //res.second.realStartValues.erase(mappedCref->second); // NOTE: should we keep unreferenced signals in ssm and ssv when importing ?
               mappedCref = res.second.mappedEntry.erase(mappedCref);
-              logWarning("deleting start value \"" + std::string(owner + front) + "\"" + " in \"" + std::string(res.second.ssmFile) + "\""  + " resources, because the identifier couldn't be resolved to any system signal in the replacing model");
+              std::string errorMsg = "deleting start value \"" + std::string(owner + front) + "\"" + " in \"" + std::string(res.second.ssmFile) + "\""  + " resources, because the identifier couldn't be resolved to any system signal in the replacing model";
+              logWarning(errorMsg);
+              warningList.push_back(errorMsg);
             }
           }
           ++ mappedCref;
@@ -696,7 +698,9 @@ oms_status_enu_t oms::Values::updateOrDeleteStartValueInReplacedComponent(Values
             {
               // if (res.second.ssmFile.empty()) should we keep the unreferenced signals in ssv which does not have any reference in ssm when importing?
               res.second.realStartValues.erase(name.first); // delete the start value as signal does not exist in replaced component
-              logWarning("deleting start value \"" + std::string(owner + front) + "\"" + " in \"" + std::string(res.first) + "\""  + " resources, because the identifier couldn't be resolved to any system signal in the replacing model");
+              std::string errorMsg = "deleting start value \"" + std::string(owner + front) + "\"" + " in \"" + std::string(res.first) + "\""  + " resources, because the identifier couldn't be resolved to any system signal in the replacing model";
+              logWarning(errorMsg);
+              warningList.push_back(errorMsg);
             }
           }
         }

--- a/src/OMSimulatorLib/Values.h
+++ b/src/OMSimulatorLib/Values.h
@@ -91,7 +91,7 @@ namespace oms
     oms_status_enu_t importFromSnapshot(const pugi::xml_node& node, const std::string& sspVersion, const Snapshot& snapshot);
     oms_status_enu_t importFromSnapshot(const Snapshot& snapshot, const std::string& ssvFilePath, const std::string& ssmFilename);
     oms_status_enu_t deleteStartValue(const ComRef& cref);
-    oms_status_enu_t updateOrDeleteStartValueInReplacedComponent(Values& value, const ComRef& owner);
+    oms_status_enu_t updateOrDeleteStartValueInReplacedComponent(Values& value, const ComRef& owner, std::vector<std::string>& warningList);
     oms_status_enu_t deleteStartValueInResources(const ComRef& cref);
 
     oms_status_enu_t deleteReferencesInSSD(const std::string& filename);

--- a/src/OMSimulatorLua/OMSimulatorLua.c
+++ b/src/OMSimulatorLua/OMSimulatorLua.c
@@ -1145,17 +1145,19 @@ static int OMSimulatorLua_oms_replaceSubModel(lua_State *L)
   const char* cref = lua_tostring(L, 1);
   const char* fmuPath = lua_tostring(L, 2);
   bool dryRun = lua_toboolean(L, 3);
+  int warningCount = 0;
 
-  oms_status_enu_t status = oms_replaceSubModel(cref, fmuPath, dryRun);
+  oms_status_enu_t status = oms_replaceSubModel(cref, fmuPath, dryRun, &warningCount);
 
   if (status!=oms_status_ok)
   {
     return luaL_error(L, "oms_replaceSubModel(%s,%s,%s) failed", cref, fmuPath, dryRun);
   }
 
+  lua_pushinteger(L, warningCount);
   lua_pushinteger(L, status);
 
-  return 1;
+  return 2;
 }
 
 //oms_status_enu_t oms_instantiate(const char* ident);

--- a/src/OMSimulatorLua/OMSimulatorLua.c
+++ b/src/OMSimulatorLua/OMSimulatorLua.c
@@ -847,7 +847,7 @@ static int OMSimulatorLua_oms_addConnector(lua_State *L)
   return 1;
 }
 
-//oms_status_enu_t oms_addConnection(const char *crefA, const char *crefB);
+//oms_status_enu_t oms_addConnection(const char *crefA, const char *crefB, bool suppressUnitConversion);
 static int OMSimulatorLua_oms_addConnection(lua_State *L)
 {
   if (lua_gettop(L) != 2 && lua_gettop(L) != 3)
@@ -1133,21 +1133,24 @@ static int OMSimulatorLua_oms_addSubModel(lua_State *L)
   return 1;
 }
 
-//oms_status_enu_t oms_replaceSubModel(const char* cref, const char* fmuPath);
+//oms_status_enu_t oms_replaceSubModel(const char* cref, const char* fmuPath, bool replaceSubModel);
 static int OMSimulatorLua_oms_replaceSubModel(lua_State *L)
 {
-  if (lua_gettop(L) != 2)
-    return luaL_error(L, "expecting exactly 2 arguments");
+  if (lua_gettop(L) != 3)
+    return luaL_error(L, "expecting exactly 3 arguments");
   luaL_checktype(L, 1, LUA_TSTRING);
   luaL_checktype(L, 2, LUA_TSTRING);
+  luaL_checktype(L, 3, LUA_TBOOLEAN);
 
   const char* cref = lua_tostring(L, 1);
   const char* fmuPath = lua_tostring(L, 2);
-  oms_status_enu_t status = oms_replaceSubModel(cref, fmuPath);
+  bool replaceSubModel = lua_toboolean(L, 3);
+
+  oms_status_enu_t status = oms_replaceSubModel(cref, fmuPath, replaceSubModel);
 
   if (status!=oms_status_ok)
   {
-    return luaL_error(L, "oms_replaceSubModel(%s,%s) failed", cref, fmuPath);
+    return luaL_error(L, "oms_replaceSubModel(%s,%s,%s) failed", cref, fmuPath, replaceSubModel);
   }
 
   lua_pushinteger(L, status);

--- a/src/OMSimulatorLua/OMSimulatorLua.c
+++ b/src/OMSimulatorLua/OMSimulatorLua.c
@@ -1133,7 +1133,7 @@ static int OMSimulatorLua_oms_addSubModel(lua_State *L)
   return 1;
 }
 
-//oms_status_enu_t oms_replaceSubModel(const char* cref, const char* fmuPath, bool replaceSubModel);
+//oms_status_enu_t oms_replaceSubModel(const char* cref, const char* fmuPath, bool dryRun);
 static int OMSimulatorLua_oms_replaceSubModel(lua_State *L)
 {
   if (lua_gettop(L) != 3)
@@ -1144,13 +1144,13 @@ static int OMSimulatorLua_oms_replaceSubModel(lua_State *L)
 
   const char* cref = lua_tostring(L, 1);
   const char* fmuPath = lua_tostring(L, 2);
-  bool replaceSubModel = lua_toboolean(L, 3);
+  bool dryRun = lua_toboolean(L, 3);
 
-  oms_status_enu_t status = oms_replaceSubModel(cref, fmuPath, replaceSubModel);
+  oms_status_enu_t status = oms_replaceSubModel(cref, fmuPath, dryRun);
 
   if (status!=oms_status_ok)
   {
-    return luaL_error(L, "oms_replaceSubModel(%s,%s,%s) failed", cref, fmuPath, replaceSubModel);
+    return luaL_error(L, "oms_replaceSubModel(%s,%s,%s) failed", cref, fmuPath, dryRun);
   }
 
   lua_pushinteger(L, status);

--- a/src/OMSimulatorPython/capi.py
+++ b/src/OMSimulatorPython/capi.py
@@ -125,7 +125,7 @@ class capi:
     self.obj.oms_removeSignalsFromResults.restype = ctypes.c_int
     self.obj.oms_rename.argtypes = [ctypes.c_char_p, ctypes.c_char_p]
     self.obj.oms_rename.restype = ctypes.c_int
-    self.obj.oms_replaceSubModel.argtypes = [ctypes.c_char_p, ctypes.c_char_p]
+    self.obj.oms_replaceSubModel.argtypes = [ctypes.c_char_p, ctypes.c_char_p, ctypes.c_bool]
     self.obj.oms_replaceSubModel.restype = ctypes.c_int
     self.obj.oms_reset.argtypes = [ctypes.c_char_p]
     self.obj.oms_reset.restype = ctypes.c_int
@@ -340,8 +340,8 @@ class capi:
     return self.obj.oms_removeSignalsFromResults(cref.encode(), regex.encode())
   def rename(self, cref, newcref):
     return self.obj.oms_rename(cref.encode(), newcref.encode())
-  def replaceSubModel(self, cref, fmuPath):
-    return self.obj.oms_replaceSubModel(cref.encode(), fmuPath.encode())
+  def replaceSubModel(self, cref, fmuPath, replaceSubModel):
+    return self.obj.oms_replaceSubModel(cref.encode(), fmuPath.encode(), replaceSubModel)
   def reset(self, cref):
     return self.obj.oms_reset(cref.encode())
   def setBoolean(self, signal, value):

--- a/src/OMSimulatorPython/capi.py
+++ b/src/OMSimulatorPython/capi.py
@@ -125,7 +125,7 @@ class capi:
     self.obj.oms_removeSignalsFromResults.restype = ctypes.c_int
     self.obj.oms_rename.argtypes = [ctypes.c_char_p, ctypes.c_char_p]
     self.obj.oms_rename.restype = ctypes.c_int
-    self.obj.oms_replaceSubModel.argtypes = [ctypes.c_char_p, ctypes.c_char_p, ctypes.c_bool]
+    self.obj.oms_replaceSubModel.argtypes = [ctypes.c_char_p, ctypes.c_char_p, ctypes.c_bool, ctypes.POINTER(ctypes.c_int)]
     self.obj.oms_replaceSubModel.restype = ctypes.c_int
     self.obj.oms_reset.argtypes = [ctypes.c_char_p]
     self.obj.oms_reset.restype = ctypes.c_int
@@ -340,8 +340,10 @@ class capi:
     return self.obj.oms_removeSignalsFromResults(cref.encode(), regex.encode())
   def rename(self, cref, newcref):
     return self.obj.oms_rename(cref.encode(), newcref.encode())
-  def replaceSubModel(self, cref, fmuPath, replaceSubModel):
-    return self.obj.oms_replaceSubModel(cref.encode(), fmuPath.encode(), replaceSubModel)
+  def replaceSubModel(self, cref, fmuPath, dryRun):
+    value = ctypes.c_int()
+    status = self.obj.oms_replaceSubModel(cref.encode(), fmuPath.encode(), dryRun, ctypes.byref(value))
+    return [value.value, status]
   def reset(self, cref):
     return self.obj.oms_reset(cref.encode())
   def setBoolean(self, signal, value):

--- a/testsuite/simulation/replaceSubmodel1.lua
+++ b/testsuite/simulation/replaceSubmodel1.lua
@@ -3,7 +3,7 @@
 -- linux: no
 -- mingw32: no
 -- mingw64: yes
--- win: yes
+-- win: no
 -- mac: no
 
 oms_setCommandLineOption("--suppressPath=true")

--- a/testsuite/simulation/replaceSubmodel1.lua
+++ b/testsuite/simulation/replaceSubmodel1.lua
@@ -42,7 +42,7 @@ oms_delete("model")
 
 oms_importFile("replaceSubmodel1.ssp")
 
-oms_replaceSubModel("model.root.A", "../resources/replaceA_extended.fmu")
+oms_replaceSubModel("model.root.A", "../resources/replaceA_extended.fmu", false)
 src, status = oms_exportSnapshot("model")
 print(src)
 
@@ -310,6 +310,7 @@ oms_delete("model")
 -- info:      model.root.B.z      : -15.0
 -- error:   [getVariable] Unknown signal "model.root.A.dummy"
 -- warning: deleting connection "A.dummy ==> B.u1", as signal "dummy" couldn't be resolved to any signal in the replaced submodel "../resources/replaceA_extended.fmu"
+-- warning: deleting start value "A.t" in "inline" resources, because the identifier couldn't be resolved to any system signal in the replacing model
 -- <?xml version="1.0"?>
 -- <oms:snapshot
 --   xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
@@ -546,6 +547,6 @@ oms_delete("model")
 -- info:      model.root.B.u      : 10.0
 -- info:      model.root.B.u1     : -13.0
 -- info:      model.root.B.z      : -15.0
--- info:    1 warnings
+-- info:    2 warnings
 -- info:    1 errors
 -- endResult

--- a/testsuite/simulation/replaceSubmodel1.lua
+++ b/testsuite/simulation/replaceSubmodel1.lua
@@ -42,7 +42,8 @@ oms_delete("model")
 
 oms_importFile("replaceSubmodel1.ssp")
 
-oms_replaceSubModel("model.root.A", "../resources/replaceA_extended.fmu", false)
+count, status = oms_replaceSubModel("model.root.A", "../resources/replaceA_extended.fmu", false)
+-- print("info : WarningCount: " .. count)
 src, status = oms_exportSnapshot("model")
 print(src)
 

--- a/testsuite/simulation/replaceSubmodel1.lua
+++ b/testsuite/simulation/replaceSubmodel1.lua
@@ -42,8 +42,7 @@ oms_delete("model")
 
 oms_importFile("replaceSubmodel1.ssp")
 
-count, status = oms_replaceSubModel("model.root.A", "../resources/replaceA_extended.fmu", false)
--- print("info : WarningCount: " .. count)
+oms_replaceSubModel("model.root.A", "../resources/replaceA_extended.fmu", false)
 src, status = oms_exportSnapshot("model")
 print(src)
 

--- a/testsuite/simulation/replaceSubmodel10.lua
+++ b/testsuite/simulation/replaceSubmodel10.lua
@@ -3,7 +3,7 @@
 -- linux: no
 -- mingw32: no
 -- mingw64: yes
--- win: yes
+-- win: no
 -- mac: no
 
 oms_setCommandLineOption("--suppressPath=true")

--- a/testsuite/simulation/replaceSubmodel10.lua
+++ b/testsuite/simulation/replaceSubmodel10.lua
@@ -1,0 +1,544 @@
+-- status: correct
+-- teardown_command: rm -rf replacesubmodel_10_lua/
+-- linux: no
+-- mingw32: no
+-- mingw64: yes
+-- win: yes
+-- mac: no
+
+oms_setCommandLineOption("--suppressPath=true")
+oms_setTempDirectory("./replacesubmodel_10_lua/")
+
+oms_newModel("model")
+
+oms_addSystem("model.root", oms_system_wc)
+
+oms_addSubModel("model.root.A", "../resources/replaceA.fmu")
+oms_addSubModel("model.root.B", "../resources/replaceB.fmu")
+
+oms_newResources("model.root:root.ssv")
+
+oms_setReal("model.root.A.u", 10.0)
+oms_setReal("model.root.A.t", -10.0)
+oms_setReal("model.root.B.u1", -13.0)
+oms_setReal("model.root.B.z", -15.0)
+
+-- add connections
+oms_addConnection("model.root.A.y", "model.root.B.u")
+oms_addConnection("model.root.A.dummy", "model.root.B.u1")
+
+oms_setResultFile("model", "replaceSubmodel10.mat")
+
+src, status = oms_exportSnapshot("model")
+print(src)
+
+print("info:    Before replacing the Model")
+print("info:      model.root.A.u      : " .. oms_getReal("model.root.A.u"))
+print("info:      model.root.B.u      : " .. oms_getReal("model.root.B.u"))
+print("info:      model.root.B.u1     : " .. oms_getReal("model.root.B.u1"))
+print("info:      model.root.B.z      : " .. oms_getReal("model.root.B.z"))
+
+oms_export("model", "replaceSubmodel10.ssp")
+oms_terminate("model")
+oms_delete("model")
+
+oms_importFile("replaceSubmodel10.ssp")
+
+-- reimport the old snapshot and replacing is not done
+oms_replaceSubModel("model.root.A", "../resources/replaceA_extended.fmu", true)
+src, status = oms_exportSnapshot("model")
+print(src)
+
+print("info:    After replacing the Model")
+print("info:      model.root.A.u      : " .. oms_getReal("model.root.A.u"))
+print("info:      model.root.B.u      : " .. oms_getReal("model.root.B.u"))
+print("info:      model.root.B.u1     : " .. oms_getReal("model.root.B.u1"))
+print("info:      model.root.B.z      : " .. oms_getReal("model.root.B.z"))
+
+oms_instantiate("model")
+
+oms_initialize("model")
+
+print("info:    Initialize")
+print("info:      model.root.A.u      : " .. oms_getReal("model.root.A.u"))
+print("info:      model.root.A.y      : " .. oms_getReal("model.root.A.y"))
+print("info:      model.root.B.u      : " .. oms_getReal("model.root.B.u"))
+print("info:      model.root.B.u1     : " .. oms_getReal("model.root.B.u1"))
+print("info:      model.root.B.z      : " .. oms_getReal("model.root.B.z"))
+
+oms_simulate("model")
+
+print("info:    Simulate")
+print("info:      model.root.A.u      : " .. oms_getReal("model.root.A.u"))
+print("info:      model.root.A.y      : " .. oms_getReal("model.root.A.y"))
+print("info:      model.root.B.u      : " .. oms_getReal("model.root.B.u"))
+print("info:      model.root.B.u1     : " .. oms_getReal("model.root.B.u1"))
+print("info:      model.root.B.z      : " .. oms_getReal("model.root.B.z"))
+
+oms_terminate("model")
+oms_delete("model")
+
+-- Result:
+-- <?xml version="1.0"?>
+-- <oms:snapshot
+--   xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
+--   partial="false">
+--   <oms:file
+--     name="SystemStructure.ssd">
+--     <ssd:SystemStructureDescription
+--       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
+--       xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription"
+--       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
+--       xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping"
+--       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
+--       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
+--       name="model"
+--       version="1.0">
+--       <ssd:System
+--         name="root">
+--         <ssd:ParameterBindings>
+--           <ssd:ParameterBinding
+--             source="resources/root.ssv" />
+--         </ssd:ParameterBindings>
+--         <ssd:Elements>
+--           <ssd:Component
+--             name="B"
+--             type="application/x-fmu-sharedlibrary"
+--             source="resources/0002_B.fmu">
+--             <ssd:Connectors>
+--               <ssd:Connector
+--                 name="u"
+--                 kind="input">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="0.000000"
+--                   y="0.333333" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="u1"
+--                 kind="input">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="0.000000"
+--                   y="0.666667" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="y"
+--                 kind="output">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="1.000000"
+--                   y="0.500000" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="z"
+--                 kind="parameter">
+--                 <ssc:Real />
+--               </ssd:Connector>
+--             </ssd:Connectors>
+--           </ssd:Component>
+--           <ssd:Component
+--             name="A"
+--             type="application/x-fmu-sharedlibrary"
+--             source="resources/0001_A.fmu">
+--             <ssd:Connectors>
+--               <ssd:Connector
+--                 name="u"
+--                 kind="input">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="0.000000"
+--                   y="0.500000" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="dummy"
+--                 kind="output">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="1.000000"
+--                   y="0.333333" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="y"
+--                 kind="output">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="1.000000"
+--                   y="0.666667" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="t"
+--                 kind="parameter">
+--                 <ssc:Real />
+--               </ssd:Connector>
+--             </ssd:Connectors>
+--           </ssd:Component>
+--         </ssd:Elements>
+--         <ssd:Connections>
+--           <ssd:Connection
+--             startElement="A"
+--             startConnector="y"
+--             endElement="B"
+--             endConnector="u" />
+--           <ssd:Connection
+--             startElement="A"
+--             startConnector="dummy"
+--             endElement="B"
+--             endConnector="u1" />
+--         </ssd:Connections>
+--         <ssd:Annotations>
+--           <ssc:Annotation
+--             type="org.openmodelica">
+--             <oms:Annotations>
+--               <oms:SimulationInformation>
+--                 <oms:FixedStepMaster
+--                   description="oms-ma"
+--                   stepSize="0.001000"
+--                   absoluteTolerance="0.000100"
+--                   relativeTolerance="0.000100" />
+--               </oms:SimulationInformation>
+--             </oms:Annotations>
+--           </ssc:Annotation>
+--         </ssd:Annotations>
+--       </ssd:System>
+--       <ssd:DefaultExperiment
+--         startTime="0.000000"
+--         stopTime="1.000000">
+--         <ssd:Annotations>
+--           <ssc:Annotation
+--             type="org.openmodelica">
+--             <oms:Annotations>
+--               <oms:SimulationInformation
+--                 resultFile="replaceSubmodel10.mat"
+--                 loggingInterval="0.000000"
+--                 bufferSize="1"
+--                 signalFilter="resources/signalFilter.xml" />
+--             </oms:Annotations>
+--           </ssc:Annotation>
+--         </ssd:Annotations>
+--       </ssd:DefaultExperiment>
+--     </ssd:SystemStructureDescription>
+--   </oms:file>
+--   <oms:file
+--     name="resources/root.ssv">
+--     <ssv:ParameterSet
+--       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
+--       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
+--       version="1.0"
+--       name="parameters">
+--       <ssv:Parameters>
+--         <ssv:Parameter
+--           name="B.z">
+--           <ssv:Real
+--             value="-15" />
+--         </ssv:Parameter>
+--         <ssv:Parameter
+--           name="B.u1">
+--           <ssv:Real
+--             value="-13" />
+--         </ssv:Parameter>
+--         <ssv:Parameter
+--           name="A.u">
+--           <ssv:Real
+--             value="10" />
+--         </ssv:Parameter>
+--         <ssv:Parameter
+--           name="A.t">
+--           <ssv:Real
+--             value="-10" />
+--         </ssv:Parameter>
+--       </ssv:Parameters>
+--     </ssv:ParameterSet>
+--   </oms:file>
+--   <oms:file
+--     name="resources/signalFilter.xml">
+--     <oms:SignalFilter
+--       version="1.0">
+--       <oms:Variable
+--         name="model.root.B.u"
+--         type="Real"
+--         kind="input" />
+--       <oms:Variable
+--         name="model.root.B.u1"
+--         type="Real"
+--         kind="input" />
+--       <oms:Variable
+--         name="model.root.B.y"
+--         type="Real"
+--         kind="output" />
+--       <oms:Variable
+--         name="model.root.B.z"
+--         type="Real"
+--         kind="parameter" />
+--       <oms:Variable
+--         name="model.root.A.x"
+--         type="Real"
+--         kind="unknown" />
+--       <oms:Variable
+--         name="model.root.A.der(x)"
+--         type="Real"
+--         kind="unknown" />
+--       <oms:Variable
+--         name="model.root.A.dummy"
+--         type="Real"
+--         kind="output" />
+--       <oms:Variable
+--         name="model.root.A.u"
+--         type="Real"
+--         kind="input" />
+--       <oms:Variable
+--         name="model.root.A.y"
+--         type="Real"
+--         kind="output" />
+--       <oms:Variable
+--         name="model.root.A.t"
+--         type="Real"
+--         kind="parameter" />
+--     </oms:SignalFilter>
+--   </oms:file>
+-- </oms:snapshot>
+--
+-- info:    Before replacing the Model
+-- info:      model.root.A.u      : 10.0
+-- info:      model.root.B.u      : 1.0
+-- info:      model.root.B.u1     : -13.0
+-- info:      model.root.B.z      : -15.0
+-- error:   [getVariable] Unknown signal "model.root.A.dummy"
+-- warning: deleting connection "A.dummy ==> B.u1", as signal "dummy" couldn't be resolved to any signal in the replaced submodel "../resources/replaceA_extended.fmu"
+-- warning: deleting start value "A.t" in "resources/root.ssv" resources, because the identifier couldn't be resolved to any system signal in the replacing model
+-- <?xml version="1.0"?>
+-- <oms:snapshot
+--   xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
+--   partial="false">
+--   <oms:file
+--     name="SystemStructure.ssd">
+--     <ssd:SystemStructureDescription
+--       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
+--       xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription"
+--       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
+--       xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping"
+--       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
+--       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
+--       name="model"
+--       version="1.0">
+--       <ssd:System
+--         name="root">
+--         <ssd:ParameterBindings>
+--           <ssd:ParameterBinding
+--             source="resources/root.ssv" />
+--         </ssd:ParameterBindings>
+--         <ssd:Elements>
+--           <ssd:Component
+--             name="B"
+--             type="application/x-fmu-sharedlibrary"
+--             source="resources/0002_B.fmu">
+--             <ssd:Connectors>
+--               <ssd:Connector
+--                 name="u"
+--                 kind="input">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="0.000000"
+--                   y="0.333333" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="u1"
+--                 kind="input">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="0.000000"
+--                   y="0.666667" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="y"
+--                 kind="output">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="1.000000"
+--                   y="0.500000" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="z"
+--                 kind="parameter">
+--                 <ssc:Real />
+--               </ssd:Connector>
+--             </ssd:Connectors>
+--           </ssd:Component>
+--           <ssd:Component
+--             name="A"
+--             type="application/x-fmu-sharedlibrary"
+--             source="resources/0001_A.fmu">
+--             <ssd:Connectors>
+--               <ssd:Connector
+--                 name="u"
+--                 kind="input">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="0.000000"
+--                   y="0.500000" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="dummy"
+--                 kind="output">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="1.000000"
+--                   y="0.333333" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="y"
+--                 kind="output">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="1.000000"
+--                   y="0.666667" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="t"
+--                 kind="parameter">
+--                 <ssc:Real />
+--               </ssd:Connector>
+--             </ssd:Connectors>
+--           </ssd:Component>
+--         </ssd:Elements>
+--         <ssd:Connections>
+--           <ssd:Connection
+--             startElement="A"
+--             startConnector="y"
+--             endElement="B"
+--             endConnector="u" />
+--           <ssd:Connection
+--             startElement="A"
+--             startConnector="dummy"
+--             endElement="B"
+--             endConnector="u1" />
+--         </ssd:Connections>
+--         <ssd:Annotations>
+--           <ssc:Annotation
+--             type="org.openmodelica">
+--             <oms:Annotations>
+--               <oms:SimulationInformation>
+--                 <oms:FixedStepMaster
+--                   description="oms-ma"
+--                   stepSize="0.001000"
+--                   absoluteTolerance="0.000100"
+--                   relativeTolerance="0.000100" />
+--               </oms:SimulationInformation>
+--             </oms:Annotations>
+--           </ssc:Annotation>
+--         </ssd:Annotations>
+--       </ssd:System>
+--       <ssd:DefaultExperiment
+--         startTime="0.000000"
+--         stopTime="1.000000">
+--         <ssd:Annotations>
+--           <ssc:Annotation
+--             type="org.openmodelica">
+--             <oms:Annotations>
+--               <oms:SimulationInformation
+--                 resultFile="replaceSubmodel10.mat"
+--                 loggingInterval="0.000000"
+--                 bufferSize="1"
+--                 signalFilter="resources/signalFilter.xml" />
+--             </oms:Annotations>
+--           </ssc:Annotation>
+--         </ssd:Annotations>
+--       </ssd:DefaultExperiment>
+--     </ssd:SystemStructureDescription>
+--   </oms:file>
+--   <oms:file
+--     name="resources/root.ssv">
+--     <ssv:ParameterSet
+--       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
+--       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
+--       version="1.0"
+--       name="parameters">
+--       <ssv:Parameters>
+--         <ssv:Parameter
+--           name="B.z">
+--           <ssv:Real
+--             value="-15" />
+--         </ssv:Parameter>
+--         <ssv:Parameter
+--           name="B.u1">
+--           <ssv:Real
+--             value="-13" />
+--         </ssv:Parameter>
+--         <ssv:Parameter
+--           name="A.u">
+--           <ssv:Real
+--             value="10" />
+--         </ssv:Parameter>
+--         <ssv:Parameter
+--           name="A.t">
+--           <ssv:Real
+--             value="-10" />
+--         </ssv:Parameter>
+--       </ssv:Parameters>
+--     </ssv:ParameterSet>
+--   </oms:file>
+--   <oms:file
+--     name="resources/signalFilter.xml">
+--     <oms:SignalFilter
+--       version="1.0">
+--       <oms:Variable
+--         name="model.root.B.u"
+--         type="Real"
+--         kind="input" />
+--       <oms:Variable
+--         name="model.root.B.u1"
+--         type="Real"
+--         kind="input" />
+--       <oms:Variable
+--         name="model.root.B.y"
+--         type="Real"
+--         kind="output" />
+--       <oms:Variable
+--         name="model.root.B.z"
+--         type="Real"
+--         kind="parameter" />
+--       <oms:Variable
+--         name="model.root.A.x"
+--         type="Real"
+--         kind="unknown" />
+--       <oms:Variable
+--         name="model.root.A.dummy"
+--         type="Real"
+--         kind="output" />
+--       <oms:Variable
+--         name="model.root.A.u"
+--         type="Real"
+--         kind="input" />
+--       <oms:Variable
+--         name="model.root.A.y"
+--         type="Real"
+--         kind="output" />
+--       <oms:Variable
+--         name="model.root.A.t"
+--         type="Real"
+--         kind="parameter" />
+--     </oms:SignalFilter>
+--   </oms:file>
+-- </oms:snapshot>
+--
+-- info:    After replacing the Model
+-- info:      model.root.A.u      : 10.0
+-- info:      model.root.B.u      : 1.0
+-- info:      model.root.B.u1     : -13.0
+-- info:      model.root.B.z      : -15.0
+-- info:    Result file: replaceSubmodel10.mat (bufferSize=1)
+-- info:    Initialize
+-- info:      model.root.A.u      : 10.0
+-- info:      model.root.A.y      : 10.0
+-- info:      model.root.B.u      : 10.0
+-- info:      model.root.B.u1     : 10.0
+-- info:      model.root.B.z      : -15.0
+-- info:    Simulate
+-- info:      model.root.A.u      : 10.0
+-- info:      model.root.A.y      : 10.0
+-- info:      model.root.B.u      : 10.0
+-- info:      model.root.B.u1     : 10.0
+-- info:      model.root.B.z      : -15.0
+-- info:    2 warnings
+-- info:    1 errors
+-- endResult

--- a/testsuite/simulation/replaceSubmodel2.lua
+++ b/testsuite/simulation/replaceSubmodel2.lua
@@ -3,7 +3,7 @@
 -- linux: no
 -- mingw32: no
 -- mingw64: yes
--- win: yes
+-- win: no
 -- mac: no
 
 oms_setCommandLineOption("--suppressPath=true")

--- a/testsuite/simulation/replaceSubmodel2.lua
+++ b/testsuite/simulation/replaceSubmodel2.lua
@@ -44,7 +44,7 @@ oms_delete("model")
 
 oms_importFile("replaceSubmodel2.ssp")
 
-oms_replaceSubModel("model.root.A", "../resources/replaceA_extended.fmu")
+oms_replaceSubModel("model.root.A", "../resources/replaceA_extended.fmu", false)
 src, status = oms_exportSnapshot("model")
 print(src)
 
@@ -304,6 +304,7 @@ oms_delete("model")
 -- info:      model.root.B.z      : -15.0
 -- error:   [getVariable] Unknown signal "model.root.A.dummy"
 -- warning: deleting connection "A.dummy ==> B.u1", as signal "dummy" couldn't be resolved to any signal in the replaced submodel "../resources/replaceA_extended.fmu"
+-- warning: deleting start value "A.t" in "resources/root.ssv" resources, because the identifier couldn't be resolved to any system signal in the replacing model
 -- <?xml version="1.0"?>
 -- <oms:snapshot
 --   xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
@@ -531,6 +532,6 @@ oms_delete("model")
 -- info:      model.root.B.u      : 10.0
 -- info:      model.root.B.u1     : -13.0
 -- info:      model.root.B.z      : -15.0
--- info:    1 warnings
+-- info:    2 warnings
 -- info:    1 errors
 -- endResult

--- a/testsuite/simulation/replaceSubmodel3.lua
+++ b/testsuite/simulation/replaceSubmodel3.lua
@@ -3,7 +3,7 @@
 -- linux: no
 -- mingw32: no
 -- mingw64: yes
--- win: yes
+-- win: no
 -- mac: no
 
 oms_setCommandLineOption("--suppressPath=true")

--- a/testsuite/simulation/replaceSubmodel3.lua
+++ b/testsuite/simulation/replaceSubmodel3.lua
@@ -45,7 +45,7 @@ oms_delete("model")
 
 oms_importFile("replaceSubmodel3.ssp")
 
-oms_replaceSubModel("model.root.A", "../resources/replaceA_extended.fmu")
+oms_replaceSubModel("model.root.A", "../resources/replaceA_extended.fmu", false)
 src, status = oms_exportSnapshot("model")
 print(src)
 
@@ -320,6 +320,7 @@ oms_delete("model")
 -- info:      model.root.B.z      : -15.0
 -- error:   [getVariable] Unknown signal "model.root.A.dummy"
 -- warning: deleting connection "A.dummy ==> B.u1", as signal "dummy" couldn't be resolved to any signal in the replaced submodel "../resources/replaceA_extended.fmu"
+-- warning: deleting start value "A.t" in "resources/replaceA.ssv" resources, because the identifier couldn't be resolved to any system signal in the replacing model
 -- <?xml version="1.0"?>
 -- <oms:snapshot
 --   xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
@@ -562,6 +563,6 @@ oms_delete("model")
 -- info:      model.root.B.u      : 10.0
 -- info:      model.root.B.u1     : -13.0
 -- info:      model.root.B.z      : -15.0
--- info:    1 warnings
+-- info:    2 warnings
 -- info:    1 errors
 -- endResult

--- a/testsuite/simulation/replaceSubmodel4.lua
+++ b/testsuite/simulation/replaceSubmodel4.lua
@@ -3,7 +3,7 @@
 -- linux: no
 -- mingw32: no
 -- mingw64: yes
--- win: yes
+-- win: no
 -- mac: no
 
 oms_setCommandLineOption("--suppressPath=true")

--- a/testsuite/simulation/replaceSubmodel4.lua
+++ b/testsuite/simulation/replaceSubmodel4.lua
@@ -21,7 +21,7 @@ print("info:      model.root.B.u      : " .. oms_getReal("model.root.B.u"))
 print("info:      model.root.B.u1     : " .. oms_getReal("model.root.B.u1"))
 print("info:      model.root.B.z      : " .. oms_getReal("model.root.B.z"))
 
-oms_replaceSubModel("model.root.A", "../resources/replaceA_extended.fmu")
+oms_replaceSubModel("model.root.A", "../resources/replaceA_extended.fmu", false)
 
 src, status = oms_exportSnapshot("model")
 print(src)
@@ -291,6 +291,8 @@ oms_delete("model")
 -- info:      model.root.B.z      : -15.0
 -- error:   [getVariable] Unknown signal "model.root.A.dummy"
 -- warning: deleting connection "A.dummy ==> B.u1", as signal "dummy" couldn't be resolved to any signal in the replaced submodel "../resources/replaceA_extended.fmu"
+-- warning: deleting start value "A.t" in "resources/root.ssm" resources, because the identifier couldn't be resolved to any system signal in the replacing model
+-- warning: deleting start value "A.t" in "resources/root.ssv" resources, because the identifier couldn't be resolved to any system signal in the replacing model
 -- <?xml version="1.0"?>
 -- <oms:snapshot
 --   xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
@@ -533,6 +535,6 @@ oms_delete("model")
 -- info:      model.root.B.u      : 10.0
 -- info:      model.root.B.u1     : -13.0
 -- info:      model.root.B.z      : -15.0
--- info:    1 warnings
+-- info:    3 warnings
 -- info:    1 errors
 -- endResult

--- a/testsuite/simulation/replaceSubmodel5.lua
+++ b/testsuite/simulation/replaceSubmodel5.lua
@@ -3,7 +3,7 @@
 -- linux: no
 -- mingw32: no
 -- mingw64: yes
--- win: yes
+-- win: no
 -- mac: no
 
 oms_setCommandLineOption("--suppressPath=true")

--- a/testsuite/simulation/replaceSubmodel5.lua
+++ b/testsuite/simulation/replaceSubmodel5.lua
@@ -21,7 +21,7 @@ print("info:      model.root.B.u      : " .. oms_getReal("model.root.B.u"))
 print("info:      model.root.B.u1     : " .. oms_getReal("model.root.B.u1"))
 print("info:      model.root.B.z      : " .. oms_getReal("model.root.B.z"))
 
-oms_replaceSubModel("model.root.A", "../resources/replaceA_extended.fmu")
+oms_replaceSubModel("model.root.A", "../resources/replaceA_extended.fmu", false)
 
 src, status = oms_exportSnapshot("model")
 print(src)
@@ -283,6 +283,8 @@ oms_delete("model")
 -- info:      model.root.B.z      : 1.0
 -- error:   [getVariable] Unknown signal "model.root.A.dummy"
 -- warning: deleting connection "A.dummy ==> B.u1", as signal "dummy" couldn't be resolved to any signal in the replaced submodel "../resources/replaceA_extended.fmu"
+-- warning: deleting start value "A.t" in "resources/root.ssm" resources, because the identifier couldn't be resolved to any system signal in the replacing model
+-- warning: deleting start value "A.t" in "resources/root.ssv" resources, because the identifier couldn't be resolved to any system signal in the replacing model
 -- <?xml version="1.0"?>
 -- <oms:snapshot
 --   xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
@@ -517,6 +519,6 @@ oms_delete("model")
 -- info:      model.root.B.u      : 10.0
 -- info:      model.root.B.u1     : 1.0
 -- info:      model.root.B.z      : 1.0
--- info:    1 warnings
+-- info:    3 warnings
 -- info:    1 errors
 -- endResult

--- a/testsuite/simulation/replaceSubmodel6.py
+++ b/testsuite/simulation/replaceSubmodel6.py
@@ -3,7 +3,7 @@
 ## linux: no
 ## mingw32: no
 ## mingw64: yes
-## win: yes
+## win: no
 ## mac: no
 
 from OMSimulator import OMSimulator

--- a/testsuite/simulation/replaceSubmodel6.py
+++ b/testsuite/simulation/replaceSubmodel6.py
@@ -45,7 +45,7 @@ oms.delete("model")
 
 oms.importFile("replaceSubmodel6.ssp")
 
-oms.replaceSubModel("model.root.A", "../resources/replaceA_extended.fmu")
+oms.replaceSubModel("model.root.A", "../resources/replaceA_extended.fmu", False)
 src, status = oms.exportSnapshot("model")
 print(src)
 
@@ -81,6 +81,7 @@ oms.delete("model")
 ## Result:
 ## error:   [getVariable] Unknown signal "model.root.A.dummy"
 ## warning: deleting connection "A.dummy ==> B.u1", as signal "dummy" couldn't be resolved to any signal in the replaced submodel "../resources/replaceA_extended.fmu"
+## warning: deleting start value "A.t" in "inline" resources, because the identifier couldn't be resolved to any system signal in the replacing model
 ## <?xml version="1.0"?>
 ## <oms:snapshot
 ##   xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
@@ -550,6 +551,6 @@ oms.delete("model")
 ## info:      model.root.B.u      :  10.0
 ## info:      model.root.B.u1     :  -13.0
 ## info:      model.root.B.z      :  -15.0
-## info:    1 warnings
+## info:    2 warnings
 ## info:    1 errors
 ## endResult

--- a/testsuite/simulation/replaceSubmodel6.py
+++ b/testsuite/simulation/replaceSubmodel6.py
@@ -45,7 +45,9 @@ oms.delete("model")
 
 oms.importFile("replaceSubmodel6.ssp")
 
-oms.replaceSubModel("model.root.A", "../resources/replaceA_extended.fmu", False)
+count, status = oms.replaceSubModel("model.root.A", "../resources/replaceA_extended.fmu", False)
+## print("info:  warningCount  : " , count)
+
 src, status = oms.exportSnapshot("model")
 print(src)
 

--- a/testsuite/simulation/replaceSubmodel6.py
+++ b/testsuite/simulation/replaceSubmodel6.py
@@ -45,8 +45,7 @@ oms.delete("model")
 
 oms.importFile("replaceSubmodel6.ssp")
 
-count, status = oms.replaceSubModel("model.root.A", "../resources/replaceA_extended.fmu", False)
-## print("info:  warningCount  : " , count)
+oms.replaceSubModel("model.root.A", "../resources/replaceA_extended.fmu", False)
 
 src, status = oms.exportSnapshot("model")
 print(src)

--- a/testsuite/simulation/replaceSubmodel7.py
+++ b/testsuite/simulation/replaceSubmodel7.py
@@ -3,7 +3,7 @@
 ## linux: no
 ## mingw32: no
 ## mingw64: yes
-## win: yes
+## win: no
 ## mac: no
 
 from OMSimulator import OMSimulator

--- a/testsuite/simulation/replaceSubmodel7.py
+++ b/testsuite/simulation/replaceSubmodel7.py
@@ -47,7 +47,7 @@ oms.delete("model")
 
 oms.importFile("replaceSubmodel7.ssp")
 
-oms.replaceSubModel("model.root.A", "../resources/replaceA_extended.fmu")
+oms.replaceSubModel("model.root.A", "../resources/replaceA_extended.fmu", False)
 src, status = oms.exportSnapshot("model")
 print(src)
 
@@ -83,6 +83,7 @@ oms.delete("model")
 ## Result:
 ## error:   [getVariable] Unknown signal "model.root.A.dummy"
 ## warning: deleting connection "A.dummy ==> B.u1", as signal "dummy" couldn't be resolved to any signal in the replaced submodel "../resources/replaceA_extended.fmu"
+## warning: deleting start value "A.t" in "resources/root.ssv" resources, because the identifier couldn't be resolved to any system signal in the replacing model
 ## <?xml version="1.0"?>
 ## <oms:snapshot
 ##   xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
@@ -534,6 +535,6 @@ oms.delete("model")
 ## info:      model.root.B.u      :  10.0
 ## info:      model.root.B.u1     :  -13.0
 ## info:      model.root.B.z      :  -15.0
-## info:    1 warnings
+## info:    2 warnings
 ## info:    1 errors
 ## endResult

--- a/testsuite/simulation/replaceSubmodel8.lua
+++ b/testsuite/simulation/replaceSubmodel8.lua
@@ -3,7 +3,7 @@
 -- linux: no
 -- mingw32: no
 -- mingw64: yes
--- win: yes
+-- win: no
 -- mac: no
 
 oms_setCommandLineOption("--suppressPath=true")

--- a/testsuite/simulation/replaceSubmodel8.lua
+++ b/testsuite/simulation/replaceSubmodel8.lua
@@ -37,7 +37,7 @@ oms_delete("model")
 
 oms_importFile("replaceSubmodel8.ssp")
 
-oms_replaceSubModel("model.root.A", "../resources/replaceA_extended.fmu")
+oms_replaceSubModel("model.root.A", "../resources/replaceA_extended.fmu", false)
 src, status = oms_exportSnapshot("model")
 print(src)
 

--- a/testsuite/simulation/replaceSubmodel9.lua
+++ b/testsuite/simulation/replaceSubmodel9.lua
@@ -3,7 +3,7 @@
 -- linux: no
 -- mingw32: no
 -- mingw64: yes
--- win: yes
+-- win: no
 -- mac: no
 
 oms_setCommandLineOption("--suppressPath=true")

--- a/testsuite/simulation/replaceSubmodel9.lua
+++ b/testsuite/simulation/replaceSubmodel9.lua
@@ -1,0 +1,559 @@
+-- status: correct
+-- teardown_command: rm -rf replacesubmodel_09_lua/
+-- linux: no
+-- mingw32: no
+-- mingw64: yes
+-- win: yes
+-- mac: no
+
+oms_setCommandLineOption("--suppressPath=true")
+oms_setTempDirectory("./replacesubmodel_09_lua/")
+
+oms_newModel("model")
+
+oms_addSystem("model.root", oms_system_wc)
+
+oms_addSubModel("model.root.A", "../resources/replaceA.fmu")
+oms_addSubModel("model.root.B", "../resources/replaceB.fmu")
+
+oms_setReal("model.root.A.u", 10.0)
+oms_setReal("model.root.A.t", -10.0)
+oms_setReal("model.root.B.u1", -13.0)
+oms_setReal("model.root.B.z", -15.0)
+
+-- add connections
+oms_addConnection("model.root.A.y", "model.root.B.u")
+oms_addConnection("model.root.A.dummy", "model.root.B.u1")
+
+oms_setResultFile("model", "replaceSubmodel9.mat")
+
+src, status = oms_exportSnapshot("model")
+print(src)
+
+print("info:    Before replacing the Model")
+print("info:      model.root.A.u      : " .. oms_getReal("model.root.A.u"))
+print("info:      model.root.B.u      : " .. oms_getReal("model.root.B.u"))
+print("info:      model.root.B.u1     : " .. oms_getReal("model.root.B.u1"))
+print("info:      model.root.B.z      : " .. oms_getReal("model.root.B.z"))
+
+oms_export("model", "replaceSubmodel9.ssp")
+oms_terminate("model")
+oms_delete("model")
+
+oms_importFile("replaceSubmodel9.ssp")
+
+-- reimport the old snapshot and replacing is not done
+oms_replaceSubModel("model.root.A", "../resources/replaceA_extended.fmu", true)
+src, status = oms_exportSnapshot("model")
+print(src)
+
+print("info:    After replacing the Model")
+print("info:      model.root.A.u      : " .. oms_getReal("model.root.A.u"))
+print("info:      model.root.B.u      : " .. oms_getReal("model.root.B.u"))
+print("info:      model.root.B.u1     : " .. oms_getReal("model.root.B.u1"))
+print("info:      model.root.B.z      : " .. oms_getReal("model.root.B.z"))
+
+oms_instantiate("model")
+oms_initialize("model")
+
+print("info:    Initialize")
+print("info:      model.root.A.u      : " .. oms_getReal("model.root.A.u"))
+print("info:      model.root.A.y      : " .. oms_getReal("model.root.A.y"))
+print("info:      model.root.B.u      : " .. oms_getReal("model.root.B.u"))
+print("info:      model.root.B.u1     : " .. oms_getReal("model.root.B.u1"))
+print("info:      model.root.B.z      : " .. oms_getReal("model.root.B.z"))
+
+oms_simulate("model")
+
+print("info:    Simulate")
+print("info:      model.root.A.u      : " .. oms_getReal("model.root.A.u"))
+print("info:      model.root.A.y      : " .. oms_getReal("model.root.A.y"))
+print("info:      model.root.B.u      : " .. oms_getReal("model.root.B.u"))
+print("info:      model.root.B.u1     : " .. oms_getReal("model.root.B.u1"))
+print("info:      model.root.B.z      : " .. oms_getReal("model.root.B.z"))
+
+oms_terminate("model")
+oms_delete("model")
+
+-- Result:
+-- <?xml version="1.0"?>
+-- <oms:snapshot
+--   xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
+--   partial="false">
+--   <oms:file
+--     name="SystemStructure.ssd">
+--     <ssd:SystemStructureDescription
+--       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
+--       xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription"
+--       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
+--       xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping"
+--       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
+--       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
+--       name="model"
+--       version="1.0">
+--       <ssd:System
+--         name="root">
+--         <ssd:Elements>
+--           <ssd:Component
+--             name="B"
+--             type="application/x-fmu-sharedlibrary"
+--             source="resources/0002_B.fmu">
+--             <ssd:Connectors>
+--               <ssd:Connector
+--                 name="u"
+--                 kind="input">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="0.000000"
+--                   y="0.333333" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="u1"
+--                 kind="input">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="0.000000"
+--                   y="0.666667" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="y"
+--                 kind="output">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="1.000000"
+--                   y="0.500000" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="z"
+--                 kind="parameter">
+--                 <ssc:Real />
+--               </ssd:Connector>
+--             </ssd:Connectors>
+--             <ssd:ParameterBindings>
+--               <ssd:ParameterBinding>
+--                 <ssd:ParameterValues>
+--                   <ssv:ParameterSet
+--                     version="1.0"
+--                     name="parameters">
+--                     <ssv:Parameters>
+--                       <ssv:Parameter
+--                         name="z">
+--                         <ssv:Real
+--                           value="-15" />
+--                       </ssv:Parameter>
+--                       <ssv:Parameter
+--                         name="u1">
+--                         <ssv:Real
+--                           value="-13" />
+--                       </ssv:Parameter>
+--                     </ssv:Parameters>
+--                   </ssv:ParameterSet>
+--                 </ssd:ParameterValues>
+--               </ssd:ParameterBinding>
+--             </ssd:ParameterBindings>
+--           </ssd:Component>
+--           <ssd:Component
+--             name="A"
+--             type="application/x-fmu-sharedlibrary"
+--             source="resources/0001_A.fmu">
+--             <ssd:Connectors>
+--               <ssd:Connector
+--                 name="u"
+--                 kind="input">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="0.000000"
+--                   y="0.500000" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="dummy"
+--                 kind="output">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="1.000000"
+--                   y="0.333333" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="y"
+--                 kind="output">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="1.000000"
+--                   y="0.666667" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="t"
+--                 kind="parameter">
+--                 <ssc:Real />
+--               </ssd:Connector>
+--             </ssd:Connectors>
+--             <ssd:ParameterBindings>
+--               <ssd:ParameterBinding>
+--                 <ssd:ParameterValues>
+--                   <ssv:ParameterSet
+--                     version="1.0"
+--                     name="parameters">
+--                     <ssv:Parameters>
+--                       <ssv:Parameter
+--                         name="u">
+--                         <ssv:Real
+--                           value="10" />
+--                       </ssv:Parameter>
+--                       <ssv:Parameter
+--                         name="t">
+--                         <ssv:Real
+--                           value="-10" />
+--                       </ssv:Parameter>
+--                     </ssv:Parameters>
+--                   </ssv:ParameterSet>
+--                 </ssd:ParameterValues>
+--               </ssd:ParameterBinding>
+--             </ssd:ParameterBindings>
+--           </ssd:Component>
+--         </ssd:Elements>
+--         <ssd:Connections>
+--           <ssd:Connection
+--             startElement="A"
+--             startConnector="y"
+--             endElement="B"
+--             endConnector="u" />
+--           <ssd:Connection
+--             startElement="A"
+--             startConnector="dummy"
+--             endElement="B"
+--             endConnector="u1" />
+--         </ssd:Connections>
+--         <ssd:Annotations>
+--           <ssc:Annotation
+--             type="org.openmodelica">
+--             <oms:Annotations>
+--               <oms:SimulationInformation>
+--                 <oms:FixedStepMaster
+--                   description="oms-ma"
+--                   stepSize="0.001000"
+--                   absoluteTolerance="0.000100"
+--                   relativeTolerance="0.000100" />
+--               </oms:SimulationInformation>
+--             </oms:Annotations>
+--           </ssc:Annotation>
+--         </ssd:Annotations>
+--       </ssd:System>
+--       <ssd:DefaultExperiment
+--         startTime="0.000000"
+--         stopTime="1.000000">
+--         <ssd:Annotations>
+--           <ssc:Annotation
+--             type="org.openmodelica">
+--             <oms:Annotations>
+--               <oms:SimulationInformation
+--                 resultFile="replaceSubmodel9.mat"
+--                 loggingInterval="0.000000"
+--                 bufferSize="1"
+--                 signalFilter="resources/signalFilter.xml" />
+--             </oms:Annotations>
+--           </ssc:Annotation>
+--         </ssd:Annotations>
+--       </ssd:DefaultExperiment>
+--     </ssd:SystemStructureDescription>
+--   </oms:file>
+--   <oms:file
+--     name="resources/signalFilter.xml">
+--     <oms:SignalFilter
+--       version="1.0">
+--       <oms:Variable
+--         name="model.root.B.u"
+--         type="Real"
+--         kind="input" />
+--       <oms:Variable
+--         name="model.root.B.u1"
+--         type="Real"
+--         kind="input" />
+--       <oms:Variable
+--         name="model.root.B.y"
+--         type="Real"
+--         kind="output" />
+--       <oms:Variable
+--         name="model.root.B.z"
+--         type="Real"
+--         kind="parameter" />
+--       <oms:Variable
+--         name="model.root.A.x"
+--         type="Real"
+--         kind="unknown" />
+--       <oms:Variable
+--         name="model.root.A.der(x)"
+--         type="Real"
+--         kind="unknown" />
+--       <oms:Variable
+--         name="model.root.A.dummy"
+--         type="Real"
+--         kind="output" />
+--       <oms:Variable
+--         name="model.root.A.u"
+--         type="Real"
+--         kind="input" />
+--       <oms:Variable
+--         name="model.root.A.y"
+--         type="Real"
+--         kind="output" />
+--       <oms:Variable
+--         name="model.root.A.t"
+--         type="Real"
+--         kind="parameter" />
+--     </oms:SignalFilter>
+--   </oms:file>
+-- </oms:snapshot>
+--
+-- info:    Before replacing the Model
+-- info:      model.root.A.u      : 10.0
+-- info:      model.root.B.u      : 1.0
+-- info:      model.root.B.u1     : -13.0
+-- info:      model.root.B.z      : -15.0
+-- error:   [getVariable] Unknown signal "model.root.A.dummy"
+-- warning: deleting connection "A.dummy ==> B.u1", as signal "dummy" couldn't be resolved to any signal in the replaced submodel "../resources/replaceA_extended.fmu"
+-- warning: deleting start value "A.t" in "inline" resources, because the identifier couldn't be resolved to any system signal in the replacing model
+-- <?xml version="1.0"?>
+-- <oms:snapshot
+--   xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
+--   partial="false">
+--   <oms:file
+--     name="SystemStructure.ssd">
+--     <ssd:SystemStructureDescription
+--       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
+--       xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription"
+--       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
+--       xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping"
+--       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
+--       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
+--       name="model"
+--       version="1.0">
+--       <ssd:System
+--         name="root">
+--         <ssd:Elements>
+--           <ssd:Component
+--             name="B"
+--             type="application/x-fmu-sharedlibrary"
+--             source="resources/0002_B.fmu">
+--             <ssd:Connectors>
+--               <ssd:Connector
+--                 name="u"
+--                 kind="input">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="0.000000"
+--                   y="0.333333" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="u1"
+--                 kind="input">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="0.000000"
+--                   y="0.666667" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="y"
+--                 kind="output">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="1.000000"
+--                   y="0.500000" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="z"
+--                 kind="parameter">
+--                 <ssc:Real />
+--               </ssd:Connector>
+--             </ssd:Connectors>
+--             <ssd:ParameterBindings>
+--               <ssd:ParameterBinding>
+--                 <ssd:ParameterValues>
+--                   <ssv:ParameterSet
+--                     version="1.0"
+--                     name="parameters">
+--                     <ssv:Parameters>
+--                       <ssv:Parameter
+--                         name="z">
+--                         <ssv:Real
+--                           value="-15" />
+--                       </ssv:Parameter>
+--                       <ssv:Parameter
+--                         name="u1">
+--                         <ssv:Real
+--                           value="-13" />
+--                       </ssv:Parameter>
+--                     </ssv:Parameters>
+--                   </ssv:ParameterSet>
+--                 </ssd:ParameterValues>
+--               </ssd:ParameterBinding>
+--             </ssd:ParameterBindings>
+--           </ssd:Component>
+--           <ssd:Component
+--             name="A"
+--             type="application/x-fmu-sharedlibrary"
+--             source="resources/0001_A.fmu">
+--             <ssd:Connectors>
+--               <ssd:Connector
+--                 name="u"
+--                 kind="input">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="0.000000"
+--                   y="0.500000" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="dummy"
+--                 kind="output">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="1.000000"
+--                   y="0.333333" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="y"
+--                 kind="output">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="1.000000"
+--                   y="0.666667" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="t"
+--                 kind="parameter">
+--                 <ssc:Real />
+--               </ssd:Connector>
+--             </ssd:Connectors>
+--             <ssd:ParameterBindings>
+--               <ssd:ParameterBinding>
+--                 <ssd:ParameterValues>
+--                   <ssv:ParameterSet
+--                     version="1.0"
+--                     name="parameters">
+--                     <ssv:Parameters>
+--                       <ssv:Parameter
+--                         name="u">
+--                         <ssv:Real
+--                           value="10" />
+--                       </ssv:Parameter>
+--                       <ssv:Parameter
+--                         name="t">
+--                         <ssv:Real
+--                           value="-10" />
+--                       </ssv:Parameter>
+--                     </ssv:Parameters>
+--                   </ssv:ParameterSet>
+--                 </ssd:ParameterValues>
+--               </ssd:ParameterBinding>
+--             </ssd:ParameterBindings>
+--           </ssd:Component>
+--         </ssd:Elements>
+--         <ssd:Connections>
+--           <ssd:Connection
+--             startElement="A"
+--             startConnector="y"
+--             endElement="B"
+--             endConnector="u" />
+--           <ssd:Connection
+--             startElement="A"
+--             startConnector="dummy"
+--             endElement="B"
+--             endConnector="u1" />
+--         </ssd:Connections>
+--         <ssd:Annotations>
+--           <ssc:Annotation
+--             type="org.openmodelica">
+--             <oms:Annotations>
+--               <oms:SimulationInformation>
+--                 <oms:FixedStepMaster
+--                   description="oms-ma"
+--                   stepSize="0.001000"
+--                   absoluteTolerance="0.000100"
+--                   relativeTolerance="0.000100" />
+--               </oms:SimulationInformation>
+--             </oms:Annotations>
+--           </ssc:Annotation>
+--         </ssd:Annotations>
+--       </ssd:System>
+--       <ssd:DefaultExperiment
+--         startTime="0.000000"
+--         stopTime="1.000000">
+--         <ssd:Annotations>
+--           <ssc:Annotation
+--             type="org.openmodelica">
+--             <oms:Annotations>
+--               <oms:SimulationInformation
+--                 resultFile="replaceSubmodel9.mat"
+--                 loggingInterval="0.000000"
+--                 bufferSize="1"
+--                 signalFilter="resources/signalFilter.xml" />
+--             </oms:Annotations>
+--           </ssc:Annotation>
+--         </ssd:Annotations>
+--       </ssd:DefaultExperiment>
+--     </ssd:SystemStructureDescription>
+--   </oms:file>
+--   <oms:file
+--     name="resources/signalFilter.xml">
+--     <oms:SignalFilter
+--       version="1.0">
+--       <oms:Variable
+--         name="model.root.B.u"
+--         type="Real"
+--         kind="input" />
+--       <oms:Variable
+--         name="model.root.B.u1"
+--         type="Real"
+--         kind="input" />
+--       <oms:Variable
+--         name="model.root.B.y"
+--         type="Real"
+--         kind="output" />
+--       <oms:Variable
+--         name="model.root.B.z"
+--         type="Real"
+--         kind="parameter" />
+--       <oms:Variable
+--         name="model.root.A.x"
+--         type="Real"
+--         kind="unknown" />
+--       <oms:Variable
+--         name="model.root.A.dummy"
+--         type="Real"
+--         kind="output" />
+--       <oms:Variable
+--         name="model.root.A.u"
+--         type="Real"
+--         kind="input" />
+--       <oms:Variable
+--         name="model.root.A.y"
+--         type="Real"
+--         kind="output" />
+--       <oms:Variable
+--         name="model.root.A.t"
+--         type="Real"
+--         kind="parameter" />
+--     </oms:SignalFilter>
+--   </oms:file>
+-- </oms:snapshot>
+--
+-- info:    After replacing the Model
+-- info:      model.root.A.u      : 10.0
+-- info:      model.root.B.u      : 1.0
+-- info:      model.root.B.u1     : -13.0
+-- info:      model.root.B.z      : -15.0
+-- info:    Result file: replaceSubmodel9.mat (bufferSize=1)
+-- info:    Initialize
+-- info:      model.root.A.u      : 10.0
+-- info:      model.root.A.y      : 10.0
+-- info:      model.root.B.u      : 10.0
+-- info:      model.root.B.u1     : 10.0
+-- info:      model.root.B.z      : -15.0
+-- info:    Simulate
+-- info:      model.root.A.u      : 10.0
+-- info:      model.root.A.y      : 10.0
+-- info:      model.root.B.u      : 10.0
+-- info:      model.root.B.u1     : 10.0
+-- info:      model.root.B.z      : -15.0
+-- info:    2 warnings
+-- info:    1 errors
+-- endResult


### PR DESCRIPTION
### Purpose

This PR displays warning messages to users when `replacingSubModel` and also extends the API `oms_replaceSubModel` which allows the users to set true or false when replacing the subModel 

```
oms_status_enu_t oms_replaceSubModel(const char* cref, const char* fmuPath, bool replaceSubModel)
if (replaceSubModel==true)
  showwarnings, reimport the snapshot and replacing is not done
else
  show warnings and replace is done
```
