### PR TITLE
configure libOMSimulator relative dll path

### DIFF
--- a/src/OMSimulatorPython/CMakeLists.txt
+++ b/src/OMSimulatorPython/CMakeLists.txt
@@ -10,6 +10,17 @@ ELSE ()
   set(OMSIMULATORLIB_STRING "libOMSimulator.so")
 ENDIF ()
 
+## If OMSimulator is being built as part of OpenModelica and that is set by "OPENMODELICA_NEW_CMAKE_BUILD"
+## account for the "omc" directory added in the lib dir (lib/omc/OMSimulator versus lib/OMSimulator)
+## currently this sets the path only for windows
+## TODO fix the paths for linux
+if(OPENMODELICA_NEW_CMAKE_BUILD)
+  set(OMSIMULATOR_PYTHON_RELATIVE_DLL_DIR "../../../bin")
+else()
+  set(OMSIMULATOR_PYTHON_RELATIVE_DLL_DIR "../../bin")
+endif()
+
+
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/__init__.py" "${CMAKE_CURRENT_BINARY_DIR}/__init__.py" @ONLY)
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/capi.py" "${CMAKE_CURRENT_BINARY_DIR}/capi.py" @ONLY)
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/OMSimulatorPython3.in" "${CMAKE_CURRENT_BINARY_DIR}/OMSimulatorPython3" @ONLY)

--- a/src/OMSimulatorPython/capi.py
+++ b/src/OMSimulatorPython/capi.py
@@ -10,7 +10,7 @@ class capi:
       omslib = os.path.join(dirname, "..", "@OMSIMULATORLIB_STRING@")
 
     if os.name == 'nt': # Windows
-      omslib = os.path.join(dirname, "../../bin/", "@OMSIMULATORLIB_STRING@")
+      omslib = os.path.join(dirname, "@OMSIMULATOR_PYTHON_RELATIVE_DLL_DIR@", "@OMSIMULATORLIB_STRING@")
       dllDir = os.add_dll_directory(os.path.dirname(omslib))
     self.obj=ctypes.CDLL(omslib)
     if os.name == 'nt': # Windows


### PR DESCRIPTION
### Related Issues

https://github.com/OpenModelica/OpenModelica/issues/11514

### Purpose

This PR fixes configuring` libOMSimulator.dll` path when building as standalone from `OMSimulator` versus `OpenModelica` super project

