### PR TITLE
add XercesValidator

### DIFF
--- a/.CI/alpine/Dockerfile
+++ b/.CI/alpine/Dockerfile
@@ -1,4 +1,4 @@
 # We need gcc 8 for filesystem support
 FROM alpine:3.12
 
-RUN apk add -U libtool automake g++ git cmake make readline-dev musl-dev
+RUN apk add -U libtool automake g++ gcc git cmake make readline-dev musl-dev util-linux

--- a/.CI/alpine/Dockerfile
+++ b/.CI/alpine/Dockerfile
@@ -1,4 +1,4 @@
 # We need gcc 8 for filesystem support
 FROM alpine:3.12
 
-RUN apk add -U libtool automake g++ gcc git cmake make readline-dev musl-dev util-linux
+RUN apk add -U libtool automake g++ git cmake make readline-dev musl-dev util-linux linux-headers

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,9 @@ ENDIF()
 
 message(STATUS "Platform string: ${PLATFORM_STRING}")
 
+### add schema root location which will be used by XercesValidator.cpp
+add_compile_definitions("SCHEMA_ROOT=${CMAKE_SOURCE_DIR}/schema")
+
 ##########################
 
 add_subdirectory(3rdParty)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,9 +53,6 @@ ENDIF()
 
 message(STATUS "Platform string: ${PLATFORM_STRING}")
 
-### add schema root location which will be used by XercesValidator.cpp
-add_compile_definitions("SCHEMA_ROOT=${CMAKE_SOURCE_DIR}/schema")
-
 ##########################
 
 add_subdirectory(3rdParty)
@@ -76,6 +73,8 @@ if(OM_OMS_ENABLE_PIP)
 endif()
 
 add_subdirectory(doc)
+
+add_subdirectory(schema)
 
 ## Add the testsuite directory (which adds the target testsuite-depends which in turn depends
 ## on omc-diff and testssuite-resources) only if OMSimulator is being used standalone.

--- a/schema/CMakeLists.txt
+++ b/schema/CMakeLists.txt
@@ -1,0 +1,2 @@
+install(DIRECTORY fmi2 fmi3 ssp
+        DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/OMSimulator/schema)

--- a/schema/ssp/SystemStructureCommon.xsd
+++ b/schema/ssp/SystemStructureCommon.xsd
@@ -1,0 +1,480 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified"
+    xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
+    targetNamespace="http://ssp-standard.org/SSP1/SystemStructureCommon">
+    <xs:annotation>
+        <xs:documentation xml:lang="en">
+            This is the normative XML Schema 1.0 schema for the MAP SSP
+            SystemStructure 1.0 common content across formats.
+            
+            Version: 1.0
+
+            Copyright 2016 -- 2019 Modelica Association Project "SSP"
+
+            Redistribution and use in source and binary forms, with or
+            without modification, are permitted provided that the
+            following conditions are met:
+
+            1. Redistributions of source code must retain the above
+               copyright notice, this list of conditions and the
+               following disclaimer.
+
+            2. Redistributions in binary form must reproduce the above
+               copyright notice, this list of conditions and the
+               following disclaimer in the documentation and/or other
+               materials provided with the distribution.
+
+            THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+            CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+            INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+            MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+            DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+            CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+            INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+            (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+            GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+            BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+            LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+            (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+            OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+            POSSIBILITY OF SUCH DAMAGE.
+        </xs:documentation>
+    </xs:annotation>
+    
+    <xs:attributeGroup name="ABaseElement">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                This attribute group specifies the attributes common to all model elements.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="id" type="xs:ID" use="optional">
+            <xs:annotation>
+                <xs:documentation xml:lang="en">
+                    This attribute gives the model element a file-wide unique id which can
+                    be referenced from other elements or via URI fragment identifier.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="description" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation xml:lang="en">
+                    This attribute gives a human readable longer description of the
+                    model element, which can be shown to the user where appropriate. 
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:attributeGroup>
+    
+    <xs:attributeGroup name="ATopLevelMetaData">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                This attribute group specifies the optional meta-data attributes common to 
+                all top-level container elements of all defined file formats.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute name="author" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation xml:lang="en">
+                    This attribute gives the name of the author of this file's content. 
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="fileversion" type="xs:normalizedString" use="optional">
+            <xs:annotation>
+                <xs:documentation xml:lang="en">
+                    This attribute gives a version number for this file's content. 
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="copyright" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation xml:lang="en">
+                    This attribute gives copyright information for this file's content. 
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="license" type="xs:string" use="optional">
+            <xs:annotation>
+                <xs:documentation xml:lang="en">
+                    This attribute gives license information for this file's content. 
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="generationTool" type="xs:normalizedString">
+            <xs:annotation>
+                <xs:documentation xml:lang="en">
+                    This attribute gives the name of the tool that generated this file. 
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="generationDateAndTime" type="xs:dateTime">
+            <xs:annotation>
+                <xs:documentation xml:lang="en">
+                    This attribute gives the date and time this file was generated. 
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:attributeGroup>
+    
+    <xs:complexType name="TEnumerations">
+        <xs:sequence>
+            <xs:element name="Enumeration" minOccurs="1" maxOccurs="unbounded" type="ssc:TEnumeration"/>
+        </xs:sequence>
+    </xs:complexType>
+    
+    <xs:complexType name="TEnumeration">
+        <xs:sequence>
+            <xs:element name="Item" minOccurs="1" maxOccurs="unbounded">
+                <xs:complexType>
+                    <xs:attribute name="name" type="xs:string" use="required">
+                        <xs:annotation>
+                            <xs:documentation xml:lang="en">Name of the Enumeration Item</xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="value" type="xs:int" use="required">
+                        <xs:annotation>
+                            <xs:documentation xml:lang="en">The Value of the Enumeration Item</xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="Annotations" minOccurs="0" type="ssc:TAnnotations"/>
+        </xs:sequence>
+        <xs:attributeGroup ref="ssc:ABaseElement"/>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation xml:lang="en">
+                    This attribute specifies the name of the enumeration in the system description,
+                    which must be unique within in the system description.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+    
+    <xs:complexType name="TUnits">
+        <xs:sequence>
+            <xs:element name="Unit" minOccurs="1" maxOccurs="unbounded" type="ssc:TUnit"/>
+        </xs:sequence>
+    </xs:complexType>
+    
+    <xs:complexType name="TUnit">
+        <xs:sequence>
+            <xs:element name="BaseUnit">
+                <xs:complexType>
+                    <xs:attribute name="kg" type="xs:int" default="0">
+                        <xs:annotation>
+                            <xs:documentation>Exponent of SI base unit "kg"</xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="m" type="xs:int" default="0">
+                        <xs:annotation>
+                            <xs:documentation>Exponent of SI base unit "m"</xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="s" type="xs:int" default="0">
+                        <xs:annotation>
+                            <xs:documentation>Exponent of SI base unit "s"</xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="A" type="xs:int" default="0">
+                        <xs:annotation>
+                            <xs:documentation>Exponent of SI base unit "A"</xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="K" type="xs:int" default="0">
+                        <xs:annotation>
+                            <xs:documentation>Exponent of SI base unit "K"</xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="mol" type="xs:int" default="0">
+                        <xs:annotation>
+                            <xs:documentation>Exponent of SI base unit "mol"</xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="cd" type="xs:int" default="0">
+                        <xs:annotation>
+                            <xs:documentation>Exponent of SI base unit "cd"</xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="rad" type="xs:int" default="0">
+                        <xs:annotation>
+                            <xs:documentation>Exponent of SI derived unit "rad"</xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="factor" type="xs:double" default="1"/>
+                    <xs:attribute name="offset" type="xs:double" default="0"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="Annotations" minOccurs="0" type="ssc:TAnnotations"/>
+        </xs:sequence>
+        <xs:attributeGroup ref="ssc:ABaseElement"/>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation xml:lang="en">
+                    This attribute specifies the name of the unit in the system description,
+                    which must be unique within in the system description.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+    
+    <xs:complexType name="TAnnotations">
+        <xs:sequence maxOccurs="unbounded">
+            <xs:element name="Annotation">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:any namespace="##any" processContents="lax" minOccurs="0"/>
+                    </xs:sequence>
+                    <xs:attribute name="type" type="xs:normalizedString" use="required">
+                        <xs:annotation>
+                            <xs:documentation xml:lang="en">
+                                The unique name of the type of the annotation.
+                                
+                                In order to ensure uniqueness all types should be identified
+                                with reverse domain name notation (cf. Java package names
+                                or Apple UTIs) of a domain that is controlled by the entity
+                                defining the semantics and content of the annotation.
+                                
+                                For vendor-specific annotations this would e.g. be a domain
+                                controlled by the tool vendor.
+                                
+                                For MAP-SSP defined annotations, this will be a domain under
+                                the org.modelica prefix.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+    
+    <xs:group name="GTypeChoice">
+        <xs:choice>
+            <xs:annotation>
+                <xs:documentation xml:lang="en">
+                    This element gives the type of a connector or signal dictionary entry
+                    (called entity below).
+                </xs:documentation>
+            </xs:annotation>
+            <xs:element name="Real">
+                <xs:complexType>
+                    <xs:attribute name="unit" type="xs:string" use="optional">
+                        <xs:annotation>
+                            <xs:documentation xml:lang="en">
+                                This attribute gives the unit of the entity and must
+                                reference one of the unit definitions provided in the Units
+                                element of the containing file.
+                                
+                                If a unit is not supplied, the unit is determined through
+                                default mechanisms: For FMU components, the unit of the
+                                underlying variable would be used, for systems the units
+                                of connected underlying connectors could be used if unambiguous.
+                                If a unit cannot be deduced unambinguously, the user should
+                                be informed of this error.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="Integer">
+                <xs:complexType>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="Boolean">
+                <xs:complexType>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="String">
+                <xs:complexType>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="Enumeration">
+                <xs:complexType>
+                    <xs:attribute name="name" type="xs:string" use="required">
+                        <xs:annotation>
+                            <xs:documentation xml:lang="en">
+                                This attribute specifies the name of the enumeration
+                                which references into the set of defined enumerations
+                                of the system structure description, as contained in
+                                the Enumerations element of the root element.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="Binary">
+                <xs:complexType>
+                    <xs:attribute name="mime-type" type="xs:string" default="application/octet-stream">
+                        <xs:annotation>
+                            <xs:documentation xml:lang="en">
+                                This optional attribute specifies the MIME type of the
+                                underlying binary data, which defaults to the non-specific
+                                application/octet-stream type.  This information can be
+                                used by the implementation to detect mismatches between
+                                connected binary connectors, or provide automatic means of
+                                conversion between different formats.  It should be noted
+                                that the implementation is not required to provide this
+                                service, i.e. it remains the responsibility of the operator 
+                                to ensure only compatible binary connectors are connected.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
+        </xs:choice>
+    </xs:group>
+    
+    <xs:group name="GTransformationChoice">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                This element specifies the transformation to be applied to a value prior to its
+                use in a connection or parameter mapping.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice>
+            <xs:element name="LinearTransformation">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">
+                        This element provides for a linear transformation to be performed on the
+                        parameter values and is valid for parameters of a continuous type.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:attribute name="factor" type="xs:double" use="optional" default="1.0">
+                        <xs:annotation>
+                            <xs:documentation xml:lang="en">
+                                This attribute specifies an optional factor value to use in a linear
+                                transformation of the source parameter value to the target parameter
+                                value, i.e. in the calculation target = factor * source + offset.
+                                
+                                Note that conversions based on different units are performed, unless
+                                prevented by suppressUnitConversion, prior to the application of the
+                                linear transformation, i.e. the value of source is already converted
+                                to the target unit in the formula above.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="offset" type="xs:double" use="optional" default="0.0">
+                        <xs:annotation>
+                            <xs:documentation xml:lang="en">
+                                This attribute specifies an optional offset value to use in a linear
+                                transformation of the source parameter value to the target parameter
+                                value, i.e. in the calculation target = factor * source + offset.
+                                
+                                Note that conversions based on different units are performed, unless
+                                prevented by suppressUnitConversion, prior to the application of the
+                                linear transformation, i.e. the value of source is already converted
+                                to the target unit in the formula above.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="BooleanMappingTransformation">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">
+                        This element provides for a transformation of boolean parameter values
+                        based on a mapping table and is valid for parameters of boolean type.
+                        Each mapping table entry is provided by a MapEntry element.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="MapEntry" minOccurs="1" maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:attribute name="source" type="xs:boolean" use="required">
+                                    <xs:annotation>
+                                        <xs:documentation xml:lang="en">
+                                            This attribute gives the value of the parameter in the
+                                            parameter source that this entry applies to.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="target" type="xs:boolean" use="required">
+                                    <xs:annotation>
+                                        <xs:documentation xml:lang="en">
+                                            This attribute gives the value of the parameter to use
+                                            when applying it to the system or component that is to be
+                                            parametrized.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="IntegerMappingTransformation">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">
+                        This element provides for a transformation of integer parameter values
+                        based on a mapping table and is valid for parameters of integer and 
+                        enumeration type.  Each mapping table entry is provided by a MapEntry
+                        element.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="MapEntry" minOccurs="1" maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:attribute name="source" type="xs:int" use="required">
+                                    <xs:annotation>
+                                        <xs:documentation xml:lang="en">
+                                            This attribute gives the value of the parameter in the
+                                            parameter source that this entry applies to.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="target" type="xs:int" use="required">
+                                    <xs:annotation>
+                                        <xs:documentation xml:lang="en">
+                                            This attribute gives the value of the parameter to use
+                                            when applying it to the system or component that is to be
+                                            parametrized.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="EnumerationMappingTransformation">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">
+                        This element provides for a transformation of enumeration parameter values
+                        based on a mapping table of their enumeration item names and is valid for
+                        parameters of enumeration type.  Each mapping table entry is provided by a
+                        MapEntry element.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="MapEntry" minOccurs="1" maxOccurs="unbounded">
+                            <xs:complexType>
+                                <xs:attribute name="source" type="xs:string" use="required">
+                                    <xs:annotation>
+                                        <xs:documentation xml:lang="en">
+                                            This attribute gives the value of the parameter in the
+                                            parameter source that this entry applies to.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="target" type="xs:string" use="required">
+                                    <xs:annotation>
+                                        <xs:documentation xml:lang="en">
+                                            This attribute gives the value of the parameter to use
+                                            when applying it to the system or component that is to be
+                                            parametrized.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                            </xs:complexType>
+                        </xs:element>
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:choice>
+    </xs:group>
+    
+</xs:schema>

--- a/schema/ssp/SystemStructureDescription.xsd
+++ b/schema/ssp/SystemStructureDescription.xsd
@@ -1,0 +1,950 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified"
+    xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription"
+    xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
+    targetNamespace="http://ssp-standard.org/SSP1/SystemStructureDescription"
+    attributeFormDefault="unqualified">
+    <xs:annotation>
+        <xs:documentation xml:lang="en">
+            This is the normative XML Schema 1.0 schema for the MAP SSP
+            SystemStructureDescription 1.0 format.
+
+            Version: 1.0
+
+            Copyright 2016 -- 2019 Modelica Association Project "SSP"
+
+            Redistribution and use in source and binary forms, with or
+            without modification, are permitted provided that the
+            following conditions are met:
+
+            1. Redistributions of source code must retain the above
+               copyright notice, this list of conditions and the
+               following disclaimer.
+
+            2. Redistributions in binary form must reproduce the above
+               copyright notice, this list of conditions and the
+               following disclaimer in the documentation and/or other
+               materials provided with the distribution.
+
+            THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+            CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+            INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+            MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+            DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+            CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+            INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+            (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+            GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+            BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+            LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+            (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+            OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+            POSSIBILITY OF SUCH DAMAGE.
+        </xs:documentation>
+    </xs:annotation>
+
+    <xs:import namespace="http://ssp-standard.org/SSP1/SystemStructureCommon" schemaLocation="SystemStructureCommon.xsd"/>
+
+    <xs:element name="SystemStructureDescription">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="System" type="ssd:TSystem"/>
+                <xs:element name="Enumerations" minOccurs="0" type="ssc:TEnumerations"/>
+                <xs:element name="Units" minOccurs="0" type="ssc:TUnits"/>
+                <xs:element name="DefaultExperiment" minOccurs="0" type="ssd:TDefaultExperiment"/>
+                <xs:element name="Annotations" minOccurs="0" type="ssc:TAnnotations"/>
+            </xs:sequence>
+            <xs:attribute name="version" use="required">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">
+                        Version of SSD format, 1.0 for this release.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:normalizedString">
+                        <xs:pattern value="1[.][0-9]+(-.*)?"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:attribute>
+            <xs:attribute name="name" type="xs:string" use="required">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">
+                        This attribute gives the system structure a name, which can be used
+                        for purposes of presenting the system structure to the user, e.g.
+                        when selecting individual variant SSDs from an SSP.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
+            <xs:attributeGroup ref="ssc:ABaseElement"/>
+            <xs:attributeGroup ref="ssc:ATopLevelMetaData"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:complexType name="TElement">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                This is the base type for all elements, currently consisting of components and systems.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="Connectors" minOccurs="0" type="ssd:TConnectors">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">
+                        The set of connectors of this element, which represent
+                        the interface of the element to the outside world.
+
+                        For components the set of connectors must match variable/ports
+                        of the underlying component implementation, e.g. the referenced
+                        FMU, by name.
+
+                        Note that there is no requirement that connectors must
+                        be present for all variables/ports of an underlying
+                        component implementation.  Only those connectors must
+                        be present which are referenced in connections inside
+                        the SSD.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="ElementGeometry" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">
+                        This optional element defines the geometry information of the component.
+                        (x1,y1) and (x2,y2) define the positions of the lower-left and upper-right
+                        corners of the component in the coordinate system of the parent.
+                        x1>x2 indicates horizontal flipping, y1>y2 indicates vertical flipping.
+                        The optional attribute rotation (in degrees) defines an additional rotation
+                        (applied after flipping), where positive numbers indicate left rotation (x->y).
+                        The coordinate system is oriented: x -> right, y -> up.
+
+                        The optional attribute iconSource defines an icon URI with the same semantics as
+                        for the source attribute of the Component element.  If defined, this icon overrides
+                        any icon that may be defined e.g. in an .fmu file (as disccused in the FMI group).
+                        The optional attribute rotation defines the rotation (in degrees) of the icon.
+                        The optional attribute FixedAspectRatio defines whether the icon shall be fit
+                        into the extent defined by (x1,y1), (x2,y2) and iconRotation with fixed aspect
+                        ratio. The optional attribute iconFlip defines whether any flipping indicated
+                        by (x1,y1), (x2, y2) shall be applied to the icon graphics, too.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:attribute name="x1" type="xs:double" use="required"/>
+                    <xs:attribute name="y1" type="xs:double" use="required"/>
+                    <xs:attribute name="x2" type="xs:double" use="required"/>
+                    <xs:attribute name="y2" type="xs:double" use="required"/>
+                    <xs:attribute name="rotation" type="xs:double" use="optional" default="0.0"/>
+                    <xs:attribute name="iconSource" type="xs:anyURI" use="optional"/>
+                    <xs:attribute name="iconRotation" type="xs:double" use="optional" default="0.0"/>
+                    <xs:attribute name="iconFlip" type="xs:boolean" use="optional" default="false"/>
+                    <xs:attribute name="iconFixedAspectRatio" type="xs:boolean" use="optional" default="false"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="ParameterBindings" minOccurs="0" type="ssd:TParameterBindings">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">
+                        The set of parameter bindings for this element.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+        <xs:attributeGroup ref="ssc:ABaseElement"/>
+        <xs:attribute name="name" use="required">
+            <xs:annotation>
+                <xs:documentation xml:lang="en">
+                    This attribute gives the element a name, which shall be unique
+                    within the directly enclosing system. The name is used for
+                    purposes of specifying the element's connectors in connections.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:minLength value="1"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+
+    <xs:complexType name="TComponent">
+        <xs:complexContent>
+            <xs:extension base="ssd:TElement">
+                <xs:sequence>
+                    <xs:element name="Annotations" minOccurs="0" type="ssc:TAnnotations"/>
+                </xs:sequence>
+                <xs:attribute name="type" type="xs:string" use="optional" default="application/x-fmu-sharedlibrary">
+                    <xs:annotation>
+                        <xs:documentation xml:lang="en">
+                            This attribute specifies the MIME type of the component, which defaults to
+                            application/x-fmu-sharedlibrary to indicate an FMU.  When referencing another
+                            system structure definition file, the MIME type application/x-ssp-definition
+                            is used, and the MIME type application/x-ssp-package is used for referenced
+                            system structure packages (SSPs). No further types are currently defined.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="source" type="xs:anyURI" use="required">
+                    <xs:annotation>
+                        <xs:documentation xml:lang="en">
+                            This attribute indicates the source of the component as an URI
+                            (cf. RFC 3986).  For purposes of the resolution of relative URIs
+                            the base URI is the URI of the SSD.  Therefore for components
+                            that are located alongside the SSD, relative URIs without scheme
+                            and authority can and should be used to specify the component
+                            sources.  For components that are packaged inside an SSP that
+                            contains this SSD, this is mandatory (in this way, the SSD URIs
+                            remain valid after unpacking the SSP into the filesystem).
+
+                            E.g. for an FMU called MyDemoFMU.fmu, that is located in the
+                            resources directory of an SSP, the correct URI would be
+                            "resources/MyDemoFMU.fmu".
+
+                            When referencing another SSP, by default the default SSD of the
+                            SSP (i.e. SystemStructure.ssd) is referenced.  When a non-default
+                            SSD should be selected, then the name of the non-default SSD must
+                            be given through a fragment identifier, i.e. the URI
+                            "resources/SubSSP.ssp#VariantB.ssd" would reference the VariantB.ssd
+                            of SubSSP.ssp located in the resources directory relative to this SSD.
+
+                            When the URI is a same-document URI with a fragment identifier, e.g.
+                            "#other-system", then the fragment identifier should identify a
+                            system element in this SSD document with an id attribute identical
+                            to the fragment identifier.  This mechanism can be used to instantiate
+                            an embedded system definition multiple times through reference to
+                            its definition element.
+
+                            Note that implementations are only required to support relative URIs
+                            as specified above, and that especially relative URIs that move beyond
+                            the baseURI (e.g. go "up" a level via ..) are not required to be
+                            supported by implementations, and are in fact often not supported for
+                            security or other reasons.  Implementations are also not required to
+                            support any absolute URIs and any specific URI schemes (but are of
+                            course allowed to support any and all kinds of URIs where useful).
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="implementation" use="optional" default="any">
+                    <xs:annotation>
+                        <xs:documentation xml:lang="en">
+                            When the referenced component is an FMU that contains multiple
+                            implementations (e.g. Co-Simulation and Model Exchange), this optional
+                            attribute can be used to determine which FMU implementation should be
+                            employed.  If the attribute is missing or uses the default value "any",
+                            the importing tool is free to choose what kind of FMU implementation
+                            to use.  If the value is "CoSimulation" or "ModelExchange" the corresponding
+                            FMU implementation must be used.  It is an error if the specified type
+                            of FMU implementation is not present in the FMU.
+                        </xs:documentation>
+                    </xs:annotation>
+                    <xs:simpleType>
+                        <xs:restriction base="xs:string">
+                            <xs:enumeration value="any"/>
+                            <xs:enumeration value="ModelExchange"/>
+                            <xs:enumeration value="CoSimulation"/>
+                        </xs:restriction>
+                    </xs:simpleType>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="TSignalDictionaries">
+        <xs:sequence>
+            <xs:element name="SignalDictionary" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">
+                        This element defines a signal dictionary, describing the signal dictionary
+                        entries present in the signal dictionary.
+
+                        The contents of the element can be used to provide a signal dictionary
+                        inline, in which case the source attribute of the SignalDictionary element
+                        must be empty.
+
+                        The contents must be an ssb:SignalDictionary element, if the type attribute
+                        of this element is application/x-ssp-signal-dictionary, or any other valid
+                        XML content if the type attribute references another MIME type (in that case
+                        there should be a layered specification that defines how embedding the content
+                        works for that MIME type).
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:choice>
+                        <!-- NOTE: In XML Schema 1.1 this choice would also contain the following entry:
+
+                             <xs:element ref="ssb:SignalDictionary"/>
+
+                             which specifies the proper way to directly embed a SignalDictionary inline.
+                             Due to restrictions in XML Schema 1.0, this would lead to a violation of the
+                             unique particle attribution schema component constraint, since the embedded
+                             ssb:SignalDictionary element would also be matched by the more generic xs:any
+                             specification.  Since XML Schema 1.1 validators are still rare compared with
+                             1.0 validators, the default schema files for SSP are still restricted to 1.0;
+                             however if you have access to a 1.1 validator/validating parser, you can
+                             use the 1.1 variant of these stylesheets instead.
+                        -->
+                        <xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+                    </xs:choice>
+                    <xs:attributeGroup ref="ssc:ABaseElement"/>
+                    <xs:attribute name="type" type="xs:string" use="optional" default="application/x-ssp-signal-dictionary"/>
+                    <xs:attribute name="source" type="xs:anyURI" use="optional">
+                        <xs:annotation>
+                            <xs:documentation xml:lang="en">
+                                This attribute indicates the source of the signal dictionary as a URI
+                                (cf. RFC 3986).  For purposes of the resolution of relative URIs
+                                the base URI is the URI of the SSD.
+
+                                If the source attribute is missing, the signal dictionary is provided
+                                inline as contents of the SignalDictionary element, which must be
+                                empty otherwise.
+
+                                For the default type application/x-ssp-signal-dictionary such inline
+                                content must be an ssb:SignalDictionary element.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="name" type="xs:string" use="required">
+                        <xs:annotation>
+                            <xs:documentation xml:lang="en">
+                                This attribute gives the signal dictionary a name, which shall be
+                                unique within the directly enclosing system. The name is used for
+                                purposes of specifying the signal dictionary referenced by a
+                                signal dictionary reference.  Name lookups occur in hierarchical
+                                fashion, i.e. the name is first looked up in the system that
+                                contains a signal dictionary reference.  If that lookup yields
+                                no match, the lookup is performed on the enclosing system, etc.,
+                                until a match is found.  It is an error if no matching signal
+                                dictionary is found.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="TSignalDictionaryReference">
+        <xs:complexContent>
+            <xs:extension base="ssd:TElement">
+                <xs:sequence>
+                    <xs:element name="Annotations" minOccurs="0" type="ssc:TAnnotations"/>
+                </xs:sequence>
+                <xs:attribute name="dictionary" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation xml:lang="en">
+                            This attribute gives the name of the signal dictionary that is to
+                            be referenced.  Name lookups occur in hierarchical fashion, i.e.
+                            the name is first looked up in the system that contains a signal
+                            dictionary reference.  If that lookup yields no match, the lookup
+                            is performed on the enclosing system, etc., until a match is found.
+                            It is an error if no matching signal dictionary is found.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="TSystem">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                This element describes a system, which can contain components and other systems as elements,
+                connectors as an interface to the outside world, and connections connecting the connectors
+                of itself and of its elements to another.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="ssd:TElement">
+                <xs:sequence>
+                    <xs:element name="Elements" minOccurs="0">
+                        <xs:complexType>
+                            <xs:sequence>
+                                <xs:choice maxOccurs="unbounded">
+                                    <xs:element name="Component" type="ssd:TComponent"/>
+                                    <xs:element name="SignalDictionaryReference" type="ssd:TSignalDictionaryReference"/>
+                                    <xs:element name="System" type="ssd:TSystem"/>
+                                </xs:choice>
+                            </xs:sequence>
+                        </xs:complexType>
+                    </xs:element>
+                    <xs:element name="Connections" minOccurs="0">
+                        <xs:complexType>
+                            <xs:sequence>
+                                <xs:element name="Connection" maxOccurs="unbounded">
+                                    <xs:annotation>
+                                        <xs:documentation xml:lang="en">
+                                            This element specifies a connection between two connectors,
+                                            either of the system or its directly contained elements.
+                                            Note that connections between connectors on a system are
+                                            allowed, so neither startElement nor endElement has to be
+                                            supplied.
+
+                                            Note also that the terms start and end in the attribute names
+                                            of the connector, like startElement or endConnector, do not
+                                            denote directionality of the data flow implied by the connector.
+                                            That is determined by the combination of the semantics of the
+                                            actual connectors (variables/ports) connected and their kind
+                                            attributes:
+
+                                            For component to component connections as well as for connections
+                                            between two connectors at the system level, currently the kind of
+                                            one connector must be output and of another connector must be
+                                            input, or for parameter connections the kind of one connector
+                                            must be calculatedParameter and the other must be parameter.
+                                            Information flows from the output/calculatedParameter to the
+                                            input/parameter connector.
+
+                                            For system to component connections the kinds of the connectors
+                                            must match, i.e. either both are input or both output or both
+                                            parameter or both calculatedParameter.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                    <xs:complexType>
+                                        <xs:sequence>
+                                            <xs:group ref="ssc:GTransformationChoice" minOccurs="0" maxOccurs="1">
+                                                <xs:annotation>
+                                                    <xs:documentation xml:lang="en">
+                                                        This optional element specifies a transformation that is to be applied to the
+                                                        source value prior to its conveyance to the target.
+                                                    </xs:documentation>
+                                                </xs:annotation>
+                                            </xs:group>
+                                            <xs:element name="ConnectionGeometry" minOccurs="0">
+                                                <xs:annotation>
+                                                    <xs:documentation xml:lang="en">
+                                                        This optional element defines the geometry information of the connection.
+                                                        The start and end coordinates of the connection are derived automatically
+                                                        through the coordinates of the corresponding connectors.  The only relevant
+                                                        geometry information provided by the connection geometry is a, by default
+                                                        empty, list of intermediate waypoint coordinates, which are to be interpreted
+                                                        as for the svg:polyline primitive, i.e. as waypoints for straight line
+                                                        segments, with the first and last points added automatically based on the
+                                                        translated coordinates of the start and end connectors.
+
+                                                        Note that x and y coordinates are in the coordinate system of the
+                                                        enclosing system.
+                                                    </xs:documentation>
+                                                </xs:annotation>
+                                                <xs:complexType>
+                                                    <xs:attribute name="pointsX" use="required">
+                                                        <xs:simpleType>
+                                                            <xs:list itemType="xs:double"/>
+                                                        </xs:simpleType>
+                                                    </xs:attribute>
+                                                    <xs:attribute name="pointsY" use="required">
+                                                        <xs:simpleType>
+                                                            <xs:list itemType="xs:double"/>
+                                                        </xs:simpleType>
+                                                    </xs:attribute>
+                                                </xs:complexType>
+                                            </xs:element>
+                                            <xs:element name="Annotations" minOccurs="0" type="ssc:TAnnotations"/>
+                                        </xs:sequence>
+                                        <xs:attributeGroup ref="ssc:ABaseElement"/>
+                                        <xs:attribute name="startElement" type="xs:string" use="optional">
+                                            <xs:annotation>
+                                                <xs:documentation xml:lang="en">
+                                                    This attribute gives the name of the element that contains
+                                                    the connector given as startConnector.  If the attribute
+                                                    is elided, then the startConnector names a connector on
+                                                    this system.
+                                                </xs:documentation>
+                                            </xs:annotation>
+                                        </xs:attribute>
+                                        <xs:attribute name="startConnector" type="xs:string" use="required">
+                                            <xs:annotation>
+                                                <xs:documentation xml:lang="en">
+                                                    This attribute gives the name of the connector that is
+                                                    the start of the connection.  If startElement is not
+                                                    supplied this indicates a connector on this system,
+                                                    otherwise the connector is to be found on the given
+                                                    element.
+                                                </xs:documentation>
+                                            </xs:annotation>
+                                        </xs:attribute>
+                                        <xs:attribute name="endElement" type="xs:string" use="optional">
+                                            <xs:annotation>
+                                                <xs:documentation xml:lang="en">
+                                                    This attribute gives the name of the element that contains
+                                                    the connector given as endConnector.  If the attribute
+                                                    is elided, then the endConnector names a connector on
+                                                    this system.
+                                                </xs:documentation>
+                                            </xs:annotation>
+                                        </xs:attribute>
+                                        <xs:attribute name="endConnector" type="xs:string" use="required">
+                                            <xs:annotation>
+                                                <xs:documentation xml:lang="en">
+                                                    This attribute gives the name of the connector that is
+                                                    the end of the connection.  If endElement is not
+                                                    supplied this indicates a connector on this system,
+                                                    otherwise the connector is to be found on the given
+                                                    element.
+                                                </xs:documentation>
+                                            </xs:annotation>
+                                        </xs:attribute>
+                                        <xs:attribute name="suppressUnitConversion" type="xs:boolean" use="optional" default="false">
+                                            <xs:annotation>
+                                                <xs:documentation xml:lang="en">
+                                                    This attribute specifies whether automatic conversions between start
+                                                    and end connector are performed using unit information potentially
+                                                    available for both start and end definitions.  If this attribute is
+                                                    supplied and its value is true, then the environment will not perform
+                                                    any automatic unit conversions, otherwise automatic unit
+                                                    conversions can be performed.  This is also useful in conjunction with
+                                                    the optional linear transformation supplied via the LinearTransformation
+                                                    element: With suppressUnitConversion = true, the linear transformation
+                                                    is performed instead of any unit conversions, whereas otherwise the
+                                                    linear transformation is performed in addition to any unit conversions.
+                                                </xs:documentation>
+                                            </xs:annotation>
+                                        </xs:attribute>
+                                    </xs:complexType>
+                                </xs:element>
+                            </xs:sequence>
+                        </xs:complexType>
+                    </xs:element>
+                    <xs:element name="SignalDictionaries" minOccurs="0" type="ssd:TSignalDictionaries"/>
+                    <xs:element name="SystemGeometry" minOccurs="0">
+                        <xs:annotation>
+                            <xs:documentation xml:lang="en">
+                                This optional element defines the extent of the system canvas.
+                                (x1,y1) and (x2,y2) define the lower-left and upper-right
+                                corner, respectively.
+
+                                Different from ElementGeometry, where x1>x2 and y1>y2 indicate
+                                flipping, x1 &lt; x2 and y1 &lt; y2 must hold here.
+
+                                If undefined, the system canvas extent defaults to the bounding
+                                box of all ElementGeometry elements of the child elements of the
+                                system.
+
+                                When displaying the content of a sub-system together with the
+                                enclosing parent system, the transformation of co-coordinates
+                                inside the sub-system to co-ordinates in the parent system is defined
+                                by the transformation from SystemGeometry.{x1,y1,x2,y2} to
+                                ElementGeometry.{x1', y1', x2', y2'}, where ElementGeometry.z'
+                                is the respective coordinate of the sub-system when instantiated
+                                in the parent system after rotation.
+                            </xs:documentation>
+                        </xs:annotation>
+                        <xs:complexType>
+                            <xs:attribute name="x1" type="xs:double" use="required"/>
+                            <xs:attribute name="y1" type="xs:double" use="required"/>
+                            <xs:attribute name="x2" type="xs:double" use="required"/>
+                            <xs:attribute name="y2" type="xs:double" use="required"/>
+                        </xs:complexType>
+                    </xs:element>
+                    <xs:element name="GraphicalElements" minOccurs="0">
+                        <xs:annotation>
+                            <xs:documentation xml:lang="en">
+                                This optional element contains the set of purely graphical elements
+                                that are contained in the system, e.g. things like notes, which have no
+                                semantic impact on the system but aid in presentation of the system in
+                                graphical user interfaces.
+
+                                Currently the only graphical element defined is the Note element, which
+                                allows for simple textual notes to be placed into the system diagram, but
+                                in the future more elements might be added as needed for exchange of
+                                graphical information.
+                            </xs:documentation>
+                        </xs:annotation>
+                        <xs:complexType>
+                            <xs:sequence>
+                                <xs:choice maxOccurs="unbounded">
+                                    <xs:element name="Note">
+                                        <xs:annotation>
+                                            <xs:documentation xml:lang="en">
+                                                This element defines a graphical note to be placed on the canvas of the
+                                                enclosing system.  It is sized using the attributes so that the coordinates
+                                                (x1,y1) and (x2,y2) define the positions of the lower-left and upper-right
+                                                corners of the note in the coordinate system of the parent.
+
+                                                The note text is given by the text attribute.  The presentation expectation
+                                                is that the text is automatically sized ad wrapped in such a way that it
+                                                fits the note area.  If this would lead to too small text, it might be
+                                                necessary to provide an interactive method (like expanding triangle, or popup,
+                                                or other means) to show the remainder of the note text.  Inside the text
+                                                attribute, newlines indicate paragraph breaks.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                        <xs:complexType>
+                                            <xs:attribute name="x1" type="xs:double" use="required"/>
+                                            <xs:attribute name="y1" type="xs:double" use="required"/>
+                                            <xs:attribute name="x2" type="xs:double" use="required"/>
+                                            <xs:attribute name="y2" type="xs:double" use="required"/>
+                                            <xs:attribute name="text" type="xs:string" use="required"/>
+                                        </xs:complexType>
+                                    </xs:element>
+                                </xs:choice>
+                            </xs:sequence>
+                        </xs:complexType>
+                    </xs:element>
+                    <xs:element name="Annotations" minOccurs="0" type="ssc:TAnnotations"/>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="TConnectors">
+        <xs:sequence>
+            <xs:element name="Connector" maxOccurs="unbounded">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:group ref="ssc:GTypeChoice" minOccurs="0">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">
+                                    This element gives the type of the connector.
+
+                                    If a type is not supplied, the type is determined through
+                                    default mechanisms: For FMU components, the type of the
+                                    underlying variable would be used, for systems the types
+                                    of connected underlying connectors could be used if unambiguous.
+                                    If a type cannot be deduced unambinguously, the user should
+                                    be informed of this error. Equally, if the type of the connector
+                                    differs from the type of the underlying FMU variable this
+                                    constitutes an error.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:group>
+                        <xs:element name="ConnectorGeometry" minOccurs="0">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">
+                                    This optional element gives the geometry information of the connector.
+                                    Note that x and y coordinates are in a special coordinate system, where
+                                    0,0 is the lower-left corner of the component/system, and 1,1 is the
+                                    upper-right corner of the component, regardless of aspect ratio.
+
+                                    For systems the placement of connectors for the inside and outside
+                                    view of the system is identical, the special coordinate system is just
+                                    translated to different actual coordinate systems, namely the one
+                                    determined by the ElementGeometry for the outside view, and the
+                                    one determined by SystemGeometry for the inside view.
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:attribute name="x" type="xs:double" use="required"/>
+                                <xs:attribute name="y" type="xs:double" use="required"/>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="Annotations" minOccurs="0" type="ssc:TAnnotations"/>
+                    </xs:sequence>
+                    <xs:attributeGroup ref="ssc:ABaseElement"/>
+                    <xs:attribute name="name" use="required">
+                        <xs:annotation>
+                            <xs:documentation xml:lang="en">
+                                This attribute gives the connector a name, which
+                                shall be unique within the component or system and,
+                                for components, must match the name of a relevant
+                                variable/port in the underlying component implementation,
+                                e.g. the referenced FMU.
+
+                                Note that there is no requirement that connectors must
+                                be present for all variables/ports of an underlying
+                                component implementation.  Only those connectors must
+                                be present which are referenced in connections inside
+                                the SSD.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="kind" use="required">
+                        <xs:annotation>
+                            <xs:documentation xml:lang="en">
+                                This attribute specifies the kind of the given connector,
+                                which indicates whether the connector is an input, an
+                                output, both (inout), a parameter or a calculated parameter (i.e.
+                                a parameter that is calculated by the component during initialization).
+                                For components this must match the related kind of the underlying
+                                component implementation, e.g. for referenced FMUs it must match the
+                                combination of variability and causality.
+
+                                For FMI 2.0 this means that the causality of the variable must
+                                match the kind of the connector.
+
+                                For FMI 1.0 this means that for connectors of kind input or output
+                                the causality of the variable must be input or output and the
+                                variability of the variable must be discrete or continuous (for
+                                outputs also constant and parameter are allowable).  For connectors
+                                of kind parameter the causality must be input or internal and the
+                                variablity must be parameter.  For connectors of kind
+                                calculatedParameter the causality must be output and the variablity
+                                must be parameter.
+
+                                For SignalDictionaryReferences, the kind of a given connector can
+                                additionally be 'inout', which indicates that the semantics of the
+                                connector are derived from the connections going to the connector.
+                                This can be used for example to allow a connector to function as
+                                both an input and output within the same SignaleDictionaryReference.
+                            </xs:documentation>
+                        </xs:annotation>
+                        <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                                <xs:enumeration value="input"/>
+                                <xs:enumeration value="output"/>
+                                <xs:enumeration value="parameter"/>
+                                <xs:enumeration value="calculatedParameter"/>
+                                <xs:enumeration value="inout"/>
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="TParameterBindings">
+        <xs:sequence maxOccurs="unbounded">
+            <xs:element name="ParameterBinding">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">
+                        This provides a parameter binding for a component or system.  For FMU components this
+                        allows the parametrization of the FMU's parameters and start values of other variables
+                        with a parameter source (e.g. a parameter file).  Note that in this case the names
+                        provided in the parameter source must match the names of the FMU variables, or must be
+                        mapped to the names of the FMU variables through a ParameterMapping element, or are
+                        ignored if no matching variable is found.
+
+                        For systems the names in the parameter source must either match the hierarchical names
+                        of parameters or other variables in the system, or must be mapped to those names through
+                        a ParameterMapping element, or are ignored if no matching variable is found.
+
+                        The hierarchical names of the parameters or other variables of a system are formed in the
+                        following way: Any variables of the system exposed through connectors of the system have
+                        the name of the connector as their name.  For all elements of the system, the hierarchical
+                        names of the variables of those elements are formed by prepending the element name and a
+                        dot to the hierarchical names of the variables in that element.  E.g. for a system A
+                        containing a system B which contains an exposed parameter named SP1 and an element C with
+                        a parameter P2, the hierarchical names of the parameters in system A are B.SP1 and B.C.P2
+                        respectively.  The hierarchical name of those parameters inside system B are SP1 and C.P2
+                        respectively.
+
+                        More than one ParameterBinding can be supplied, in which case all of the parameters found
+                        will be used to parametrize the component, with parameter values in ParameterBinding
+                        sources appearing at a succeeding position in the element order taking priority over prior
+                        sources at the same hierarchy level, should a parameter be included in more than one
+                        ParameterBinding source.
+
+                        When ParameterBinding sources on multiple levels of the hierarchy supply values for the
+                        same parameter, bindings at a higher hierarchy level take precedence over lower levels,
+                        i.e. bindings at a system level take precedence over bindings at a sub-system or component
+                        level.
+
+                        Parameter bindings for FMU components can be used to set any initial values in the
+                        FMU which are legal to change.  It is assumed that the parameterization is applied
+                        prior to initializing for FMI 1.0, or before entering initialization mode for FMI 2.0.
+                        This means that variables eligible for parameterization are those with:
+                          * either causality = "input" or a start value for FMI 1.0
+                          * variability != "constant" and initial = "exact" or "approx" for FMI 2.0
+
+                        All kinds of system connectors can be parameterized.  In case the system level connectors
+                        are connected to FMU components, the parameterization must be compatible with the variable
+                        in the connected FMU.
+
+                        ParameterBindings that apply to a component that references another SSD/SSP are handled
+                        as if the top-level system of the SSD/SSP was present in the enclosing system instead of
+                        the component with one special case: Any parameter bindings in the component are treated
+                        as if they were present in the top-level system of the SSP/SSD after all parameter bindings
+                        of the system.  Therefore they take priority over any of the existing parameter bindings
+                        (for parameters with identical names).
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="ParameterValues" minOccurs="0">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">
+                                    This optional element can be used to provide parameter values inline
+                                    to the parameter binding, in which case the source attribute of the
+                                    ParameterBinding element must be empty.
+
+                                    The contents must be an ssv:ParameterSet element, if the type attribute
+                                    of the ParameterBinding element is application/x-ssp-parameter-set, or
+                                    any other valid XML content if the type attribute references another
+                                    MIME type (in that case there should be a layered specification that
+                                    defines how embedding the content works for that MIME type).
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:choice>
+                                    <!-- NOTE: In XML Schema 1.1 this choice would also contain the following entry:
+
+                                         <xs:element ref="ssv:ParameterSet"/>
+
+                                         which specifies the proper way to directly embed a ParameterSet inline.
+                                         Due to restrictions in XML Schema 1.0, this would lead to a violation of the
+                                         unique particle attribution schema component constraint, since the embedded
+                                         ssv:ParameterSet element would also be matched by the more generic xs:any
+                                         specification.  Since XML Schema 1.1 validators are still rare compared with
+                                         1.0 validators, the default schema files for SSP are still restricted to 1.0;
+                                         however if you have access to a 1.1 validator/validating parser, you can
+                                         use the 1.1 variant of these stylesheets instead.
+                                    -->
+                                    <xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+                                </xs:choice>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="ParameterMapping" minOccurs="0">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">
+                                    This element provides an optional parameter mapping, which specifies how
+                                    the parameter names and values provided in the parameter source are to be
+                                    mapped to the parameters of the component or system in question.  If no
+                                    mapping is supplied, the parameter names of the parameter source are used
+                                    as is for name matching against the names of parameters in the component
+                                    or system and the values of the parameter source are not transformed further
+                                    before being applied.
+
+                                    The contents of the element can be used to provide a parameter mapping
+                                    inline, in which case the source attribute of the ParameterMapping element
+                                    must be empty.
+
+                                    The contents must be an ssm:ParameterMapping element, if the type attribute
+                                    of this element is application/x-ssp-parameter-mapping, or any other valid
+                                    XML content if the type attribute references another MIME type (in that case
+                                    there should be a layered specification that defines how embedding the content
+                                    works for that MIME type).
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:choice>
+                                    <!-- NOTE: In XML Schema 1.1 this choice would also contain the following entry:
+
+                                         <xs:element ref="ssm:ParameterMapping"/>
+
+                                         which specifies the proper way to directly embed a ParameterMapping inline.
+                                         Due to restrictions in XML Schema 1.0, this would lead to a violation of the
+                                         unique particle attribution schema component constraint, since the embedded
+                                         ssm:ParameterMapping element would also be matched by the more generic xs:any
+                                         specification.  Since XML Schema 1.1 validators are still rare compared with
+                                         1.0 validators, the default schema files for SSP are still restricted to 1.0;
+                                         however if you have access to a 1.1 validator/validating parser, you can
+                                         use the 1.1 variant of these stylesheets instead.
+                                    -->
+                                    <xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+                                </xs:choice>
+                                <xs:attributeGroup ref="ssc:ABaseElement"/>
+                                <xs:attribute name="type" type="xs:string" use="optional" default="application/x-ssp-parameter-mapping"/>
+                                <xs:attribute name="source" type="xs:anyURI" use="optional">
+                                    <xs:annotation>
+                                        <xs:documentation xml:lang="en">
+                                            This attribute indicates the source of the parameter mapping as a URI
+                                            (cf. RFC 3986).  For purposes of the resolution of relative URIs
+                                            the base URI is the URI of the SSD, if the sourcebase attribute
+                                            is not specified or is specified as SSD, and the URI of the
+                                            referenced component if the base attribute is specified as component.
+                                            This allows the specification of parameter mapping sources that reside
+                                            inside the component (e.g. an FMU) through relative URIs.
+
+                                            If the source attribute is missing, the parameter mapping is provided
+                                            inline as contents of the ParameterMapping element, which must be
+                                            empty otherwise.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="sourceBase" use="optional" default="SSD">
+                                    <xs:annotation>
+                                        <xs:documentation xml:lang="en">
+                                            Defines the base the source URI is resolved against:  If the attribute
+                                            is missing or is specified as SSD, the source is resolved against the
+                                            URI of the SSD, if the attribute is specified as component the URI is
+                                            resolved against the (resolved) URI of the component source.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                    <xs:simpleType>
+                                        <xs:restriction base="xs:string">
+                                            <xs:enumeration value="SSD"/>
+                                            <xs:enumeration value="component"/>
+                                        </xs:restriction>
+                                    </xs:simpleType>
+                                </xs:attribute>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="Annotations" minOccurs="0" type="ssc:TAnnotations"/>
+                    </xs:sequence>
+                    <xs:attributeGroup ref="ssc:ABaseElement"/>
+                    <xs:attribute name="type" type="xs:string" use="optional" default="application/x-ssp-parameter-set">
+                        <xs:annotation>
+                            <xs:documentation xml:lang="en">
+                                This attribute specifies the MIME type of the parameter source, which defaults
+                                to application/x-ssp-parameter-set to indicate the SSP parameter set file format.
+                                No further types are currently defined, but can of course be added at a later
+                                date, e.g. for pre-existing parameter file formats, like CDF, etc.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="source" type="xs:anyURI" use="optional">
+                        <xs:annotation>
+                            <xs:documentation xml:lang="en">
+                                This attribute indicates the source of the parameters as a URI
+                                (cf. RFC 3986).  For purposes of the resolution of relative URIs
+                                the base URI is the URI of the SSD, if the sourcebase attribute
+                                is not specified or is specified as SSD, and the URI of the
+                                referenced component if the base attribute is specified as component.
+                                This allows the specification of parameter sources that reside inside
+                                the component (e.g. an FMU) through relative URIs.
+
+                                Access to parameter sets over the SSP Parameter Repository Protocol
+                                is mediated through URIs with the http or https scheme.
+
+                                If the source attribute is missing, the parameter mapping is provided
+                                inline as contents of a ParameterValues element, which must not be
+                                present otherwise.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="sourceBase" use="optional" default="SSD">
+                        <xs:annotation>
+                            <xs:documentation xml:lang="en">
+                                Defines the base the source URI is resolved against:  If the attribute
+                                is missing or is specified as SSD, the source is resolved against the
+                                URI of the SSD, if the attribute is specified as component the URI is
+                                resolved against the (resolved) URI of the component source.
+                            </xs:documentation>
+                        </xs:annotation>
+                        <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                                <xs:enumeration value="SSD"/>
+                                <xs:enumeration value="component"/>
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:attribute>
+                    <xs:attribute name="prefix" type="xs:string" use="optional" default="">
+                        <xs:annotation>
+                            <xs:documentation xml:lang="en">
+                                Defines the optional prefix for name resolution and mapping purposes
+                                for this binding.  If this attribute is empty or not supplied no
+                                prefix is used for name resolution and mapping, otherwise the specified
+                                prefix is prepended to all names in the parameter source prior to
+                                processing the normal name resolution or name mapping rules.  This
+                                allows the user to apply a parameter set normally intended for a component
+                                (and thus containing bare parameter names) at a system level targeted to
+                                one element of the system by supplying the name of the element plus a dot
+                                as a prefix on the binding, thus causing all parameter names in the parameter
+                                set to be treated as if they were specified with proper hierarchical names.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="TDefaultExperiment">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                The attributes of this element, if present, specify reasonable default values
+                for running an experiment of the given system.  Any tool is free to ignore this
+                information.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="Annotations" minOccurs="0" type="ssc:TAnnotations"/>
+        </xs:sequence>
+        <xs:attribute name="startTime" type="xs:double" use="optional">
+            <xs:annotation>
+                <xs:documentation xml:lang="en">Default start time of simulation</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="stopTime" type="xs:double" use="optional">
+            <xs:annotation>
+                <xs:documentation xml:lang="en">Default stop time of simulation</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+</xs:schema>

--- a/schema/ssp/SystemStructureDescription11.xsd
+++ b/schema/ssp/SystemStructureDescription11.xsd
@@ -1,0 +1,922 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified"
+    xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription"
+    xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
+    xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
+    xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping"
+    xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
+    targetNamespace="http://ssp-standard.org/SSP1/SystemStructureDescription"
+    xmlns:vc="http://www.w3.org/2007/XMLSchema-versioning" vc:minVersion="1.1">
+    <xs:annotation>
+        <xs:documentation xml:lang="en">
+            This is the XML Schema 1.1 schema for the MAP SSP
+            SystemStructureDescription 1.0 format.  It is provided
+            as a non-normative alternative to the XML Schema 1.0 schema
+            to support simpler cross-namespace validation of SSD files.
+            
+            Version: 1.0
+
+            Copyright 2016 -- 2019 Modelica Association Project "SSP"
+
+            Redistribution and use in source and binary forms, with or
+            without modification, are permitted provided that the
+            following conditions are met:
+
+            1. Redistributions of source code must retain the above
+               copyright notice, this list of conditions and the
+               following disclaimer.
+
+            2. Redistributions in binary form must reproduce the above
+               copyright notice, this list of conditions and the
+               following disclaimer in the documentation and/or other
+               materials provided with the distribution.
+
+            THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+            CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+            INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+            MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+            DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+            CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+            INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+            (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+            GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+            BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+            LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+            (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+            OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+            POSSIBILITY OF SUCH DAMAGE.
+        </xs:documentation>
+    </xs:annotation>
+    
+    <xs:import namespace="http://ssp-standard.org/SSP1/SystemStructureCommon" schemaLocation="SystemStructureCommon.xsd"/>
+    <xs:import namespace="http://ssp-standard.org/SSP1/SystemStructureParameterValues" schemaLocation="SystemStructureParameterValues.xsd"/>
+    <xs:import namespace="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" schemaLocation="SystemStructureParameterMapping.xsd"/>
+    <xs:import namespace="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" schemaLocation="SystemStructureSignalDictionary.xsd"/>
+    
+    <xs:element name="SystemStructureDescription">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="System" type="ssd:TSystem"/>
+                <xs:element name="Enumerations" minOccurs="0" type="ssc:TEnumerations"/>
+                <xs:element name="Units" minOccurs="0" type="ssc:TUnits"/>
+                <xs:element name="DefaultExperiment" minOccurs="0" type="ssd:TDefaultExperiment"/>
+                <xs:element name="Annotations" minOccurs="0" type="ssc:TAnnotations"/>
+            </xs:sequence>
+            <xs:attribute name="version" use="required">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">
+                        Version of SSD format, 1.0 for this release.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:normalizedString">
+                        <xs:pattern value="1[.][0-9]+(-.*)?"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:attribute>
+            <xs:attribute name="name" type="xs:string" use="required">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">
+                        This attribute gives the system structure a name, which can be used
+                        for purposes of presenting the system structure to the user, e.g.
+                        when selecting individual variant SSDs from an SSP.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
+            <xs:attributeGroup ref="ssc:ABaseElement"/>
+            <xs:attributeGroup ref="ssc:ATopLevelMetaData"/>
+        </xs:complexType>
+    </xs:element>
+        
+    <xs:complexType name="TElement">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                This is the base type for all elements, currently consisting of components and systems.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="Connectors" minOccurs="0" type="ssd:TConnectors">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">
+                        The set of connectors of this element, which represent
+                        the interface of the element to the outside world.
+ 
+                        For components the set of connectors must match variable/ports
+                        of the underlying component implementation, e.g. the referenced
+                        FMU, by name.
+ 
+                        Note that there is no requirement that connectors must
+                        be present for all variables/ports of an underlying
+                        component implementation.  Only those connectors must
+                        be present which are referenced in connections inside
+                        the SSD.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="ElementGeometry" minOccurs="0">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">
+                        This optional element defines the geometry information of the component.
+                        (x1,y1) and (x2,y2) define the positions of the lower-left and upper-right
+                        corners of the component in the coordinate system of the parent.
+                        x1>x2 indicates horizontal flipping, y1>y2 indicates vertical flipping.
+                        The optional attribute rotation (in degrees) defines an additional rotation
+                        (applied after flipping), where positive numbers indicate left rotation (x->y).
+                        The coordinate system is oriented: x -> right, y -> up.
+                        
+                        The optional attribute iconSource defines an icon URI with the same semantics as
+                        for the source attribute of the Component element.  If defined, this icon overrides
+                        any icon that may be defined e.g. in an .fmu file (as disccused in the FMI group).
+                        The optional attribute rotation defines the rotation (in degrees) of the icon.
+                        The optional attribute FixedAspectRatio defines whether the icon shall be fit
+                        into the extent defined by (x1,y1), (x2,y2) and iconRotation with fixed aspect
+                        ratio. The optional attribute iconFlip defines whether any flipping indicated
+                        by (x1,y1), (x2, y2) shall be applied to the icon graphics, too.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:attribute name="x1" type="xs:double" use="required"/>
+                    <xs:attribute name="y1" type="xs:double" use="required"/>
+                    <xs:attribute name="x2" type="xs:double" use="required"/>
+                    <xs:attribute name="y2" type="xs:double" use="required"/>
+                    <xs:attribute name="rotation" type="xs:double" use="optional" default="0.0"/>
+                    <xs:attribute name="iconSource" type="xs:anyURI" use="optional"/>
+                    <xs:attribute name="iconRotation" type="xs:double" use="optional" default="0.0"/>
+                    <xs:attribute name="iconFlip" type="xs:boolean" use="optional" default="false"/>
+                    <xs:attribute name="iconFixedAspectRatio" type="xs:boolean" use="optional" default="false"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="ParameterBindings" minOccurs="0" type="ssd:TParameterBindings">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">
+                        The set of parameter bindings for this element.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+        <xs:attributeGroup ref="ssc:ABaseElement"/>
+        <xs:attribute name="name" use="required">
+            <xs:annotation>
+                <xs:documentation xml:lang="en">
+                    This attribute gives the element a name, which shall be unique
+                    within the directly enclosing system. The name is used for
+                    purposes of specifying the element's connectors in connections.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:minLength value="1"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+    
+    <xs:complexType name="TComponent">
+        <xs:complexContent>
+            <xs:extension base="ssd:TElement">
+                <xs:sequence>
+                    <xs:element name="Annotations" minOccurs="0" type="ssc:TAnnotations"/>
+                </xs:sequence>
+                <xs:attribute name="type" type="xs:string" use="optional" default="application/x-fmu-sharedlibrary">
+                    <xs:annotation>
+                        <xs:documentation xml:lang="en">
+                            This attribute specifies the MIME type of the component, which defaults to
+                            application/x-fmu-sharedlibrary to indicate an FMU.  When referencing another
+                            system structure definition file, the MIME type application/x-ssp-definition
+                            is used, and the MIME type application/x-ssp-package is used for referenced
+                            system structure packages (SSPs). No further types are currently defined.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="source" type="xs:anyURI" use="required">
+                    <xs:annotation>
+                        <xs:documentation xml:lang="en">
+                            This attribute indicates the source of the component as an URI
+                            (cf. RFC 3986).  For purposes of the resolution of relative URIs
+                            the base URI is the URI of the SSD.  Therefore for components
+                            that are located alongside the SSD, relative URIs without scheme
+                            and authority can and should be used to specify the component
+                            sources.  For components that are packaged inside an SSP that
+                            contains this SSD, this is mandatory (in this way, the SSD URIs
+                            remain valid after unpacking the SSP into the filesystem).
+                            
+                            E.g. for an FMU called MyDemoFMU.fmu, that is located in the
+                            resources directory of an SSP, the correct URI would be
+                            "resources/MyDemoFMU.fmu".
+                            
+                            When referencing another SSP, by default the default SSD of the
+                            SSP (i.e. SystemStructure.ssd) is referenced.  When a non-default
+                            SSD should be selected, then the name of the non-default SSD must 
+                            be given through a fragment identifier, i.e. the URI 
+                            "resources/SubSSP.ssp#VariantB.ssd" would reference the VariantB.ssd
+                            of SubSSP.ssp located in the resources directory relative to this SSD.
+                            
+                            When the URI is a same-document URI with a fragment identifier, e.g.
+                            "#other-system", then the fragment identifier should identify a
+                            system element in this SSD document with an id attribute identical
+                            to the fragment identifier.  This mechanism can be used to instantiate
+                            an embedded system definition multiple times through reference to
+                            its definition element.
+                            
+                            Note that implementations are only required to support relative URIs
+                            as specified above, and that especially relative URIs that move beyond
+                            the baseURI (e.g. go "up" a level via ..) are not required to be
+                            supported by implementations, and are in fact often not supported for
+                            security or other reasons.  Implementations are also not required to
+                            support any absolute URIs and any specific URI schemes (but are of
+                            course allowed to support any and all kinds of URIs where useful).
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+                <xs:attribute name="implementation" use="optional" default="any">
+                    <xs:annotation>
+                        <xs:documentation xml:lang="en">
+                            When the referenced component is an FMU that contains multiple
+                            implementations (e.g. Co-Simulation and Model Exchange), this optional
+                            attribute can be used to determine which FMU implementation should be
+                            employed.  If the attribute is missing or uses the default value "any",
+                            the importing tool is free to choose what kind of FMU implementation
+                            to use.  If the value is "CoSimulation" or "ModelExchange" the corresponding
+                            FMU implementation must be used.  It is an error if the specified type
+                            of FMU implementation is not present in the FMU.
+                        </xs:documentation>
+                    </xs:annotation>
+                    <xs:simpleType>
+                        <xs:restriction base="xs:string">
+                            <xs:enumeration value="any"/>
+                            <xs:enumeration value="ModelExchange"/>
+                            <xs:enumeration value="CoSimulation"/>
+                        </xs:restriction>
+                    </xs:simpleType>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="TSignalDictionaries">
+        <xs:sequence>
+            <xs:element name="SignalDictionary" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">
+                        This element defines a signal dictionary, describing the signal dictionary
+                        entries present in the signal dictionary.
+                        
+                        The contents of the element can be used to provide a signal dictionary
+                        inline, in which case the source attribute of the SignalDictionary element
+                        must be empty.
+                        
+                        The contents must be an ssb:SignalDictionary element, if the type attribute
+                        of this element is application/x-ssp-signal-dictionary, or any other valid 
+                        XML content if the type attribute references another MIME type (in that case
+                        there should be a layered specification that defines how embedding the content
+                        works for that MIME type).
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:choice>
+                        <xs:element ref="ssb:SignalDictionary"/>
+                        <xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+                    </xs:choice>
+                    <xs:attributeGroup ref="ssc:ABaseElement"/>
+                    <xs:attribute name="type" type="xs:string" use="optional" default="application/x-ssp-signal-dictionary"/>
+                    <xs:attribute name="source" type="xs:anyURI" use="optional">
+                        <xs:annotation>
+                            <xs:documentation xml:lang="en">
+                                This attribute indicates the source of the signal dictionary as a URI
+                                (cf. RFC 3986).  For purposes of the resolution of relative URIs
+                                the base URI is the URI of the SSD.
+                                
+                                If the source attribute is missing, the signal dictionary is provided
+                                inline as contents of the SignalDictionary element, which must be
+                                empty otherwise.
+                                
+                                For the default type application/x-ssp-signal-dictionary such inline
+                                content must be an ssb:SignalDictionary element.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="name" type="xs:string" use="required">
+                        <xs:annotation>
+                            <xs:documentation xml:lang="en">
+                                This attribute gives the signal dictionary a name, which shall be
+                                unique within the directly enclosing system. The name is used for
+                                purposes of specifying the signal dictionary referenced by a
+                                signal dictionary reference.  Name lookups occur in hierarchical
+                                fashion, i.e. the name is first looked up in the system that
+                                contains a signal dictionary reference.  If that lookup yields
+                                no match, the lookup is performed on the enclosing system, etc.,
+                                until a match is found.  It is an error if no matching signal
+                                dictionary is found.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+    
+    <xs:complexType name="TSignalDictionaryReference">
+        <xs:complexContent>
+            <xs:extension base="ssd:TElement">
+                <xs:sequence>
+                    <xs:element name="Annotations" minOccurs="0" type="ssc:TAnnotations"/>
+                </xs:sequence>
+                <xs:attribute name="dictionary" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation xml:lang="en">
+                            This attribute gives the name of the signal dictionary that is to
+                            be referenced.  Name lookups occur in hierarchical fashion, i.e. 
+                            the name is first looked up in the system that contains a signal
+                            dictionary reference.  If that lookup yields no match, the lookup
+                            is performed on the enclosing system, etc., until a match is found.
+                            It is an error if no matching signal dictionary is found.
+                        </xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    
+    <xs:complexType name="TSystem">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                This element describes a system, which can contain components and other systems as elements,
+                connectors as an interface to the outside world, and connections connecting the connectors
+                of itself and of its elements to another.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexContent>
+            <xs:extension base="ssd:TElement">
+                <xs:sequence>
+                    <xs:element name="Elements" minOccurs="0">
+                        <xs:complexType>
+                            <xs:sequence>
+                                <xs:choice maxOccurs="unbounded">
+                                    <xs:element name="Component" type="ssd:TComponent"/>
+                                    <xs:element name="SignalDictionaryReference" type="ssd:TSignalDictionaryReference"/>
+                                    <xs:element name="System" type="ssd:TSystem"/>
+                                </xs:choice>
+                            </xs:sequence>
+                        </xs:complexType>
+                    </xs:element>
+                    <xs:element name="Connections" minOccurs="0">
+                        <xs:complexType>
+                            <xs:sequence>
+                                <xs:element name="Connection" maxOccurs="unbounded">
+                                    <xs:annotation>
+                                        <xs:documentation xml:lang="en">
+                                            This element specifies a connection between two connectors,
+                                            either of the system or its directly contained elements.
+                                            Note that connections between connectors on a system are
+                                            allowed, so neither startElement nor endElement has to be
+                                            supplied.
+                                            
+                                            Note also that the terms start and end in the attribute names
+                                            of the connector, like startElement or endConnector, do not
+                                            denote directionality of the data flow implied by the connector.
+                                            That is determined by the combination of the semantics of the
+                                            actual connectors (variables/ports) connected and their kind
+                                            attributes:
+                                            
+                                            For component to component connections as well as for connections
+                                            between two connectors at the system level, currently the kind of
+                                            one connector must be output and of another connector must be
+                                            input, or for parameter connections the kind of one connector
+                                            must be calculatedParameter and the other must be parameter.
+                                            Information flows from the output/calculatedParameter to the
+                                            input/parameter connector.
+                                            
+                                            For system to component connections the kinds of the connectors
+                                            must match, i.e. either both are input or both output or both
+                                            parameter or both calculatedParameter.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                    <xs:complexType>
+                                        <xs:sequence>
+                                            <xs:group ref="ssc:GTransformationChoice" minOccurs="0" maxOccurs="1">
+                                                <xs:annotation>
+                                                    <xs:documentation xml:lang="en">
+                                                        This optional element specifies a transformation that is to be applied to the
+                                                        source value prior to its conveyance to the target.
+                                                    </xs:documentation>
+                                                </xs:annotation>
+                                            </xs:group>
+                                            <xs:element name="ConnectionGeometry" minOccurs="0">
+                                                <xs:annotation>
+                                                    <xs:documentation xml:lang="en">
+                                                        This optional element defines the geometry information of the connection.
+                                                        The start and end coordinates of the connection are derived automatically
+                                                        through the coordinates of the corresponding connectors.  The only relevant
+                                                        geometry information provided by the connection geometry is a, by default
+                                                        empty, list of intermediate waypoint coordinates, which are to be interpreted
+                                                        as for the svg:polyline primitive, i.e. as waypoints for straight line 
+                                                        segments, with the first and last points added automatically based on the
+                                                        translated coordinates of the start and end connectors.
+                                                        
+                                                        Note that x and y coordinates are in the coordinate system of the
+                                                        enclosing system.
+                                                    </xs:documentation>
+                                                </xs:annotation>
+                                                <xs:complexType>
+                                                    <xs:attribute name="pointsX" use="required">
+                                                        <xs:simpleType>
+                                                            <xs:list itemType="xs:double"/>
+                                                        </xs:simpleType>
+                                                    </xs:attribute>
+                                                    <xs:attribute name="pointsY" use="required">
+                                                        <xs:simpleType>
+                                                            <xs:list itemType="xs:double"/>
+                                                        </xs:simpleType>
+                                                    </xs:attribute>
+                                                </xs:complexType>
+                                            </xs:element>
+                                            <xs:element name="Annotations" minOccurs="0" type="ssc:TAnnotations"/>
+                                        </xs:sequence>
+                                        <xs:attributeGroup ref="ssc:ABaseElement"/>
+                                        <xs:attribute name="startElement" type="xs:string" use="optional">
+                                            <xs:annotation>
+                                                <xs:documentation xml:lang="en">
+                                                    This attribute gives the name of the element that contains
+                                                    the connector given as startConnector.  If the attribute
+                                                    is elided, then the startConnector names a connector on
+                                                    this system.
+                                                </xs:documentation>
+                                            </xs:annotation>
+                                        </xs:attribute>
+                                        <xs:attribute name="startConnector" type="xs:string" use="required">
+                                            <xs:annotation>
+                                                <xs:documentation xml:lang="en">
+                                                    This attribute gives the name of the connector that is
+                                                    the start of the connection.  If startElement is not
+                                                    supplied this indicates a connector on this system,
+                                                    otherwise the connector is to be found on the given
+                                                    element.
+                                                </xs:documentation>
+                                            </xs:annotation>
+                                        </xs:attribute>
+                                        <xs:attribute name="endElement" type="xs:string" use="optional">
+                                            <xs:annotation>
+                                                <xs:documentation xml:lang="en">
+                                                    This attribute gives the name of the element that contains
+                                                    the connector given as endConnector.  If the attribute
+                                                    is elided, then the endConnector names a connector on
+                                                    this system.
+                                                </xs:documentation>
+                                            </xs:annotation>
+                                        </xs:attribute>
+                                        <xs:attribute name="endConnector" type="xs:string" use="required">
+                                            <xs:annotation>
+                                                <xs:documentation xml:lang="en">
+                                                    This attribute gives the name of the connector that is
+                                                    the end of the connection.  If endElement is not
+                                                    supplied this indicates a connector on this system,
+                                                    otherwise the connector is to be found on the given
+                                                    element.
+                                                </xs:documentation>
+                                            </xs:annotation>
+                                        </xs:attribute>
+                                        <xs:attribute name="suppressUnitConversion" type="xs:boolean" use="optional" default="false">
+                                            <xs:annotation>
+                                                <xs:documentation xml:lang="en">
+                                                    This attribute specifies whether automatic conversions between start
+                                                    and end connector are performed using unit information potentially
+                                                    available for both start and end definitions.  If this attribute is
+                                                    supplied and its value is true, then the environment will not perform
+                                                    any automatic unit conversions, otherwise automatic unit
+                                                    conversions can be performed.  This is also useful in conjunction with 
+                                                    the optional linear transformation supplied via the LinearTransformation
+                                                    element: With suppressUnitConversion = true, the linear transformation
+                                                    is performed instead of any unit conversions, whereas otherwise the
+                                                    linear transformation is performed in addition to any unit conversions.
+                                                </xs:documentation>
+                                            </xs:annotation>
+                                        </xs:attribute>
+                                    </xs:complexType>
+                                </xs:element>
+                            </xs:sequence>
+                        </xs:complexType>
+                    </xs:element>
+                    <xs:element name="SignalDictionaries" minOccurs="0" type="ssd:TSignalDictionaries"/>
+                    <xs:element name="SystemGeometry" minOccurs="0">
+                        <xs:annotation>
+                            <xs:documentation xml:lang="en">
+                                This optional element defines the extent of the system canvas. 
+                                (x1,y1) and (x2,y2) define the lower-left and upper-right 
+                                corner, respectively.
+
+                                Different from ElementGeometry, where x1>x2 and y1>y2 indicate
+                                flipping, x1 &lt; x2 and y1 &lt; y2 must hold here.
+                                
+                                If undefined, the system canvas extent defaults to the bounding
+                                box of all ElementGeometry elements of the child elements of the
+                                system.
+                                
+                                When displaying the content of a sub-system together with the
+                                enclosing parent system, the transformation of co-coordinates
+                                inside the sub-system to co-ordinates in the parent system is defined
+                                by the transformation from SystemGeometry.{x1,y1,x2,y2} to 
+                                ElementGeometry.{x1', y1', x2', y2'}, where ElementGeometry.z' 
+                                is the respective coordinate of the sub-system when instantiated
+                                in the parent system after rotation.
+                            </xs:documentation>
+                        </xs:annotation>
+                        <xs:complexType>
+                            <xs:attribute name="x1" type="xs:double" use="required"/>
+                            <xs:attribute name="y1" type="xs:double" use="required"/>
+                            <xs:attribute name="x2" type="xs:double" use="required"/>
+                            <xs:attribute name="y2" type="xs:double" use="required"/>
+                        </xs:complexType>
+                    </xs:element>
+                    <xs:element name="GraphicalElements" minOccurs="0">
+                        <xs:annotation>
+                            <xs:documentation xml:lang="en">
+                                This optional element contains the set of purely graphical elements
+                                that are contained in the system, e.g. things like notes, which have no
+                                semantic impact on the system but aid in presentation of the system in
+                                graphical user interfaces.
+                                
+                                Currently the only graphical element defined is the Note element, which
+                                allows for simple textual notes to be placed into the system diagram, but
+                                in the future more elements might be added as needed for exchange of
+                                graphical information.
+                            </xs:documentation>
+                        </xs:annotation>
+                        <xs:complexType>
+                            <xs:sequence>
+                                <xs:choice maxOccurs="unbounded">
+                                    <xs:element name="Note">
+                                        <xs:annotation>
+                                            <xs:documentation xml:lang="en">
+                                                This element defines a graphical note to be placed on the canvas of the
+                                                enclosing system.  It is sized using the attributes so that the coordinates
+                                                (x1,y1) and (x2,y2) define the positions of the lower-left and upper-right
+                                                corners of the note in the coordinate system of the parent.
+                                                
+                                                The note text is given by the text attribute.  The presentation expectation
+                                                is that the text is automatically sized ad wrapped in such a way that it
+                                                fits the note area.  If this would lead to too small text, it might be
+                                                necessary to provide an interactive method (like expanding triangle, or popup,
+                                                or other means) to show the remainder of the note text.  Inside the text
+                                                attribute, newlines indicate paragraph breaks.
+                                            </xs:documentation>
+                                        </xs:annotation>
+                                        <xs:complexType>
+                                            <xs:attribute name="x1" type="xs:double" use="required"/>
+                                            <xs:attribute name="y1" type="xs:double" use="required"/>
+                                            <xs:attribute name="x2" type="xs:double" use="required"/>
+                                            <xs:attribute name="y2" type="xs:double" use="required"/>
+                                            <xs:attribute name="text" type="xs:string" use="required"/>
+                                        </xs:complexType>
+                                    </xs:element>
+                                </xs:choice>
+                            </xs:sequence>
+                        </xs:complexType>
+                    </xs:element>
+                    <xs:element name="Annotations" minOccurs="0" type="ssc:TAnnotations"/>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+
+    <xs:complexType name="TConnectors">
+        <xs:sequence>
+            <xs:element name="Connector" maxOccurs="unbounded">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:group ref="ssc:GTypeChoice" minOccurs="0">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">
+                                    This element gives the type of the connector.
+                                    
+                                    If a type is not supplied, the type is determined through
+                                    default mechanisms: For FMU components, the type of the
+                                    underlying variable would be used, for systems the types
+                                    of connected underlying connectors could be used if unambiguous.
+                                    If a type cannot be deduced unambinguously, the user should
+                                    be informed of this error. Equally, if the type of the connector
+                                    differs from the type of the underlying FMU variable this
+                                    constitutes an error.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:group>
+                        <xs:element name="ConnectorGeometry" minOccurs="0">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">
+                                    This optional element gives the geometry information of the connector.
+                                    Note that x and y coordinates are in a special coordinate system, where
+                                    0,0 is the lower-left corner of the component/system, and 1,1 is the
+                                    upper-right corner of the component, regardless of aspect ratio.
+                                    
+                                    For systems the placement of connectors for the inside and outside
+                                    view of the system is identical, the special coordinate system is just
+                                    translated to different actual coordinate systems, namely the one
+                                    determined by the ElementGeometry for the outside view, and the
+                                    one determined by SystemGeometry for the inside view.
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:attribute name="x" type="xs:double" use="required"/>
+                                <xs:attribute name="y" type="xs:double" use="required"/>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="Annotations" minOccurs="0" type="ssc:TAnnotations"/>
+                    </xs:sequence>
+                    <xs:attributeGroup ref="ssc:ABaseElement"/>
+                    <xs:attribute name="name" use="required">
+                        <xs:annotation>
+                            <xs:documentation xml:lang="en">
+                                This attribute gives the connector a name, which
+                                shall be unique within the component or system and,
+                                for components, must match the name of a relevant 
+                                variable/port in the underlying component implementation,
+                                e.g. the referenced FMU.
+                                
+                                Note that there is no requirement that connectors must
+                                be present for all variables/ports of an underlying
+                                component implementation.  Only those connectors must
+                                be present which are referenced in connections inside
+                                the SSD.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="kind" use="required">
+                        <xs:annotation>
+                            <xs:documentation xml:lang="en">
+                                This attribute specifies the kind of the given connector,
+                                which indicates whether the connector is an input, an
+                                output, both (inout), a parameter or a calculated parameter (i.e.
+                                a parameter that is calculated by the component during initialization).
+                                For components this must match the related kind of the underlying
+                                component implementation, e.g. for referenced FMUs it must match the
+                                combination of variability and causality.
+                                
+                                For FMI 2.0 this means that the causality of the variable must
+                                match the kind of the connector.
+                                
+                                For FMI 1.0 this means that for connectors of kind input or output
+                                the causality of the variable must be input or output and the
+                                variability of the variable must be discrete or continuous (for
+                                outputs also constant and parameter are allowable).  For connectors
+                                of kind parameter the causality must be input or internal and the
+                                variablity must be parameter.  For connectors of kind
+                                calculatedParameter the causality must be output and the variablity
+                                must be parameter.
+                                
+                                For SignalDictionaryReferences, the kind of a given connector can
+                                additionally be 'inout', which indicates that the semantics of the
+                                connector are derived from the connections going to the connector.
+                                This can be used for example to allow a connector to function as
+                                both an input and output within the same SignaleDictionaryReference.
+                            </xs:documentation>
+                        </xs:annotation>
+                        <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                                <xs:enumeration value="input"/>
+                                <xs:enumeration value="output"/>
+                                <xs:enumeration value="parameter"/>
+                                <xs:enumeration value="calculatedParameter"/>
+                                <xs:enumeration value="inout"/>
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="TParameterBindings">
+        <xs:sequence maxOccurs="unbounded">
+            <xs:element name="ParameterBinding">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">
+                        This provides a parameter binding for a component or system.  For FMU components this
+                        allows the parametrization of the FMU's parameters and start values of other variables
+                        with a parameter source (e.g. a parameter file).  Note that in this case the names
+                        provided in the parameter source must match the names of the FMU variables, or must be
+                        mapped to the names of the FMU variables through a ParameterMapping element, or are
+                        ignored if no matching variable is found.
+                        
+                        For systems the names in the parameter source must either match the hierarchical names
+                        of parameters or other variables in the system, or must be mapped to those names through
+                        a ParameterMapping element, or are ignored if no matching variable is found.
+                        
+                        The hierarchical names of the parameters or other variables of a system are formed in the
+                        following way: Any variables of the system exposed through connectors of the system have
+                        the name of the connector as their name.  For all elements of the system, the hierarchical
+                        names of the variables of those elements are formed by prepending the element name and a
+                        dot to the hierarchical names of the variables in that element.  E.g. for a system A
+                        containing a system B which contains an exposed parameter named SP1 and an element C with
+                        a parameter P2, the hierarchical names of the parameters in system A are B.SP1 and B.C.P2
+                        respectively.  The hierarchical name of those parameters inside system B are SP1 and C.P2
+                        respectively.
+                        
+                        More than one ParameterBinding can be supplied, in which case all of the parameters found
+                        will be used to parametrize the component, with parameter values in ParameterBinding
+                        sources appearing at a succeeding position in the element order taking priority over prior
+                        sources at the same hierarchy level, should a parameter be included in more than one 
+                        ParameterBinding source.
+                        
+                        When ParameterBinding sources on multiple levels of the hierarchy supply values for the 
+                        same parameter, bindings at a higher hierarchy level take precedence over lower levels,
+                        i.e. bindings at a system level take precedence over bindings at a sub-system or component
+                        level.
+
+                        Parameter bindings for FMU components can be used to set any initial values in the
+                        FMU which are legal to change.  It is assumed that the parameterization is applied
+                        prior to initializing for FMI 1.0, or before entering initialization mode for FMI 2.0.
+                        This means that variables eligible for parameterization are those with:
+                          * either causality = "input" or a start value for FMI 1.0
+                          * variability != "constant" and initial = "exact" or "approx" for FMI 2.0
+
+                        All kinds of system connectors can be parameterized.  In case the system level connectors
+                        are connected to FMU components, the parameterization must be compatible with the variable
+                        in the connected FMU.
+                        
+                        ParameterBindings that apply to a component that references another SSD/SSP are handled
+                        as if the top-level system of the SSD/SSP was present in the enclosing system instead of
+                        the component with one special case: Any parameter bindings in the component are treated
+                        as if they were present in the top-level system of the SSP/SSD after all parameter bindings
+                        of the system.  Therefore they take priority over any of the existing parameter bindings
+                        (for parameters with identical names).
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="ParameterValues" minOccurs="0">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">
+                                    This optional element can be used to provide parameter values inline
+                                    to the parameter binding, in which case the source attribute of the
+                                    ParameterBinding element must be empty.
+                                    
+                                    The contents must be an ssv:ParameterSet element, if the type attribute
+                                    of the ParameterBinding element is application/x-ssp-parameter-set, or
+                                    any other valid XML content if the type attribute references another
+                                    MIME type (in that case there should be a layered specification that
+                                    defines how embedding the content works for that MIME type).
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:choice>
+                                    <xs:element ref="ssv:ParameterSet"/>
+                                    <xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+                                </xs:choice>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="ParameterMapping" minOccurs="0">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">
+                                    This element provides an optional parameter mapping, which specifies how
+                                    the parameter names and values provided in the parameter source are to be
+                                    mapped to the parameters of the component or system in question.  If no
+                                    mapping is supplied, the parameter names of the parameter source are used
+                                    as is for name matching against the names of parameters in the component
+                                    or system and the values of the parameter source are not transformed further
+                                    before being applied.
+                                    
+                                    The contents of the element can be used to provide a parameter mapping
+                                    inline, in which case the source attribute of the ParameterMapping element
+                                    must be empty.
+                                    
+                                    The contents must be an ssm:ParameterMapping element, if the type attribute
+                                    of this element is application/x-ssp-parameter-mapping, or any other valid
+                                    XML content if the type attribute references another MIME type (in that case
+                                    there should be a layered specification that defines how embedding the content
+                                    works for that MIME type).
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:choice>
+                                    <xs:element ref="ssm:ParameterMapping"/>
+                                    <xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+                                </xs:choice>
+                                <xs:attributeGroup ref="ssc:ABaseElement"/>
+                                <xs:attribute name="type" type="xs:string" use="optional" default="application/x-ssp-parameter-mapping"/>
+                                <xs:attribute name="source" type="xs:anyURI" use="optional">
+                                    <xs:annotation>
+                                        <xs:documentation xml:lang="en">
+                                            This attribute indicates the source of the parameter mapping as a URI
+                                            (cf. RFC 3986).  For purposes of the resolution of relative URIs
+                                            the base URI is the URI of the SSD, if the sourcebase attribute
+                                            is not specified or is specified as SSD, and the URI of the
+                                            referenced component if the base attribute is specified as component.
+                                            This allows the specification of parameter mapping sources that reside
+                                            inside the component (e.g. an FMU) through relative URIs.
+                                            
+                                            If the source attribute is missing, the parameter mapping is provided
+                                            inline as contents of the ParameterMapping element, which must be
+                                            empty otherwise.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                </xs:attribute>
+                                <xs:attribute name="sourceBase" use="optional" default="SSD">
+                                    <xs:annotation>
+                                        <xs:documentation xml:lang="en">
+                                            Defines the base the source URI is resolved against:  If the attribute
+                                            is missing or is specified as SSD, the source is resolved against the
+                                            URI of the SSD, if the attribute is specified as component the URI is
+                                            resolved against the (resolved) URI of the component source.
+                                        </xs:documentation>
+                                    </xs:annotation>
+                                    <xs:simpleType>
+                                        <xs:restriction base="xs:string">
+                                            <xs:enumeration value="SSD"/>
+                                            <xs:enumeration value="component"/>
+                                        </xs:restriction>
+                                    </xs:simpleType>
+                                </xs:attribute>
+                            </xs:complexType>
+                        </xs:element>
+                        <xs:element name="Annotations" minOccurs="0" type="ssc:TAnnotations"/>
+                    </xs:sequence>
+                    <xs:attributeGroup ref="ssc:ABaseElement"/>
+                    <xs:attribute name="type" type="xs:string" use="optional" default="application/x-ssp-parameter-set">
+                        <xs:annotation>
+                            <xs:documentation xml:lang="en">
+                                This attribute specifies the MIME type of the parameter source, which defaults
+                                to application/x-ssp-parameter-set to indicate the SSP parameter set file format.
+                                No further types are currently defined, but can of course be added at a later
+                                date, e.g. for pre-existing parameter file formats, like CDF, etc.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="source" type="xs:anyURI" use="optional">
+                        <xs:annotation>
+                            <xs:documentation xml:lang="en">
+                                This attribute indicates the source of the parameters as a URI
+                                (cf. RFC 3986).  For purposes of the resolution of relative URIs
+                                the base URI is the URI of the SSD, if the sourcebase attribute
+                                is not specified or is specified as SSD, and the URI of the
+                                referenced component if the base attribute is specified as component.
+                                This allows the specification of parameter sources that reside inside
+                                the component (e.g. an FMU) through relative URIs.
+                                
+                                Access to parameter sets over the SSP Parameter Repository Protocol
+                                is mediated through URIs with the http or https scheme.
+                                
+                                If the source attribute is missing, the parameter mapping is provided
+                                inline as contents of a ParameterValues element, which must not be
+                                present otherwise.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="sourceBase" use="optional" default="SSD">
+                        <xs:annotation>
+                            <xs:documentation xml:lang="en">
+                                Defines the base the source URI is resolved against:  If the attribute
+                                is missing or is specified as SSD, the source is resolved against the
+                                URI of the SSD, if the attribute is specified as component the URI is
+                                resolved against the (resolved) URI of the component source.
+                            </xs:documentation>
+                        </xs:annotation>
+                        <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                                <xs:enumeration value="SSD"/>
+                                <xs:enumeration value="component"/>
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:attribute>
+                    <xs:attribute name="prefix" type="xs:string" use="optional" default="">
+                        <xs:annotation>
+                            <xs:documentation xml:lang="en">
+                                Defines the optional prefix for name resolution and mapping purposes
+                                for this binding.  If this attribute is empty or not supplied no
+                                prefix is used for name resolution and mapping, otherwise the specified
+                                prefix is prepended to all names in the parameter source prior to
+                                processing the normal name resolution or name mapping rules.  This
+                                allows the user to apply a parameter set normally intended for a component
+                                (and thus containing bare parameter names) at a system level targeted to
+                                one element of the system by supplying the name of the element plus a dot
+                                as a prefix on the binding, thus causing all parameter names in the parameter
+                                set to be treated as if they were specified with proper hierarchical names.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+    
+    <xs:complexType name="TDefaultExperiment">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                The attributes of this element, if present, specify reasonable default values
+                for running an experiment of the given system.  Any tool is free to ignore this
+                information.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="Annotations" minOccurs="0" type="ssc:TAnnotations"/>
+        </xs:sequence>
+        <xs:attribute name="startTime" type="xs:double" use="optional">
+            <xs:annotation>
+                <xs:documentation xml:lang="en">Default start time of simulation</xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="stopTime" type="xs:double" use="optional">
+            <xs:annotation>
+                <xs:documentation xml:lang="en">Default stop time of simulation</xs:documentation>
+            </xs:annotation>            
+        </xs:attribute>
+    </xs:complexType>
+</xs:schema>

--- a/schema/ssp/SystemStructureParameterMapping.xsd
+++ b/schema/ssp/SystemStructureParameterMapping.xsd
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified"
+    xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping"
+    xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
+    targetNamespace="http://ssp-standard.org/SSP1/SystemStructureParameterMapping">
+    <xs:annotation>
+        <xs:documentation xml:lang="en">
+            This is the normative XML Schema 1.0 schema for the MAP SSP
+            SystemStructureParameterMapping 1.0 format.
+            
+            Version: 1.0
+
+            Copyright 2016 -- 2019 Modelica Association Project "SSP"
+
+            Redistribution and use in source and binary forms, with or
+            without modification, are permitted provided that the
+            following conditions are met:
+
+            1. Redistributions of source code must retain the above
+               copyright notice, this list of conditions and the
+               following disclaimer.
+
+            2. Redistributions in binary form must reproduce the above
+               copyright notice, this list of conditions and the
+               following disclaimer in the documentation and/or other
+               materials provided with the distribution.
+
+            THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+            CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+            INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+            MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+            DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+            CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+            INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+            (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+            GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+            BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+            LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+            (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+            OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+            POSSIBILITY OF SUCH DAMAGE.
+        </xs:documentation>
+    </xs:annotation>
+    
+    <xs:import namespace="http://ssp-standard.org/SSP1/SystemStructureCommon" schemaLocation="SystemStructureCommon.xsd"/>
+    
+    <xs:element name="ParameterMapping">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="MappingEntry" minOccurs="0" maxOccurs="unbounded" type="ssm:TMappingEntry"/>
+                <xs:element name="Annotations" minOccurs="0" type="ssc:TAnnotations"/>
+            </xs:sequence>
+            <xs:attribute name="version" use="required">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">
+                        Version of SSM format, 1.0 for this release.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:normalizedString">
+                        <xs:pattern value="1[.][0-9]+(-.*)?"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:attribute>
+            <xs:attributeGroup ref="ssc:ABaseElement"/>
+            <xs:attributeGroup ref="ssc:ATopLevelMetaData"/>
+        </xs:complexType>
+    </xs:element>
+    
+    <xs:complexType name="TMappingEntry">
+        <xs:sequence>
+            <xs:group ref="ssc:GTransformationChoice" minOccurs="0" maxOccurs="1">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">
+                        This optional element specifies a transformation that is to be applied to
+                        the parameter value prior to its application to its target parameter.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:group>
+            <xs:element name="Annotations" minOccurs="0" type="ssc:TAnnotations"/>
+        </xs:sequence>
+        <xs:attributeGroup ref="ssc:ABaseElement"/>
+        <xs:attribute name="source" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation xml:lang="en">
+                    This attribute specifies the name of the parameter in the parameter source
+                    that is to be mapped to a new name and/or provided with a transformation
+                    in this mapping entry.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="target" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation xml:lang="en">
+                    This attribute specifies the name of the parameter in the system or
+                    component that is to be parametrized, i.e. that is the target of this
+                    mapping entry.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="suppressUnitConversion" type="xs:boolean" use="optional" default="false">
+            <xs:annotation>
+                <xs:documentation xml:lang="en">
+                    This attribute specifies whether automatic conversions between start
+                    and end connector are performed using unit information potentially
+                    available for both start and end definitions.  If this attribute is
+                    supplied and its value is true, then the environment will not perform
+                    any automatic unit conversions, otherwise automatic unit
+                    conversions can be performed.  This is also useful in conjunction with 
+                    the optional linear transformation supplied via the LinearTransformation
+                    element: With suppressUnitConversion = true, the linear transformation
+                    is performed instead of any unit conversions, whereas otherwise the
+                    linear transformation is performed in addition to any unit conversions.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+   
+</xs:schema>

--- a/schema/ssp/SystemStructureParameterValues.xsd
+++ b/schema/ssp/SystemStructureParameterValues.xsd
@@ -1,0 +1,218 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified"
+    xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
+    xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
+    targetNamespace="http://ssp-standard.org/SSP1/SystemStructureParameterValues">
+    <xs:annotation>
+        <xs:documentation xml:lang="en">
+            This is the normative XML Schema 1.0 schema for the MAP SSP
+            SystemStructureParameterValues 1.0 format.
+                        
+            Version: 1.0
+
+            Copyright 2016 -- 2019 Modelica Association Project "SSP"
+
+            Redistribution and use in source and binary forms, with or
+            without modification, are permitted provided that the
+            following conditions are met:
+
+            1. Redistributions of source code must retain the above
+               copyright notice, this list of conditions and the
+               following disclaimer.
+
+            2. Redistributions in binary form must reproduce the above
+               copyright notice, this list of conditions and the
+               following disclaimer in the documentation and/or other
+               materials provided with the distribution.
+
+            THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+            CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+            INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+            MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+            DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+            CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+            INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+            (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+            GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+            BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+            LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+            (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+            OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+            POSSIBILITY OF SUCH DAMAGE.
+        </xs:documentation>
+    </xs:annotation>
+    
+    <xs:import namespace="http://ssp-standard.org/SSP1/SystemStructureCommon" schemaLocation="SystemStructureCommon.xsd"/>
+    
+    <xs:element name="ParameterSet">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="Parameters" type="ssv:TParameters"/>
+                <xs:element name="Enumerations" minOccurs="0" type="ssc:TEnumerations"/>
+                <xs:element name="Units" minOccurs="0" type="ssc:TUnits"/>
+                <xs:element name="Annotations" minOccurs="0" type="ssc:TAnnotations"/>
+            </xs:sequence>
+            <xs:attribute name="version" use="required">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">
+                        Version of SSV format, 1.0 for this release.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:normalizedString">
+                        <xs:pattern value="1[.][0-9]+(-.*)?"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:attribute>
+            <xs:attributeGroup ref="ssc:ABaseElement"/>
+            <xs:attribute name="name" type="xs:string" use="required">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">
+                        Name of the Parameter Set.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:attribute>
+            <xs:attributeGroup ref="ssc:ATopLevelMetaData"/>
+        </xs:complexType>
+    </xs:element>
+        
+    <xs:complexType name="TParameters">
+        <xs:sequence>
+            <xs:element name="Parameter" minOccurs="0" maxOccurs="unbounded" type="ssv:TParameter"/>
+        </xs:sequence>
+    </xs:complexType>
+        
+    <xs:complexType name="TParameter">
+        <xs:sequence>
+            <xs:choice>
+                <xs:element name="Real">
+                    <xs:complexType>
+                        <xs:attribute name="value" type="xs:double" use="required">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">
+                                    This attribute gives the value of the parameter.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                        <xs:attribute name="unit" type="xs:string" use="optional">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">
+                                    This attribute gives the unit of the parameter value and must
+                                    reference one of the unit definitions provided in the Units
+                                    element of the enclosing file.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="Integer">
+                    <xs:complexType>
+                        <xs:attribute name="value" type="xs:int" use="required">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">
+                                    This attribute gives the value of the parameter.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="Boolean">
+                    <xs:complexType>
+                        <xs:attribute name="value" type="xs:boolean" use="required">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">
+                                    This attribute gives the value of the parameter.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="String">
+                    <xs:complexType>
+                        <xs:attribute name="value" type="xs:string" use="required">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">
+                                    This attribute gives the value of the parameter.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="Enumeration">
+                    <xs:complexType>
+                        <xs:attribute name="value" type="xs:string" use="required">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">
+                                    This attribute gives the value of the parameter as 
+                                    the enumeration item name.  Note that the actual
+                                    numeric value this value is mapped to at run time
+                                    will depend on the item mapping of the enumeration
+                                    type of the variables being parameterized.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                        <xs:attribute name="name" type="xs:string" use="optional">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">
+                                    This attribute specifies the name of the enumeration
+                                    which references into the set of defined enumerations
+                                    of the system structure description, as contained in
+                                    the Enumerations element of the root element.
+                                    
+                                    This attribute is optional; if it is not specified, then
+                                    the list of valid enumeration items with their names and
+                                    values is not specified, and the interpretation of the
+                                    enumeration value is left solely to the variables that
+                                    are being parameterized.
+                                    
+                                    If the attribute is specified, implementations MAY use
+                                    that information for user interface purposes, and/or
+                                    for additional consistency checking. 
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="Binary">
+                    <xs:complexType>
+                        <xs:attribute name="mime-type" type="xs:string" default="application/octet-stream">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">
+                                    This optional attribute specifies the MIME type of the
+                                    underlying binary data, which defaults to the non-specific
+                                    application/octet-stream type.  This information can be
+                                    used by the implementation to detect mismatches between
+                                    binary parameters, or provide automatic conversions
+                                    between different formats.  It should be noted that the
+                                    implementation is not required to provide this service,
+                                    i.e. it remains the responsibility of the operator to
+                                    ensure only compatible binary connectors/parameters are
+                                    connected.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                        <xs:attribute name="value" type="xs:hexBinary" use="required">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">
+                                    This attribute gives the value of the parameter as a
+                                    hex encoded binary value.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                    </xs:complexType>
+                </xs:element>
+            </xs:choice>
+            <xs:element name="Annotations" minOccurs="0" type="ssc:TAnnotations"/>
+        </xs:sequence>
+        <xs:attributeGroup ref="ssc:ABaseElement"/>
+        <xs:attribute name="name" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation xml:lang="en">
+                    This attribute specifies the name of the parameter in the parameter set,
+                    which must be unique within in the parameter set.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+     
+</xs:schema>

--- a/schema/ssp/SystemStructureSignalDictionary.xsd
+++ b/schema/ssp/SystemStructureSignalDictionary.xsd
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified"
+    xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
+    xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
+    targetNamespace="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary">
+    <xs:annotation>
+        <xs:documentation xml:lang="en">
+            This is the normative XML Schema 1.0 schema for the MAP SSP
+            SystemStructureSignalDictionary 1.0 format.
+            
+            Version: 1.0
+
+            Copyright 2016 -- 2019 Modelica Association Project "SSP"
+
+            Redistribution and use in source and binary forms, with or
+            without modification, are permitted provided that the
+            following conditions are met:
+
+            1. Redistributions of source code must retain the above
+               copyright notice, this list of conditions and the
+               following disclaimer.
+
+            2. Redistributions in binary form must reproduce the above
+               copyright notice, this list of conditions and the
+               following disclaimer in the documentation and/or other
+               materials provided with the distribution.
+
+            THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+            CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+            INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+            MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+            DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+            CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+            INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+            (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+            GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+            BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+            LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+            (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+            OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+            POSSIBILITY OF SUCH DAMAGE.
+        </xs:documentation>
+    </xs:annotation>
+    
+    <xs:import namespace="http://ssp-standard.org/SSP1/SystemStructureCommon" schemaLocation="SystemStructureCommon.xsd"/>
+    
+    <xs:element name="SignalDictionary">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="DictionaryEntry" minOccurs="0" maxOccurs="unbounded" type="ssb:TDictionaryEntry"/>
+                <xs:element name="Enumerations" minOccurs="0" type="ssc:TEnumerations"/>
+                <xs:element name="Units" minOccurs="0" type="ssc:TUnits"/>
+                <xs:element name="Annotations" minOccurs="0" type="ssc:TAnnotations"/>
+            </xs:sequence>
+            <xs:attribute name="version" use="required">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">
+                        Version of SSB format, 1.0 for this release.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:simpleType>
+                    <xs:restriction base="xs:normalizedString">
+                        <xs:pattern value="1[.][0-9]+(-.*)?"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:attribute>
+            <xs:attributeGroup ref="ssc:ABaseElement"/>
+            <xs:attributeGroup ref="ssc:ATopLevelMetaData"/>
+        </xs:complexType>
+    </xs:element>
+    
+    <xs:complexType name="TDictionaryEntry">
+        <xs:sequence>
+            <xs:group ref="ssc:GTypeChoice"/>
+            <xs:element name="Annotations" minOccurs="0" type="ssc:TAnnotations"/>
+        </xs:sequence>
+        <xs:attributeGroup ref="ssc:ABaseElement"/>
+        <xs:attribute name="name" use="required">
+            <xs:annotation>
+                <xs:documentation xml:lang="en">
+                    This attribute gives the dictionary entry a name, which
+                    shall be unique within the signal dictionary.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+    </xs:complexType>
+       
+</xs:schema>

--- a/src/OMSimulatorLib/CMakeLists.txt
+++ b/src/OMSimulatorLib/CMakeLists.txt
@@ -61,6 +61,7 @@ set(OMSIMULATORLIB_SOURCES
       SystemWC.cpp
       Values.cpp
       Variable.cpp
+      XercesValidator.cpp
       ssd/ConnectionGeometry.cpp
       ssd/ConnectorGeometry.cpp
       ssd/ElementGeometry.cpp

--- a/src/OMSimulatorLib/CMakeLists.txt
+++ b/src/OMSimulatorLib/CMakeLists.txt
@@ -61,6 +61,7 @@ set(OMSIMULATORLIB_SOURCES
       SystemWC.cpp
       Values.cpp
       Variable.cpp
+      whereami.c
       XercesValidator.cpp
       ssd/ConnectionGeometry.cpp
       ssd/ConnectorGeometry.cpp

--- a/src/OMSimulatorLib/Scope.cpp
+++ b/src/OMSimulatorLib/Scope.cpp
@@ -30,7 +30,7 @@
  */
 
 #include "Scope.h"
-
+#include "XercesValidator.h"
 #include "Flags.h"
 #include "System.h"
 #include "Component.h"
@@ -38,6 +38,7 @@
 #include "miniunz.h"
 #include <time.h>
 #include "ssd/Tags.h"
+#include <iostream>
 
 oms::Scope::Scope()
   : tempDir(".")
@@ -195,6 +196,9 @@ oms_status_enu_t oms::Scope::importModel(const std::string& filename, char** _cr
   const char* systemStructure = ::miniunz_onefile_to_memory(filename.c_str(), "SystemStructure.ssd");
   if (!systemStructure)
     return logError("failed to extract \"SystemStructure.ssd\" from \"" + std::string(filename) + "\"");
+
+  XercesValidator xercesValidator;
+  xercesValidator.validateSSD(systemStructure, filename);
 
   Snapshot snapshot;
   oms_status_enu_t status = snapshot.importResourceMemory("SystemStructure.ssd", systemStructure);

--- a/src/OMSimulatorLib/XercesValidator.cpp
+++ b/src/OMSimulatorLib/XercesValidator.cpp
@@ -121,7 +121,7 @@ oms_status_enu_t oms::XercesValidator::validateSSD(const char *ssd, const std::s
 
   // load the schema
   if (domParser.loadGrammar(filesystem::absolute(schemaFilePath).generic_string().c_str(), Grammar::SchemaGrammarType) == NULL)
-      return logError("could not load the ssd schema file :" + std::string(schemaFilePath));
+      return logError("could not load the ssd schema file: " + filesystem::absolute(schemaFilePath).generic_string());
 
   ParserErrorHandler parserErrorHandler("SystemStructure.ssd", filePath.c_str());
 

--- a/src/OMSimulatorLib/XercesValidator.cpp
+++ b/src/OMSimulatorLib/XercesValidator.cpp
@@ -54,6 +54,9 @@
 
 using namespace xercesc_3_2;
 
+#define STRING(x) #x
+#define XSTRING(x) STRING(x)
+
 class ParserErrorHandler : public ErrorHandler
 {
 public:
@@ -116,11 +119,14 @@ oms_status_enu_t oms::XercesValidator::validateSSD(const char *ssd, const std::s
     return oms_status_error;
   }
 
-  const char* schemaFilePath = "../../schema/ssp/SystemStructureDescription.xsd";
+  // get the SCHEMA_ROOT location defined in the cmake
+  filesystem::path schemaRootPath (XSTRING(SCHEMA_ROOT));
+  filesystem::path schemaFilePath = schemaRootPath / "ssp/SystemStructureDescription.xsd";
+
   XercesDOMParser domParser;
 
   // load the schema
-  if (domParser.loadGrammar(filesystem::absolute(schemaFilePath).generic_string().c_str(), Grammar::SchemaGrammarType) == NULL)
+  if (domParser.loadGrammar(schemaFilePath.generic_string().c_str(), Grammar::SchemaGrammarType) == NULL)
       return logError("could not load the ssd schema file: " + filesystem::absolute(schemaFilePath).generic_string());
 
   ParserErrorHandler parserErrorHandler("SystemStructure.ssd", filePath.c_str());
@@ -133,7 +139,8 @@ oms_status_enu_t oms::XercesValidator::validateSSD(const char *ssd, const std::s
   domParser.setValidationSchemaFullChecking(true);
   domParser.setValidationConstraintFatal(true);
   // domParser.setExternalNoNamespaceSchemaLocation(schemaFilePath); // set this for noNameSpace
-  domParser.setExternalSchemaLocation("http://ssp-standard.org/SSP1/SystemStructureDescription ../../schema/ssp/SystemStructureDescription.xsd");
+  std::string ssdTargetNameSpacePath = "http://ssp-standard.org/SSP1/SystemStructureDescription " + schemaFilePath.generic_string();
+  domParser.setExternalSchemaLocation(ssdTargetNameSpacePath.c_str());
 
   xercesc::MemBufInputSource pMemBufIS((const XMLByte*)ssd, std::string(ssd).size() , "ssdfile");
   domParser.parse(pMemBufIS);

--- a/src/OMSimulatorLib/XercesValidator.cpp
+++ b/src/OMSimulatorLib/XercesValidator.cpp
@@ -34,6 +34,7 @@
 #include "Logging.h"
 #include "ssd/Tags.h"
 #include "Util.h"
+#include "OMSFileSystem.h"
 
 #include <iostream>
 #include <map>
@@ -119,7 +120,7 @@ oms_status_enu_t oms::XercesValidator::validateSSD(const char *ssd, const std::s
   XercesDOMParser domParser;
 
   // load the schema
-  if (domParser.loadGrammar(schemaFilePath, Grammar::SchemaGrammarType) == NULL)
+  if (domParser.loadGrammar(filesystem::absolute(schemaFilePath).generic_string().c_str(), Grammar::SchemaGrammarType) == NULL)
       return logError("could not load the ssd schema file :" + std::string(schemaFilePath));
 
   ParserErrorHandler parserErrorHandler("SystemStructure.ssd", filePath.c_str());

--- a/src/OMSimulatorLib/XercesValidator.cpp
+++ b/src/OMSimulatorLib/XercesValidator.cpp
@@ -128,11 +128,11 @@ oms_status_enu_t oms::XercesValidator::validateSSD(const char *ssd, const std::s
     wai_getModulePath(path, length, &dirname_length);
     path[length] = '\0';
 
-    // printf("executable path: %s\n", path);
+    //printf("executable path: %s\n", path);
     path[dirname_length] = '\0';
-    free(path);
-    // printf("  dirname: %s\n", path);
-    // printf("  basename: %s\n", path + dirname_length + 1);
+    // free(path);
+    //printf("  dirname: %s\n", path);
+    //printf("  basename: %s\n", path + dirname_length + 1);
   }
 
   filesystem::path schemaRootPath (path);

--- a/src/OMSimulatorLib/XercesValidator.cpp
+++ b/src/OMSimulatorLib/XercesValidator.cpp
@@ -1,0 +1,144 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-CurrentYear, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF GPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.2.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GPL VERSION 3,
+ * ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the Open Source Modelica
+ * Consortium (OSMC) Public License (OSMC-PL) are obtained
+ * from OSMC, either from the above address,
+ * from the URLs: http://www.ida.liu.se/projects/OpenModelica or
+ * http://www.openmodelica.org, and in the OpenModelica distribution.
+ * GNU version 3 is obtained from: http://www.gnu.org/copyleft/gpl.html.
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+#include "XercesValidator.h"
+
+#include "Logging.h"
+#include "ssd/Tags.h"
+#include "Util.h"
+
+#include <iostream>
+#include <map>
+#include "miniunz.h"
+#include <string>
+
+#include <xercesc/parsers/XercesDOMParser.hpp>
+#include <xercesc/dom/DOM.hpp>
+#include <xercesc/sax/HandlerBase.hpp>
+#include <xercesc/framework/MemBufInputSource.hpp>
+
+#include <xercesc/util/XMLString.hpp>
+#include <xercesc/validators/common/Grammar.hpp>
+#include <xercesc/util/PlatformUtils.hpp>
+#include <xercesc/sax/ErrorHandler.hpp>
+#include <xercesc/sax/SAXParseException.hpp>
+
+using namespace xercesc_3_2;
+
+class ParserErrorHandler : public ErrorHandler
+{
+public:
+  const char *fileName = "";
+  const char *filePath = "";
+  ParserErrorHandler(const char *fileName_, const char *filePath_)
+  {
+    fileName = fileName_;
+    filePath = filePath_;
+  }
+private:
+    void reportParseException(const SAXParseException &ex)
+    {
+      char *msg = XMLString::transcode(ex.getMessage());
+      logError("invalid " + std::string(fileName) + " detected in file " + "\"" + std::string(filePath) + "\"" + " at line: " + std::to_string(ex.getLineNumber()) + " column: " + std::to_string(ex.getColumnNumber()) + ", " + std::string(msg));
+      XMLString::release(&msg);
+    }
+
+public:
+    void warning(const SAXParseException &ex)
+    {
+      reportParseException(ex);
+    }
+
+    void error(const SAXParseException &ex)
+    {
+      reportParseException(ex);
+    }
+
+    void fatalError(const SAXParseException &ex)
+    {
+      reportParseException(ex);
+    }
+
+    void resetErrors()
+    {
+    }
+};
+
+oms::XercesValidator::XercesValidator()
+{
+}
+
+oms::XercesValidator::~XercesValidator()
+{
+  XMLPlatformUtils::Terminate();
+}
+
+oms_status_enu_t oms::XercesValidator::validateSSD(const char *ssd, const std::string& filePath)
+{
+  try
+  {
+    XMLPlatformUtils::Initialize();
+  }
+  catch (const XMLException &toCatch)
+  {
+    char *message = XMLString::transcode(toCatch.getMessage());
+    logError("Xerces error during initialization: "+ std::string(message));
+    XMLString::release(&message);
+    return oms_status_error;
+  }
+
+  const char* schemaFilePath = "../../schema/ssp/SystemStructureDescription.xsd";
+  XercesDOMParser domParser;
+
+  // load the schema
+  if (domParser.loadGrammar(schemaFilePath, Grammar::SchemaGrammarType) == NULL)
+      return logError("could not load the ssd schema file :" + std::string(schemaFilePath));
+
+  ParserErrorHandler parserErrorHandler("SystemStructure.ssd", filePath.c_str());
+
+  domParser.setErrorHandler(&parserErrorHandler);
+  domParser.cacheGrammarFromParse(true);
+  domParser.setValidationScheme(XercesDOMParser::Val_Always);
+  domParser.setDoNamespaces(true);
+  domParser.setDoSchema(true);
+  domParser.setValidationSchemaFullChecking(true);
+  domParser.setValidationConstraintFatal(true);
+  // domParser.setExternalNoNamespaceSchemaLocation(schemaFilePath); // set this for noNameSpace
+  domParser.setExternalSchemaLocation("http://ssp-standard.org/SSP1/SystemStructureDescription ../../schema/ssp/SystemStructureDescription.xsd");
+
+  xercesc::MemBufInputSource pMemBufIS((const XMLByte*)ssd, std::string(ssd).size() , "ssdfile");
+  domParser.parse(pMemBufIS);
+
+  if (domParser.getErrorCount() > 0)
+      return logError("SystemStructure.ssd does not conform to the SSP standard schema");
+
+  return oms_status_ok;
+}

--- a/src/OMSimulatorLib/XercesValidator.cpp
+++ b/src/OMSimulatorLib/XercesValidator.cpp
@@ -119,13 +119,13 @@ oms_status_enu_t oms::XercesValidator::validateSSD(const char *ssd, const std::s
 
   int dirname_length;
   char * path;
-  int length = wai_getExecutablePath(NULL, 0, &dirname_length);
+  int length = wai_getModulePath(NULL, 0, &dirname_length);
   if (length > 0)
   {
     path = (char*)malloc(length + 1);
     if (!path)
       abort();
-    wai_getExecutablePath(path, length, &dirname_length);
+    wai_getModulePath(path, length, &dirname_length);
     path[length] = '\0';
 
     // printf("executable path: %s\n", path);
@@ -136,8 +136,16 @@ oms_status_enu_t oms::XercesValidator::validateSSD(const char *ssd, const std::s
   }
 
   filesystem::path schemaRootPath (path);
-  filesystem::path schemaFilePath = schemaRootPath / "../share/OMSimulator/schema/ssp/SystemStructureDescription.xsd";
+  filesystem::path schemaFilePath;
+
+  schemaFilePath = schemaRootPath / "../share/OMSimulator/schema/ssp/SystemStructureDescription.xsd";
   // std::cout << "schemaPath: " << schemaFilePath.generic_string() << "\n" << filesystem::absolute(schemaFilePath).generic_string() << "\n";
+
+  // for windows and mingw libOMSimulator.dll is put in "install/bin" directory and for linux and other platforms
+  // the shared libraries are put in "install/lib/x86_64-linux-gnu/", so to find the schema location we have to move two directories back
+  if (!filesystem::exists(schemaFilePath))
+    schemaFilePath = schemaRootPath / "../../share/OMSimulator/schema/ssp/SystemStructureDescription.xsd";
+
   XercesDOMParser domParser;
 
   // load the schema

--- a/src/OMSimulatorLib/XercesValidator.cpp
+++ b/src/OMSimulatorLib/XercesValidator.cpp
@@ -62,7 +62,7 @@ private:
   void reportParseException(const SAXParseException &ex)
   {
     char *msg = XMLString::transcode(ex.getMessage());
-    logWarning("invalid " + std::string(fileName) + " detected in file " + "\"" + std::string(filePath) + "\"" + " at line: " + std::to_string(ex.getLineNumber()) + " column: " + std::to_string(ex.getColumnNumber()) + ", " + std::string(msg));
+    logWarning("invalid \"" + std::string(fileName) + "\""  + " detected in file " + "\"" + std::string(filePath) + "\"" + " at line: " + std::to_string(ex.getLineNumber()) + " column: " + std::to_string(ex.getColumnNumber()) + ", " + std::string(msg));
     XMLString::release(&msg);
   }
 public:

--- a/src/OMSimulatorLib/XercesValidator.cpp
+++ b/src/OMSimulatorLib/XercesValidator.cpp
@@ -30,6 +30,7 @@
  */
 
 #include "XercesValidator.h"
+#include "whereami.h"
 
 #include "Logging.h"
 #include "ssd/Tags.h"
@@ -53,10 +54,6 @@
 #include <xercesc/sax/SAXParseException.hpp>
 
 using namespace xercesc_3_2;
-
-#define STRING(x) #x
-#define XSTRING(x) STRING(x)
-
 class ParserErrorHandler : public ErrorHandler
 {
 public:
@@ -119,10 +116,28 @@ oms_status_enu_t oms::XercesValidator::validateSSD(const char *ssd, const std::s
     return oms_status_error;
   }
 
-  // get the SCHEMA_ROOT location defined in the cmake
-  filesystem::path schemaRootPath (XSTRING(SCHEMA_ROOT));
-  filesystem::path schemaFilePath = schemaRootPath / "ssp/SystemStructureDescription.xsd";
 
+  int dirname_length;
+  char * path;
+  int length = wai_getExecutablePath(NULL, 0, &dirname_length);
+  if (length > 0)
+  {
+    path = (char*)malloc(length + 1);
+    if (!path)
+      abort();
+    wai_getExecutablePath(path, length, &dirname_length);
+    path[length] = '\0';
+
+    // printf("executable path: %s\n", path);
+    path[dirname_length] = '\0';
+    free(path);
+    // printf("  dirname: %s\n", path);
+    // printf("  basename: %s\n", path + dirname_length + 1);
+  }
+
+  filesystem::path schemaRootPath (path);
+  filesystem::path schemaFilePath = schemaRootPath / "../share/OMSimulator/schema/ssp/SystemStructureDescription.xsd";
+  // std::cout << "schemaPath: " << schemaFilePath.generic_string() << "\n" << filesystem::absolute(schemaFilePath).generic_string() << "\n";
   XercesDOMParser domParser;
 
   // load the schema

--- a/src/OMSimulatorLib/XercesValidator.cpp
+++ b/src/OMSimulatorLib/XercesValidator.cpp
@@ -33,15 +33,8 @@
 #include "whereami.h"
 
 #include "Logging.h"
-#include "ssd/Tags.h"
-#include "Util.h"
 #include "OMSFileSystem.h"
 #include "OMSString.h"
-
-#include <iostream>
-#include <map>
-#include "miniunz.h"
-#include <string>
 
 #include <xercesc/parsers/XercesDOMParser.hpp>
 #include <xercesc/dom/DOM.hpp>
@@ -66,32 +59,28 @@ public:
     filePath = filePath_;
   }
 private:
-    void reportParseException(const SAXParseException &ex)
-    {
-      char *msg = XMLString::transcode(ex.getMessage());
-      logError("invalid " + std::string(fileName) + " detected in file " + "\"" + std::string(filePath) + "\"" + " at line: " + std::to_string(ex.getLineNumber()) + " column: " + std::to_string(ex.getColumnNumber()) + ", " + std::string(msg));
-      XMLString::release(&msg);
-    }
-
+  void reportParseException(const SAXParseException &ex)
+  {
+    char *msg = XMLString::transcode(ex.getMessage());
+    logWarning("invalid " + std::string(fileName) + " detected in file " + "\"" + std::string(filePath) + "\"" + " at line: " + std::to_string(ex.getLineNumber()) + " column: " + std::to_string(ex.getColumnNumber()) + ", " + std::string(msg));
+    XMLString::release(&msg);
+  }
 public:
-    void warning(const SAXParseException &ex)
-    {
-      reportParseException(ex);
-    }
-
-    void error(const SAXParseException &ex)
-    {
-      reportParseException(ex);
-    }
-
-    void fatalError(const SAXParseException &ex)
-    {
-      reportParseException(ex);
-    }
-
-    void resetErrors()
-    {
-    }
+  void warning(const SAXParseException &ex)
+  {
+    reportParseException(ex);
+  }
+  void error(const SAXParseException &ex)
+  {
+    reportParseException(ex);
+  }
+  void fatalError(const SAXParseException &ex)
+  {
+    reportParseException(ex);
+  }
+  void resetErrors()
+  {
+  }
 };
 
 oms::XercesValidator::XercesValidator()
@@ -123,7 +112,6 @@ std::string oms::XercesValidator::getExecutablePath()
   path[length] = '\0';
 
   //std::cout << "executable path: " <<  path << "\n";
-
   path[dirname_length] = '\0';
   //std::cout << "dirname: "<<  path << "\n";
   //std::cout << "basename: "<<  path + dirname_length + 1;
@@ -133,8 +121,6 @@ std::string oms::XercesValidator::getExecutablePath()
 
   return executablePath;
 }
-
-
 
 oms_status_enu_t oms::XercesValidator::validateSSD(const char *ssd, const std::string& filePath)
 {
@@ -190,7 +176,7 @@ oms_status_enu_t oms::XercesValidator::validateSSD(const char *ssd, const std::s
   domParser.parse(pMemBufIS);
 
   if (domParser.getErrorCount() > 0)
-      return logError("SystemStructure.ssd does not conform to the SSP standard schema");
+      return logWarning("\"SystemStructure.ssd\" does not conform to the SSP standard schema");
 
   return oms_status_ok;
 }

--- a/src/OMSimulatorLib/XercesValidator.h
+++ b/src/OMSimulatorLib/XercesValidator.h
@@ -1,0 +1,53 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-CurrentYear, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF GPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.2.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GPL VERSION 3,
+ * ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the Open Source Modelica
+ * Consortium (OSMC) Public License (OSMC-PL) are obtained
+ * from OSMC, either from the above address,
+ * from the URLs: http://www.ida.liu.se/projects/OpenModelica or
+ * http://www.openmodelica.org, and in the OpenModelica distribution.
+ * GNU version 3 is obtained from: http://www.gnu.org/copyleft/gpl.html.
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+#ifndef _OMS_XERCES_VALIDATOR_H_
+#define _OMS_XERCES_VALIDATOR_H_
+
+#include "ComRef.h"
+#include "OMSFileSystem.h"
+#include "Snapshot.h"
+#include "OMSimulator/Types.h"
+
+#include <map>
+
+namespace oms
+{
+  class XercesValidator
+  {
+  public:
+    XercesValidator();
+    ~XercesValidator();
+    oms_status_enu_t validateSSD(const char * ssd, const std::string& filePath);
+  };
+}
+
+#endif

--- a/src/OMSimulatorLib/XercesValidator.h
+++ b/src/OMSimulatorLib/XercesValidator.h
@@ -47,6 +47,7 @@ namespace oms
     XercesValidator();
     ~XercesValidator();
     oms_status_enu_t validateSSD(const char * ssd, const std::string& filePath);
+    std::string getExecutablePath();
   };
 }
 

--- a/src/OMSimulatorLib/whereami.c
+++ b/src/OMSimulatorLib/whereami.c
@@ -1,0 +1,804 @@
+// (‑●‑●)> dual licensed under the WTFPL v2 and MIT licenses
+//   without any warranty.
+//   by Gregory Pakosz (@gpakosz)
+// https://github.com/gpakosz/whereami
+
+// in case you want to #include "whereami.c" in a larger compilation unit
+#if !defined(WHEREAMI_H)
+#include <whereami.h>
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#if defined(__linux__) || defined(__CYGWIN__)
+#undef _DEFAULT_SOURCE
+#define _DEFAULT_SOURCE
+#elif defined(__APPLE__)
+#undef _DARWIN_C_SOURCE
+#define _DARWIN_C_SOURCE
+#define _DARWIN_BETTER_REALPATH
+#endif
+
+#if !defined(WAI_MALLOC) || !defined(WAI_FREE) || !defined(WAI_REALLOC)
+#include <stdlib.h>
+#endif
+
+#if !defined(WAI_MALLOC)
+#define WAI_MALLOC(size) malloc(size)
+#endif
+
+#if !defined(WAI_FREE)
+#define WAI_FREE(p) free(p)
+#endif
+
+#if !defined(WAI_REALLOC)
+#define WAI_REALLOC(p, size) realloc(p, size)
+#endif
+
+#ifndef WAI_NOINLINE
+#if defined(_MSC_VER)
+#define WAI_NOINLINE __declspec(noinline)
+#elif defined(__GNUC__)
+#define WAI_NOINLINE __attribute__((noinline))
+#else
+#error unsupported compiler
+#endif
+#endif
+
+#if defined(_MSC_VER)
+#define WAI_RETURN_ADDRESS() _ReturnAddress()
+#elif defined(__GNUC__)
+#define WAI_RETURN_ADDRESS() __builtin_extract_return_addr(__builtin_return_address(0))
+#else
+#error unsupported compiler
+#endif
+
+#if defined(_WIN32)
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#if defined(_MSC_VER)
+#pragma warning(push, 3)
+#endif
+#include <windows.h>
+#include <intrin.h>
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+#include <stdbool.h>
+
+static int WAI_PREFIX(getModulePath_)(HMODULE module, char* out, int capacity, int* dirname_length)
+{
+  wchar_t buffer1[MAX_PATH];
+  wchar_t buffer2[MAX_PATH];
+  wchar_t* path = NULL;
+  int length = -1;
+  bool ok;
+
+  for (ok = false; !ok; ok = true)
+  {
+    DWORD size;
+    int length_, length__;
+
+    size = GetModuleFileNameW(module, buffer1, sizeof(buffer1) / sizeof(buffer1[0]));
+
+    if (size == 0)
+      break;
+    else if (size == (DWORD)(sizeof(buffer1) / sizeof(buffer1[0])))
+    {
+      DWORD size_ = size;
+      do
+      {
+        wchar_t* path_;
+
+        path_ = (wchar_t*)WAI_REALLOC(path, sizeof(wchar_t) * size_ * 2);
+        if (!path_)
+          break;
+        size_ *= 2;
+        path = path_;
+        size = GetModuleFileNameW(module, path, size_);
+      }
+      while (size == size_);
+
+      if (size == size_)
+        break;
+    }
+    else
+      path = buffer1;
+
+    if (!_wfullpath(buffer2, path, MAX_PATH))
+      break;
+    length_ = (int)wcslen(buffer2);
+    length__ = WideCharToMultiByte(CP_UTF8, 0, buffer2, length_ , out, capacity, NULL, NULL);
+
+    if (length__ == 0)
+      length__ = WideCharToMultiByte(CP_UTF8, 0, buffer2, length_, NULL, 0, NULL, NULL);
+    if (length__ == 0)
+      break;
+
+    if (length__ <= capacity && dirname_length)
+    {
+      int i;
+
+      for (i = length__ - 1; i >= 0; --i)
+      {
+        if (out[i] == '\\')
+        {
+          *dirname_length = i;
+          break;
+        }
+      }
+    }
+
+    length = length__;
+  }
+
+  if (path != buffer1)
+    WAI_FREE(path);
+
+  return ok ? length : -1;
+}
+
+WAI_NOINLINE WAI_FUNCSPEC
+int WAI_PREFIX(getExecutablePath)(char* out, int capacity, int* dirname_length)
+{
+  return WAI_PREFIX(getModulePath_)(NULL, out, capacity, dirname_length);
+}
+
+WAI_NOINLINE WAI_FUNCSPEC
+int WAI_PREFIX(getModulePath)(char* out, int capacity, int* dirname_length)
+{
+  HMODULE module;
+  int length = -1;
+
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable: 4054)
+#endif
+  if (GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT, (LPCTSTR)WAI_RETURN_ADDRESS(), &module))
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+  {
+    length = WAI_PREFIX(getModulePath_)(module, out, capacity, dirname_length);
+  }
+
+  return length;
+}
+
+#elif defined(__linux__) || defined(__CYGWIN__) || defined(__sun) || defined(WAI_USE_PROC_SELF_EXE)
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#if defined(__linux__)
+#include <linux/limits.h>
+#else
+#include <limits.h>
+#endif
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
+#include <inttypes.h>
+#include <stdbool.h>
+
+#if !defined(WAI_PROC_SELF_EXE)
+#if defined(__sun)
+#define WAI_PROC_SELF_EXE "/proc/self/path/a.out"
+#else
+#define WAI_PROC_SELF_EXE "/proc/self/exe"
+#endif
+#endif
+
+WAI_FUNCSPEC
+int WAI_PREFIX(getExecutablePath)(char* out, int capacity, int* dirname_length)
+{
+  char buffer[PATH_MAX];
+  char* resolved = NULL;
+  int length = -1;
+  bool ok;
+
+  for (ok = false; !ok; ok = true)
+  {
+    resolved = realpath(WAI_PROC_SELF_EXE, buffer);
+    if (!resolved)
+      break;
+
+    length = (int)strlen(resolved);
+    if (length <= capacity)
+    {
+      memcpy(out, resolved, length);
+
+      if (dirname_length)
+      {
+        int i;
+
+        for (i = length - 1; i >= 0; --i)
+        {
+          if (out[i] == '/')
+          {
+            *dirname_length = i;
+            break;
+          }
+        }
+      }
+    }
+  }
+
+  return ok ? length : -1;
+}
+
+#if !defined(WAI_PROC_SELF_MAPS_RETRY)
+#define WAI_PROC_SELF_MAPS_RETRY 5
+#endif
+
+#if !defined(WAI_PROC_SELF_MAPS)
+#if defined(__sun)
+#define WAI_PROC_SELF_MAPS "/proc/self/map"
+#else
+#define WAI_PROC_SELF_MAPS "/proc/self/maps"
+#endif
+#endif
+
+#if defined(__ANDROID__) || defined(ANDROID)
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <unistd.h>
+#endif
+#include <stdbool.h>
+
+WAI_NOINLINE WAI_FUNCSPEC
+int WAI_PREFIX(getModulePath)(char* out, int capacity, int* dirname_length)
+{
+  int length = -1;
+  FILE* maps = NULL;
+
+  for (int r = 0; r < WAI_PROC_SELF_MAPS_RETRY; ++r)
+  {
+    maps = fopen(WAI_PROC_SELF_MAPS, "r");
+    if (!maps)
+      break;
+
+    for (;;)
+    {
+      char buffer[PATH_MAX < 1024 ? 1024 : PATH_MAX];
+      uint64_t low, high;
+      char perms[5];
+      uint64_t offset;
+      uint32_t major, minor;
+      char path[PATH_MAX];
+      uint32_t inode;
+
+      if (!fgets(buffer, sizeof(buffer), maps))
+        break;
+
+      if (sscanf(buffer, "%" PRIx64 "-%" PRIx64 " %s %" PRIx64 " %x:%x %u %s\n", &low, &high, perms, &offset, &major, &minor, &inode, path) == 8)
+      {
+        uint64_t addr = (uintptr_t)WAI_RETURN_ADDRESS();
+        if (low <= addr && addr <= high)
+        {
+          char* resolved;
+
+          resolved = realpath(path, buffer);
+          if (!resolved)
+            break;
+
+          length = (int)strlen(resolved);
+#if defined(__ANDROID__) || defined(ANDROID)
+          if (length > 4
+              &&buffer[length - 1] == 'k'
+              &&buffer[length - 2] == 'p'
+              &&buffer[length - 3] == 'a'
+              &&buffer[length - 4] == '.')
+          {
+            int fd = open(path, O_RDONLY);
+            if (fd == -1)
+            {
+              length = -1; // retry
+              break;
+            }
+
+            char* begin = (char*)mmap(0, offset, PROT_READ, MAP_SHARED, fd, 0);
+            if (begin == MAP_FAILED)
+            {
+              close(fd);
+              length = -1; // retry
+              break;
+            }
+
+            char* p = begin + offset - 30; // minimum size of local file header
+            while (p >= begin) // scan backwards
+            {
+              if (*((uint32_t*)p) == 0x04034b50UL) // local file header signature found
+              {
+                uint16_t length_ = *((uint16_t*)(p + 26));
+
+                if (length + 2 + length_ < (int)sizeof(buffer))
+                {
+                  memcpy(&buffer[length], "!/", 2);
+                  memcpy(&buffer[length + 2], p + 30, length_);
+                  length += 2 + length_;
+                }
+
+                break;
+              }
+
+              --p;
+            }
+
+            munmap(begin, offset);
+            close(fd);
+          }
+#endif
+          if (length <= capacity)
+          {
+            memcpy(out, resolved, length);
+
+            if (dirname_length)
+            {
+              int i;
+
+              for (i = length - 1; i >= 0; --i)
+              {
+                if (out[i] == '/')
+                {
+                  *dirname_length = i;
+                  break;
+                }
+              }
+            }
+          }
+
+          break;
+        }
+      }
+    }
+
+    fclose(maps);
+    maps = NULL;
+
+    if (length != -1)
+      break;
+  }
+
+  return length;
+}
+
+#elif defined(__APPLE__)
+
+#include <mach-o/dyld.h>
+#include <limits.h>
+#include <stdlib.h>
+#include <string.h>
+#include <dlfcn.h>
+#include <stdbool.h>
+
+WAI_FUNCSPEC
+int WAI_PREFIX(getExecutablePath)(char* out, int capacity, int* dirname_length)
+{
+  char buffer1[PATH_MAX];
+  char buffer2[PATH_MAX];
+  char* path = buffer1;
+  char* resolved = NULL;
+  int length = -1;
+  bool ok;
+
+  for (ok = false; !ok; ok = true)
+  {
+    uint32_t size = (uint32_t)sizeof(buffer1);
+    if (_NSGetExecutablePath(path, &size) == -1)
+    {
+      path = (char*)WAI_MALLOC(size);
+      if (!_NSGetExecutablePath(path, &size))
+        break;
+    }
+
+    resolved = realpath(path, buffer2);
+    if (!resolved)
+      break;
+
+    length = (int)strlen(resolved);
+    if (length <= capacity)
+    {
+      memcpy(out, resolved, length);
+
+      if (dirname_length)
+      {
+        int i;
+
+        for (i = length - 1; i >= 0; --i)
+        {
+          if (out[i] == '/')
+          {
+            *dirname_length = i;
+            break;
+          }
+        }
+      }
+    }
+  }
+
+  if (path != buffer1)
+    WAI_FREE(path);
+
+  return ok ? length : -1;
+}
+
+WAI_NOINLINE WAI_FUNCSPEC
+int WAI_PREFIX(getModulePath)(char* out, int capacity, int* dirname_length)
+{
+  char buffer[PATH_MAX];
+  char* resolved = NULL;
+  int length = -1;
+
+  for(;;)
+  {
+    Dl_info info;
+
+    if (dladdr(WAI_RETURN_ADDRESS(), &info))
+    {
+      resolved = realpath(info.dli_fname, buffer);
+      if (!resolved)
+        break;
+
+      length = (int)strlen(resolved);
+      if (length <= capacity)
+      {
+        memcpy(out, resolved, length);
+
+        if (dirname_length)
+        {
+          int i;
+
+          for (i = length - 1; i >= 0; --i)
+          {
+            if (out[i] == '/')
+            {
+              *dirname_length = i;
+              break;
+            }
+          }
+        }
+      }
+    }
+
+    break;
+  }
+
+  return length;
+}
+
+#elif defined(__QNXNTO__)
+
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <dlfcn.h>
+#include <stdbool.h>
+
+#if !defined(WAI_PROC_SELF_EXE)
+#define WAI_PROC_SELF_EXE "/proc/self/exefile"
+#endif
+
+WAI_FUNCSPEC
+int WAI_PREFIX(getExecutablePath)(char* out, int capacity, int* dirname_length)
+{
+  char buffer1[PATH_MAX];
+  char buffer2[PATH_MAX];
+  char* resolved = NULL;
+  FILE* self_exe = NULL;
+  int length = -1;
+  bool ok;
+
+  for (ok = false; !ok; ok = true)
+  {
+    self_exe = fopen(WAI_PROC_SELF_EXE, "r");
+    if (!self_exe)
+      break;
+
+    if (!fgets(buffer1, sizeof(buffer1), self_exe))
+      break;
+
+    resolved = realpath(buffer1, buffer2);
+    if (!resolved)
+      break;
+
+    length = (int)strlen(resolved);
+    if (length <= capacity)
+    {
+      memcpy(out, resolved, length);
+
+      if (dirname_length)
+      {
+        int i;
+
+        for (i = length - 1; i >= 0; --i)
+        {
+          if (out[i] == '/')
+          {
+            *dirname_length = i;
+            break;
+          }
+        }
+      }
+    }
+  }
+
+  fclose(self_exe);
+
+  return ok ? length : -1;
+}
+
+WAI_FUNCSPEC
+int WAI_PREFIX(getModulePath)(char* out, int capacity, int* dirname_length)
+{
+  char buffer[PATH_MAX];
+  char* resolved = NULL;
+  int length = -1;
+
+  for(;;)
+  {
+    Dl_info info;
+
+    if (dladdr(WAI_RETURN_ADDRESS(), &info))
+    {
+      resolved = realpath(info.dli_fname, buffer);
+      if (!resolved)
+        break;
+
+      length = (int)strlen(resolved);
+      if (length <= capacity)
+      {
+        memcpy(out, resolved, length);
+
+        if (dirname_length)
+        {
+          int i;
+
+          for (i = length - 1; i >= 0; --i)
+          {
+            if (out[i] == '/')
+            {
+              *dirname_length = i;
+              break;
+            }
+          }
+        }
+      }
+    }
+
+    break;
+  }
+
+  return length;
+}
+
+#elif defined(__DragonFly__) || defined(__FreeBSD__) || \
+      defined(__FreeBSD_kernel__) || defined(__NetBSD__) || defined(__OpenBSD__)
+
+#include <limits.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/sysctl.h>
+#include <dlfcn.h>
+#include <stdbool.h>
+
+#if defined(__OpenBSD__)
+
+#include <unistd.h>
+
+WAI_FUNCSPEC
+int WAI_PREFIX(getExecutablePath)(char* out, int capacity, int* dirname_length)
+{
+  char buffer1[4096];
+  char buffer2[PATH_MAX];
+  char buffer3[PATH_MAX];
+  char** argv = (char**)buffer1;
+  char* resolved = NULL;
+  int length = -1;
+  bool ok;
+
+  for (ok = false; !ok; ok = true)
+  {
+    int mib[4] = { CTL_KERN, KERN_PROC_ARGS, getpid(), KERN_PROC_ARGV };
+    size_t size;
+
+    if (sysctl(mib, 4, NULL, &size, NULL, 0) != 0)
+        break;
+
+    if (size > sizeof(buffer1))
+    {
+      argv = (char**)WAI_MALLOC(size);
+      if (!argv)
+        break;
+    }
+
+    if (sysctl(mib, 4, argv, &size, NULL, 0) != 0)
+        break;
+
+    if (strchr(argv[0], '/'))
+    {
+      resolved = realpath(argv[0], buffer2);
+      if (!resolved)
+        break;
+    }
+    else
+    {
+      const char* PATH = getenv("PATH");
+      if (!PATH)
+        break;
+
+      size_t argv0_length = strlen(argv[0]);
+
+      const char* begin = PATH;
+      while (1)
+      {
+        const char* separator = strchr(begin, ':');
+        const char* end = separator ? separator : begin + strlen(begin);
+
+        if (end - begin > 0)
+        {
+          if (*(end -1) == '/')
+            --end;
+
+          if (((end - begin) + 1 + argv0_length + 1) <= sizeof(buffer2))
+          {
+            memcpy(buffer2, begin, end - begin);
+            buffer2[end - begin] = '/';
+            memcpy(buffer2 + (end - begin) + 1, argv[0], argv0_length + 1);
+
+            resolved = realpath(buffer2, buffer3);
+            if (resolved)
+              break;
+          }
+        }
+
+        if (!separator)
+          break;
+
+        begin = ++separator;
+      }
+
+      if (!resolved)
+        break;
+    }
+
+    length = (int)strlen(resolved);
+    if (length <= capacity)
+    {
+      memcpy(out, resolved, length);
+
+      if (dirname_length)
+      {
+        int i;
+
+        for (i = length - 1; i >= 0; --i)
+        {
+          if (out[i] == '/')
+          {
+            *dirname_length = i;
+            break;
+          }
+        }
+      }
+    }
+  }
+
+  if (argv != (char**)buffer1)
+    WAI_FREE(argv);
+
+  return ok ? length : -1;
+}
+
+#else
+
+WAI_FUNCSPEC
+int WAI_PREFIX(getExecutablePath)(char* out, int capacity, int* dirname_length)
+{
+  char buffer1[PATH_MAX];
+  char buffer2[PATH_MAX];
+  char* path = buffer1;
+  char* resolved = NULL;
+  int length = -1;
+  bool ok;
+
+  for (ok = false; !ok; ok = true)
+  {
+#if defined(__NetBSD__)
+    int mib[4] = { CTL_KERN, KERN_PROC_ARGS, -1, KERN_PROC_PATHNAME };
+#else
+    int mib[4] = { CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, -1 };
+#endif
+    size_t size = sizeof(buffer1);
+
+    if (sysctl(mib, 4, path, &size, NULL, 0) != 0)
+        break;
+
+    resolved = realpath(path, buffer2);
+    if (!resolved)
+      break;
+
+    length = (int)strlen(resolved);
+    if (length <= capacity)
+    {
+      memcpy(out, resolved, length);
+
+      if (dirname_length)
+      {
+        int i;
+
+        for (i = length - 1; i >= 0; --i)
+        {
+          if (out[i] == '/')
+          {
+            *dirname_length = i;
+            break;
+          }
+        }
+      }
+    }
+  }
+
+  return ok ? length : -1;
+}
+
+#endif
+
+WAI_NOINLINE WAI_FUNCSPEC
+int WAI_PREFIX(getModulePath)(char* out, int capacity, int* dirname_length)
+{
+  char buffer[PATH_MAX];
+  char* resolved = NULL;
+  int length = -1;
+
+  for(;;)
+  {
+    Dl_info info;
+
+    if (dladdr(WAI_RETURN_ADDRESS(), &info))
+    {
+      resolved = realpath(info.dli_fname, buffer);
+      if (!resolved)
+        break;
+
+      length = (int)strlen(resolved);
+      if (length <= capacity)
+      {
+        memcpy(out, resolved, length);
+
+        if (dirname_length)
+        {
+          int i;
+
+          for (i = length - 1; i >= 0; --i)
+          {
+            if (out[i] == '/')
+            {
+              *dirname_length = i;
+              break;
+            }
+          }
+        }
+      }
+    }
+
+    break;
+  }
+
+  return length;
+}
+
+#else
+
+#error unsupported platform
+
+#endif
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/OMSimulatorLib/whereami.h
+++ b/src/OMSimulatorLib/whereami.h
@@ -1,0 +1,67 @@
+// (‑●‑●)> dual licensed under the WTFPL v2 and MIT licenses
+//   without any warranty.
+//   by Gregory Pakosz (@gpakosz)
+// https://github.com/gpakosz/whereami
+
+#ifndef WHEREAMI_H
+#define WHEREAMI_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef WAI_FUNCSPEC
+  #define WAI_FUNCSPEC
+#endif
+#ifndef WAI_PREFIX
+#define WAI_PREFIX(function) wai_##function
+#endif
+
+/**
+ * Returns the path to the current executable.
+ *
+ * Usage:
+ *  - first call `int length = wai_getExecutablePath(NULL, 0, NULL);` to
+ *    retrieve the length of the path
+ *  - allocate the destination buffer with `path = (char*)malloc(length + 1);`
+ *  - call `wai_getExecutablePath(path, length, NULL)` again to retrieve the
+ *    path
+ *  - add a terminal NUL character with `path[length] = '\0';`
+ *
+ * @param out destination buffer, optional
+ * @param capacity destination buffer capacity
+ * @param dirname_length optional recipient for the length of the dirname part
+ *   of the path.
+ *
+ * @return the length of the executable path on success (without a terminal NUL
+ * character), otherwise `-1`
+ */
+WAI_FUNCSPEC
+int WAI_PREFIX(getExecutablePath)(char* out, int capacity, int* dirname_length);
+
+/**
+ * Returns the path to the current module
+ *
+ * Usage:
+ *  - first call `int length = wai_getModulePath(NULL, 0, NULL);` to retrieve
+ *    the length  of the path
+ *  - allocate the destination buffer with `path = (char*)malloc(length + 1);`
+ *  - call `wai_getModulePath(path, length, NULL)` again to retrieve the path
+ *  - add a terminal NUL character with `path[length] = '\0';`
+ *
+ * @param out destination buffer, optional
+ * @param capacity destination buffer capacity
+ * @param dirname_length optional recipient for the length of the dirname part
+ *   of the path.
+ *
+ * @return the length of the module path on success (without a terminal NUL
+ * character), otherwise `-1`
+ */
+WAI_FUNCSPEC
+int WAI_PREFIX(getModulePath)(char* out, int capacity, int* dirname_length);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // #ifndef WHEREAMI_H

--- a/testsuite/AircraftVehicleDemonstrator/embrace.py
+++ b/testsuite/AircraftVehicleDemonstrator/embrace.py
@@ -67,7 +67,7 @@ oms.terminate("embrace")
 oms.delete("embrace")
 
 ## Result:
-## warning: invalid "SystemStructure.ssd" detected in file "../../resources/embrace_TwoConf.ssp" at line: 17 column: 26, missing required attribute 'name'
+## warning: invalid "SystemStructure.ssd" detected in file "../../resources/embrace.ssp" at line: 17 column: 26, missing required attribute 'name'
 ## warning: "SystemStructure.ssd" does not conform to the SSP standard schema
 ## info:    Result file: sim_results.mat (bufferSize=1)
 ## info:    Initialize:

--- a/testsuite/AircraftVehicleDemonstrator/embrace.py
+++ b/testsuite/AircraftVehicleDemonstrator/embrace.py
@@ -76,4 +76,6 @@ oms.delete("embrace")
 ## info:      embrace.root.ECS_HW.pipeC.L               :  1.0
 ## info:      embrace.root.ECS_HW.pipeB.L               :  0.976535328081166
 ## info:      embrace.root.ECS_HW.pipeA.L               :  0.976535328081166
+## info:    2 warnings
+## info:    0 errors
 ## endResult

--- a/testsuite/AircraftVehicleDemonstrator/embrace.py
+++ b/testsuite/AircraftVehicleDemonstrator/embrace.py
@@ -67,6 +67,8 @@ oms.terminate("embrace")
 oms.delete("embrace")
 
 ## Result:
+## warning: invalid "SystemStructure.ssd" detected in file "../../resources/embrace_TwoConf.ssp" at line: 17 column: 26, missing required attribute 'name'
+## warning: "SystemStructure.ssd" does not conform to the SSP standard schema
 ## info:    Result file: sim_results.mat (bufferSize=1)
 ## info:    Initialize:
 ## info:      embrace.root.ECS_HW.coolinPackAir.looptype:  2

--- a/testsuite/AircraftVehicleDemonstrator/embrace_test2Conf.py
+++ b/testsuite/AircraftVehicleDemonstrator/embrace_test2Conf.py
@@ -76,6 +76,8 @@ oms.terminate("model")
 oms.delete("model")
 
 ## Result:
+## warning: invalid "SystemStructure.ssd" detected in file "../../resources/embrace_TwoConf.ssp" at line: 17 column: 26, missing required attribute 'name'
+## warning: "SystemStructure.ssd" does not conform to the SSP standard schema
 ## info:    Result file: sim_results_ECS_Conf1.mat (bufferSize=1)
 ## info:    Initialize:
 ## info:      model.root.ECS_HW.coolinPackAir.looptype:  2

--- a/testsuite/AircraftVehicleDemonstrator/embrace_test2Conf.py
+++ b/testsuite/AircraftVehicleDemonstrator/embrace_test2Conf.py
@@ -85,4 +85,6 @@ oms.delete("model")
 ## info:      model.root.ECS_HW.pipeC.L               :  1.0
 ## info:      model.root.ECS_HW.pipeB.L               :  7.41248272578546
 ## info:      model.root.ECS_HW.pipeA.L               :  7.39290438403619
+## info:    2 warnings
+## info:    0 errors
 ## endResult

--- a/testsuite/api/reduceSSV.lua
+++ b/testsuite/api/reduceSSV.lua
@@ -16,12 +16,13 @@ function readFile(filename)
 
 oms_setCommandLineOption("--suppressPath=true")
 oms_setTempDirectory("./reducessv_01_lua/")
+oms_setWorkingDirectory("./reducessv_01_lua/")
 
 oms_newModel("model")
 
-oms_reduceSSV("model", "../resources/importParameterMapping/resources/import_parameter_mapping.ssv", "../resources/importParameterMapping/resources/import_parameter_mapping.ssm")
+oms_reduceSSV("model", "../../resources/importParameterMapping/resources/import_parameter_mapping.ssv", "../../resources/importParameterMapping/resources/import_parameter_mapping.ssm")
 
-readFile("../resources/importParameterMapping/resources/import_parameter_mapping.ssv")
+readFile("../../resources/importParameterMapping/resources/import_parameter_mapping.ssv")
 readFile("reduced.ssv")
 
 

--- a/testsuite/api/reduceSSV.py
+++ b/testsuite/api/reduceSSV.py
@@ -19,12 +19,13 @@ oms = OMSimulator()
 
 oms.setCommandLineOption("--suppressPath=true")
 oms.setTempDirectory("./reducessv_01_py/")
+oms.setWorkingDirectory("./reducessv_01_py/")
 
 oms.newModel("model")
 
-oms.reduceSSV("model", "../resources/importParameterMapping/resources/import_parameter_mapping.ssv", "../resources/importParameterMapping/resources/import_parameter_mapping.ssm")
+oms.reduceSSV("model", "../../resources/importParameterMapping/resources/import_parameter_mapping.ssv", "../../resources/importParameterMapping/resources/import_parameter_mapping.ssm")
 
-readFile("../resources/importParameterMapping/resources/import_parameter_mapping.ssv")
+readFile("../../resources/importParameterMapping/resources/import_parameter_mapping.ssv")
 readFile("reduced.ssv")
 
 

--- a/testsuite/resources/CMakeLists.txt
+++ b/testsuite/resources/CMakeLists.txt
@@ -75,6 +75,7 @@ set(OM_OMS_TESTSUITE_RESOURCES_SSPS
         ${CMAKE_CURRENT_SOURCE_DIR}/import_export_parameters2
         ${CMAKE_CURRENT_SOURCE_DIR}/import_export_parameters3
         ${CMAKE_CURRENT_SOURCE_DIR}/importExportAllResources
+        ${CMAKE_CURRENT_SOURCE_DIR}/invalidSSP
         ${CMAKE_CURRENT_SOURCE_DIR}/replaceSubmodel4
         ${CMAKE_CURRENT_SOURCE_DIR}/replaceSubmodel5
 )

--- a/testsuite/resources/Makefile
+++ b/testsuite/resources/Makefile
@@ -73,6 +73,7 @@ import_export_parameters1 \
 import_export_parameters2 \
 import_export_parameters3 \
 importExportAllResources \
+invalidSSP \
 replaceSubmodel4 \
 replaceSubmodel5 \
 

--- a/testsuite/resources/invalidSSP/SystemStructure.ssd
+++ b/testsuite/resources/invalidSSP/SystemStructure.ssd
@@ -1,0 +1,95 @@
+<ssd:SystemStructureDescription
+  xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
+  xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription"
+  xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
+  xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping"
+  xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
+  xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
+  name="invalidSSP"
+  version="1.0">
+  <ssd:System
+    name="root">
+    <ssd:Connectors>
+      <ssd:Connector
+        name="C1"
+        type="Real"
+        kind="input">
+        <ssc:Real />
+      </ssd:Connector>
+    </ssd:Connectors>
+    <ssd:ParameterBindings>
+      <ssd:ParameterBinding
+        source="resources/Root.ssv" />
+      <ssd:ParameterBinding
+        source="resources/System1.ssv" />
+    </ssd:ParameterBindings>
+    <ssd:Elements>
+      <ssd:System
+        name="System1">
+        <ssd:Connectors>
+          <ssd:Connector
+            name="C1"
+            kind="input">
+            <ssc:Real />
+          </ssd:Connector>
+          <ssd:Connector
+            name="C2"
+            kind="parameter">
+            <ssc:Real />
+          </ssd:Connector>
+          <ssd:Connector
+            name="C3"
+            kind="output">
+            <ssc:Real />
+          </ssd:Connector>
+        </ssd:Connectors>
+        <ssd:Annotations>
+          <ssc:Annotation
+            type="org.openmodelica">
+            <oms:Annotations>
+              <oms:SimulationInformation>
+                <oms:VariableStepSolver
+                  description="euler"
+                  absoluteTolerance="0.0001"
+                  relativeTolerance="0.0001"
+                  minimumStepSize="0.0001"
+                  maximumStepSize="0.1"
+                  initialStepSize="0.0001" />
+              </oms:SimulationInformation>
+            </oms:Annotations>
+          </ssc:Annotation>
+        </ssd:Annotations>
+      </ssd:System>
+    </ssd:Elements>
+    <ssd:Annotations>
+      <ssc:Annotation
+        type="org.openmodelica">
+        <oms:Annotations>
+          <oms:SimulationInformation>
+            <oms:FixedStepMaster
+              description="oms-ma"
+              stepSize="0.001000"
+              absoluteTolerance="0.000100"
+              relativeTolerance="0.000100" />
+          </oms:SimulationInformation>
+        </oms:Annotations>
+      </ssc:Annotation>
+    </ssd:Annotations>
+  </ssd:System>
+  <ssd:DefaultExperiment
+    startTime="0.000000"
+    stopTime="1.000000">
+    <ssd:Annotations>
+      <ssc:Annotation
+        type="org.openmodelica">
+        <oms:Annotations>
+          <oms:SimulationInformation
+            resultFile="importStartValues_res.mat"
+            loggingInterval="0.000000"
+            bufferSize="10"
+            signalFilter="resources/signalFilter.xml" />
+        </oms:Annotations>
+      </ssc:Annotation>
+    </ssd:Annotations>
+  </ssd:DefaultExperiment>
+</ssd:SystemStructureDescription>

--- a/testsuite/resources/invalidSSP/resources/Root.ssv
+++ b/testsuite/resources/invalidSSP/resources/Root.ssv
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ssv:ParameterSet xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" version="1.0" name="parameters">
+	<ssv:Parameters>
+		<ssv:Parameter name="C1">
+			<ssv:Real value="-10.5" />
+		</ssv:Parameter>
+	</ssv:Parameters>
+</ssv:ParameterSet>

--- a/testsuite/resources/invalidSSP/resources/System1.ssv
+++ b/testsuite/resources/invalidSSP/resources/System1.ssv
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ssv:ParameterSet xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" version="1.0" name="parameters">
+	<ssv:Parameters>
+		<ssv:Parameter name="System1.C2">
+			<ssv:Real value="3.5" />
+		</ssv:Parameter>
+		<ssv:Parameter name="System1.C1">
+			<ssv:Real value="-13.5" />
+		</ssv:Parameter>
+	</ssv:Parameters>
+</ssv:ParameterSet>

--- a/testsuite/resources/invalidSSP/resources/signalFilter.xml
+++ b/testsuite/resources/invalidSSP/resources/signalFilter.xml
@@ -1,0 +1,19 @@
+<oms:SignalFilter
+  version="1.0">
+  <oms:Variable
+    name="importStartValues.root.C1"
+    type="Real"
+    kind="input" />
+  <oms:Variable
+    name="importStartValues.root.System1.C1"
+    type="Real"
+    kind="input" />
+  <oms:Variable
+    name="importStartValues.root.System1.C2"
+    type="Real"
+    kind="parameter" />
+  <oms:Variable
+    name="importStartValues.root.System1.C3"
+    type="Real"
+    kind="output" />
+</oms:SignalFilter>

--- a/testsuite/simulation/PI_Controller.lua
+++ b/testsuite/simulation/PI_Controller.lua
@@ -107,6 +107,8 @@ oms_terminate("PI_Controller")
 oms_delete("PI_Controller")
 
 -- Result:
+-- warning: invalid "SystemStructure.ssd" detected in file "PI_Controller.ssp" at line: 78 column: 32, missing required attribute 'name'
+-- warning: "SystemStructure.ssd" does not conform to the SSP standard schema
 -- info:    Parameter settings
 -- info:      PI_Controller.co_sim.addP.k1: 1.0
 -- info:      PI_Controller.co_sim.addP.k2: -1.0
@@ -123,4 +125,6 @@ oms_delete("PI_Controller")
 -- info:    Simulation
 -- info:      limiter.u: -10.041439549286
 -- info:      limiter.y: -10.041439549286
+-- info:    2 warnings
+-- info:    0 errors
 -- endResult

--- a/testsuite/simulation/importStartValues1.lua
+++ b/testsuite/simulation/importStartValues1.lua
@@ -28,6 +28,8 @@ oms_delete("importStartValues")
 
 
 -- Result:
+-- warning: invalid "SystemStructure.ssd" detected in file "../../resources/importStartValues1.ssp" at line: 72 column: 33, element 'Elements' is not allowed for content model '((Component|SignalDictionaryReference|System))'
+-- warning: "SystemStructure.ssd" does not conform to the SSP standard schema
 -- warning: Wrong/deprecated content detected but successfully loaded. Please re-export the SSP file to avoid this message.
 -- warning: Wrong/deprecated content detected but successfully loaded. Please re-export the SSP file to avoid this message.
 -- warning: Wrong/deprecated content detected but successfully loaded. Please re-export the SSP file to avoid this message.
@@ -246,9 +248,9 @@ oms_delete("importStartValues")
 --     </oms:SignalFilter>
 --   </oms:file>
 -- </oms:snapshot>
---
+-- 
 -- info:    model doesn't contain any continuous state
 -- info:    Result file: importStartValues1_res.mat (bufferSize=10)
--- info:    5 warnings
+-- info:    7 warnings
 -- info:    0 errors
 -- endResult

--- a/testsuite/validate/Makefile
+++ b/testsuite/validate/Makefile
@@ -1,0 +1,51 @@
+TEST = ../rtest -v
+
+TESTFILES = \
+validateSSP.py \
+
+# Run make failingtest
+FAILINGTESTFILES = \
+
+# Dependency files that are not .lua or Makefile
+# Add them here or they will be cleaned.
+DEPENDENCIES = \
+*.lua \
+*.py \
+Makefile \
+
+CLEAN = `ls | grep -w -v -f deps.tmp`
+
+.PHONY : test clean getdeps failingtest
+
+test:
+	@echo
+	@echo Running tests...
+	@$(TEST) $(TESTFILES)
+
+baseline:
+	@echo
+	@echo Updating baselines...
+	@$(TEST) -b $(TESTFILES)
+
+# Cleans all files that are not listed as dependencies
+clean:
+	@echo $(DEPENDENCIES) | sed 's/ /\\\|/g' > deps.tmp
+	@rm -rf $(CLEAN)
+
+# Run this if you want to list out the files (dependencies).
+# do it after cleaning and updating the folder
+# then you can get a list of file names (which must be dependencies
+# since you got them from repository + your own new files)
+# then add them to the DEPENDENCIES. You can find the
+# list in deps.txt
+getdeps:
+	@echo $(DEPENDENCIES) | sed 's/ /\\\|/g' > deps.tmp
+	@echo $(CLEAN) | sed -r 's/deps.txt|deps.tmp//g' | sed 's/ / \\\n/g' > deps.txt
+	@echo Dependency list saved in deps.txt.
+	@echo Copy the list from deps.txt and add it to the Makefile @DEPENDENCIES
+
+failingtest:
+	@echo
+	@echo Running failing tests...
+	@echo
+	@$(TEST) $(FAILINGTESTFILES)

--- a/testsuite/validate/validateSSP.py
+++ b/testsuite/validate/validateSSP.py
@@ -16,8 +16,8 @@ model = oms.importFile('../resources/invalidSSP.ssp')
 model.delete()
 
 ## Result:
-## error:   [reportParseException] invalid SystemStructure.ssd detected in file "../resources/invalidSSP.ssp" at line: 16 column: 22, attribute 'type' is not declared for element 'Connector'
-## error:   [validateSSD] SystemStructure.ssd does not conform to the SSP standard schema
-## info:    0 warnings
-## info:    2 errors
+## warning: invalid SystemStructure.ssd detected in file "../resources/invalidSSP.ssp" at line: 16 column: 22, attribute 'type' is not declared for element 'Connector'
+## warning: SystemStructure.ssd does not conform to the SSP standard schema
+## info:    2 warnings
+## info:    0 errors
 ## endResult

--- a/testsuite/validate/validateSSP.py
+++ b/testsuite/validate/validateSSP.py
@@ -1,0 +1,23 @@
+## status: correct
+## teardown_command: rm -rf validateSSP-py/
+## linux: yes
+## mac: no
+## mingw32: yes
+## mingw64: yes
+## win: yes
+
+import OMSimulator as oms
+
+oms.setCommandLineOption('--suppressPath=true')
+oms.setTempDirectory('./validateSSP-py/')
+
+model = oms.importFile('../resources/invalidSSP.ssp')
+
+model.delete()
+
+## Result:
+## error:   [reportParseException] invalid SystemStructure.ssd detected in file "../resources/invalidSSP.ssp" at line: 16 column: 22, attribute 'type' is not declared for element 'Connector'
+## error:   [validateSSD] SystemStructure.ssd does not conform to the SSP standard schema
+## info:    0 warnings
+## info:    2 errors
+## endResult

--- a/testsuite/validate/validateSSP.py
+++ b/testsuite/validate/validateSSP.py
@@ -16,8 +16,8 @@ model = oms.importFile('../resources/invalidSSP.ssp')
 model.delete()
 
 ## Result:
-## warning: invalid SystemStructure.ssd detected in file "../resources/invalidSSP.ssp" at line: 16 column: 22, attribute 'type' is not declared for element 'Connector'
-## warning: SystemStructure.ssd does not conform to the SSP standard schema
+## warning: invalid "SystemStructure.ssd" detected in file "../resources/invalidSSP.ssp" at line: 16 column: 22, attribute 'type' is not declared for element 'Connector'
+## warning: "SystemStructure.ssd" does not conform to the SSP standard schema
 ## info:    2 warnings
 ## info:    0 errors
 ## endResult


### PR DESCRIPTION
### Purpose

This PR implements xml validation to SSP and FMU's.  

For SSP the following files are validated

1. SystemStructure.ssd, 
2. .ssv 
3. .ssm

For FMU's  the following files are validated

1. modeldescription.xml

- [ ] TODO
- [x] validate .ssd 
- [ ] validate .ssv and .ssm 
- [ ] validate modeldescription.xml
