### PR TITLE
skip csv files for top level model when exporting ssv templates

### DIFF
--- a/src/OMSimulatorLib/Model.cpp
+++ b/src/OMSimulatorLib/Model.cpp
@@ -510,6 +510,12 @@ oms_status_enu_t oms::Model::exportSSVTemplate(const oms::ComRef& cref, const st
 
   for (const auto& component : system->getComponents())
   {
+    // skip csv files for top level model and export the remaining fmus in the model
+    if (cref.isEmpty())
+    {
+      if (component.second->getType() == oms_component_table)
+        continue;
+    }
     if(component.first == tail || cref.isEmpty() || cref.isValidIdent()) // allow querying single component or whole model
     {
       if (oms_status_ok != component.second->exportToSSVTemplate(ssvNode, snapshot))
@@ -528,6 +534,12 @@ oms_status_enu_t oms::Model::exportSSVTemplate(const oms::ComRef& cref, const st
   {
     for (const auto &component : subsytem.second->getComponents())
     {
+      // skip csv files for top level model and export the remaining fmus in the model
+      if (cref.isEmpty())
+      {
+        if (component.second->getType() == oms_component_table)
+          continue;
+      }
       if (component.first == tailA || cref.isEmpty() || (system->getSystem(frontA) && tailA.isEmpty()))
       {
         if (oms_status_ok != component.second->exportToSSVTemplate(ssvNode, snapshot))


### PR DESCRIPTION
### Purpose

This PR skips the tables and csv files when exporting ssv templates for top level model so that the fmus in the model are exported to ssv template
