### PR TITLE
fix OMSimulator pip package

### DIFF
--- a/src/OMSimulatorLib/XercesValidator.cpp
+++ b/src/OMSimulatorLib/XercesValidator.cpp
@@ -179,11 +179,21 @@ oms_status_enu_t oms::XercesValidator::validateSSP(const char *ssd, const std::s
     schemaSSCPath = schemaRootPath / "../../../share/OMSimulator/schema/ssp/SystemStructureCommon.xsd";
   }
 
+  //check schema path location in python pip package, the schemas are copied to "OMSimulator/schema"
+  if (!filesystem::exists(schemaSSDPath))
+  {
+    schemaSSDPath = schemaRootPath / "schema/ssp/SystemStructureDescription.xsd";
+    schemaSSVPath = schemaRootPath / "schema/ssp/SystemStructureParameterValues.xsd";
+    schemaSSMPath = schemaRootPath / "schema/ssp/SystemStructureParameterMapping.xsd";
+    schemaSSCPath = schemaRootPath / "schema/ssp/SystemStructureCommon.xsd";
+  }
+
+
   XercesDOMParser domParser;
 
   // load the schema
   if (domParser.loadGrammar(schemaSSDPath.generic_string().c_str(), Grammar::SchemaGrammarType) == NULL)
-    return logError("could not load the ssd schema file: " + filesystem::absolute(schemaSSDPath).generic_string());
+    return logWarning("could not load the ssd schema file: " + filesystem::absolute(schemaSSDPath).generic_string() + ", hence validation of ssd file will not be perfomed according to SSP Standard");
 
   std::string sspVariant = "";
 
@@ -272,11 +282,17 @@ oms_status_enu_t oms::XercesValidator::validateFMU(const char *modeldescription,
     schemaFmiModeldescriptionPath = schemaRootPath / "../../../share/OMSimulator/schema/fmi2/fmi2ModelDescription.xsd";
   }
 
+  //check schema path location in python pip package, the schemas are copied to "OMSimulator/schema"
+  if (!filesystem::exists(schemaFmiModeldescriptionPath))
+  {
+    schemaFmiModeldescriptionPath = schemaRootPath / "schema/fmi2/fmi2ModelDescription.xsd";
+  }
+
   XercesDOMParser domParser;
 
   // load the schema
   if (domParser.loadGrammar(schemaFmiModeldescriptionPath.generic_string().c_str(), Grammar::SchemaGrammarType) == NULL)
-    return logError("could not load the ssd schema file: " + filesystem::absolute(schemaFmiModeldescriptionPath).generic_string());
+    return logWarning("could not load the FMI schema file: " + filesystem::absolute(schemaFmiModeldescriptionPath).generic_string() + ", hence validation of \"modeldescription.xml\" with FMI 2.0 standard will not be performed");
 
   ParserErrorHandler parserErrorHandler("modeldescription.xml", filePath.c_str());
 

--- a/src/OMSimulatorPython/capi.py
+++ b/src/OMSimulatorPython/capi.py
@@ -4,16 +4,24 @@ import os
 class capi:
   def __init__(self):
     dirname = os.path.dirname(__file__)
+    ## look for dll in the current directory for the python pip package
     omslib = os.path.join(dirname, "@OMSIMULATORLIB_STRING@")
-    # attempt to fix #8163 on Linux
-    if not os.path.exists(omslib):
-      omslib = os.path.join(dirname, "..", "@OMSIMULATORLIB_STRING@")
 
-    if os.name == 'nt': # Windows
-      omslib = os.path.join(dirname, "@OMSIMULATOR_PYTHON_RELATIVE_DLL_DIR@", "@OMSIMULATORLIB_STRING@")
-      dllDir = os.add_dll_directory(os.path.dirname(omslib))
+    dllSearchPath = False
+
+    ## look for dll in the OpenModelica top level directory or OMSimulator stand alone directory
+    if not os.path.exists(omslib):
+      if os.name == 'nt': # Windows
+        omslib = os.path.join(dirname, "@OMSIMULATOR_PYTHON_RELATIVE_DLL_DIR@", "@OMSIMULATORLIB_STRING@")
+        dllDir = os.add_dll_directory(os.path.dirname(omslib))
+        dllSearchPath = True
+      else:
+        # attempt to fix #8163 on Linux
+        omslib = os.path.join(dirname, "..", "@OMSIMULATORLIB_STRING@")
+
     self.obj=ctypes.CDLL(omslib)
-    if os.name == 'nt': # Windows
+
+    if os.name == 'nt' and dllSearchPath: # Windows
       dllDir.close()
 
     self.obj.oms_activateVariant.argtypes = [ctypes.c_char_p, ctypes.c_char_p]

--- a/src/pip/CMakeLists.txt
+++ b/src/pip/CMakeLists.txt
@@ -1,7 +1,7 @@
 project(pip)
 
 set(CMAKE_INSTALL_BINDIR ${CMAKE_INSTALL_BINDIR}/pip)
-set(CMAKE_INSTALL_DATADIR ${CMAKE_INSTALL_DATADIR}/pip)
+# set(CMAKE_INSTALL_DATADIR ${CMAKE_INSTALL_DATADIR}/pip)
 
 IF (OMS_VERSION_STRING MATCHES "^(.*)\\.post(.*)-g(.*)$")
   set(OMS_BUILD_TYPE "nightly")
@@ -14,4 +14,4 @@ configure_file("${CMAKE_CURRENT_SOURCE_DIR}/setup.py" "${CMAKE_CURRENT_BINARY_DI
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/setup.py"
         TYPE BIN)
 install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/README.md"  "${CMAKE_SOURCE_DIR}/OSMC-License.txt"
-        TYPE DATA)
+        TYPE BIN)

--- a/src/pip/setup.py
+++ b/src/pip/setup.py
@@ -37,6 +37,7 @@ import sysconfig
 import tempfile
 from distutils.command.build_py import build_py
 from distutils.dir_util import copy_tree
+from distutils.file_util import copy_file
 
 from setuptools import setup
 
@@ -70,16 +71,16 @@ class my_build_py(build_py):
     # download the zip directory from url
     if (sysconfig.get_platform() == 'linux-x86_64'):
       response = requests.get('https://build.openmodelica.org/omsimulator/nightly/linux-amd64/OMSimulator-linux-amd64-@OMS_VERSION_STRING@.tar.gz')
-    elif (sysconfig.get_platform() == 'linux-i386'):
-      response = requests.get('https://build.openmodelica.org/omsimulator/nightly/linux-i386/OMSimulator-linux-i386-@OMS_VERSION_STRING@.tar.gz')
-    elif (sysconfig.get_platform() == 'linux-arm32'):
-      response = requests.get('https://build.openmodelica.org/omsimulator/nightly/linux-arm32/OMSimulator-linux-arm32-@OMS_VERSION_STRING@.tar.gz')
-    elif (sysconfig.get_platform() == 'mingw' and platform.architecture()[0] == '64bit'):
+      dllpath  = "lib/x86_64-linux-gnu/libOMSimulator.so"
+    elif (sysconfig.get_platform() == "mingw_x86_64_ucrt" or (sysconfig.get_platform() == 'mingw' and platform.architecture()[0] == '64bit')):
       response = requests.get('https://build.openmodelica.org/omsimulator/nightly/win-mingw-ucrt64/OMSimulator-mingw-ucrt64-@OMS_VERSION_STRING@.zip')
+      dllpath  = "bin/libOMSimulator.dll"
     elif (sysconfig.get_platform() == 'win-amd64'):
       response = requests.get('https://build.openmodelica.org/omsimulator/nightly/win-msvc64/OMSimulator-win64-@OMS_VERSION_STRING@.zip')
+      dllpath  = "bin/OMSimulator.dll"
     elif (platform.system() == 'Darwin'):
       response = requests.get('https://build.openmodelica.org/omsimulator/nightly/osx/OMSimulator-osx-@OMS_VERSION_STRING@.zip')
+      dllpath  = "lib/libOMSimulator.dylib"
     else:
       raise Exception("Platform not supported for {} ".format(sysconfig.get_platform()))
 
@@ -111,6 +112,12 @@ class my_build_py(build_py):
 
     # copy OMSimulator package to root directory
     copy_tree(os.path.join(zipDir, 'lib/OMSimulator'), target_dir)
+
+    # copy schema path to OMSimulator/schema
+    copy_tree(os.path.join(zipDir, 'share/OMSimulator/schema'), target_dir +"/schema")
+
+    # copy dll to root directory
+    copy_file(os.path.join(zipDir, dllpath), target_dir)
 
     # remove the zip directory after copying the files
     shutil.rmtree(zipDir)


### PR DESCRIPTION
### Related Issues

https://github.com/OpenModelica/OMSimulator/issues/1283

### Purpose

This PR fixes the `OMSimulator pip package` according to the new cmake build system.

### TODO

- [x] fix the setup.py file to copy the dlls according to the new build path