### PR TITLE
check for root System when exporting and importing resources/signalFilter.xml

### DIFF
--- a/src/OMSimulatorLib/Model.cpp
+++ b/src/OMSimulatorLib/Model.cpp
@@ -849,7 +849,9 @@ oms_status_enu_t oms::Model::exportToSSD(Snapshot& snapshot) const
   oms_simulation_information.append_attribute("resultFile") = resultFilename.c_str();
   oms_simulation_information.append_attribute("loggingInterval") = std::to_string(loggingInterval).c_str();
   oms_simulation_information.append_attribute("bufferSize") = std::to_string(bufferSize).c_str();
-  oms_simulation_information.append_attribute("signalFilter") = signalFilterFilename.c_str();
+  // check for root system exist and export signalFilter
+  if (system)
+    oms_simulation_information.append_attribute("signalFilter") = signalFilterFilename.c_str();
 
   return oms_status_ok;
 }
@@ -1576,6 +1578,10 @@ std::string oms::Model::escapeSpecialCharacters(const std::string& regex)
 
 oms_status_enu_t oms::Model::importSignalFilter(const std::string& filename, const Snapshot& snapshot)
 {
+  // check for system and do not import signalFilter if system == NULL
+  if (!system)
+    return oms_status_ok;
+
   if (".*" == filename) // avoid error messages for older ssp files
   {
     addSignalsToResults(".*");

--- a/testsuite/api/test01.lua
+++ b/testsuite/api/test01.lua
@@ -175,7 +175,7 @@ printStatus(status, 3)
 -- 		<ssd:Annotations>
 -- 			<ssc:Annotation type="org.openmodelica">
 -- 				<oms:Annotations>
--- 					<oms:SimulationInformation resultFile="test01lua_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter="resources/signalFilter.xml" />
+-- 					<oms:SimulationInformation resultFile="test01lua_res.mat" loggingInterval="0.000000" bufferSize="10" />
 -- 				</oms:Annotations>
 -- 			</ssc:Annotation>
 -- 		</ssd:Annotations>

--- a/testsuite/api/test01.py
+++ b/testsuite/api/test01.py
@@ -175,7 +175,7 @@ printStatus(status, 3)
 ## 		<ssd:Annotations>
 ## 			<ssc:Annotation type="org.openmodelica">
 ## 				<oms:Annotations>
-## 					<oms:SimulationInformation resultFile="test01py_res.mat" loggingInterval="0.000000" bufferSize="10" signalFilter="resources/signalFilter.xml" />
+## 					<oms:SimulationInformation resultFile="test01py_res.mat" loggingInterval="0.000000" bufferSize="10" />
 ## 				</oms:Annotations>
 ## 			</ssc:Annotation>
 ## 		</ssd:Annotations>

--- a/testsuite/simulation/Makefile
+++ b/testsuite/simulation/Makefile
@@ -7,6 +7,7 @@ activateVariant3.lua \
 checkUnits.lua \
 deleteConnector.lua \
 deleteConnector1.lua \
+deleteRootSystem.lua \
 deleteReferencesAndStartValues.lua \
 deleteStartValues.lua \
 deleteStartValuesInSSV.lua \

--- a/testsuite/simulation/deleteRootSystem.lua
+++ b/testsuite/simulation/deleteRootSystem.lua
@@ -1,0 +1,61 @@
+-- status: correct
+-- teardown_command: rm -rf deleteRootSystem/
+-- linux: yes
+-- ucrt64: yes
+-- win: yes
+-- mac: yes
+
+oms_setCommandLineOption("--suppressPath=true")
+oms_setTempDirectory("./deleteRootSystem_lua/")
+oms_setWorkingDirectory("./deleteRootSystem_lua/")
+
+oms_newModel("model")
+
+oms_addSystem("model.Root", oms_system_wc)
+
+
+oms_addSubModel("model.Root.Gain", "../../resources/Modelica.Blocks.Math.Gain.fmu")
+
+oms_delete("model.Root")
+
+src = oms_exportSnapshot("model")
+print(src)
+
+oms_importSnapshot("model", src)
+
+-- Result:
+-- <?xml version="1.0"?>
+-- <oms:snapshot
+--   xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
+--   partial="false">
+--   <oms:file
+--     name="SystemStructure.ssd">
+--     <ssd:SystemStructureDescription
+--       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
+--       xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription"
+--       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
+--       xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping"
+--       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
+--       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
+--       name="model"
+--       version="1.0">
+--       <ssd:DefaultExperiment
+--         startTime="0.000000"
+--         stopTime="1.000000">
+--         <ssd:Annotations>
+--           <ssc:Annotation
+--             type="org.openmodelica">
+--             <oms:Annotations>
+--               <oms:SimulationInformation
+--                 resultFile="model_res.mat"
+--                 loggingInterval="0.000000"
+--                 bufferSize="10" />
+--             </oms:Annotations>
+--           </ssc:Annotation>
+--         </ssd:Annotations>
+--       </ssd:DefaultExperiment>
+--     </ssd:SystemStructureDescription>
+--   </oms:file>
+-- </oms:snapshot>
+--
+-- endResult


### PR DESCRIPTION
### Purpose

Export and import Signal Filter only when root System exists.


