### PR TITLE
Initial CMake based Doxygen doc generation.

### DIFF
--- a/doc/dev/OMSimulatorLib/CMakeLists.txt
+++ b/doc/dev/OMSimulatorLib/CMakeLists.txt
@@ -1,0 +1,35 @@
+
+
+## Set the relevant doxygen options. Refer to the Doxygen file in this directory for
+## more information about these options. Note that the Doxygen file is not used by this.
+## It is just left there documentation purposes right now.
+
+set(DOXYGEN_GENERATE_HTML YES)
+set(DOXYGEN_GENERATE_LATEX NO)
+
+set(DOXYGEN_PROJECT_NAME OMSimulatorLib)
+set(DOXYGEN_PROJECT_BRIEF "The OMSimulator project is a FMI-based co-simulation environment that supports ordinary (i.e., non-delayed) and TLM connections.")
+
+set(DOXYGEN_EXTRACT_ALL YES)
+set(DOXYGEN_EXTRACT_PRIVATE YES)
+set(DOXYGEN_EXTRACT_PACKAGE YES)
+set(DOXYGEN_EXTRACT_STATIC YES)
+set(DOXYGEN_EXTRACT_RECURSIVE YES)
+
+set(DOXYGEN_TEMPLATE_RELATIONS YES)
+set(DOXYGEN_CALL_GRAPH YES)
+set(DOXYGEN_CALLER_GRAPH YES)
+
+set(DOXYGEN_DOT_IMAGE_FORMAT svg)
+set(DOXYGEN_INTERACTIVE_SVG YES)
+
+
+set(DOXYGEN_USE_MDFILE_AS_MAINPAGE ${CMAKE_CURRENT_SOURCE_DIR}/mainpage.md)
+
+doxygen_add_docs(doc-doxygen
+                ${PROJECT_SOURCE_DIR}/src/OMSimulatorLib/ ${CMAKE_CURRENT_SOURCE_DIR}/mainpage.md
+                COMMENT "Generating doxygen documentation."
+)
+
+# add_custom_target(doc-doxygen
+#                   COMMAND ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile)


### PR DESCRIPTION
  - This adds CMake support for the `Doxygen` based documentation generation. All relevant options which were set in the `Doxyfile` used for the `Makefile` based build are set for CMake accordingly. I hope I have not missed any.

    The image generation is changed from `.png` to `.svg` and support for interactive `svg`s (zoom and pan) are enabled.

  - The generation is not enabled yet. Just the functionality is added for now. 
