### PR TITLE
fix replaceSubModel from memory

### DIFF
--- a/src/OMSimulatorLib/Component.h
+++ b/src/OMSimulatorLib/Component.h
@@ -79,8 +79,9 @@ namespace oms
     virtual const FMUInfo* getFMUInfo() const { return nullptr; }
     virtual oms_status_enu_t deleteStartValue(const ComRef& cref) { return oms_status_ok; }
     virtual std::vector<Values> getValuesResources() { return{}; }
-    virtual oms_status_enu_t setValuesResources(std::vector<Values>& allResources) { return oms_status_ok; }
-    virtual oms_status_enu_t updateOrDeleteStartValueInReplacedComponent(std::vector<std::string>& warningList) { return oms_status_ok; }
+    virtual Values& getValues() {return values;}
+    virtual oms_status_enu_t setValuesResources(Values& values) { return oms_status_ok; }
+    virtual oms_status_enu_t updateOrDeleteStartValueInReplacedComponent(std::vector<std::string> &warningList) { return oms_status_ok; }
     virtual oms_status_enu_t exportToSSMTemplate(pugi::xml_node& ssmNode) { return logError_NotImplemented; }
     virtual oms_status_enu_t exportToSSVTemplate(pugi::xml_node& ssvNode, Snapshot& snapshot) { return logError_NotImplemented; }
     virtual oms_status_enu_t freeState() { return logError_NotImplemented; }
@@ -165,6 +166,7 @@ namespace oms
     oms_component_enu_t type;
     std::string path;  ///< resource file (fmu, mat)
     std::string tempDir;  ///< unzipped fmu
+    Values values;
   };
 }
 

--- a/src/OMSimulatorLib/ComponentFMUCS.cpp
+++ b/src/OMSimulatorLib/ComponentFMUCS.cpp
@@ -1716,15 +1716,17 @@ oms_status_enu_t oms::ComponentFMUCS::deleteStartValue(const ComRef& cref)
   return oms_status_error;
 }
 
-oms_status_enu_t oms::ComponentFMUCS::setValuesResources(std::vector<Values>& allValuesResources)
+oms_status_enu_t oms::ComponentFMUCS::setValuesResources(Values& values)
 {
-  this->values.parameterResources = allValuesResources;
-  return oms_status_ok;
-}
+  // set all ssv and ssm resources from the old component to replacing component
+  this->values.parameterResources = values.parameterResources;
+  // set all user define values from the old component to replacing component as user defined values have higher priority
+  // over modeldescription.xml
+  this->values.realStartValues = values.realStartValues;
+  this->values.integerStartValues = values.integerValues;
+  this->values.booleanStartValues = values.booleanStartValues;
 
-std::vector<oms::Values> oms::ComponentFMUCS::getValuesResources()
-{
-  return this->values.parameterResources;
+  return oms_status_ok;
 }
 
 oms_status_enu_t oms::ComponentFMUCS::updateOrDeleteStartValueInReplacedComponent(std::vector<std::string>& warningList)

--- a/src/OMSimulatorLib/ComponentFMUCS.h
+++ b/src/OMSimulatorLib/ComponentFMUCS.h
@@ -77,6 +77,9 @@ namespace oms
 
     Variable* getVariable(const ComRef& cref);
 
+    Values& getValues() { return values; }
+    oms_status_enu_t setValuesResources(Values& values);
+
     oms_status_enu_t getBoolean(const ComRef& cref, bool& value);
     oms_status_enu_t getBoolean(const fmi2ValueReference& vr, bool& value);
     oms_status_enu_t getInteger(const ComRef& cref, int& value);
@@ -96,8 +99,6 @@ namespace oms
 
     oms_status_enu_t deleteStartValue(const ComRef& cref);
     oms_status_enu_t updateOrDeleteStartValueInReplacedComponent(std::vector<std::string>& warningList);
-    oms_status_enu_t setValuesResources(std::vector<Values>& allValuesResources);
-    std::vector<Values> getValuesResources();
 
     oms_status_enu_t setFmuTime(double time) {this->time = time; return oms_status_ok;}
     fmiHandle* getFMU() {return fmu;}

--- a/src/OMSimulatorLib/ComponentFMUME.cpp
+++ b/src/OMSimulatorLib/ComponentFMUME.cpp
@@ -1529,15 +1529,17 @@ oms_status_enu_t oms::ComponentFMUME::deleteStartValue(const ComRef& cref)
   return oms_status_error;
 }
 
-oms_status_enu_t oms::ComponentFMUME::setValuesResources(std::vector<Values>& allValuesResources)
+oms_status_enu_t oms::ComponentFMUME::setValuesResources(Values& values)
 {
-  this->values.parameterResources = allValuesResources;
-  return oms_status_ok;
-}
+  // set all ssv and ssm resources from the old component to replacing component
+  this->values.parameterResources = values.parameterResources;
+  // set all user define values from the old component to replacing component as user defined values have higher priority
+  // over modeldescription.xml
+  this->values.realStartValues = values.realStartValues;
+  this->values.integerStartValues = values.integerValues;
+  this->values.booleanStartValues = values.booleanStartValues;
 
-std::vector<oms::Values> oms::ComponentFMUME::getValuesResources()
-{
-  return this->values.parameterResources;
+  return oms_status_ok;
 }
 
 oms_status_enu_t oms::ComponentFMUME::updateOrDeleteStartValueInReplacedComponent(std::vector<std::string>& warningList)

--- a/src/OMSimulatorLib/ComponentFMUME.h
+++ b/src/OMSimulatorLib/ComponentFMUME.h
@@ -73,6 +73,9 @@ namespace oms
 
     Variable* getVariable(const ComRef& cref);
 
+    Values& getValues() { return values; }
+    oms_status_enu_t setValuesResources(Values& values);
+
     oms_status_enu_t getBoolean(const ComRef& cref, bool& value);
     oms_status_enu_t getBoolean(const fmi2ValueReference& vr, bool& value);
     oms_status_enu_t getInteger(const ComRef& cref, int& value);
@@ -92,8 +95,6 @@ namespace oms
 
     oms_status_enu_t deleteStartValue(const ComRef& cref);
     oms_status_enu_t updateOrDeleteStartValueInReplacedComponent(std::vector<std::string>& warningList);
-    oms_status_enu_t setValuesResources(std::vector<Values>& allValuesResources);
-    std::vector<Values> getValuesResources();
 
     oms_status_enu_t registerSignalsForResultFile(ResultWriter& resultFile);
     oms_status_enu_t updateSignals(ResultWriter& resultWriter);

--- a/src/OMSimulatorLib/System.cpp
+++ b/src/OMSimulatorLib/System.cpp
@@ -399,8 +399,7 @@ oms_status_enu_t oms::System::replaceSubModel(const oms::ComRef& cref, const std
       replaceComponent->getElement()->setGeometry(component->second->getElement()->getGeometry());
 
       // copy all the resources from old component to replacing component
-      std::vector<Values> allResources = component->second->getValuesResources();
-      replaceComponent->setValuesResources(allResources);
+      replaceComponent->setValuesResources(component->second->getValues());
 
       // update or delete the start value in ssv of with the replaced component
       replaceComponent->updateOrDeleteStartValueInReplacedComponent(warningList);

--- a/testsuite/simulation/Makefile
+++ b/testsuite/simulation/Makefile
@@ -74,6 +74,8 @@ replaceSubmodel9.lua \
 replaceSubmodel10.lua \
 replaceSubmodel11.py \
 replaceSubmodel12.py \
+replaceSubmodel13.py \
+replaceSubmodel14.py \
 setExternalInputs.lua \
 simulation.lua \
 simulation.py \

--- a/testsuite/simulation/replaceSubmodel13.py
+++ b/testsuite/simulation/replaceSubmodel13.py
@@ -1,0 +1,44 @@
+## status: correct
+## teardown_command: rm -rf replacesubmodel_13_py/
+## linux: no
+## mingw32: no
+## mingw64: yes
+## win: no
+## mac: no
+
+from OMSimulator import OMSimulator
+oms = OMSimulator()
+
+oms.setCommandLineOption("--suppressPath=true")
+oms.setTempDirectory("./replacesubmodel_13_py/")
+oms.setWorkingDirectory("./replacesubmodel_13_py/")
+
+oms.newModel("model")
+
+oms.addSystem("model.root", oms.system_wc)
+
+oms.addSubModel("model.root.A", "../../resources/replaceA.fmu")
+
+## priority over modeldescription.xml
+oms.setReal("model.root.A.u", 10.0)
+
+print("info:    Before replacing the Model")
+print("info:      model.root.A.u      : " , oms.getReal("model.root.A.u")[0])
+
+oms.replaceSubModel("model.root.A", "../../resources/replaceA_extended.fmu", False)
+
+# src, status = oms.exportSnapshot("model")
+# print(src)
+
+print("info:    After replacing the Model")
+print("info:      model.root.A.u      : " , oms.getReal("model.root.A.u")[0])
+
+oms.terminate("model")
+oms.delete("model")
+
+## Result:
+## info:    Before replacing the Model
+## info:      model.root.A.u      :  10.0
+## info:    After replacing the Model
+## info:      model.root.A.u      :  10.0
+## endResult

--- a/testsuite/simulation/replaceSubmodel14.py
+++ b/testsuite/simulation/replaceSubmodel14.py
@@ -1,0 +1,39 @@
+## status: correct
+## teardown_command: rm -rf replacesubmodel_14_py/
+## linux: no
+## mingw32: no
+## mingw64: yes
+## win: no
+## mac: no
+
+from OMSimulator import OMSimulator
+oms = OMSimulator()
+
+oms.setCommandLineOption("--suppressPath=true")
+oms.setTempDirectory("./replacesubmodel_14_py/")
+oms.setWorkingDirectory("./replacesubmodel_14_py/")
+
+oms.newModel("model")
+
+oms.addSystem("model.root", oms.system_wc)
+
+oms.addSubModel("model.root.A", "../../resources/replaceA.fmu")
+
+print("info:    Before replacing the Model")
+print("info:      model.root.A.u      : " , oms.getReal("model.root.A.u")[0])
+
+oms.replaceSubModel("model.root.A", "../../resources/replaceA_extended.fmu", False)
+
+## no priority exists read the new value from modeldescription.xml from the replaced component
+print("info:    After replacing the Model")
+print("info:      model.root.A.u      : " , oms.getReal("model.root.A.u")[0])
+
+oms.terminate("model")
+oms.delete("model")
+
+## Result:
+## info:    Before replacing the Model
+## info:      model.root.A.u      :  5.0
+## info:    After replacing the Model
+## info:      model.root.A.u      :  7.0
+## endResult


### PR DESCRIPTION
### Related Issues

https://github.com/OpenModelica/OMSimulator/issues/1262

### Purpose

This PR fixes issues when `replacingSubModel` from memory without export to a `ssp` file

