### PR TITLE
Update the arm64 macOS PR job.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,18 +56,6 @@ add_subdirectory(3rdParty)
 
 
 ##########################
-# Configuring for Python
-find_package(PythonLibs)
-IF(PYTHONLIBS_FOUND)
-  message(STATUS "Found Python")
-  message(STATUS "  PYTHON_VERSION:      " ${PYTHONLIBS_VERSION_STRING})
-  message(STATUS "  PYTHON_LIBRARIES:    " ${PYTHON_LIBRARIES})
-  message(STATUS "  PYTHON_INCLUDE_DIRS: " ${PYTHON_INCLUDE_DIRS})
-ELSE()
-  MESSAGE(WARNING, "Python library not found.")
-ENDIF()
-
-##########################
 # Add project modules
 add_subdirectory(src/OMSimulatorLib)
 add_subdirectory(src/OMSimulator)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -210,23 +210,9 @@ pipeline {
             beforeAgent true
           }
           stages {
-            stage('cross-compile') {
+            stage('arm64-macOS') {
               agent {
-                docker {
-                  image 'docker.openmodelica.org/osxcross-omsimulator:v2.0'
-                  label 'linux'
-                  alwaysPull true
-                }
-              }
-              environment {
-                CROSS_TRIPLE = "x86_64-apple-darwin15"
-                CC = "${env.CROSS_TRIPLE}-cc"
-                CXX = "${env.CROSS_TRIPLE}-c++"
-                AR = "${env.CROSS_TRIPLE}-ar"
-                RANLIB = "${env.CROSS_TRIPLE}-ranlib"
-                FMIL_FLAGS = '-DFMILIB_FMI_PLATFORM=darwin64'
-                detected_OS = 'Darwin'
-                VERBOSE = '1'
+                label 'M1'
               }
               steps {
                 buildOMS()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -204,15 +204,18 @@ pipeline {
           }
         }
 
-        stage('osxcross') {
+        stage('arm64-macOS') {
           when {
             expression { return shouldWeBuildMacOSArm64() }
             beforeAgent true
           }
           stages {
-            stage('arm64-macOS') {
+            stage('build') {
               agent {
                 label 'M1'
+              }
+              environment {
+                PATH="/opt/homebrew/bin:/opt/homebrew/opt/openjdk/bin:/usr/local/bin:${env.PATH}"
               }
               steps {
                 buildOMS()
@@ -231,7 +234,7 @@ pipeline {
                 expression { return false }
               } */
               agent {
-                label 'osx'
+                label 'M1'
               }
               steps {
                 unstash name: 'osx-install'


### PR DESCRIPTION
- The job used to be a cross-compilation for `arm64 macOS` on a `x64 Linux` host. It is now changed to simply run on the mac M1 machine we have. 