### PR TITLE
Set install component when part of OpenModelica.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,10 +13,16 @@ set(CXX_STANDARD_REQUIRED ON)
 ## Make sure we do not start relying on extensions down the road.
 set(CMAKE_CXX_EXTENSIONS OFF)
 
-## If OMSimulator is not being built as part of OpenModelica
+## If OMSimulator is NOT being built as part of OpenModelica
 ## include the required settings here.
 if(NOT OPENMODELICA_SUPERPROJECT)
   include(OMSimulatorTopLevelSettings)
+endif()
+
+## If OMSimulator is being built as part of OpenModelica
+## set the install component to 'omsimulator' for all tagets built by it.
+if(NOT OPENMODELICA_SUPERPROJECT)
+  set(CMAKE_INSTALL_DEFAULT_COMPONENT_NAME omsimulator)
 endif()
 
 


### PR DESCRIPTION
  - When OMSimulator is built as part of OpenModelica, set the install component to `omsimulator` for all targets built by it. OpenModelica has multiple install components and so this needs to be set as well. Otherwise CMake will put it under the 'unknown' install component it creates automatically.

  - This can be changed to be set always (even when not part of OpenModelica) It should work just fine as well. For now, it is set only when it is actually required (i.e, OMsimulator is part of OpenModelica.)
