### PR TITLE
Do not statically link libgcc and libstdc++.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -515,25 +515,6 @@ EXIT /b 1
       }
     }
 
-    stage('cross-compilation') {
-      agent {
-        docker {
-          image 'anheuermann/ompython:wine-bionic'
-          label 'linux'
-          alwaysPull true
-        }
-      }
-      environment {
-        HOME = "${env.WORKSPACE}"
-      }
-      steps {
-        unstash name: 'mingw64-install'
-        sh """
-        wine64 install/bin/OMSimulator.exe --version
-        """
-      }
-    }
-
     stage('upload') {
       parallel {
 

--- a/src/OMSimulator/CMakeLists.txt
+++ b/src/OMSimulator/CMakeLists.txt
@@ -2,10 +2,6 @@ project(OMSimulator)
 
 add_executable(OMSimulator main.cpp)
 
-IF (WIN32 AND MINGW)
-  set(CMAKE_EXE_LINKER_FLAGS "-static -static-libgcc -static-libstdc++")
-ENDIF ()
-
 target_link_libraries(OMSimulator PUBLIC OMSimulatorLib_static)
 
 install(TARGETS OMSimulator DESTINATION bin)


### PR DESCRIPTION
  - This is not recommend in general but it is also not good for us specifically. To begin with, it just assumes the compiler is always `gcc`. Compiling OMSimulator with, for example, MinGW64 `clang` and then linking to `libstdc++` instead of `libc++` will, in the least, give you those warnings about duplicate sections having different sizes. For other compilers/runtimes it can have a more serious effect. I think the final executable segfaults for clang on MinGW-64's UCRT system.

  - There is no need for this. The only benefit of it was probably not having to ship `libgcc `and `libstdc++` with the OMSimulator binaries when making a package from the MinGW build. However, there is an `MSVC `build for Windows and that should be the one used for creating real Windows packages. The MinGW packages should be used for MSYS/MinGW systems only.

