### PR TITLE
retain elementGeometry when replacing submodel

### DIFF
--- a/src/OMSimulatorLib/ComponentFMUCS.cpp
+++ b/src/OMSimulatorLib/ComponentFMUCS.cpp
@@ -1814,6 +1814,7 @@ oms_status_enu_t oms::ComponentFMUCS::updateOrDeleteStartValueInReplacedComponen
   else
   {
     // inline parameter settings, no need to update the values
+    return oms_status_ok;
   }
 
   return oms_status_error;

--- a/src/OMSimulatorLib/ComponentFMUME.cpp
+++ b/src/OMSimulatorLib/ComponentFMUME.cpp
@@ -1596,6 +1596,7 @@ oms_status_enu_t oms::ComponentFMUME::updateOrDeleteStartValueInReplacedComponen
   else
   {
     // inline parameter settings, no need to update the values
+    return oms_status_ok;
   }
 
   return oms_status_error;

--- a/src/OMSimulatorLib/System.cpp
+++ b/src/OMSimulatorLib/System.cpp
@@ -335,7 +335,7 @@ oms_status_enu_t oms::System::replaceSubModel(const oms::ComRef& cref, const std
       show warnings and replace is done
   */
 
-   // get full snapshot
+  // get full snapshot
   char* fullsnapshot = NULL;
   getModel().exportSnapshot("", &fullsnapshot);
 
@@ -392,6 +392,9 @@ oms_status_enu_t oms::System::replaceSubModel(const oms::ComRef& cref, const std
           }
         }
       }
+
+      //copy the element geometry position of old component to the replacing component which will be used in OMEdit
+      replaceComponent->getElement()->setGeometry(component->second->getElement()->getGeometry());
 
       // copy all the resources from old component to replacing component
       std::vector<Values> allResources = component->second->getValuesResources();

--- a/src/OMSimulatorLib/Values.cpp
+++ b/src/OMSimulatorLib/Values.cpp
@@ -654,11 +654,11 @@ oms_status_enu_t oms::Values::updateOrDeleteStartValueInReplacedComponent(Values
               front = mappedCref->second;
             if (oms_status_ok != value.getRealFromModeldescription(front, value_))
             {
-              //res.second.realStartValues.erase(mappedCref->second); // NOTE: should we keep unreferenced signals in ssm and ssv when importing ?
-              mappedCref = res.second.mappedEntry.erase(mappedCref);
               std::string errorMsg = "deleting start value \"" + std::string(owner + front) + "\"" + " in \"" + std::string(res.second.ssmFile) + "\""  + " resources, because the identifier couldn't be resolved to any system signal in the replacing model";
               logWarning(errorMsg);
               warningList.push_back(errorMsg);
+              //res.second.realStartValues.erase(mappedCref->second); // NOTE: should we keep unreferenced signals in ssm and ssv when importing ?
+              mappedCref = res.second.mappedEntry.erase(mappedCref);
             }
           }
           ++ mappedCref;
@@ -696,11 +696,11 @@ oms_status_enu_t oms::Values::updateOrDeleteStartValueInReplacedComponent(Values
             }
             else
             {
-              // if (res.second.ssmFile.empty()) should we keep the unreferenced signals in ssv which does not have any reference in ssm when importing?
-              res.second.realStartValues.erase(name.first); // delete the start value as signal does not exist in replaced component
               std::string errorMsg = "deleting start value \"" + std::string(owner + front) + "\"" + " in \"" + std::string(res.first) + "\""  + " resources, because the identifier couldn't be resolved to any system signal in the replacing model";
               logWarning(errorMsg);
               warningList.push_back(errorMsg);
+              // if (res.second.ssmFile.empty()) should we keep the unreferenced signals in ssv which does not have any reference in ssm when importing?
+              res.second.realStartValues.erase(name.first); // delete the start value as signal does not exist in replaced component
             }
           }
         }
@@ -708,7 +708,7 @@ oms_status_enu_t oms::Values::updateOrDeleteStartValueInReplacedComponent(Values
     }
   }
 
-  return oms_status_error;
+  return oms_status_ok;
 }
 
 oms_status_enu_t oms::Values::deleteStartValueInResources(const ComRef& cref)


### PR DESCRIPTION
### Purpose

This PR retains the `element geometry position` when `replacing submodel`, which will be used in `OMEdit`, to retain positions and connections.


