### PR TITLE
Adjust configuration to fit well with OpenModelica.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ message("cmake version is: ${CMAKE_VERSION}")
 cmake_minimum_required(VERSION 3.14)
 
 project(OMSimulator)
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/config.cmake/")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/config.cmake/")
 
 
 ### Standards ###############################################################################################


### PR DESCRIPTION
  - OMSimulator standalone has no issues and works just fine. However, we need to consider some things when it is being built as part of OpenModelica.

      - Sundials exists in OpenModelica's 3rdParty as well as OMSimulator's
        3rdParty. It creates the same named targets in both. This is not
        allowed. So if OMSimulator is part of OpenModelica (not standalone)
        skip adding its 3rdParty/Sundials and just use the targets already
        added by OpenModelica. Just create aliases for them.

      - FMIL continues to create issues as usual. This time from across
        the horizon. FMIL comes with `minizip `(among other things) and uses
        it in the usual contrived FMIL way. OMSimulator also comes with its
        own `minizip`. So, as a workaround, just rename OMSimulator's `minizip` to `oms_minizip`
        and use it with that name. It should be fine since it is only used
        locally and is not supposed to be installed anyway.
