### PR TITLE
MSYS2 change MINGW64 to UCRT64

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -345,6 +345,25 @@ EXIT /b 1
           }
         }
 
+        stage('ucrt64-clang') {
+          agent {
+            label 'omsimulator-windows'
+          }
+          environment {
+            OMDEV = "C:\\OMDev"
+            OMDEV_MSYS = "${env.OMDEV}\\tools\\msys"
+            MSYSTEM_DIR_PREFIX = "ucrt64"
+            PATH = "${env.PATH};${env.OMDEV_MSYS}\\${env.MSYSTEM_DIR_PREFIX}\\bin\\;${env.OMDEV_MSYS}\\usr\\bin;C:\\bin\\git\\bin;C:\\bin\\git\\usr\\bin;"
+            CC="clang"
+            CXX="clang++"
+            MSYSTEM = "MINGW64"
+            VERBOSE = '1'
+          }
+
+          steps {
+             buildOMS()
+          }
+        }
 
         stage('msvc64') {
           stages {

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ The testsuite of OMSimulator is run on Jenkins for every commit and creating
 [test reports](https://test.openmodelica.org/jenkins/job/OMSimulator/job/master/lastSuccessfulBuild/testReport/).
 The project is tested for the following OS:
    - linux64 without OMPython
-   - mingw64
+   - cross-compiled msys64
    - msvc64
    - cross-compiled OSX
 

--- a/src/OMSimulatorLib/ComponentFMUME.cpp
+++ b/src/OMSimulatorLib/ComponentFMUME.cpp
@@ -148,7 +148,7 @@ oms::Component* oms::ComponentFMUME::NewComponent(const oms::ComRef& cref, oms::
   fmiVersion_t version = fmi4c_getFmiVersion(component->fmu);
   if (fmiVersion2 != version)
   {
-    logError("Unsupported FMI version: " + version);
+    logError("Unsupported FMI version: " + std::to_string(version));
     delete component;
     return NULL;
   }

--- a/testsuite/difftool/Makefile
+++ b/testsuite/difftool/Makefile
@@ -1,11 +1,11 @@
-ifdef OMDEV
-	CC = gcc
-	EXT=".exe"
-endif
-
 # ugly fix for macosx
 detected_OS := $(shell uname -s)
 OMBUILDDIR =../../install/
+
+ifeq (MINGW,$(findstring MINGW,$(detected_OS)))
+	CC = gcc
+	EXT=".exe"
+endif
 
 $(OMBUILDDIR)/bin/omc-diff$(EXT): lex.yy.o $(OMBUILDDIR)/bin
 	$(CC) -o $@ lex.yy.o

--- a/testsuite/rtest
+++ b/testsuite/rtest
@@ -17,7 +17,12 @@ if ($cwd =~ m/(.*)testsuite\/(.+)$/) {
   if ($os =~ /MINGW/) {
     if ($os =~ /MINGW64/) {
       $PLATFORM = "mingw";
-      $TEST_PLATFORM = "mingw64";
+        if ($ENV{'MSYSTEM'} =~ /UCRT64/) {
+          $TEST_PLATFORM = "ucrt64";
+        }
+        else {
+          $TEST_PLATFORM = "mingw64";
+        }
     }
     else {
       $PLATFORM = "mingw";


### PR DESCRIPTION
### Related Issues

For OpenModelica we want to use the newer Universal C Runtime (UCRT) on Windows, see https://github.com/OpenModelica/OpenModelica/pull/10939.
For this it would also be good if OMSimulator can be build with MSYS2 and UCRT64 as well as MINGW64.

## Changes
  - Adding `OMDEV_MSYS` environment variables to Jenkinsfile and build scripts.
  - Remove 32 bit support (there is no 32 bit Windows, Ubuntu any more)
