### PR TITLE
attempts to fix git path in windows

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -385,7 +385,7 @@ EXIT /b 1
                 bat 'hostname'
                 writeFile file: "buildZip.sh", text: """#!/bin/sh
 set -x -e
-export PATH="/c/Program Files/TortoiseSVN/bin/:C:/Program Files/Git/bin/:/c/bin/jdk/bin:/c/bin/nsis/:\$PATH:/c/bin/git/bin"
+export PATH="/c/Program Files/TortoiseSVN/bin/:/c/Program Files/Git/bin/:/c/bin/jdk/bin:/c/bin/nsis/:\$PATH:/c/bin/git/bin"
 cd "${env.WORKSPACE}/install/"
 zip -r "../OMSimulator-win64-`git describe --tags --abbrev=7 --match=v*.* --exclude=*-dev | sed \'s/-/.post/\'`.zip" *
 """

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -225,7 +225,7 @@ pipeline {
                 label 'M1'
               }
               environment {
-                PATH="/opt/homebrew/bin:/opt/homebrew/opt/openjdk/bin:/opt/homebrew/opt/icu4c/bin:/opt/homebrew/opt/icu4c/sbin:/usr/local/bin:${env.PATH}"                
+                PATH="/opt/homebrew/bin:/opt/homebrew/opt/openjdk/bin:/opt/homebrew/opt/icu4c/bin:/opt/homebrew/opt/icu4c/sbin:/usr/local/bin:${env.PATH}"
                 PKG_CONFIG_PATH="/opt/homebrew/opt/icu4c/lib/pkgconfig"
                 LDFLAGS="-L/opt/homebrew/opt/icu4c/lib"
                 CPPFLAGS="-I/opt/homebrew/opt/icu4c/include"
@@ -385,7 +385,7 @@ EXIT /b 1
                 bat 'hostname'
                 writeFile file: "buildZip.sh", text: """#!/bin/sh
 set -x -e
-export PATH="/c/Program Files/TortoiseSVN/bin/:/c/bin/jdk/bin:/c/bin/nsis/:\$PATH:/c/bin/git/bin"
+export PATH="/c/Program Files/TortoiseSVN/bin/:C:/Program Files/Git/bin/:/c/bin/jdk/bin:/c/bin/nsis/:\$PATH:/c/bin/git/bin"
 cd "${env.WORKSPACE}/install/"
 zip -r "../OMSimulator-win64-`git describe --tags --abbrev=7 --match=v*.* --exclude=*-dev | sed \'s/-/.post/\'`.zip" *
 """


### PR DESCRIPTION
### Purpose

This PR attempts to fix git path in windows for correct artifacts name, Currently the windows artifacts are exported as `OMSimulator-Windows64.zip`

### Approach

<!--- How does this change address the problem? -->
