### PR TITLE
no need to escape inside quotes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -292,7 +292,7 @@ pipeline {
                 set -x -e
                 export PATH="/c/Program Files/TortoiseSVN/bin/:/c/bin/jdk/bin:/c/bin/nsis/:\$PATH:/c/bin/git/bin"
                 cd "${env.WORKSPACE}/install/"
-                zip -r "../OMSimulator-mingw-ucrt64-`git describe --tags --abbrev=7 --match=v*.* --exclude=*-dev | sed \'s/-/.post/\'`.zip" *
+                zip -r "../OMSimulator-mingw-ucrt64-`git describe --tags --abbrev=7 --match=v*.* --exclude=*-dev | sed 's/-/.post/'`.zip" *
                 """
 
                 bat """
@@ -387,7 +387,7 @@ EXIT /b 1
 set -x -e
 export PATH="/c/Program Files/TortoiseSVN/bin/:/c/Program Files/Git/bin/:/c/bin/jdk/bin:/c/bin/nsis/:\$PATH:/c/bin/git/bin"
 cd "${env.WORKSPACE}/install/"
-zip -r "../OMSimulator-win64-`git describe --tags --abbrev=7 --match=v*.* --exclude=*-dev | sed \'s/-/.post/\'`.zip" *
+zip -r "../OMSimulator-win64-`git describe --tags --abbrev=7 --match=v*.* --exclude=*-dev | sed 's/-/.post/'`.zip" *
 """
 
                 retry(2) { bat """


### PR DESCRIPTION
### Related Issues

Windows builds do not add version info in the artifacts, attempt to fix this by not escaping single quotes inside the double quotes.
