### PR TITLE
Use the image with the update cmake version.

### DIFF
--- a/.CI/cache/Dockerfile
+++ b/.CI/cache/Dockerfile
@@ -1,5 +1,5 @@
 # Cannot be parametrized in Jenkins...
-FROM docker.openmodelica.org/build-deps:v1.16
+FROM docker.openmodelica.org/build-deps-cmake:v1.16.3
 
 # We don't know the uid of the user who will build, so make the /cache directories world writable
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,6 +49,7 @@ pipeline {
           environment {
             RUNTESTDB = "/cache/runtest/"
             NPROC = "${numPhysicalCPU}"
+            OMSFLAGS = "CMAKE=/opt/cmake-3.17.2/bin/cmake"
           }
           steps {
             buildOMS()


### PR DESCRIPTION
- `build-deps:v1.16` still does not provide a recent enough CMake version. `build-deps-cmake:v1.16.3` does.
