### PR TITLE
Remove unused configuration variables.

### DIFF
--- a/configWinVS.bat
+++ b/configWinVS.bat
@@ -63,7 +63,6 @@ IF NOT EXIST install\\win\\lib MKDIR install\\win\\lib
 
 @REM do not change the order to be consistent with line 265 config all
 IF ["%TARGET%"]==["clean"] GOTO clean
-IF ["%TARGET%"]==["xerces"] GOTO xerces
 IF ["%TARGET%"]==["pthread"] GOTO pthread
 IF ["%TARGET%"]==["omsimulator"] GOTO omsimulator
 IF ["%TARGET%"]==["all"] GOTO all
@@ -77,23 +76,6 @@ IF EXIST "build\win\" RMDIR /S /Q build\win && IF NOT ["%ERRORLEVEL%"]==["0"] GO
 IF EXIST "install\win\" RMDIR /S /Q install\win && IF NOT ["%ERRORLEVEL%"]==["0"] GOTO fail
 EXIT /B 0
 :: -- clean ---------------------------
-
-
-:: -- config xerces -------------------
-:xerces
-ECHO # config xerces
-IF EXIST "3rdParty\xerces\build\win\" RMDIR /S /Q 3rdParty\xerces\build\win
-IF EXIST "3rdParty\xerces\install\win\" RMDIR /S /Q 3rdParty\xerces\install\win
-MKDIR 3rdParty\xerces\build\win
-CD 3rdParty\xerces\build\win
-cmake.exe -G %OMS_VS_VERSION% ..\.. -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON -DCMAKE_INSTALL_PREFIX=..\..\install\win -DBUILD_SHARED_LIBS:BOOL=OFF
-IF NOT ["%ERRORLEVEL%"]==["0"] GOTO fail
-CD ..\..\..\..
-ECHO # build xerces
-msbuild.exe "3rdParty\xerces\build\win\INSTALL.vcxproj" /t:Build /p:configuration=Release /maxcpucount
-IF NOT ["%ERRORLEVEL%"]==["0"] GOTO fail
-EXIT /B 0
-:: -- config xerces -------------------
 
 
 :: -- pthread -------------------------

--- a/src/OMSimulatorPython/capi.py
+++ b/src/OMSimulatorPython/capi.py
@@ -4,13 +4,13 @@ import os
 class capi:
   def __init__(self):
     dirname = os.path.dirname(__file__)
-    omslib = os.path.join(dirname, "@OMSIMULATORLIB_DIR_STRING@", "@OMSIMULATORLIB_STRING@")
+    omslib = os.path.join(dirname, "@OMSIMULATORLIB_STRING@")
     # attempt to fix #8163 on Linux
     if not os.path.exists(omslib):
-      omslib = os.path.join(dirname, "..", "@OMSIMULATORLIB_DIR_STRING@", "@OMSIMULATORLIB_STRING@")
+      omslib = os.path.join(dirname, "..", "@OMSIMULATORLIB_STRING@")
 
     if os.name == 'nt': # Windows
-      omslib = os.path.join(dirname, "../../bin/", "@OMSIMULATORLIB_DIR_STRING@", "@OMSIMULATORLIB_STRING@")
+      omslib = os.path.join(dirname, "../../bin/", "@OMSIMULATORLIB_STRING@")
       dllDir = os.add_dll_directory(os.path.dirname(omslib))
     self.obj=ctypes.CDLL(omslib)
     if os.name == 'nt': # Windows


### PR DESCRIPTION
  - These variables are either not used or used but no longer needed. Remove them to simplify the Makefiles/scripts.

    Soon it should be time to switch the whole thing to direct CMake invocation instead of using Makefiles/Bat Scripts. Then only thing remaining is to make sure cross-compilation works as intended.

