### PR TITLE
Enable the CMake based doc generation and installation.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,3 +75,5 @@ add_subdirectory(src/OMSimulatorLua)
 add_subdirectory(src/OMSimulatorPython)
 add_subdirectory(src/OMSimulatorServer)
 add_subdirectory(src/pip)
+
+add_subdirectory(doc)

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -1,0 +1,25 @@
+
+find_package(Doxygen COMPONENTS dot)
+find_package(Sphinx)
+
+# If we find either of them then add a custom install target for documentation
+if(DOXYGEN_FOUND OR SPHINX_FOUND)
+  add_custom_target(install-docs)
+endif()
+
+if(DOXYGEN_FOUND)
+  add_subdirectory(dev/OMSimulatorLib)
+  add_dependencies(install-docs install-doxygen-docs)
+  message(STATUS "Doxygen found. Doxygen based documentation generation will be available.")
+else()
+  message(STATUS "Doxygen not found. Doxygen based documentation generation will NOT be available.")
+endif()
+
+
+if(SPHINX_FOUND)
+  add_subdirectory(UsersGuide)
+  add_dependencies(install-docs install-sphinx-docs)
+  message(STATUS "Sphinx found. Sphinx based documentation generation will be available.")
+else()
+  message(STATUS "Sphinx not found. Sphinx based documentation generation will NOT be available.")
+endif()


### PR DESCRIPTION
  - It is now possible to build the Doxygen and Sphinx documentations with CMake. There are multiple build and install targets that can be used to give more flexibility.

    `doc-doxygen-html`: Geneate the doxygen based html documentation.
    `install-doxygen-docs`: Install the doxygen based html documentation.

    `doc-sphinx-latex`: Generate the UsersGuide latex files with Sphinx.
    `doc-sphinx-latex-pdf`: Generate the UsersGuide pdf from the latex files.
    `install-sphinx-pdf-docs`: Install the UsersGuide pdfs (just one right now).

    `doc-sphinx-html`: Generate the UserGuide html files with sphinx.
    `install-sphinx-html-docs`: Install the UserGuide html files.

    `install-sphinx-docs`: Install both the html and pdf UserGuide files.

    `install-docs`: Install all documentation files. Doxygen html, Sphinx UsersGuide html, and Sphinx UsersGuide pdf.

  - These targets are created according to the availability of Doxygen and Sphinx on the system. If neither is found, there will be no `install-docs` target at all.

