### PR TITLE
Add a CMake testsuite-depends target.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,3 +77,10 @@ add_subdirectory(src/OMSimulatorServer)
 add_subdirectory(src/pip)
 
 add_subdirectory(doc)
+
+## Add the testsuite directory (which adds the target testsuite-depends which in turn depends
+## on omc-diff and testssuite-resources) only if OMSimulator is being used standalone.
+if(OMSIMULATOR_STANDALONE)
+  add_subdirectory(testsuite)
+endif()
+

--- a/testsuite/CMakeLists.txt
+++ b/testsuite/CMakeLists.txt
@@ -1,0 +1,7 @@
+
+add_subdirectory(difftool)
+add_subdirectory(resources)
+
+add_custom_target(testsuite-depends
+                    DEPENDS testsuite-resources
+                    DEPENDS omc-diff)

--- a/testsuite/difftool/CMakeLists.txt
+++ b/testsuite/difftool/CMakeLists.txt
@@ -1,0 +1,12 @@
+
+
+find_package(FLEX)
+
+if(NOT FLEX_FOUND)
+  message(WARNING "GNU Flex not found. You will not be able to use omc-diff to verify test results against expected results.")
+else()
+  FLEX_TARGET(omc_diff_lexer omc-diff.l ${CMAKE_CURRENT_BINARY_DIR}/lex.yy.c)
+  add_executable(omc-diff ${FLEX_omc_diff_lexer_OUTPUTS})
+
+  install(TARGETS omc-diff)
+endif()

--- a/testsuite/resources/CMakeLists.txt
+++ b/testsuite/resources/CMakeLists.txt
@@ -1,0 +1,123 @@
+
+set(OM_OMS_TESTSUITE_RESOURCES_FMUS
+        ${CMAKE_CURRENT_SOURCE_DIR}/A
+        ${CMAKE_CURRENT_SOURCE_DIR}/B
+        ${CMAKE_CURRENT_SOURCE_DIR}/AircraftVehicleDemonstrator.Atmosphere_Model_FMU_sf
+        ${CMAKE_CURRENT_SOURCE_DIR}/AircraftVehicleDemonstrator.bC
+        ${CMAKE_CURRENT_SOURCE_DIR}/AircraftVehicleDemonstrator.cockpit
+        ${CMAKE_CURRENT_SOURCE_DIR}/AircraftVehicleDemonstrator.consumer_A
+        ${CMAKE_CURRENT_SOURCE_DIR}/AircraftVehicleDemonstrator.consumer_B
+        ${CMAKE_CURRENT_SOURCE_DIR}/AircraftVehicleDemonstrator.eCS_Generic_Export
+        ${CMAKE_CURRENT_SOURCE_DIR}/AircraftVehicleDemonstrator.eCS_SW
+        ${CMAKE_CURRENT_SOURCE_DIR}/AircraftVehicleDemonstrator.engine
+        ${CMAKE_CURRENT_SOURCE_DIR}/ASSCExample.Class1
+        ${CMAKE_CURRENT_SOURCE_DIR}/ASSCExample.Class2
+        ${CMAKE_CURRENT_SOURCE_DIR}/DualMassOscillator.System1
+        ${CMAKE_CURRENT_SOURCE_DIR}/DualMassOscillator.System2
+        ${CMAKE_CURRENT_SOURCE_DIR}/Enum1
+        ${CMAKE_CURRENT_SOURCE_DIR}/equationPair.equation1
+        ${CMAKE_CURRENT_SOURCE_DIR}/equationPair.equation2
+        ${CMAKE_CURRENT_SOURCE_DIR}/fmidertest
+        ${CMAKE_CURRENT_SOURCE_DIR}/fmi_attributes_19
+        ${CMAKE_CURRENT_SOURCE_DIR}/HelloWorld
+        ${CMAKE_CURRENT_SOURCE_DIR}/HelloWorldWithInput
+        ${CMAKE_CURRENT_SOURCE_DIR}/Int1
+        ${CMAKE_CURRENT_SOURCE_DIR}/Lin2DimODE
+        ${CMAKE_CURRENT_SOURCE_DIR}/Modelica.Blocks.Continuous.Integrator
+        ${CMAKE_CURRENT_SOURCE_DIR}/Modelica.Blocks.Math.Add
+        ${CMAKE_CURRENT_SOURCE_DIR}/Modelica.Blocks.Math.Add3
+        ${CMAKE_CURRENT_SOURCE_DIR}/Modelica.Blocks.Math.Feedback
+        ${CMAKE_CURRENT_SOURCE_DIR}/Modelica.Blocks.Math.Gain
+        ${CMAKE_CURRENT_SOURCE_DIR}/Modelica.Blocks.Math.Product
+        ${CMAKE_CURRENT_SOURCE_DIR}/Modelica.Blocks.Nonlinear.Limiter
+        ${CMAKE_CURRENT_SOURCE_DIR}/Modelica.Blocks.Sources.Clock
+        ${CMAKE_CURRENT_SOURCE_DIR}/Modelica.Blocks.Sources.Constant
+        ${CMAKE_CURRENT_SOURCE_DIR}/Modelica.Blocks.Sources.Sine
+        ${CMAKE_CURRENT_SOURCE_DIR}/Modelica.Blocks.Sources.Step
+        ${CMAKE_CURRENT_SOURCE_DIR}/Modelica.Electrical.Analog.Examples.CauerLowPassAnalog
+        ${CMAKE_CURRENT_SOURCE_DIR}/nls.cs
+        ${CMAKE_CURRENT_SOURCE_DIR}/nls.me
+        ${CMAKE_CURRENT_SOURCE_DIR}/QuarterCarModel.DisplacementDisplacement.Chassis
+        ${CMAKE_CURRENT_SOURCE_DIR}/QuarterCarModel.DisplacementDisplacement.Wheel
+        ${CMAKE_CURRENT_SOURCE_DIR}/QuarterCarModel.DisplacementForce.Chassis
+        ${CMAKE_CURRENT_SOURCE_DIR}/QuarterCarModel.DisplacementForce.Wheel
+        ${CMAKE_CURRENT_SOURCE_DIR}/replaceA
+        ${CMAKE_CURRENT_SOURCE_DIR}/replaceB
+        ${CMAKE_CURRENT_SOURCE_DIR}/replaceA_extended
+        ${CMAKE_CURRENT_SOURCE_DIR}/str_hello_world
+        ${CMAKE_CURRENT_SOURCE_DIR}/tank1
+        ${CMAKE_CURRENT_SOURCE_DIR}/tank2
+        ${CMAKE_CURRENT_SOURCE_DIR}/tank3
+        ${CMAKE_CURRENT_SOURCE_DIR}/tlm.adder
+        ${CMAKE_CURRENT_SOURCE_DIR}/tlm.CoarseGrained1_1D
+        ${CMAKE_CURRENT_SOURCE_DIR}/tlm.CoarseGrained2_1D
+        ${CMAKE_CURRENT_SOURCE_DIR}/tlm.FineGrained1_1D
+        ${CMAKE_CURRENT_SOURCE_DIR}/tlm.FineGrained2_1D
+        ${CMAKE_CURRENT_SOURCE_DIR}/tlm.gain
+        ${CMAKE_CURRENT_SOURCE_DIR}/tlm.LowerPendulum
+        ${CMAKE_CURRENT_SOURCE_DIR}/tlm.LowerPendulumFG
+        ${CMAKE_CURRENT_SOURCE_DIR}/tlm.mass
+        ${CMAKE_CURRENT_SOURCE_DIR}/tlm.massSpring
+        ${CMAKE_CURRENT_SOURCE_DIR}/tlm.source
+        ${CMAKE_CURRENT_SOURCE_DIR}/tlm.UpperPendulum
+        ${CMAKE_CURRENT_SOURCE_DIR}/ypipe
+)
+
+set(OM_OMS_TESTSUITE_RESOURCES_SSPS
+        ${CMAKE_CURRENT_SOURCE_DIR}/embrace
+        ${CMAKE_CURRENT_SOURCE_DIR}/embrace_TwoConf
+        ${CMAKE_CURRENT_SOURCE_DIR}/import_hierarchical_ssv_sources
+        ${CMAKE_CURRENT_SOURCE_DIR}/importParameterMapping
+        ${CMAKE_CURRENT_SOURCE_DIR}/importParameterMappingInline
+        ${CMAKE_CURRENT_SOURCE_DIR}/importStartValues
+        ${CMAKE_CURRENT_SOURCE_DIR}/importStartValues1
+        ${CMAKE_CURRENT_SOURCE_DIR}/import_export_parameters1
+        ${CMAKE_CURRENT_SOURCE_DIR}/import_export_parameters2
+        ${CMAKE_CURRENT_SOURCE_DIR}/import_export_parameters3
+        ${CMAKE_CURRENT_SOURCE_DIR}/importExportAllResources
+        ${CMAKE_CURRENT_SOURCE_DIR}/replaceSubmodel4
+        ${CMAKE_CURRENT_SOURCE_DIR}/replaceSubmodel5
+)
+
+## Extract FMUs
+foreach(fmu_directory ${OM_OMS_TESTSUITE_RESOURCES_FMUS})
+  get_filename_component(fmu_name ${fmu_directory} NAME)
+  set(output_file_path ${CMAKE_CURRENT_SOURCE_DIR}/${fmu_name}.fmu)
+
+  add_custom_command(
+    # Use the modelDescrition.xml file as a dependency
+    DEPENDS ${fmu_directory}/modelDescription.xml
+    COMMAND cd ${fmu_directory}
+    COMMAND zip -r ${output_file_path} *
+    COMMAND cd ..
+    OUTPUT ${output_file_path}
+    COMMENT "Creating FMU ${output_file_path}"
+  )
+
+  set(OM_OMS_TESTSUITE_EXTRACTED_FMU_FILES ${OM_OMS_TESTSUITE_EXTRACTED_FMU_FILES} ${output_file_path})
+endforeach()
+
+## Extract SSPs
+foreach(fmu_directory ${OM_OMS_TESTSUITE_RESOURCES_SSPS})
+  get_filename_component(fmu_name ${fmu_directory} NAME)
+  set(output_file_path ${CMAKE_CURRENT_SOURCE_DIR}/${fmu_name}.ssp)
+
+  add_custom_command(
+    # Use the SystemStructure.ssd file as a dependency
+    DEPENDS ${fmu_directory}/SystemStructure.ssd
+    COMMAND cd ${fmu_directory}
+    COMMAND zip -r ${output_file_path} *
+    COMMAND cd ..
+    OUTPUT ${output_file_path}
+    COMMENT "Creating SSP ${output_file_path}"
+  )
+
+  set(OM_OMS_TESTSUITE_EXTRACTED_SSP_FILES ${OM_OMS_TESTSUITE_EXTRACTED_SSP_FILES} ${output_file_path})
+endforeach()
+
+# A custom target the depends on the extracted files.
+add_custom_target(testsuite-resources
+            DEPENDS ${OM_OMS_TESTSUITE_EXTRACTED_FMU_FILES}
+            DEPENDS ${OM_OMS_TESTSUITE_EXTRACTED_SSP_FILES}
+            COMMENT "Extracted FMUs and SSPs used by the testsuite."
+)


### PR DESCRIPTION
  - this target will build what is needed to run the `OMSimulator` testsuite. That is, it will build the `omc-diff` executable and it will also create `FMUs` and `SSPs` from the provided source files in the `resources/` folder.

  - The target **DOES NOT** and can not run the actual tests. It just prepares the required files. The actual testsing is still done using either the `Makefiles` in each directory or the `partest` perl script.

