### PR TITLE
Minor improvements and fixes.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,13 +15,13 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 ## If OMSimulator is NOT being built as part of OpenModelica
 ## include the required settings here.
-if(NOT OPENMODELICA_SUPERPROJECT)
+if(NOT OPENMODELICA_NEW_CMAKE_BUILD)
   include(OMSimulatorTopLevelSettings)
 endif()
 
 ## If OMSimulator is being built as part of OpenModelica
 ## set the install component to 'omsimulator' for all tagets built by it.
-if(OPENMODELICA_SUPERPROJECT)
+if(OPENMODELICA_NEW_CMAKE_BUILD)
   set(CMAKE_INSTALL_DEFAULT_COMPONENT_NAME omsimulator)
 endif()
 

--- a/src/OMSimulatorServer/CMakeLists.txt
+++ b/src/OMSimulatorServer/CMakeLists.txt
@@ -1,7 +1,4 @@
 project(OMSimulatorServer)
 
-# install only if build as part of the OpenModelica super project
-if(OPENMODELICA_SUPERPROJECT)
-  install(FILES OMSimulatorServer.py
+install(FILES OMSimulatorServer.py
           DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/OMSimulator/scripts)
-endif()


### PR DESCRIPTION
  - Use the CMake variable OPENMODELICA_NEW_CMAKE_BUILD to signify that OMSimulator is being built as part of the OpenModelica CMake project. This was represented by the variable OPENMODELICA_SUPERPROJECT. However, as it turns out there is no need to add a new variable. It is also more descriptive because what we really want to know is that it is part of the OpenModelica CMake build and not just part of OpenModelica (as in the autoconf build).

  - Install `src/OMSimulatorServer/OMSimulatorServer.py` all the time. While it can be done only when part of OpenModelica, it creates unnecessary complication in that we will now need an additional variable to tell us if OMSimulator is part of OpenModelica but being used by the autoconf build instead of the CMake one.
