### PR TITLE
Fix installation path specifier.

### DIFF
--- a/src/OMSimulatorServer/CMakeLists.txt
+++ b/src/OMSimulatorServer/CMakeLists.txt
@@ -2,5 +2,6 @@ project(OMSimulatorServer)
 
 # install only if build as part of the OpenModelica super project
 if(OPENMODELICA_SUPERPROJECT)
-  install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/OMSimulatorServer.py" DESTINATION ${CMAKE_INSTALL_PREFIX}/share/OMSimulator/scripts)
+  install(FILES OMSimulatorServer.py
+          DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/OMSimulator/scripts)
 endif()


### PR DESCRIPTION
  - Make the install path relative. CMAKE_INSTALL_PREFIX is added to each install path implicitly. No need to specify it. In fact it makes the packages generated from this setup not relocatable.

