### PR TITLE
use the DefaultExperiment settings from modeldescription.xml

### DIFF
--- a/include/OMSimulator/OMSimulator.h
+++ b/include/OMSimulator/OMSimulator.h
@@ -89,7 +89,7 @@ OMSAPI oms_status_enu_t OMSCALL oms_exportDependencyGraphs(const char* cref, con
 OMSAPI oms_status_enu_t OMSCALL oms_exportSnapshot(const char* cref, char** contents);
 OMSAPI oms_status_enu_t OMSCALL oms_exportSSMTemplate(const char * cref, const char * filename);
 OMSAPI oms_status_enu_t OMSCALL oms_exportSSVTemplate(const char* cref, const char* filename);
-OMSAPI oms_status_enu_t OMSCALL oms_extractFMIKind(const char* filename, oms_fmi_kind_enu_t* kind);
+OMSAPI oms_status_enu_t OMSCALL oms_extractFMIKind(const char* filename, oms_fmi_kind_enu_t* kind, oms_fmu_default_experiment_settings* defaultExperiment);
 OMSAPI oms_status_enu_t OMSCALL oms_fetchExternalModelInterfaces(const char* cref, char*** names, char*** domains, int** dimensions);
 OMSAPI void OMSCALL oms_freeMemory(void* obj);
 OMSAPI oms_status_enu_t OMSCALL oms_getBoolean(const char* cref, bool* value);

--- a/include/OMSimulator/Types.h
+++ b/include/OMSimulator/Types.h
@@ -532,6 +532,16 @@ typedef struct {
   unsigned int maxOutputDerivativeOrder;
 } oms_fmu_info_t;
 
+/*
+ *  FMU default experiment settings from modeldescription.xml
+*/
+typedef struct {
+  double startTime; // default startTime for simulation
+  double stopTime; // default stoptTime for simulation
+  double tolerance; // default relative integration tolerance
+  double stepSize; // default stepSize
+} oms_fmu_default_experiment_settings;
+
 /**
  * \brief External model specific attributes
  */

--- a/src/OMSimulatorLib/OMSimulator.cpp
+++ b/src/OMSimulatorLib/OMSimulator.cpp
@@ -1182,7 +1182,12 @@ oms_status_enu_t oms_RunFile(const char* filename)
     std::string fmuName = systemName + (oms::ComRef::isValidIdent(path.stem().string()) ? ("." + path.stem().string()) : ".fmu");
     oms_fmi_kind_enu_t kind;
 
-    status = oms_extractFMIKind(filename, &kind);
+    /* intialize the defaultExperiment with defaults set in Flags.cpp setDefaults() or
+     * values provided from user from commandLine (e.g) OMSimulator A.fmu --stopTime=10 --stepSize=10
+    */
+    oms_fmu_default_experiment_settings defaultExperiment = {oms::Flags::StartTime(), oms::Flags::StopTime(), oms::Flags::Tolerance(), oms::Flags::MaximumStepSize()};
+
+    status = oms_extractFMIKind(filename, &kind, &defaultExperiment);
     if (oms_status_ok != status) return logError("oms_extractFMIKind failed");
 
     status = oms_newModel(modelName.c_str());
@@ -1204,9 +1209,12 @@ oms_status_enu_t oms_RunFile(const char* filename)
 
     if (oms::Flags::ResultFile() != "<default>")
       oms_setResultFile(modelName.c_str(), oms::Flags::ResultFile().c_str(), 1);
-    oms_setStartTime(modelName.c_str(), oms::Flags::StartTime());
-    oms_setStopTime(modelName.c_str(), oms::Flags::StopTime());
-    oms_setTolerance(modelName.c_str(), oms::Flags::Tolerance(), oms::Flags::Tolerance());
+    oms_setStartTime(modelName.c_str(), defaultExperiment.startTime);
+    oms_setStopTime(modelName.c_str(), defaultExperiment.stopTime);
+    oms_setTolerance(modelName.c_str(), defaultExperiment.tolerance, defaultExperiment.tolerance);
+    // set the maximum stepSize
+    oms_setVariableStepSize(modelName.c_str(), oms::Flags::InitialStepSize(), oms::Flags::MinimumStepSize(), defaultExperiment.stepSize);
+
     if (kind == oms_fmi_kind_me_and_cs)
       oms_setSolver(systemName.c_str(), oms::Flags::DefaultModeIsCS() ? oms::Flags::MasterAlgorithm() : oms::Flags::Solver());
     else
@@ -1839,7 +1847,7 @@ oms_status_enu_t oms_getVariableStepSize(const char* cref, double* initialStepSi
   return oms_status_ok;
 }
 
-oms_status_enu_t oms_extractFMIKind(const char* filename, oms_fmi_kind_enu_t* kind)
+oms_status_enu_t oms_extractFMIKind(const char* filename, oms_fmi_kind_enu_t* kind, oms_fmu_default_experiment_settings* defaultExperiment)
 {
   if (!kind)
     return logError("Invalid argument \"kind=NULL\"");
@@ -1868,6 +1876,37 @@ oms_status_enu_t oms_extractFMIKind(const char* filename, oms_fmi_kind_enu_t* ki
   {
     *kind = oms_fmi_kind_unknown;
     return oms_status_error;
+  }
+
+  // get default experiment settings if exists
+  if (node.child("DefaultExperiment"))
+  {
+    /* give priority for values provided from command line,
+     * if the user overrides those variables then we should take those values
+     * and not the default values from <DefaultExperiment> in modeldescription.xml
+    */
+    if (defaultExperiment->startTime == 0.0)
+    {
+      if (node.child("DefaultExperiment").attribute("startTime").as_string() != "")
+        defaultExperiment->startTime = node.child("DefaultExperiment").attribute("startTime").as_double();
+    }
+    if (defaultExperiment->stopTime == 1.0)
+    {
+      if (node.child("DefaultExperiment").attribute("stopTime").as_string() != "")
+        defaultExperiment->stopTime = node.child("DefaultExperiment").attribute("stopTime").as_double();
+    }
+    if (defaultExperiment->tolerance == 1e-4)
+    {
+      if (node.child("DefaultExperiment").attribute("tolerance").as_string() != "")
+        defaultExperiment->tolerance = node.child("DefaultExperiment").attribute("tolerance").as_double();
+    }
+    if (defaultExperiment->stepSize == 1e-3) // maximumStepSize
+    {
+      if (node.child("DefaultExperiment").attribute("stepSize").as_string() != "")
+        defaultExperiment->stepSize = node.child("DefaultExperiment").attribute("stepSize").as_double();
+      else
+        defaultExperiment->stepSize = (defaultExperiment->stopTime - defaultExperiment->startTime) / 500;
+    }
   }
 
   return oms_status_ok;

--- a/testsuite/simulation/replaceSubmodel1.lua
+++ b/testsuite/simulation/replaceSubmodel1.lua
@@ -310,7 +310,7 @@ oms_delete("model")
 -- info:      model.root.B.u1     : -13.0
 -- info:      model.root.B.z      : -15.0
 -- error:   [getVariable] Unknown signal "model.root.A.dummy"
--- warning: deleting connection "A.dummy ==> B.u1", as signal "dummy" couldn't be resolved to any signal in the replaced submodel "../resources/replaceA_extended.fmu"
+-- warning: deleting connection "A.dummy ==> B.u1", as signal "dummy" couldn't be resolved to any signal in the replaced submodel "../../resources/replaceA_extended.fmu"
 -- warning: deleting start value "A.t" in "inline" resources, because the identifier couldn't be resolved to any system signal in the replacing model
 -- <?xml version="1.0"?>
 -- <oms:snapshot

--- a/testsuite/simulation/replaceSubmodel1.lua
+++ b/testsuite/simulation/replaceSubmodel1.lua
@@ -8,13 +8,14 @@
 
 oms_setCommandLineOption("--suppressPath=true")
 oms_setTempDirectory("./replacesubmodel_01_lua/")
+oms_setWorkingDirectory("./replacesubmodel_01_lua/")
 
 oms_newModel("model")
 
 oms_addSystem("model.root", oms_system_wc)
 
-oms_addSubModel("model.root.A", "../resources/replaceA.fmu")
-oms_addSubModel("model.root.B", "../resources/replaceB.fmu")
+oms_addSubModel("model.root.A", "../../resources/replaceA.fmu")
+oms_addSubModel("model.root.B", "../../resources/replaceB.fmu")
 
 oms_setReal("model.root.A.u", 10.0)
 oms_setReal("model.root.A.t", -10.0)
@@ -42,7 +43,7 @@ oms_delete("model")
 
 oms_importFile("replaceSubmodel1.ssp")
 
-oms_replaceSubModel("model.root.A", "../resources/replaceA_extended.fmu", false)
+oms_replaceSubModel("model.root.A", "../../resources/replaceA_extended.fmu", false)
 src, status = oms_exportSnapshot("model")
 print(src)
 

--- a/testsuite/simulation/replaceSubmodel10.lua
+++ b/testsuite/simulation/replaceSubmodel10.lua
@@ -8,13 +8,14 @@
 
 oms_setCommandLineOption("--suppressPath=true")
 oms_setTempDirectory("./replacesubmodel_10_lua/")
+oms_setWorkingDirectory("./replacesubmodel_10_lua/")
 
 oms_newModel("model")
 
 oms_addSystem("model.root", oms_system_wc)
 
-oms_addSubModel("model.root.A", "../resources/replaceA.fmu")
-oms_addSubModel("model.root.B", "../resources/replaceB.fmu")
+oms_addSubModel("model.root.A", "../../resources/replaceA.fmu")
+oms_addSubModel("model.root.B", "../../resources/replaceB.fmu")
 
 oms_newResources("model.root:root.ssv")
 
@@ -45,7 +46,7 @@ oms_delete("model")
 oms_importFile("replaceSubmodel10.ssp")
 
 -- reimport the old snapshot and replacing is not done
-oms_replaceSubModel("model.root.A", "../resources/replaceA_extended.fmu", true)
+oms_replaceSubModel("model.root.A", "../../resources/replaceA_extended.fmu", true)
 src, status = oms_exportSnapshot("model")
 print(src)
 

--- a/testsuite/simulation/replaceSubmodel10.lua
+++ b/testsuite/simulation/replaceSubmodel10.lua
@@ -305,7 +305,7 @@ oms_delete("model")
 -- info:      model.root.B.u1     : -13.0
 -- info:      model.root.B.z      : -15.0
 -- error:   [getVariable] Unknown signal "model.root.A.dummy"
--- warning: deleting connection "A.dummy ==> B.u1", as signal "dummy" couldn't be resolved to any signal in the replaced submodel "../resources/replaceA_extended.fmu"
+-- warning: deleting connection "A.dummy ==> B.u1", as signal "dummy" couldn't be resolved to any signal in the replaced submodel "../../resources/replaceA_extended.fmu"
 -- warning: deleting start value "A.t" in "resources/root.ssv" resources, because the identifier couldn't be resolved to any system signal in the replacing model
 -- <?xml version="1.0"?>
 -- <oms:snapshot

--- a/testsuite/simulation/replaceSubmodel11.py
+++ b/testsuite/simulation/replaceSubmodel11.py
@@ -11,7 +11,7 @@ oms = OMSimulator()
 
 oms.setCommandLineOption("--suppressPath=true")
 oms.setTempDirectory("./replacesubmodel_11_py/")
-oms.setWokringDirectory("./replacesubmodel_11_py/")
+oms.setWorkingDirectory("./replacesubmodel_11_py/")
 
 oms.newModel("model")
 

--- a/testsuite/simulation/replaceSubmodel11.py
+++ b/testsuite/simulation/replaceSubmodel11.py
@@ -11,13 +11,14 @@ oms = OMSimulator()
 
 oms.setCommandLineOption("--suppressPath=true")
 oms.setTempDirectory("./replacesubmodel_11_py/")
+oms.setWokringDirectory("./replacesubmodel_11_py/")
 
 oms.newModel("model")
 
 oms.addSystem("model.root", oms.system_wc)
 
-oms.addSubModel("model.root.A", "../resources/Modelica.Blocks.Sources.Sine.fmu")
-oms.addSubModel("model.root.B", "../resources/Modelica.Blocks.Math.Gain.fmu")
+oms.addSubModel("model.root.A", "../../resources/Modelica.Blocks.Sources.Sine.fmu")
+oms.addSubModel("model.root.B", "../../resources/Modelica.Blocks.Math.Gain.fmu")
 
 ## add connections
 oms.addConnection("model.root.A.y", "model.root.B.u")
@@ -33,7 +34,7 @@ oms.delete("model")
 
 oms.importFile("replaceSubmodel11.ssp")
 
-oms.replaceSubModel("model.root.B", "../resources/Modelica.Blocks.Math.Gain.fmu", False)
+oms.replaceSubModel("model.root.B", "../../resources/Modelica.Blocks.Math.Gain.fmu", False)
 
 src, status = oms.exportSnapshot("model")
 print(src)

--- a/testsuite/simulation/replaceSubmodel12.py
+++ b/testsuite/simulation/replaceSubmodel12.py
@@ -11,13 +11,14 @@ oms = OMSimulator()
 
 oms.setCommandLineOption("--suppressPath=true")
 oms.setTempDirectory("./replacesubmodel_12_py/")
+oms.setWorkingDirectory("./replacesubmodel_12_py/")
 
 oms.newModel("model")
 
 oms.addSystem("model.root", oms.system_wc)
 
-oms.addSubModel("model.root.A", "../resources/Modelica.Blocks.Sources.Sine.fmu")
-oms.addSubModel("model.root.B", "../resources/Modelica.Blocks.Math.Gain.fmu")
+oms.addSubModel("model.root.A", "../../resources/Modelica.Blocks.Sources.Sine.fmu")
+oms.addSubModel("model.root.B", "../../resources/Modelica.Blocks.Math.Gain.fmu")
 
 ## add connections
 oms.addConnection("model.root.A.y", "model.root.B.u")
@@ -33,7 +34,7 @@ oms.delete("model")
 
 oms.importFile("replaceSubmodel12.ssp")
 
-oms.replaceSubModel("model.root.B", "../resources/Modelica.Blocks.Sources.Step.fmu", False)
+oms.replaceSubModel("model.root.B", "../../resources/Modelica.Blocks.Sources.Step.fmu", False)
 
 src, status = oms.exportSnapshot("model")
 print(src)

--- a/testsuite/simulation/replaceSubmodel12.py
+++ b/testsuite/simulation/replaceSubmodel12.py
@@ -45,7 +45,7 @@ oms.delete("model")
 
 ## Result:
 ## error:   [getVariable] Unknown signal "model.root.B.u"
-## warning: deleting connection "A.y ==> B.u", as signal "u" couldn't be resolved to any signal in the replaced submodel "../resources/Modelica.Blocks.Sources.Step.fmu"
+## warning: deleting connection "A.y ==> B.u", as signal "u" couldn't be resolved to any signal in the replaced submodel "../../resources/Modelica.Blocks.Sources.Step.fmu"
 ## <?xml version="1.0"?>
 ## <oms:snapshot
 ##   xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"

--- a/testsuite/simulation/replaceSubmodel2.lua
+++ b/testsuite/simulation/replaceSubmodel2.lua
@@ -304,7 +304,7 @@ oms_delete("model")
 -- info:      model.root.B.u1     : -13.0
 -- info:      model.root.B.z      : -15.0
 -- error:   [getVariable] Unknown signal "model.root.A.dummy"
--- warning: deleting connection "A.dummy ==> B.u1", as signal "dummy" couldn't be resolved to any signal in the replaced submodel "../resources/replaceA_extended.fmu"
+-- warning: deleting connection "A.dummy ==> B.u1", as signal "dummy" couldn't be resolved to any signal in the replaced submodel "../../resources/replaceA_extended.fmu"
 -- warning: deleting start value "A.t" in "resources/root.ssv" resources, because the identifier couldn't be resolved to any system signal in the replacing model
 -- <?xml version="1.0"?>
 -- <oms:snapshot

--- a/testsuite/simulation/replaceSubmodel2.lua
+++ b/testsuite/simulation/replaceSubmodel2.lua
@@ -8,13 +8,14 @@
 
 oms_setCommandLineOption("--suppressPath=true")
 oms_setTempDirectory("./replacesubmodel_02_lua/")
+oms_setWorkingDirectory("./replacesubmodel_02_lua/")
 
 oms_newModel("model")
 
 oms_addSystem("model.root", oms_system_wc)
 
-oms_addSubModel("model.root.A", "../resources/replaceA.fmu")
-oms_addSubModel("model.root.B", "../resources/replaceB.fmu")
+oms_addSubModel("model.root.A", "../../resources/replaceA.fmu")
+oms_addSubModel("model.root.B", "../../resources/replaceB.fmu")
 
 oms_newResources("model.root:root.ssv")
 
@@ -44,7 +45,7 @@ oms_delete("model")
 
 oms_importFile("replaceSubmodel2.ssp")
 
-oms_replaceSubModel("model.root.A", "../resources/replaceA_extended.fmu", false)
+oms_replaceSubModel("model.root.A", "../../resources/replaceA_extended.fmu", false)
 src, status = oms_exportSnapshot("model")
 print(src)
 

--- a/testsuite/simulation/replaceSubmodel3.lua
+++ b/testsuite/simulation/replaceSubmodel3.lua
@@ -8,15 +8,16 @@
 
 oms_setCommandLineOption("--suppressPath=true")
 oms_setTempDirectory("./replacesubmodel_03_lua/")
+oms_setWorkingDirectory("./replacesubmodel_03_lua/")
 
 oms_newModel("model")
 
 oms_addSystem("model.root", oms_system_wc)
 
-oms_addSubModel("model.root.A", "../resources/replaceA.fmu")
+oms_addSubModel("model.root.A", "../../resources/replaceA.fmu")
 oms_newResources("model.root.A:replaceA.ssv")
 
-oms_addSubModel("model.root.B", "../resources/replaceB.fmu")
+oms_addSubModel("model.root.B", "../../resources/replaceB.fmu")
 oms_newResources("model.root.B:replaceB.ssv")
 
 oms_setReal("model.root.A.u", 10.0)
@@ -45,7 +46,7 @@ oms_delete("model")
 
 oms_importFile("replaceSubmodel3.ssp")
 
-oms_replaceSubModel("model.root.A", "../resources/replaceA_extended.fmu", false)
+oms_replaceSubModel("model.root.A", "../../resources/replaceA_extended.fmu", false)
 src, status = oms_exportSnapshot("model")
 print(src)
 

--- a/testsuite/simulation/replaceSubmodel3.lua
+++ b/testsuite/simulation/replaceSubmodel3.lua
@@ -320,7 +320,7 @@ oms_delete("model")
 -- info:      model.root.B.u1     : -13.0
 -- info:      model.root.B.z      : -15.0
 -- error:   [getVariable] Unknown signal "model.root.A.dummy"
--- warning: deleting connection "A.dummy ==> B.u1", as signal "dummy" couldn't be resolved to any signal in the replaced submodel "../resources/replaceA_extended.fmu"
+-- warning: deleting connection "A.dummy ==> B.u1", as signal "dummy" couldn't be resolved to any signal in the replaced submodel "../../resources/replaceA_extended.fmu"
 -- warning: deleting start value "A.t" in "resources/replaceA.ssv" resources, because the identifier couldn't be resolved to any system signal in the replacing model
 -- <?xml version="1.0"?>
 -- <oms:snapshot

--- a/testsuite/simulation/replaceSubmodel4.lua
+++ b/testsuite/simulation/replaceSubmodel4.lua
@@ -291,7 +291,7 @@ oms_delete("model")
 -- info:      model.root.B.u1     : -13.0
 -- info:      model.root.B.z      : -15.0
 -- error:   [getVariable] Unknown signal "model.root.A.dummy"
--- warning: deleting connection "A.dummy ==> B.u1", as signal "dummy" couldn't be resolved to any signal in the replaced submodel "../resources/replaceA_extended.fmu"
+-- warning: deleting connection "A.dummy ==> B.u1", as signal "dummy" couldn't be resolved to any signal in the replaced submodel "../../resources/replaceA_extended.fmu"
 -- warning: deleting start value "A.t" in "resources/root.ssm" resources, because the identifier couldn't be resolved to any system signal in the replacing model
 -- warning: deleting start value "A.t" in "resources/root.ssv" resources, because the identifier couldn't be resolved to any system signal in the replacing model
 -- <?xml version="1.0"?>

--- a/testsuite/simulation/replaceSubmodel4.lua
+++ b/testsuite/simulation/replaceSubmodel4.lua
@@ -8,8 +8,9 @@
 
 oms_setCommandLineOption("--suppressPath=true")
 oms_setTempDirectory("./replacesubmodel_04_lua/")
+oms_setWorkingDirectory("./replacesubmodel_04_lua/")
 
-oms_importFile("../resources/replaceSubmodel4.ssp")
+oms_importFile("../../resources/replaceSubmodel4.ssp")
 
 src, status = oms_exportSnapshot("model")
 print(src)
@@ -21,7 +22,7 @@ print("info:      model.root.B.u      : " .. oms_getReal("model.root.B.u"))
 print("info:      model.root.B.u1     : " .. oms_getReal("model.root.B.u1"))
 print("info:      model.root.B.z      : " .. oms_getReal("model.root.B.z"))
 
-oms_replaceSubModel("model.root.A", "../resources/replaceA_extended.fmu", false)
+oms_replaceSubModel("model.root.A", "../../resources/replaceA_extended.fmu", false)
 
 src, status = oms_exportSnapshot("model")
 print(src)

--- a/testsuite/simulation/replaceSubmodel5.lua
+++ b/testsuite/simulation/replaceSubmodel5.lua
@@ -8,8 +8,9 @@
 
 oms_setCommandLineOption("--suppressPath=true")
 oms_setTempDirectory("./replacesubmodel_05_lua/")
+oms_setWorkingDirectory("./replacesubmodel_05_lua/")
 
-oms_importFile("../resources/replaceSubmodel5.ssp")
+oms_importFile("../../resources/replaceSubmodel5.ssp")
 
 src, status = oms_exportSnapshot("model")
 print(src)
@@ -21,7 +22,7 @@ print("info:      model.root.B.u      : " .. oms_getReal("model.root.B.u"))
 print("info:      model.root.B.u1     : " .. oms_getReal("model.root.B.u1"))
 print("info:      model.root.B.z      : " .. oms_getReal("model.root.B.z"))
 
-oms_replaceSubModel("model.root.A", "../resources/replaceA_extended.fmu", false)
+oms_replaceSubModel("model.root.A", "../../resources/replaceA_extended.fmu", false)
 
 src, status = oms_exportSnapshot("model")
 print(src)

--- a/testsuite/simulation/replaceSubmodel5.lua
+++ b/testsuite/simulation/replaceSubmodel5.lua
@@ -283,7 +283,7 @@ oms_delete("model")
 -- info:      model.root.B.u1     : 1.0
 -- info:      model.root.B.z      : 1.0
 -- error:   [getVariable] Unknown signal "model.root.A.dummy"
--- warning: deleting connection "A.dummy ==> B.u1", as signal "dummy" couldn't be resolved to any signal in the replaced submodel "../resources/replaceA_extended.fmu"
+-- warning: deleting connection "A.dummy ==> B.u1", as signal "dummy" couldn't be resolved to any signal in the replaced submodel "../../resources/replaceA_extended.fmu"
 -- warning: deleting start value "A.t" in "resources/root.ssm" resources, because the identifier couldn't be resolved to any system signal in the replacing model
 -- warning: deleting start value "A.t" in "resources/root.ssv" resources, because the identifier couldn't be resolved to any system signal in the replacing model
 -- <?xml version="1.0"?>

--- a/testsuite/simulation/replaceSubmodel6.py
+++ b/testsuite/simulation/replaceSubmodel6.py
@@ -11,13 +11,14 @@ oms = OMSimulator()
 
 oms.setCommandLineOption("--suppressPath=true")
 oms.setTempDirectory("./replacesubmodel_06_py/")
+oms.setWorkingDirectory("./replacesubmodel_06_py/")
 
 oms.newModel("model")
 
 oms.addSystem("model.root", oms.system_wc)
 
-oms.addSubModel("model.root.A", "../resources/replaceA.fmu")
-oms.addSubModel("model.root.B", "../resources/replaceB.fmu")
+oms.addSubModel("model.root.A", "../../resources/replaceA.fmu")
+oms.addSubModel("model.root.B", "../../resources/replaceB.fmu")
 
 oms.setReal("model.root.A.u", 10.0)
 oms.setReal("model.root.A.t", -10.0)
@@ -45,7 +46,7 @@ oms.delete("model")
 
 oms.importFile("replaceSubmodel6.ssp")
 
-oms.replaceSubModel("model.root.A", "../resources/replaceA_extended.fmu", False)
+oms.replaceSubModel("model.root.A", "../../resources/replaceA_extended.fmu", False)
 
 src, status = oms.exportSnapshot("model")
 print(src)

--- a/testsuite/simulation/replaceSubmodel6.py
+++ b/testsuite/simulation/replaceSubmodel6.py
@@ -82,7 +82,7 @@ oms.delete("model")
 
 ## Result:
 ## error:   [getVariable] Unknown signal "model.root.A.dummy"
-## warning: deleting connection "A.dummy ==> B.u1", as signal "dummy" couldn't be resolved to any signal in the replaced submodel "../resources/replaceA_extended.fmu"
+## warning: deleting connection "A.dummy ==> B.u1", as signal "dummy" couldn't be resolved to any signal in the replaced submodel "../../resources/replaceA_extended.fmu"
 ## warning: deleting start value "A.t" in "inline" resources, because the identifier couldn't be resolved to any system signal in the replacing model
 ## <?xml version="1.0"?>
 ## <oms:snapshot

--- a/testsuite/simulation/replaceSubmodel7.py
+++ b/testsuite/simulation/replaceSubmodel7.py
@@ -11,13 +11,14 @@ oms = OMSimulator()
 
 oms.setCommandLineOption("--suppressPath=true")
 oms.setTempDirectory("./replacesubmodel_07_py/")
+oms.setWorkingDirectory("./replacesubmodel_07_py/")
 
 oms.newModel("model")
 
 oms.addSystem("model.root", oms.system_wc)
 
-oms.addSubModel("model.root.A", "../resources/replaceA.fmu")
-oms.addSubModel("model.root.B", "../resources/replaceB.fmu")
+oms.addSubModel("model.root.A", "../../resources/replaceA.fmu")
+oms.addSubModel("model.root.B", "../../resources/replaceB.fmu")
 
 oms.newResources("model.root:root.ssv")
 
@@ -47,7 +48,7 @@ oms.delete("model")
 
 oms.importFile("replaceSubmodel7.ssp")
 
-oms.replaceSubModel("model.root.A", "../resources/replaceA_extended.fmu", False)
+oms.replaceSubModel("model.root.A", "../../resources/replaceA_extended.fmu", False)
 src, status = oms.exportSnapshot("model")
 print(src)
 

--- a/testsuite/simulation/replaceSubmodel7.py
+++ b/testsuite/simulation/replaceSubmodel7.py
@@ -83,7 +83,7 @@ oms.delete("model")
 
 ## Result:
 ## error:   [getVariable] Unknown signal "model.root.A.dummy"
-## warning: deleting connection "A.dummy ==> B.u1", as signal "dummy" couldn't be resolved to any signal in the replaced submodel "../resources/replaceA_extended.fmu"
+## warning: deleting connection "A.dummy ==> B.u1", as signal "dummy" couldn't be resolved to any signal in the replaced submodel "../../resources/replaceA_extended.fmu"
 ## warning: deleting start value "A.t" in "resources/root.ssv" resources, because the identifier couldn't be resolved to any system signal in the replacing model
 ## <?xml version="1.0"?>
 ## <oms:snapshot

--- a/testsuite/simulation/replaceSubmodel8.lua
+++ b/testsuite/simulation/replaceSubmodel8.lua
@@ -261,7 +261,7 @@ oms_delete("model")
 -- info:      model.root.B.u1     : 1.0
 -- info:      model.root.B.z      : 1.0
 -- error:   [getVariable] Unknown signal "model.root.A.dummy"
--- warning: deleting connection "A.dummy ==> B.u1", as signal "dummy" couldn't be resolved to any signal in the replaced submodel "../resources/replaceA_extended.fmu"
+-- warning: deleting connection "A.dummy ==> B.u1", as signal "dummy" couldn't be resolved to any signal in the replaced submodel "../../resources/replaceA_extended.fmu"
 -- <?xml version="1.0"?>
 -- <oms:snapshot
 --   xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"

--- a/testsuite/simulation/replaceSubmodel8.lua
+++ b/testsuite/simulation/replaceSubmodel8.lua
@@ -8,13 +8,14 @@
 
 oms_setCommandLineOption("--suppressPath=true")
 oms_setTempDirectory("./replacesubmodel_08_lua/")
+oms_setWorkingDirectory("./replacesubmodel_08_lua/")
 
 oms_newModel("model")
 
 oms_addSystem("model.root", oms_system_wc)
 
-oms_addSubModel("model.root.A", "../resources/replaceA.fmu")
-oms_addSubModel("model.root.B", "../resources/replaceB.fmu")
+oms_addSubModel("model.root.A", "../../resources/replaceA.fmu")
+oms_addSubModel("model.root.B", "../../resources/replaceB.fmu")
 
 -- add connections
 oms_addConnection("model.root.A.y", "model.root.B.u")
@@ -37,7 +38,7 @@ oms_delete("model")
 
 oms_importFile("replaceSubmodel8.ssp")
 
-oms_replaceSubModel("model.root.A", "../resources/replaceA_extended.fmu", false)
+oms_replaceSubModel("model.root.A", "../../resources/replaceA_extended.fmu", false)
 src, status = oms_exportSnapshot("model")
 print(src)
 

--- a/testsuite/simulation/replaceSubmodel9.lua
+++ b/testsuite/simulation/replaceSubmodel9.lua
@@ -311,7 +311,7 @@ oms_delete("model")
 -- info:      model.root.B.u1     : -13.0
 -- info:      model.root.B.z      : -15.0
 -- error:   [getVariable] Unknown signal "model.root.A.dummy"
--- warning: deleting connection "A.dummy ==> B.u1", as signal "dummy" couldn't be resolved to any signal in the replaced submodel "../resources/replaceA_extended.fmu"
+-- warning: deleting connection "A.dummy ==> B.u1", as signal "dummy" couldn't be resolved to any signal in the replaced submodel "../../resources/replaceA_extended.fmu"
 -- warning: deleting start value "A.t" in "inline" resources, because the identifier couldn't be resolved to any system signal in the replacing model
 -- <?xml version="1.0"?>
 -- <oms:snapshot

--- a/testsuite/simulation/replaceSubmodel9.lua
+++ b/testsuite/simulation/replaceSubmodel9.lua
@@ -8,13 +8,14 @@
 
 oms_setCommandLineOption("--suppressPath=true")
 oms_setTempDirectory("./replacesubmodel_09_lua/")
+oms_setWorkingDirectory("./replacesubmodel_09_lua/")
 
 oms_newModel("model")
 
 oms_addSystem("model.root", oms_system_wc)
 
-oms_addSubModel("model.root.A", "../resources/replaceA.fmu")
-oms_addSubModel("model.root.B", "../resources/replaceB.fmu")
+oms_addSubModel("model.root.A", "../../resources/replaceA.fmu")
+oms_addSubModel("model.root.B", "../../resources/replaceB.fmu")
 
 oms_setReal("model.root.A.u", 10.0)
 oms_setReal("model.root.A.t", -10.0)
@@ -43,7 +44,7 @@ oms_delete("model")
 oms_importFile("replaceSubmodel9.ssp")
 
 -- reimport the old snapshot and replacing is not done
-oms_replaceSubModel("model.root.A", "../resources/replaceA_extended.fmu", true)
+oms_replaceSubModel("model.root.A", "../../resources/replaceA_extended.fmu", true)
 src, status = oms_exportSnapshot("model")
 print(src)
 


### PR DESCRIPTION
### Related Issues

https://github.com/OpenModelica/OMSimulator/issues/1269

### Purpose
This PR checks If the DefaultExperiment tag provides values for --startTime, --stopTime, stepSize and --tolerance, they should be used as defaults, instead of the built-in ones.  Of course, values provided with the --startTime, --stopTime, and --tolerance parameters when calling OMSimulator from the command line should override these defaults.

