### PR TITLE
Remove Windows building of 3rdParty/pthreads.

### DIFF
--- a/configWinVS.bat
+++ b/configWinVS.bat
@@ -63,7 +63,6 @@ IF NOT EXIST install\\win\\lib MKDIR install\\win\\lib
 
 @REM do not change the order to be consistent with line 265 config all
 IF ["%TARGET%"]==["clean"] GOTO clean
-IF ["%TARGET%"]==["pthread"] GOTO pthread
 IF ["%TARGET%"]==["omsimulator"] GOTO omsimulator
 IF ["%TARGET%"]==["all"] GOTO all
 ECHO # Error: No rule to make target '%TARGET%'.
@@ -76,20 +75,6 @@ IF EXIST "build\win\" RMDIR /S /Q build\win && IF NOT ["%ERRORLEVEL%"]==["0"] GO
 IF EXIST "install\win\" RMDIR /S /Q install\win && IF NOT ["%ERRORLEVEL%"]==["0"] GOTO fail
 EXIT /B 0
 :: -- clean ---------------------------
-
-
-:: -- pthread -------------------------
-:pthread
-ECHO # config pthread
-CD 3rdParty\pthread
-START /B /WAIT CMD /C "buildWinVS.bat %OMS_VS_TARGET%"
-IF NOT ["%ERRORLEVEL%"]==["0"] GOTO fail
-CD ..\..
-ECHO # copy pthread
-IF NOT EXIST "install\win\bin" MKDIR install\win\bin
-XCOPY /Y /F 3rdParty\pthread\install\win\lib\pthreadVC2.dll install\win\bin
-EXIT /B 0
-:: -- pthread -------------------------
 
 
 :: -- config OMSimulator --------------
@@ -109,8 +94,6 @@ EXIT /B 0
 START /B /WAIT CMD /C "%~0 %OMS_VS_TARGET% clean"
 IF NOT ["%ERRORLEVEL%"]==["0"] GOTO fail
 IF NOT EXIST "3rdParty/README.md" GOTO fail2
-START /B /WAIT CMD /C "%~0 %OMS_VS_TARGET% pthread"
-IF NOT ["%ERRORLEVEL%"]==["0"] GOTO fail
 START /B /WAIT CMD /C "%~0 %OMS_VS_TARGET% omsimulator"
 IF NOT ["%ERRORLEVEL%"]==["0"] GOTO fail
 EXIT /B 0

--- a/src/OMSimulatorPython/CMakeLists.txt
+++ b/src/OMSimulatorPython/CMakeLists.txt
@@ -28,9 +28,6 @@ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/__init__.py"
 if(MSVC)
   install(FILES OMSimulatorPython3.bat TYPE BIN
           PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ)
-  install(FILES ${CMAKE_INSTALL_PREFIX}/bin/pthreadVC2.dll
-          DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/OMSimulator
-          PERMISSIONS OWNER_EXECUTE OWNER_WRITE OWNER_READ)
 elseif(MINGW)
   install(FILES "${CMAKE_CURRENT_BINARY_DIR}/OMSimulatorPython3" OMSimulatorPython3.bat
           TYPE BIN


### PR DESCRIPTION
  - This does not seem to be used as far as I can tell. It appears that it was used by `OMTLMSimulator` which is no longer used.
