### PR TITLE
implement oms_duplicateVariant()

### DIFF
--- a/src/OMSimulatorLib/Component.h
+++ b/src/OMSimulatorLib/Component.h
@@ -63,7 +63,7 @@ namespace oms
     virtual ~Component();
 
     virtual oms_status_enu_t addSignalsToResults(const char* regex) = 0;
-    virtual oms_status_enu_t exportToSSD(pugi::xml_node& node, Snapshot& snapshot) const = 0;
+    virtual oms_status_enu_t exportToSSD(pugi::xml_node& node, Snapshot& snapshot, std::string variantName) const = 0;
     virtual oms_status_enu_t exportToSSV(pugi::xml_node& ssvNode) { return logError_NotImplemented; }
     virtual void getFilteredUnitDefinitionsToSSD(std::map<std::string, std::map<std::string, std::string>>& unitDefinitions) { return ; }
 

--- a/src/OMSimulatorLib/ComponentFMUCS.cpp
+++ b/src/OMSimulatorLib/ComponentFMUCS.cpp
@@ -394,7 +394,7 @@ oms_status_enu_t oms::ComponentFMUCS::exportToSSD(pugi::xml_node& node, Snapshot
         return oms_status_error;
 
   // export ParameterBindings at component level
-  values.exportParameterBindings(node, snapshot);
+  values.exportParameterBindings(node, snapshot, getParentSystem()->getModel().getVariantName());
 
   return oms_status_ok;
 }

--- a/src/OMSimulatorLib/ComponentFMUCS.cpp
+++ b/src/OMSimulatorLib/ComponentFMUCS.cpp
@@ -366,7 +366,7 @@ oms::Component* oms::ComponentFMUCS::NewComponent(const pugi::xml_node& node, om
   return component;
 }
 
-oms_status_enu_t oms::ComponentFMUCS::exportToSSD(pugi::xml_node& node, Snapshot& snapshot) const
+oms_status_enu_t oms::ComponentFMUCS::exportToSSD(pugi::xml_node& node, Snapshot& snapshot, std::string variantName) const
 {
 #if !defined(NO_TLM)
   if (tlmbusconnectors[0])
@@ -394,7 +394,7 @@ oms_status_enu_t oms::ComponentFMUCS::exportToSSD(pugi::xml_node& node, Snapshot
         return oms_status_error;
 
   // export ParameterBindings at component level
-  values.exportParameterBindings(node, snapshot, getParentSystem()->getModel().getVariantName());
+  values.exportParameterBindings(node, snapshot, variantName);
 
   return oms_status_ok;
 }

--- a/src/OMSimulatorLib/ComponentFMUCS.h
+++ b/src/OMSimulatorLib/ComponentFMUCS.h
@@ -60,7 +60,7 @@ namespace oms
     static Component* NewComponent(const pugi::xml_node& node, System* parentSystem, const std::string& sspVersion, const Snapshot& snapshot);
     const FMUInfo* getFMUInfo() const {return &(this->fmuInfo);}
 
-    oms_status_enu_t exportToSSD(pugi::xml_node& node, Snapshot& snapshot) const;
+    oms_status_enu_t exportToSSD(pugi::xml_node& node, Snapshot& snapshot, std::string variantName) const;
     oms_status_enu_t exportToSSV(pugi::xml_node& ssvNode);
     void getFilteredUnitDefinitionsToSSD(std::map<std::string, std::map<std::string, std::string>>& unitDefinitions);
     oms_status_enu_t exportToSSVTemplate(pugi::xml_node& ssvNode, Snapshot& snapshot);

--- a/src/OMSimulatorLib/ComponentFMUME.cpp
+++ b/src/OMSimulatorLib/ComponentFMUME.cpp
@@ -367,7 +367,7 @@ oms::Component* oms::ComponentFMUME::NewComponent(const pugi::xml_node& node, om
   return component;
 }
 
-oms_status_enu_t oms::ComponentFMUME::exportToSSD(pugi::xml_node& node, Snapshot& snapshot) const
+oms_status_enu_t oms::ComponentFMUME::exportToSSD(pugi::xml_node& node, Snapshot& snapshot, std::string variantName) const
 {
 #if !defined(NO_TLM)
   if (tlmbusconnectors[0])
@@ -395,7 +395,7 @@ oms_status_enu_t oms::ComponentFMUME::exportToSSD(pugi::xml_node& node, Snapshot
         return oms_status_error;
 
   // export ParameterBindings at component level
-  values.exportParameterBindings(node, snapshot, getParentSystem()->getModel().getVariantName());
+  values.exportParameterBindings(node, snapshot, variantName);
 
   return oms_status_ok;
 }

--- a/src/OMSimulatorLib/ComponentFMUME.cpp
+++ b/src/OMSimulatorLib/ComponentFMUME.cpp
@@ -395,7 +395,7 @@ oms_status_enu_t oms::ComponentFMUME::exportToSSD(pugi::xml_node& node, Snapshot
         return oms_status_error;
 
   // export ParameterBindings at component level
-  values.exportParameterBindings(node, snapshot);
+  values.exportParameterBindings(node, snapshot, getParentSystem()->getModel().getVariantName());
 
   return oms_status_ok;
 }

--- a/src/OMSimulatorLib/ComponentFMUME.h
+++ b/src/OMSimulatorLib/ComponentFMUME.h
@@ -57,7 +57,7 @@ namespace oms
     static Component* NewComponent(const pugi::xml_node& node, System* parentSystem,  const std::string& sspVersion, const Snapshot& snapshot);
     const FMUInfo* getFMUInfo() const {return &(this->fmuInfo);}
 
-    oms_status_enu_t exportToSSD(pugi::xml_node& node, Snapshot& snapshot) const;
+    oms_status_enu_t exportToSSD(pugi::xml_node& node, Snapshot& snapshot, std::string variantName) const;
     oms_status_enu_t exportToSSV(pugi::xml_node& ssvNode);
     void getFilteredUnitDefinitionsToSSD(std::map<std::string, std::map<std::string, std::string>>& unitDefinitions);
     oms_status_enu_t exportToSSVTemplate(pugi::xml_node& ssvNode, Snapshot& snapshot);

--- a/src/OMSimulatorLib/ComponentTable.cpp
+++ b/src/OMSimulatorLib/ComponentTable.cpp
@@ -161,7 +161,7 @@ oms::Component* oms::ComponentTable::NewComponent(const pugi::xml_node& node, om
   return component;
 }
 
-oms_status_enu_t oms::ComponentTable::exportToSSD(pugi::xml_node& node, Snapshot& snapshot) const
+oms_status_enu_t oms::ComponentTable::exportToSSD(pugi::xml_node& node, Snapshot& snapshot, std::string variantName) const
 {
   node.append_attribute("name") = this->getCref().c_str();
   node.append_attribute("type") = "application/table";

--- a/src/OMSimulatorLib/ComponentTable.h
+++ b/src/OMSimulatorLib/ComponentTable.h
@@ -55,7 +55,7 @@ namespace oms
     static Component* NewComponent(const oms::ComRef& cref, System* parentSystem, const std::string& path);
     static Component* NewComponent(const pugi::xml_node& node, System* parentSystem, const std::string& sspVersion, const Snapshot& snapshot);
 
-    oms_status_enu_t exportToSSD(pugi::xml_node& node, Snapshot& snapshot) const;
+    oms_status_enu_t exportToSSD(pugi::xml_node& node, Snapshot& snapshot, std::string variantName) const;
     oms_status_enu_t exportToSSVTemplate(pugi::xml_node& ssvNode) {return oms_status_ok;}
     oms_status_enu_t exportToSSMTemplate(pugi::xml_node& ssmNode) {return oms_status_ok;}
     oms_status_enu_t instantiate();

--- a/src/OMSimulatorLib/Model.cpp
+++ b/src/OMSimulatorLib/Model.cpp
@@ -200,7 +200,7 @@ oms_status_enu_t oms::Model::duplicateVariant(const ComRef& crefA, const ComRef&
 
   // set the current variantName
   this->variantName = std::string(crefB) + ".ssd";
-
+  this->signalFilterFilename = "resources/signalFilter_" + std::string(crefB) + ".xml";
   return oms_status_ok;
 }
 

--- a/src/OMSimulatorLib/Model.cpp
+++ b/src/OMSimulatorLib/Model.cpp
@@ -360,7 +360,7 @@ oms_status_enu_t oms::Model::list(const oms::ComRef& cref, char** contents)
       pugi::xml_node ssdNode = snapshot.getTemplateResourceNodeSSD("SystemStructure.ssd", this->getCref());
       pugi::xml_node system_node = ssdNode.append_child(oms::ssp::Draft20180219::ssd::system);
 
-      subsystem->exportToSSD(system_node, snapshot);
+      subsystem->exportToSSD(system_node, snapshot, this->variantName);
       doc.append_copy(snapshot.getResourceNode("SystemStructure.ssd").first_child());
     }
     else
@@ -373,7 +373,7 @@ oms_status_enu_t oms::Model::list(const oms::ComRef& cref, char** contents)
       pugi::xml_node ssdNode = snapshot.getTemplateResourceNodeSSD("SystemStructure.ssd", this->getCref());
       pugi::xml_node system_node = ssdNode.append_child(oms::ssp::Draft20180219::ssd::system);
 
-      component->exportToSSD(system_node, snapshot);
+      component->exportToSSD(system_node, snapshot, this->variantName);
       doc.append_copy(snapshot.getResourceNode("SystemStructure.ssd").first_child());
     }
   }
@@ -725,7 +725,7 @@ oms_status_enu_t oms::Model::exportToSSD(Snapshot& snapshot) const
   if (system)
   {
     pugi::xml_node system_node = ssdNode.append_child(oms::ssp::Draft20180219::ssd::system);
-    if (oms_status_ok != system->exportToSSD(system_node, snapshot))
+    if (oms_status_ok != system->exportToSSD(system_node, snapshot, this->variantName))
       return logError("export of system failed");
   }
 

--- a/src/OMSimulatorLib/Model.h
+++ b/src/OMSimulatorLib/Model.h
@@ -138,6 +138,8 @@ namespace oms
 
     std::vector<char*> listVariants;  ///< list of all variants copied when user create a new variant using oms_duplicateVariant()
 
+    std::string getVariantName() {return variantName;}
+
   private: // methods
     Model(const ComRef& cref, const std::string& tempDir);
 

--- a/src/OMSimulatorLib/Model.h
+++ b/src/OMSimulatorLib/Model.h
@@ -78,6 +78,7 @@ namespace oms
     oms_status_enu_t addResources(const ComRef& cref, const std::string& path);
     oms_status_enu_t deleteReferencesInSSD(const ComRef& cref);
     oms_status_enu_t deleteResourcesInSSP(const std::string& filename);
+    oms_status_enu_t duplicateVariant(const ComRef& crefA, const ComRef& crefB);
     oms_status_enu_t referenceResources(const ComRef& cref, const std::string& ssmFile);
     oms_status_enu_t reduceSSV(const std::string& ssvfile, const std::string& ssmfile, const std::string& filepath);
     oms_status_enu_t exportToSSD(Snapshot& snapshot) const;
@@ -135,6 +136,8 @@ namespace oms
 
     std::vector<std::string> importedResources;  ///< list of imported resources from ssp
 
+    std::vector<char*> listVariants;  ///< list of all variants copied when user create a new variant using oms_duplicateVariant()
+
   private: // methods
     Model(const ComRef& cref, const std::string& tempDir);
 
@@ -168,6 +171,8 @@ namespace oms
 
     std::string resultFilename; ///< default <name>_res.mat
     std::string signalFilterFilename = "resources/signalFilter.xml";
+
+    std::string variantName = "SystemStructure.ssd";  ///< default name
 
     std::vector<std::string> externalResources;  ///< list of external ssv or ssm resources from filesystem
 

--- a/src/OMSimulatorLib/OMSimulator.cpp
+++ b/src/OMSimulatorLib/OMSimulator.cpp
@@ -916,6 +916,25 @@ oms_status_enu_t oms_addSubModel(const char* cref, const char* fmuPath)
   return system->addSubModel(tail, fmuPath);
 }
 
+oms_status_enu_t oms_duplicateVariant(const char* crefA, const char* crefB)
+{
+  oms::ComRef tail(crefA);
+  oms::ComRef front = tail.pop_front();
+
+  oms::Model* model = oms::Scope::GetInstance().getModel(front);
+  if (!model)
+    return logError_ModelNotInScope(front);
+
+  return model->duplicateVariant(tail, crefB);
+
+  // front = tail.pop_front();
+  // oms::System* system = model->getSystem(front);
+  // if (!system)
+  //   return logError_SystemNotInModel(model->getCref(), front);
+
+  // return system->addSubModel(tail, crefB);
+}
+
 oms_status_enu_t oms_replaceSubModel(const char* cref, const char* fmuPath, bool dryRun, int* warningCount)
 {
   oms::ComRef tail(cref);

--- a/src/OMSimulatorLib/OMSimulator.cpp
+++ b/src/OMSimulatorLib/OMSimulator.cpp
@@ -927,12 +927,6 @@ oms_status_enu_t oms_duplicateVariant(const char* crefA, const char* crefB)
 
   return model->duplicateVariant(tail, crefB);
 
-  // front = tail.pop_front();
-  // oms::System* system = model->getSystem(front);
-  // if (!system)
-  //   return logError_SystemNotInModel(model->getCref(), front);
-
-  // return system->addSubModel(tail, crefB);
 }
 
 oms_status_enu_t oms_replaceSubModel(const char* cref, const char* fmuPath, bool dryRun, int* warningCount)

--- a/src/OMSimulatorLib/OMSimulator.h
+++ b/src/OMSimulatorLib/OMSimulator.h
@@ -82,6 +82,7 @@ OMSAPI oms_status_enu_t OMSCALL oms_deleteConnectorFromBus(const char* busCref, 
 OMSAPI oms_status_enu_t OMSCALL oms_deleteConnectorFromTLMBus(const char* busCref, const char* connectorCref);
 OMSAPI oms_status_enu_t OMSCALL oms_deleteResources(const char* cref);
 OMSAPI oms_status_enu_t OMSCALL oms_doStep(const char* cref);
+OMSAPI oms_status_enu_t OMSCALL oms_duplicateVariant(const char* crefA, const char* crefB);
 OMSAPI oms_status_enu_t OMSCALL oms_export(const char* cref, const char* filename);
 OMSAPI oms_status_enu_t OMSCALL oms_exportDependencyGraphs(const char* cref, const char* initialization, const char* event, const char* simulation);
 OMSAPI oms_status_enu_t OMSCALL oms_exportSnapshot(const char* cref, char** contents);

--- a/src/OMSimulatorLib/System.cpp
+++ b/src/OMSimulatorLib/System.cpp
@@ -678,7 +678,14 @@ oms_status_enu_t oms::System::exportToSSD(pugi::xml_node& node, Snapshot& snapsh
     }
   }
 
-  values.exportParameterBindings(node, snapshot, parentModel->getVariantName());
+  // get variant name
+  std::string variantName = "";
+  if (parentModel)
+    variantName = parentModel->getVariantName();
+  else
+    variantName = parentSystem->parentModel->getVariantName();
+
+  values.exportParameterBindings(node, snapshot, variantName);
 
   if (subelements.size() > 1)
   {

--- a/src/OMSimulatorLib/System.cpp
+++ b/src/OMSimulatorLib/System.cpp
@@ -660,7 +660,7 @@ oms_status_enu_t oms::System::listUnconnectedConnectors(char** contents) const
   return oms_status_ok;
 }
 
-oms_status_enu_t oms::System::exportToSSD(pugi::xml_node& node, Snapshot& snapshot) const
+oms_status_enu_t oms::System::exportToSSD(pugi::xml_node& node, Snapshot& snapshot, std::string variantName) const
 {
   node.append_attribute("name") = this->getCref().c_str();
 
@@ -678,12 +678,12 @@ oms_status_enu_t oms::System::exportToSSD(pugi::xml_node& node, Snapshot& snapsh
     }
   }
 
-  // get variant name
-  std::string variantName = "";
-  if (parentModel)
-    variantName = parentModel->getVariantName();
-  else
-    variantName = parentSystem->parentModel->getVariantName();
+  // // get variant name
+  // std::string variantName = "";
+  // if (parentModel)
+  //   variantName = parentModel->getVariantName();
+  // else
+  //   variantName = parentSystem->parentModel->getVariantName();
 
   values.exportParameterBindings(node, snapshot, variantName);
 
@@ -693,13 +693,13 @@ oms_status_enu_t oms::System::exportToSSD(pugi::xml_node& node, Snapshot& snapsh
     for (const auto& subsystem : subsystems)
     {
       pugi::xml_node system_node = elements_node.append_child(oms::ssp::Draft20180219::ssd::system);
-      if (oms_status_ok != subsystem.second->exportToSSD(system_node, snapshot))
+      if (oms_status_ok != subsystem.second->exportToSSD(system_node, snapshot, variantName))
         return logError("export of system failed");
     }
     for (const auto& component : components)
     {
       pugi::xml_node component_node = elements_node.append_child(oms::ssp::Draft20180219::ssd::component);
-      if (oms_status_ok != component.second->exportToSSD(component_node, snapshot))
+      if (oms_status_ok != component.second->exportToSSD(component_node, snapshot, variantName))
         return logError("export of component failed");
     }
   }

--- a/src/OMSimulatorLib/System.cpp
+++ b/src/OMSimulatorLib/System.cpp
@@ -678,7 +678,7 @@ oms_status_enu_t oms::System::exportToSSD(pugi::xml_node& node, Snapshot& snapsh
     }
   }
 
-  values.exportParameterBindings(node, snapshot);
+  values.exportParameterBindings(node, snapshot, parentModel->getVariantName());
 
   if (subelements.size() > 1)
   {

--- a/src/OMSimulatorLib/System.h
+++ b/src/OMSimulatorLib/System.h
@@ -98,7 +98,7 @@ namespace oms
     oms_status_enu_t replaceSubModel(const ComRef& cref, const std::string& fmuPath, bool dryRun, int& warningCount);
     bool isValidScalarVariable(Component* referenceComponent, Component* replacingComponent, Connection* connection, const ComRef& crefA, const ComRef& crefB, const ComRef& signalName, const std::string& path, std::vector<std::string>& warningList);
     bool validCref(const ComRef& cref);
-    oms_status_enu_t exportToSSD(pugi::xml_node& node, Snapshot& snapshot) const;
+    oms_status_enu_t exportToSSD(pugi::xml_node& node, Snapshot& snapshot, std::string variantName) const;
     oms_status_enu_t exportToSSV(Snapshot& snapshot) const;
     oms_status_enu_t importFromSnapshot(const pugi::xml_node& node, const std::string& sspVersion, const Snapshot& snapshot);
     void setGeometry(const ssd::ElementGeometry& geometry) {element.setGeometry(&geometry);}

--- a/src/OMSimulatorLib/TLM/ExternalModel.cpp
+++ b/src/OMSimulatorLib/TLM/ExternalModel.cpp
@@ -87,7 +87,7 @@ oms_status_enu_t oms::ExternalModel::getRealParameter(const std::string& var, do
   return oms_status_error;
 }
 
-oms_status_enu_t oms::ExternalModel::exportToSSD(pugi::xml_node& node, Snapshot& snapshot) const
+oms_status_enu_t oms::ExternalModel::exportToSSD(pugi::xml_node& node, Snapshot& snapshot, std::string variantName) const
 {
   pugi::xml_node annotations_node = node.append_child(oms::ssp::Draft20180219::ssd::annotations);
   pugi::xml_node annotation_node = annotations_node.append_child(oms::ssp::Version1_0::ssc::annotation);

--- a/src/OMSimulatorLib/TLM/ExternalModel.h
+++ b/src/OMSimulatorLib/TLM/ExternalModel.h
@@ -60,7 +60,7 @@ namespace oms
     const std::string getStartScript() const {return externalModelInfo.getStartScript();}
     const std::map<std::string, oms::Option<double>>& getRealParameters() const {return realParameters;}
 
-    oms_status_enu_t exportToSSD(pugi::xml_node& node, Snapshot& snapshot) const;
+    oms_status_enu_t exportToSSD(pugi::xml_node& node, Snapshot& snapshot, std::string variantName) const;
     oms_status_enu_t instantiate();
     oms_status_enu_t initialize();
     oms_status_enu_t terminate();

--- a/src/OMSimulatorLib/Values.h
+++ b/src/OMSimulatorLib/Values.h
@@ -112,7 +112,7 @@ namespace oms
     oms_status_enu_t rename(const oms::ComRef& oldCref, const oms::ComRef& newCref);
     oms_status_enu_t renameInResources(const oms::ComRef& oldCref, const oms::ComRef& newCref);
 
-    void exportParameterBindings(pugi::xml_node& node, Snapshot& snapshot) const;
+    void exportParameterBindings(pugi::xml_node& node, Snapshot& snapshot, std::string variantName) const;
 
     bool hasResources(); ///< returns if the system or subsystem or submodule have parameter resources either as ssv or inline
 

--- a/src/OMSimulatorLua/OMSimulatorLua.c
+++ b/src/OMSimulatorLua/OMSimulatorLua.c
@@ -1133,6 +1133,30 @@ static int OMSimulatorLua_oms_addSubModel(lua_State *L)
   return 1;
 }
 
+//oms_status_enu_t oms_duplicateVariant(const char* crefA, const char* crefB)
+static int OMSimulatorLua_oms_duplicateVariant(lua_State *L)
+{
+  if (lua_gettop(L) != 2)
+    return luaL_error(L, "expecting exactly 2 arguments");
+  luaL_checktype(L, 1, LUA_TSTRING);
+  luaL_checktype(L, 2, LUA_TSTRING);
+
+  const char* crefA = lua_tostring(L, 1);
+  const char* crefB = lua_tostring(L, 2);
+
+
+  oms_status_enu_t status = oms_duplicateVariant(crefA, crefB);
+
+  if (status!=oms_status_ok)
+  {
+    return luaL_error(L, "oms_duplicateVariant(%s,%s) failed", crefA, crefB);
+  }
+
+  lua_pushinteger(L, status);
+
+  return 1;
+}
+
 //oms_status_enu_t oms_replaceSubModel(const char* cref, const char* fmuPath, bool dryRun);
 static int OMSimulatorLua_oms_replaceSubModel(lua_State *L)
 {
@@ -1475,6 +1499,7 @@ DLLEXPORT int luaopen_OMSimulatorLua(lua_State *L)
   REGISTER_LUA_CALL(oms_deleteConnectorFromBus);
   REGISTER_LUA_CALL(oms_deleteConnectorFromTLMBus);
   REGISTER_LUA_CALL(oms_deleteResources);
+  REGISTER_LUA_CALL(oms_duplicateVariant);
   REGISTER_LUA_CALL(oms_export);
   REGISTER_LUA_CALL(oms_exportDependencyGraphs);
   REGISTER_LUA_CALL(oms_exportSnapshot);

--- a/testsuite/simulation/Makefile
+++ b/testsuite/simulation/Makefile
@@ -9,6 +9,7 @@ deleteStartValues.lua \
 deleteStartValuesInSSV.lua \
 deleteStartValuesInSSV1.lua \
 deleteStartValuesInSSV2.lua \
+duplicateVariant1.lua \
 DualMassOscillator.lua \
 Enumeration.lua \
 Enumeration2.lua \

--- a/testsuite/simulation/Makefile
+++ b/testsuite/simulation/Makefile
@@ -11,6 +11,7 @@ deleteStartValuesInSSV1.lua \
 deleteStartValuesInSSV2.lua \
 duplicateVariant1.lua \
 duplicateVariant2.lua \
+duplicateVariant3.lua \
 DualMassOscillator.lua \
 Enumeration.lua \
 Enumeration2.lua \

--- a/testsuite/simulation/Makefile
+++ b/testsuite/simulation/Makefile
@@ -10,6 +10,7 @@ deleteStartValuesInSSV.lua \
 deleteStartValuesInSSV1.lua \
 deleteStartValuesInSSV2.lua \
 duplicateVariant1.lua \
+duplicateVariant2.lua \
 DualMassOscillator.lua \
 Enumeration.lua \
 Enumeration2.lua \

--- a/testsuite/simulation/duplicateVariant1.lua
+++ b/testsuite/simulation/duplicateVariant1.lua
@@ -1,0 +1,431 @@
+-- status: correct
+-- teardown_command: rm -rf duplicatevariant_01_lua/
+-- linux: yes
+-- mingw32: no
+-- mingw64: yes
+-- win: no
+-- mac: no
+
+oms_setCommandLineOption("--suppressPath=true")
+oms_setTempDirectory("./duplicatevariant_01_lua/")
+
+oms_newModel("model")
+
+oms_addSystem("model.root", oms_system_wc)
+
+oms_addSubModel("model.root.A", "../resources/Modelica.Blocks.Math.Gain.fmu")
+oms_setReal("model.root.A.k", 10)
+
+-- export SystemStructure.ssd
+src, status = oms_exportSnapshot("model")
+print(src)
+
+oms_duplicateVariant("model", "varA")
+oms_setReal("model.root.A.u", -10)
+
+-- export varA.ssd
+src, status = oms_exportSnapshot("model")
+print(src)
+
+oms_duplicateVariant("model", "varB")
+oms_setReal("model.root.A.u", -13)
+oms_setReal("model.root.A.k", -100)
+
+oms_setResultFile("model", "duplicatevariant1.mat")
+
+-- export varB.ssd
+src, status = oms_exportSnapshot("model")
+print(src)
+
+oms_export("model", "multiVariant1.ssp")
+
+oms_terminate("model")
+oms_delete("model")
+
+-- Result:
+-- <?xml version="1.0"?>
+-- <oms:snapshot
+--   xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
+--   partial="false">
+--   <oms:file
+--     name="SystemStructure.ssd">
+--     <ssd:SystemStructureDescription
+--       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
+--       xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription"
+--       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
+--       xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping"
+--       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
+--       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
+--       name="model"
+--       version="1.0">
+--       <ssd:System
+--         name="root">
+--         <ssd:Elements>
+--           <ssd:Component
+--             name="A"
+--             type="application/x-fmu-sharedlibrary"
+--             source="resources/0001_A.fmu">
+--             <ssd:Connectors>
+--               <ssd:Connector
+--                 name="u"
+--                 kind="input">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="0.000000"
+--                   y="0.500000" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="y"
+--                 kind="output">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="1.000000"
+--                   y="0.500000" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="k"
+--                 kind="parameter">
+--                 <ssc:Real
+--                   unit="1" />
+--               </ssd:Connector>
+--             </ssd:Connectors>
+--             <ssd:ParameterBindings>
+--               <ssd:ParameterBinding>
+--                 <ssd:ParameterValues>
+--                   <ssv:ParameterSet
+--                     version="1.0"
+--                     name="parameters">
+--                     <ssv:Parameters>
+--                       <ssv:Parameter
+--                         name="k">
+--                         <ssv:Real
+--                           value="10"
+--                           unit="1" />
+--                       </ssv:Parameter>
+--                     </ssv:Parameters>
+--                   </ssv:ParameterSet>
+--                 </ssd:ParameterValues>
+--               </ssd:ParameterBinding>
+--             </ssd:ParameterBindings>
+--           </ssd:Component>
+--         </ssd:Elements>
+--         <ssd:Annotations>
+--           <ssc:Annotation
+--             type="org.openmodelica">
+--             <oms:Annotations>
+--               <oms:SimulationInformation>
+--                 <oms:FixedStepMaster
+--                   description="oms-ma"
+--                   stepSize="0.001000"
+--                   absoluteTolerance="0.000100"
+--                   relativeTolerance="0.000100" />
+--               </oms:SimulationInformation>
+--             </oms:Annotations>
+--           </ssc:Annotation>
+--         </ssd:Annotations>
+--       </ssd:System>
+--       <ssd:Units>
+--         <ssc:Unit
+--           name="1">
+--           <ssc:BaseUnit />
+--         </ssc:Unit>
+--       </ssd:Units>
+--       <ssd:DefaultExperiment
+--         startTime="0.000000"
+--         stopTime="1.000000">
+--         <ssd:Annotations>
+--           <ssc:Annotation
+--             type="org.openmodelica">
+--             <oms:Annotations>
+--               <oms:SimulationInformation
+--                 resultFile="model_res.mat"
+--                 loggingInterval="0.000000"
+--                 bufferSize="10"
+--                 signalFilter="resources/signalFilter.xml" />
+--             </oms:Annotations>
+--           </ssc:Annotation>
+--         </ssd:Annotations>
+--       </ssd:DefaultExperiment>
+--     </ssd:SystemStructureDescription>
+--   </oms:file>
+--   <oms:file
+--     name="resources/signalFilter.xml">
+--     <oms:SignalFilter
+--       version="1.0">
+--       <oms:Variable
+--         name="model.root.A.u"
+--         type="Real"
+--         kind="input" />
+--       <oms:Variable
+--         name="model.root.A.y"
+--         type="Real"
+--         kind="output" />
+--       <oms:Variable
+--         name="model.root.A.k"
+--         type="Real"
+--         kind="parameter" />
+--     </oms:SignalFilter>
+--   </oms:file>
+-- </oms:snapshot>
+--
+-- <?xml version="1.0"?>
+-- <oms:snapshot
+--   xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
+--   partial="false">
+--   <oms:file
+--     name="varA.ssd">
+--     <ssd:SystemStructureDescription
+--       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
+--       xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription"
+--       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
+--       xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping"
+--       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
+--       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
+--       name="model"
+--       version="1.0">
+--       <ssd:System
+--         name="root">
+--         <ssd:Elements>
+--           <ssd:Component
+--             name="A"
+--             type="application/x-fmu-sharedlibrary"
+--             source="resources/0001_A.fmu">
+--             <ssd:Connectors>
+--               <ssd:Connector
+--                 name="u"
+--                 kind="input">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="0.000000"
+--                   y="0.500000" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="y"
+--                 kind="output">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="1.000000"
+--                   y="0.500000" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="k"
+--                 kind="parameter">
+--                 <ssc:Real
+--                   unit="1" />
+--               </ssd:Connector>
+--             </ssd:Connectors>
+--             <ssd:ParameterBindings>
+--               <ssd:ParameterBinding>
+--                 <ssd:ParameterValues>
+--                   <ssv:ParameterSet
+--                     version="1.0"
+--                     name="parameters">
+--                     <ssv:Parameters>
+--                       <ssv:Parameter
+--                         name="u">
+--                         <ssv:Real
+--                           value="-10" />
+--                       </ssv:Parameter>
+--                       <ssv:Parameter
+--                         name="k">
+--                         <ssv:Real
+--                           value="10"
+--                           unit="1" />
+--                       </ssv:Parameter>
+--                     </ssv:Parameters>
+--                   </ssv:ParameterSet>
+--                 </ssd:ParameterValues>
+--               </ssd:ParameterBinding>
+--             </ssd:ParameterBindings>
+--           </ssd:Component>
+--         </ssd:Elements>
+--         <ssd:Annotations>
+--           <ssc:Annotation
+--             type="org.openmodelica">
+--             <oms:Annotations>
+--               <oms:SimulationInformation>
+--                 <oms:FixedStepMaster
+--                   description="oms-ma"
+--                   stepSize="0.001000"
+--                   absoluteTolerance="0.000100"
+--                   relativeTolerance="0.000100" />
+--               </oms:SimulationInformation>
+--             </oms:Annotations>
+--           </ssc:Annotation>
+--         </ssd:Annotations>
+--       </ssd:System>
+--       <ssd:Units>
+--         <ssc:Unit
+--           name="1">
+--           <ssc:BaseUnit />
+--         </ssc:Unit>
+--       </ssd:Units>
+--       <ssd:DefaultExperiment
+--         startTime="0.000000"
+--         stopTime="1.000000">
+--         <ssd:Annotations>
+--           <ssc:Annotation
+--             type="org.openmodelica">
+--             <oms:Annotations>
+--               <oms:SimulationInformation
+--                 resultFile="model_res.mat"
+--                 loggingInterval="0.000000"
+--                 bufferSize="10"
+--                 signalFilter="resources/signalFilter.xml" />
+--             </oms:Annotations>
+--           </ssc:Annotation>
+--         </ssd:Annotations>
+--       </ssd:DefaultExperiment>
+--     </ssd:SystemStructureDescription>
+--   </oms:file>
+--   <oms:file
+--     name="resources/signalFilter.xml">
+--     <oms:SignalFilter
+--       version="1.0">
+--       <oms:Variable
+--         name="model.root.A.u"
+--         type="Real"
+--         kind="input" />
+--       <oms:Variable
+--         name="model.root.A.y"
+--         type="Real"
+--         kind="output" />
+--       <oms:Variable
+--         name="model.root.A.k"
+--         type="Real"
+--         kind="parameter" />
+--     </oms:SignalFilter>
+--   </oms:file>
+-- </oms:snapshot>
+--
+-- <?xml version="1.0"?>
+-- <oms:snapshot
+--   xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
+--   partial="false">
+--   <oms:file
+--     name="varB.ssd">
+--     <ssd:SystemStructureDescription
+--       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
+--       xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription"
+--       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
+--       xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping"
+--       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
+--       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
+--       name="model"
+--       version="1.0">
+--       <ssd:System
+--         name="root">
+--         <ssd:Elements>
+--           <ssd:Component
+--             name="A"
+--             type="application/x-fmu-sharedlibrary"
+--             source="resources/0001_A.fmu">
+--             <ssd:Connectors>
+--               <ssd:Connector
+--                 name="u"
+--                 kind="input">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="0.000000"
+--                   y="0.500000" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="y"
+--                 kind="output">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="1.000000"
+--                   y="0.500000" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="k"
+--                 kind="parameter">
+--                 <ssc:Real
+--                   unit="1" />
+--               </ssd:Connector>
+--             </ssd:Connectors>
+--             <ssd:ParameterBindings>
+--               <ssd:ParameterBinding>
+--                 <ssd:ParameterValues>
+--                   <ssv:ParameterSet
+--                     version="1.0"
+--                     name="parameters">
+--                     <ssv:Parameters>
+--                       <ssv:Parameter
+--                         name="u">
+--                         <ssv:Real
+--                           value="-13" />
+--                       </ssv:Parameter>
+--                       <ssv:Parameter
+--                         name="k">
+--                         <ssv:Real
+--                           value="-100"
+--                           unit="1" />
+--                       </ssv:Parameter>
+--                     </ssv:Parameters>
+--                   </ssv:ParameterSet>
+--                 </ssd:ParameterValues>
+--               </ssd:ParameterBinding>
+--             </ssd:ParameterBindings>
+--           </ssd:Component>
+--         </ssd:Elements>
+--         <ssd:Annotations>
+--           <ssc:Annotation
+--             type="org.openmodelica">
+--             <oms:Annotations>
+--               <oms:SimulationInformation>
+--                 <oms:FixedStepMaster
+--                   description="oms-ma"
+--                   stepSize="0.001000"
+--                   absoluteTolerance="0.000100"
+--                   relativeTolerance="0.000100" />
+--               </oms:SimulationInformation>
+--             </oms:Annotations>
+--           </ssc:Annotation>
+--         </ssd:Annotations>
+--       </ssd:System>
+--       <ssd:Units>
+--         <ssc:Unit
+--           name="1">
+--           <ssc:BaseUnit />
+--         </ssc:Unit>
+--       </ssd:Units>
+--       <ssd:DefaultExperiment
+--         startTime="0.000000"
+--         stopTime="1.000000">
+--         <ssd:Annotations>
+--           <ssc:Annotation
+--             type="org.openmodelica">
+--             <oms:Annotations>
+--               <oms:SimulationInformation
+--                 resultFile="duplicatevariant1.mat"
+--                 loggingInterval="0.000000"
+--                 bufferSize="1"
+--                 signalFilter="resources/signalFilter.xml" />
+--             </oms:Annotations>
+--           </ssc:Annotation>
+--         </ssd:Annotations>
+--       </ssd:DefaultExperiment>
+--     </ssd:SystemStructureDescription>
+--   </oms:file>
+--   <oms:file
+--     name="resources/signalFilter.xml">
+--     <oms:SignalFilter
+--       version="1.0">
+--       <oms:Variable
+--         name="model.root.A.u"
+--         type="Real"
+--         kind="input" />
+--       <oms:Variable
+--         name="model.root.A.y"
+--         type="Real"
+--         kind="output" />
+--       <oms:Variable
+--         name="model.root.A.k"
+--         type="Real"
+--         kind="parameter" />
+--     </oms:SignalFilter>
+--   </oms:file>
+-- </oms:snapshot>
+--
+-- endResult

--- a/testsuite/simulation/duplicateVariant1.lua
+++ b/testsuite/simulation/duplicateVariant1.lua
@@ -271,7 +271,7 @@ oms_delete("model")
 --                 resultFile="model_res.mat"
 --                 loggingInterval="0.000000"
 --                 bufferSize="10"
---                 signalFilter="resources/signalFilter.xml" />
+--                 signalFilter="resources/signalFilter_varA.xml" />
 --             </oms:Annotations>
 --           </ssc:Annotation>
 --         </ssd:Annotations>
@@ -279,7 +279,7 @@ oms_delete("model")
 --     </ssd:SystemStructureDescription>
 --   </oms:file>
 --   <oms:file
---     name="resources/signalFilter.xml">
+--     name="resources/signalFilter_varA.xml">
 --     <oms:SignalFilter
 --       version="1.0">
 --       <oms:Variable
@@ -401,7 +401,7 @@ oms_delete("model")
 --                 resultFile="duplicatevariant1.mat"
 --                 loggingInterval="0.000000"
 --                 bufferSize="1"
---                 signalFilter="resources/signalFilter.xml" />
+--                 signalFilter="resources/signalFilter_varB.xml" />
 --             </oms:Annotations>
 --           </ssc:Annotation>
 --         </ssd:Annotations>
@@ -409,7 +409,7 @@ oms_delete("model")
 --     </ssd:SystemStructureDescription>
 --   </oms:file>
 --   <oms:file
---     name="resources/signalFilter.xml">
+--     name="resources/signalFilter_varB.xml">
 --     <oms:SignalFilter
 --       version="1.0">
 --       <oms:Variable

--- a/testsuite/simulation/duplicateVariant2.lua
+++ b/testsuite/simulation/duplicateVariant2.lua
@@ -1,0 +1,426 @@
+-- status: correct
+-- teardown_command: rm -rf duplicatevariant_02_lua/
+-- linux: yes
+-- mingw32: no
+-- mingw64: yes
+-- win: no
+-- mac: no
+
+oms_setCommandLineOption("--suppressPath=true")
+oms_setTempDirectory("./duplicatevariant_02_lua/")
+
+oms_newModel("model")
+
+oms_addSystem("model.root", oms_system_wc)
+
+oms_addSubModel("model.root.A", "../resources/Modelica.Blocks.Math.Gain.fmu")
+oms_setReal("model.root.A.k", 10)
+
+-- export SystemStructure.ssd
+src, status = oms_exportSnapshot("model")
+print(src)
+
+oms_duplicateVariant("model", "varA")
+oms_setReal("model.root.A.u", -10)
+
+-- export varA.ssd
+src, status = oms_exportSnapshot("model")
+print(src)
+
+oms_duplicateVariant("model", "varB")
+oms_setReal("model.root.A.u", -13)
+oms_setReal("model.root.A.k", -100)
+
+oms_removeSignalsFromResults("model", ".*")
+oms_addSignalsToResults("model", "model.root.A.k")
+
+oms_setResultFile("model", "duplicatevariant2.mat")
+
+-- export varB.ssd
+src, status = oms_exportSnapshot("model")
+print(src)
+
+oms_export("model", "multiVariant2.ssp")
+
+oms_terminate("model")
+oms_delete("model")
+
+-- Result:
+-- <?xml version="1.0"?>
+-- <oms:snapshot
+--   xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
+--   partial="false">
+--   <oms:file
+--     name="SystemStructure.ssd">
+--     <ssd:SystemStructureDescription
+--       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
+--       xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription"
+--       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
+--       xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping"
+--       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
+--       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
+--       name="model"
+--       version="1.0">
+--       <ssd:System
+--         name="root">
+--         <ssd:Elements>
+--           <ssd:Component
+--             name="A"
+--             type="application/x-fmu-sharedlibrary"
+--             source="resources/0001_A.fmu">
+--             <ssd:Connectors>
+--               <ssd:Connector
+--                 name="u"
+--                 kind="input">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="0.000000"
+--                   y="0.500000" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="y"
+--                 kind="output">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="1.000000"
+--                   y="0.500000" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="k"
+--                 kind="parameter">
+--                 <ssc:Real
+--                   unit="1" />
+--               </ssd:Connector>
+--             </ssd:Connectors>
+--             <ssd:ParameterBindings>
+--               <ssd:ParameterBinding>
+--                 <ssd:ParameterValues>
+--                   <ssv:ParameterSet
+--                     version="1.0"
+--                     name="parameters">
+--                     <ssv:Parameters>
+--                       <ssv:Parameter
+--                         name="k">
+--                         <ssv:Real
+--                           value="10"
+--                           unit="1" />
+--                       </ssv:Parameter>
+--                     </ssv:Parameters>
+--                   </ssv:ParameterSet>
+--                 </ssd:ParameterValues>
+--               </ssd:ParameterBinding>
+--             </ssd:ParameterBindings>
+--           </ssd:Component>
+--         </ssd:Elements>
+--         <ssd:Annotations>
+--           <ssc:Annotation
+--             type="org.openmodelica">
+--             <oms:Annotations>
+--               <oms:SimulationInformation>
+--                 <oms:FixedStepMaster
+--                   description="oms-ma"
+--                   stepSize="0.001000"
+--                   absoluteTolerance="0.000100"
+--                   relativeTolerance="0.000100" />
+--               </oms:SimulationInformation>
+--             </oms:Annotations>
+--           </ssc:Annotation>
+--         </ssd:Annotations>
+--       </ssd:System>
+--       <ssd:Units>
+--         <ssc:Unit
+--           name="1">
+--           <ssc:BaseUnit />
+--         </ssc:Unit>
+--       </ssd:Units>
+--       <ssd:DefaultExperiment
+--         startTime="0.000000"
+--         stopTime="1.000000">
+--         <ssd:Annotations>
+--           <ssc:Annotation
+--             type="org.openmodelica">
+--             <oms:Annotations>
+--               <oms:SimulationInformation
+--                 resultFile="model_res.mat"
+--                 loggingInterval="0.000000"
+--                 bufferSize="10"
+--                 signalFilter="resources/signalFilter.xml" />
+--             </oms:Annotations>
+--           </ssc:Annotation>
+--         </ssd:Annotations>
+--       </ssd:DefaultExperiment>
+--     </ssd:SystemStructureDescription>
+--   </oms:file>
+--   <oms:file
+--     name="resources/signalFilter.xml">
+--     <oms:SignalFilter
+--       version="1.0">
+--       <oms:Variable
+--         name="model.root.A.u"
+--         type="Real"
+--         kind="input" />
+--       <oms:Variable
+--         name="model.root.A.y"
+--         type="Real"
+--         kind="output" />
+--       <oms:Variable
+--         name="model.root.A.k"
+--         type="Real"
+--         kind="parameter" />
+--     </oms:SignalFilter>
+--   </oms:file>
+-- </oms:snapshot>
+--
+-- <?xml version="1.0"?>
+-- <oms:snapshot
+--   xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
+--   partial="false">
+--   <oms:file
+--     name="varA.ssd">
+--     <ssd:SystemStructureDescription
+--       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
+--       xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription"
+--       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
+--       xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping"
+--       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
+--       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
+--       name="model"
+--       version="1.0">
+--       <ssd:System
+--         name="root">
+--         <ssd:Elements>
+--           <ssd:Component
+--             name="A"
+--             type="application/x-fmu-sharedlibrary"
+--             source="resources/0001_A.fmu">
+--             <ssd:Connectors>
+--               <ssd:Connector
+--                 name="u"
+--                 kind="input">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="0.000000"
+--                   y="0.500000" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="y"
+--                 kind="output">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="1.000000"
+--                   y="0.500000" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="k"
+--                 kind="parameter">
+--                 <ssc:Real
+--                   unit="1" />
+--               </ssd:Connector>
+--             </ssd:Connectors>
+--             <ssd:ParameterBindings>
+--               <ssd:ParameterBinding>
+--                 <ssd:ParameterValues>
+--                   <ssv:ParameterSet
+--                     version="1.0"
+--                     name="parameters">
+--                     <ssv:Parameters>
+--                       <ssv:Parameter
+--                         name="u">
+--                         <ssv:Real
+--                           value="-10" />
+--                       </ssv:Parameter>
+--                       <ssv:Parameter
+--                         name="k">
+--                         <ssv:Real
+--                           value="10"
+--                           unit="1" />
+--                       </ssv:Parameter>
+--                     </ssv:Parameters>
+--                   </ssv:ParameterSet>
+--                 </ssd:ParameterValues>
+--               </ssd:ParameterBinding>
+--             </ssd:ParameterBindings>
+--           </ssd:Component>
+--         </ssd:Elements>
+--         <ssd:Annotations>
+--           <ssc:Annotation
+--             type="org.openmodelica">
+--             <oms:Annotations>
+--               <oms:SimulationInformation>
+--                 <oms:FixedStepMaster
+--                   description="oms-ma"
+--                   stepSize="0.001000"
+--                   absoluteTolerance="0.000100"
+--                   relativeTolerance="0.000100" />
+--               </oms:SimulationInformation>
+--             </oms:Annotations>
+--           </ssc:Annotation>
+--         </ssd:Annotations>
+--       </ssd:System>
+--       <ssd:Units>
+--         <ssc:Unit
+--           name="1">
+--           <ssc:BaseUnit />
+--         </ssc:Unit>
+--       </ssd:Units>
+--       <ssd:DefaultExperiment
+--         startTime="0.000000"
+--         stopTime="1.000000">
+--         <ssd:Annotations>
+--           <ssc:Annotation
+--             type="org.openmodelica">
+--             <oms:Annotations>
+--               <oms:SimulationInformation
+--                 resultFile="model_res.mat"
+--                 loggingInterval="0.000000"
+--                 bufferSize="10"
+--                 signalFilter="resources/signalFilter_varA.xml" />
+--             </oms:Annotations>
+--           </ssc:Annotation>
+--         </ssd:Annotations>
+--       </ssd:DefaultExperiment>
+--     </ssd:SystemStructureDescription>
+--   </oms:file>
+--   <oms:file
+--     name="resources/signalFilter_varA.xml">
+--     <oms:SignalFilter
+--       version="1.0">
+--       <oms:Variable
+--         name="model.root.A.u"
+--         type="Real"
+--         kind="input" />
+--       <oms:Variable
+--         name="model.root.A.y"
+--         type="Real"
+--         kind="output" />
+--       <oms:Variable
+--         name="model.root.A.k"
+--         type="Real"
+--         kind="parameter" />
+--     </oms:SignalFilter>
+--   </oms:file>
+-- </oms:snapshot>
+--
+-- <?xml version="1.0"?>
+-- <oms:snapshot
+--   xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
+--   partial="false">
+--   <oms:file
+--     name="varB.ssd">
+--     <ssd:SystemStructureDescription
+--       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
+--       xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription"
+--       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
+--       xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping"
+--       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
+--       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
+--       name="model"
+--       version="1.0">
+--       <ssd:System
+--         name="root">
+--         <ssd:Elements>
+--           <ssd:Component
+--             name="A"
+--             type="application/x-fmu-sharedlibrary"
+--             source="resources/0001_A.fmu">
+--             <ssd:Connectors>
+--               <ssd:Connector
+--                 name="u"
+--                 kind="input">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="0.000000"
+--                   y="0.500000" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="y"
+--                 kind="output">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="1.000000"
+--                   y="0.500000" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="k"
+--                 kind="parameter">
+--                 <ssc:Real
+--                   unit="1" />
+--               </ssd:Connector>
+--             </ssd:Connectors>
+--             <ssd:ParameterBindings>
+--               <ssd:ParameterBinding>
+--                 <ssd:ParameterValues>
+--                   <ssv:ParameterSet
+--                     version="1.0"
+--                     name="parameters">
+--                     <ssv:Parameters>
+--                       <ssv:Parameter
+--                         name="u">
+--                         <ssv:Real
+--                           value="-13" />
+--                       </ssv:Parameter>
+--                       <ssv:Parameter
+--                         name="k">
+--                         <ssv:Real
+--                           value="-100"
+--                           unit="1" />
+--                       </ssv:Parameter>
+--                     </ssv:Parameters>
+--                   </ssv:ParameterSet>
+--                 </ssd:ParameterValues>
+--               </ssd:ParameterBinding>
+--             </ssd:ParameterBindings>
+--           </ssd:Component>
+--         </ssd:Elements>
+--         <ssd:Annotations>
+--           <ssc:Annotation
+--             type="org.openmodelica">
+--             <oms:Annotations>
+--               <oms:SimulationInformation>
+--                 <oms:FixedStepMaster
+--                   description="oms-ma"
+--                   stepSize="0.001000"
+--                   absoluteTolerance="0.000100"
+--                   relativeTolerance="0.000100" />
+--               </oms:SimulationInformation>
+--             </oms:Annotations>
+--           </ssc:Annotation>
+--         </ssd:Annotations>
+--       </ssd:System>
+--       <ssd:Units>
+--         <ssc:Unit
+--           name="1">
+--           <ssc:BaseUnit />
+--         </ssc:Unit>
+--       </ssd:Units>
+--       <ssd:DefaultExperiment
+--         startTime="0.000000"
+--         stopTime="1.000000">
+--         <ssd:Annotations>
+--           <ssc:Annotation
+--             type="org.openmodelica">
+--             <oms:Annotations>
+--               <oms:SimulationInformation
+--                 resultFile="duplicatevariant2.mat"
+--                 loggingInterval="0.000000"
+--                 bufferSize="1"
+--                 signalFilter="resources/signalFilter_varB.xml" />
+--             </oms:Annotations>
+--           </ssc:Annotation>
+--         </ssd:Annotations>
+--       </ssd:DefaultExperiment>
+--     </ssd:SystemStructureDescription>
+--   </oms:file>
+--   <oms:file
+--     name="resources/signalFilter_varB.xml">
+--     <oms:SignalFilter
+--       version="1.0">
+--       <oms:Variable
+--         name="model.root.A.k"
+--         type="Real"
+--         kind="parameter" />
+--     </oms:SignalFilter>
+--   </oms:file>
+-- </oms:snapshot>
+--
+-- endResult

--- a/testsuite/simulation/duplicateVariant3.lua
+++ b/testsuite/simulation/duplicateVariant3.lua
@@ -1,0 +1,439 @@
+-- status: correct
+-- teardown_command: rm -rf duplicatevariant_03_lua/
+-- linux: yes
+-- mingw32: no
+-- mingw64: yes
+-- win: no
+-- mac: no
+
+oms_setCommandLineOption("--suppressPath=true")
+oms_setTempDirectory("./duplicatevariant_03_lua/")
+
+oms_newModel("model")
+
+oms_addSystem("model.root", oms_system_wc)
+
+oms_addSubModel("model.root.A", "../resources/Modelica.Blocks.Math.Gain.fmu")
+oms_newResources("model.root:root1.ssv")
+
+oms_setReal("model.root.A.k", 10)
+
+-- export SystemStructure.ssd
+src, status = oms_exportSnapshot("model")
+print(src)
+
+oms_duplicateVariant("model", "varA")
+oms_setReal("model.root.A.u", -10)
+
+-- export varA.ssd
+src, status = oms_exportSnapshot("model")
+print(src)
+
+oms_duplicateVariant("model", "varB")
+oms_setReal("model.root.A.u", -13)
+oms_setReal("model.root.A.k", -100)
+
+oms_setResultFile("model", "duplicatevariant3.mat")
+
+-- export varB.ssd
+src, status = oms_exportSnapshot("model")
+print(src)
+
+oms_export("model", "multiVariant3.ssp")
+
+oms_terminate("model")
+oms_delete("model")
+
+-- Result:
+-- <?xml version="1.0"?>
+-- <oms:snapshot
+--   xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
+--   partial="false">
+--   <oms:file
+--     name="SystemStructure.ssd">
+--     <ssd:SystemStructureDescription
+--       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
+--       xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription"
+--       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
+--       xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping"
+--       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
+--       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
+--       name="model"
+--       version="1.0">
+--       <ssd:System
+--         name="root">
+--         <ssd:ParameterBindings>
+--           <ssd:ParameterBinding
+--             source="resources/root1.ssv" />
+--         </ssd:ParameterBindings>
+--         <ssd:Elements>
+--           <ssd:Component
+--             name="A"
+--             type="application/x-fmu-sharedlibrary"
+--             source="resources/0001_A.fmu">
+--             <ssd:Connectors>
+--               <ssd:Connector
+--                 name="u"
+--                 kind="input">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="0.000000"
+--                   y="0.500000" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="y"
+--                 kind="output">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="1.000000"
+--                   y="0.500000" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="k"
+--                 kind="parameter">
+--                 <ssc:Real
+--                   unit="1" />
+--               </ssd:Connector>
+--             </ssd:Connectors>
+--           </ssd:Component>
+--         </ssd:Elements>
+--         <ssd:Annotations>
+--           <ssc:Annotation
+--             type="org.openmodelica">
+--             <oms:Annotations>
+--               <oms:SimulationInformation>
+--                 <oms:FixedStepMaster
+--                   description="oms-ma"
+--                   stepSize="0.001000"
+--                   absoluteTolerance="0.000100"
+--                   relativeTolerance="0.000100" />
+--               </oms:SimulationInformation>
+--             </oms:Annotations>
+--           </ssc:Annotation>
+--         </ssd:Annotations>
+--       </ssd:System>
+--       <ssd:Units>
+--         <ssc:Unit
+--           name="1">
+--           <ssc:BaseUnit />
+--         </ssc:Unit>
+--       </ssd:Units>
+--       <ssd:DefaultExperiment
+--         startTime="0.000000"
+--         stopTime="1.000000">
+--         <ssd:Annotations>
+--           <ssc:Annotation
+--             type="org.openmodelica">
+--             <oms:Annotations>
+--               <oms:SimulationInformation
+--                 resultFile="model_res.mat"
+--                 loggingInterval="0.000000"
+--                 bufferSize="10"
+--                 signalFilter="resources/signalFilter.xml" />
+--             </oms:Annotations>
+--           </ssc:Annotation>
+--         </ssd:Annotations>
+--       </ssd:DefaultExperiment>
+--     </ssd:SystemStructureDescription>
+--   </oms:file>
+--   <oms:file
+--     name="resources/root1.ssv">
+--     <ssv:ParameterSet
+--       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
+--       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
+--       version="1.0"
+--       name="parameters">
+--       <ssv:Parameters>
+--         <ssv:Parameter
+--           name="A.k">
+--           <ssv:Real
+--             value="10" />
+--         </ssv:Parameter>
+--       </ssv:Parameters>
+--     </ssv:ParameterSet>
+--   </oms:file>
+--   <oms:file
+--     name="resources/signalFilter.xml">
+--     <oms:SignalFilter
+--       version="1.0">
+--       <oms:Variable
+--         name="model.root.A.u"
+--         type="Real"
+--         kind="input" />
+--       <oms:Variable
+--         name="model.root.A.y"
+--         type="Real"
+--         kind="output" />
+--       <oms:Variable
+--         name="model.root.A.k"
+--         type="Real"
+--         kind="parameter" />
+--     </oms:SignalFilter>
+--   </oms:file>
+-- </oms:snapshot>
+--
+-- <?xml version="1.0"?>
+-- <oms:snapshot
+--   xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
+--   partial="false">
+--   <oms:file
+--     name="varA.ssd">
+--     <ssd:SystemStructureDescription
+--       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
+--       xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription"
+--       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
+--       xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping"
+--       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
+--       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
+--       name="model"
+--       version="1.0">
+--       <ssd:System
+--         name="root">
+--         <ssd:ParameterBindings>
+--           <ssd:ParameterBinding
+--             source="resources/varA_root1.ssv" />
+--         </ssd:ParameterBindings>
+--         <ssd:Elements>
+--           <ssd:Component
+--             name="A"
+--             type="application/x-fmu-sharedlibrary"
+--             source="resources/0001_A.fmu">
+--             <ssd:Connectors>
+--               <ssd:Connector
+--                 name="u"
+--                 kind="input">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="0.000000"
+--                   y="0.500000" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="y"
+--                 kind="output">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="1.000000"
+--                   y="0.500000" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="k"
+--                 kind="parameter">
+--                 <ssc:Real
+--                   unit="1" />
+--               </ssd:Connector>
+--             </ssd:Connectors>
+--           </ssd:Component>
+--         </ssd:Elements>
+--         <ssd:Annotations>
+--           <ssc:Annotation
+--             type="org.openmodelica">
+--             <oms:Annotations>
+--               <oms:SimulationInformation>
+--                 <oms:FixedStepMaster
+--                   description="oms-ma"
+--                   stepSize="0.001000"
+--                   absoluteTolerance="0.000100"
+--                   relativeTolerance="0.000100" />
+--               </oms:SimulationInformation>
+--             </oms:Annotations>
+--           </ssc:Annotation>
+--         </ssd:Annotations>
+--       </ssd:System>
+--       <ssd:Units>
+--         <ssc:Unit
+--           name="1">
+--           <ssc:BaseUnit />
+--         </ssc:Unit>
+--       </ssd:Units>
+--       <ssd:DefaultExperiment
+--         startTime="0.000000"
+--         stopTime="1.000000">
+--         <ssd:Annotations>
+--           <ssc:Annotation
+--             type="org.openmodelica">
+--             <oms:Annotations>
+--               <oms:SimulationInformation
+--                 resultFile="model_res.mat"
+--                 loggingInterval="0.000000"
+--                 bufferSize="10"
+--                 signalFilter="resources/signalFilter_varA.xml" />
+--             </oms:Annotations>
+--           </ssc:Annotation>
+--         </ssd:Annotations>
+--       </ssd:DefaultExperiment>
+--     </ssd:SystemStructureDescription>
+--   </oms:file>
+--   <oms:file
+--     name="resources/varA_root1.ssv">
+--     <ssv:ParameterSet
+--       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
+--       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
+--       version="1.0"
+--       name="parameters">
+--       <ssv:Parameters>
+--         <ssv:Parameter
+--           name="A.u">
+--           <ssv:Real
+--             value="-10" />
+--         </ssv:Parameter>
+--         <ssv:Parameter
+--           name="A.k">
+--           <ssv:Real
+--             value="10" />
+--         </ssv:Parameter>
+--       </ssv:Parameters>
+--     </ssv:ParameterSet>
+--   </oms:file>
+--   <oms:file
+--     name="resources/signalFilter_varA.xml">
+--     <oms:SignalFilter
+--       version="1.0">
+--       <oms:Variable
+--         name="model.root.A.u"
+--         type="Real"
+--         kind="input" />
+--       <oms:Variable
+--         name="model.root.A.y"
+--         type="Real"
+--         kind="output" />
+--       <oms:Variable
+--         name="model.root.A.k"
+--         type="Real"
+--         kind="parameter" />
+--     </oms:SignalFilter>
+--   </oms:file>
+-- </oms:snapshot>
+--
+-- <?xml version="1.0"?>
+-- <oms:snapshot
+--   xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
+--   partial="false">
+--   <oms:file
+--     name="varB.ssd">
+--     <ssd:SystemStructureDescription
+--       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
+--       xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription"
+--       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
+--       xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping"
+--       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
+--       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
+--       name="model"
+--       version="1.0">
+--       <ssd:System
+--         name="root">
+--         <ssd:ParameterBindings>
+--           <ssd:ParameterBinding
+--             source="resources/varB_root1.ssv" />
+--         </ssd:ParameterBindings>
+--         <ssd:Elements>
+--           <ssd:Component
+--             name="A"
+--             type="application/x-fmu-sharedlibrary"
+--             source="resources/0001_A.fmu">
+--             <ssd:Connectors>
+--               <ssd:Connector
+--                 name="u"
+--                 kind="input">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="0.000000"
+--                   y="0.500000" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="y"
+--                 kind="output">
+--                 <ssc:Real />
+--                 <ssd:ConnectorGeometry
+--                   x="1.000000"
+--                   y="0.500000" />
+--               </ssd:Connector>
+--               <ssd:Connector
+--                 name="k"
+--                 kind="parameter">
+--                 <ssc:Real
+--                   unit="1" />
+--               </ssd:Connector>
+--             </ssd:Connectors>
+--           </ssd:Component>
+--         </ssd:Elements>
+--         <ssd:Annotations>
+--           <ssc:Annotation
+--             type="org.openmodelica">
+--             <oms:Annotations>
+--               <oms:SimulationInformation>
+--                 <oms:FixedStepMaster
+--                   description="oms-ma"
+--                   stepSize="0.001000"
+--                   absoluteTolerance="0.000100"
+--                   relativeTolerance="0.000100" />
+--               </oms:SimulationInformation>
+--             </oms:Annotations>
+--           </ssc:Annotation>
+--         </ssd:Annotations>
+--       </ssd:System>
+--       <ssd:Units>
+--         <ssc:Unit
+--           name="1">
+--           <ssc:BaseUnit />
+--         </ssc:Unit>
+--       </ssd:Units>
+--       <ssd:DefaultExperiment
+--         startTime="0.000000"
+--         stopTime="1.000000">
+--         <ssd:Annotations>
+--           <ssc:Annotation
+--             type="org.openmodelica">
+--             <oms:Annotations>
+--               <oms:SimulationInformation
+--                 resultFile="duplicatevariant3.mat"
+--                 loggingInterval="0.000000"
+--                 bufferSize="1"
+--                 signalFilter="resources/signalFilter_varB.xml" />
+--             </oms:Annotations>
+--           </ssc:Annotation>
+--         </ssd:Annotations>
+--       </ssd:DefaultExperiment>
+--     </ssd:SystemStructureDescription>
+--   </oms:file>
+--   <oms:file
+--     name="resources/varB_root1.ssv">
+--     <ssv:ParameterSet
+--       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
+--       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
+--       version="1.0"
+--       name="parameters">
+--       <ssv:Parameters>
+--         <ssv:Parameter
+--           name="A.u">
+--           <ssv:Real
+--             value="-13" />
+--         </ssv:Parameter>
+--         <ssv:Parameter
+--           name="A.k">
+--           <ssv:Real
+--             value="-100" />
+--         </ssv:Parameter>
+--       </ssv:Parameters>
+--     </ssv:ParameterSet>
+--   </oms:file>
+--   <oms:file
+--     name="resources/signalFilter_varB.xml">
+--     <oms:SignalFilter
+--       version="1.0">
+--       <oms:Variable
+--         name="model.root.A.u"
+--         type="Real"
+--         kind="input" />
+--       <oms:Variable
+--         name="model.root.A.y"
+--         type="Real"
+--         kind="output" />
+--       <oms:Variable
+--         name="model.root.A.k"
+--         type="Real"
+--         kind="parameter" />
+--     </oms:SignalFilter>
+--   </oms:file>
+-- </oms:snapshot>
+--
+-- endResult


### PR DESCRIPTION
### Related Issues

https://github.com/OpenModelica/OMSimulator/discussions/1173

### Purpose

This PR implements `oms_duplicateVariant()`  which supports `multi-Variant  modelling`. This PR also provides support to export multiple variants (e.g SystemStructure.ssd, varA.ssd, varB.ssd)  in a single `ssp` file.

### TODO

- [x] duplicate variant using oms_duplicateVariant()
- [x] add tests to support multiple variants and their local resources to ssp 
- [x] import the multivariant ssp

