### PR TITLE
do not export empty <ssd:connectors/>

### DIFF
--- a/src/OMSimulatorLib/ComponentFMUCS.cpp
+++ b/src/OMSimulatorLib/ComponentFMUCS.cpp
@@ -366,15 +366,18 @@ oms_status_enu_t oms::ComponentFMUCS::exportToSSD(pugi::xml_node& node, Snapshot
   node.append_attribute("name") = this->getCref().c_str();
   node.append_attribute("type") = "application/x-fmu-sharedlibrary";
   node.append_attribute("source") = getPath().c_str();
-  pugi::xml_node node_connectors = node.append_child(oms::ssp::Draft20180219::ssd::connectors);
 
   if (element.getGeometry())
     element.getGeometry()->exportToSSD(node);
 
-  for (const auto& connector : connectors)
-    if (connector)
-      if (oms_status_ok != connector->exportToSSD(node_connectors))
-        return oms_status_error;
+  if (connectors.size() > 1)
+  {
+    pugi::xml_node node_connectors = node.append_child(oms::ssp::Draft20180219::ssd::connectors);
+    for (const auto& connector : connectors)
+      if (connector)
+        if (oms_status_ok != connector->exportToSSD(node_connectors))
+          return oms_status_error;
+  }
 
   // export ParameterBindings at component level
   values.exportParameterBindings(node, snapshot, variantName);

--- a/src/OMSimulatorLib/ComponentFMUME.cpp
+++ b/src/OMSimulatorLib/ComponentFMUME.cpp
@@ -364,15 +364,18 @@ oms_status_enu_t oms::ComponentFMUME::exportToSSD(pugi::xml_node& node, Snapshot
   node.append_attribute("name") = this->getCref().c_str();
   node.append_attribute("type") = "application/x-fmu-sharedlibrary";
   node.append_attribute("source") = getPath().c_str();
-  pugi::xml_node node_connectors = node.append_child(oms::ssp::Draft20180219::ssd::connectors);
 
   if (element.getGeometry())
     element.getGeometry()->exportToSSD(node);
 
-  for (const auto& connector : connectors)
-    if (connector)
-      if (oms_status_ok != connector->exportToSSD(node_connectors))
-        return oms_status_error;
+  if (connectors.size() > 1)
+  {
+    pugi::xml_node node_connectors = node.append_child(oms::ssp::Draft20180219::ssd::connectors);
+    for (const auto& connector : connectors)
+      if (connector)
+        if (oms_status_ok != connector->exportToSSD(node_connectors))
+          return oms_status_error;
+  }
 
   // export ParameterBindings at component level
   values.exportParameterBindings(node, snapshot, variantName);

--- a/testsuite/simulation/import_export_signalFilter2.lua
+++ b/testsuite/simulation/import_export_signalFilter2.lua
@@ -42,8 +42,6 @@ oms_terminate("model")
 oms_delete("model")
 
 -- Result:
--- warning: invalid "SystemStructureDescription" detected in file "signalFilterVars.ssp" at line: 18 column: 27, element 'Connectors' is not allowed for content model '(Connector+)'
--- warning: "SystemStructureDescription" does not conform to the SSP standard schema
 -- <?xml version="1.0"?>
 -- <oms:snapshot
 --   xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
@@ -65,9 +63,7 @@ oms_delete("model")
 --           <ssd:Component
 --             name="testArray"
 --             type="application/x-fmu-sharedlibrary"
---             source="resources/0001_testArray.fmu">
---             <ssd:Connectors />
---           </ssd:Component>
+--             source="resources/0001_testArray.fmu" />
 --         </ssd:Elements>
 --         <ssd:Annotations>
 --           <ssc:Annotation
@@ -136,6 +132,4 @@ oms_delete("model")
 -- info:      model.root.testArray.a[2]     : 1.0
 -- info:      model.root.testArray.a[3]     : 1.0
 -- info:      model.root.testArray.x        : 0.0
--- info:    2 warnings
--- info:    0 errors
 -- endResult


### PR DESCRIPTION
### Purpose

This PR fixes `export of ssp` according to `SSP 1.0` specification
