### PR TITLE
Update the docker images used for testing PRs to 1.16

### DIFF
--- a/.CI/cache-32/Dockerfile
+++ b/.CI/cache-32/Dockerfile
@@ -1,5 +1,5 @@
 # Cannot be parametrized in Jenkins...
-FROM docker.openmodelica.org/build-deps:v1.13-i386
+FROM docker.openmodelica.org/build-deps:v1.16-i386
 
 # We don't know the uid of the user who will build, so make the /cache directories world writable
 

--- a/.CI/cache/Dockerfile
+++ b/.CI/cache/Dockerfile
@@ -1,5 +1,5 @@
 # Cannot be parametrized in Jenkins...
-FROM docker.openmodelica.org/build-deps:v1.13
+FROM docker.openmodelica.org/build-deps:v1.16
 
 # We don't know the uid of the user who will build, so make the /cache directories world writable
 


### PR DESCRIPTION
  - This provides more recent versions of tools like CMake. It is also what is currently being used by the OpenModelica repo to test its own PRs.

  - This still might not provide a recent enough CMake version. We will see how it goes. 
