### PR TITLE
Add 'asan' option to test case headers for selective ASan testing

### DIFF
--- a/.CI/cache/Dockerfile
+++ b/.CI/cache/Dockerfile
@@ -1,6 +1,7 @@
 # Cannot be parametrized in Jenkins...
-FROM docker.openmodelica.org/build-deps:v1.21.1
+FROM docker.openmodelica.org/build-deps:v1.22.2
 
 # We don't know the uid of the user who will build, so make the /cache directories world writable
 
-RUN mkdir -p /cache/runtest/ /cache/omlibrary/ && chmod ugo+rwx /cache/runtest/ /cache/omlibrary/
+RUN apt-get install libasan6 && \
+    mkdir -p /cache/runtest/ /cache/omlibrary/ && chmod ugo+rwx /cache/runtest/ /cache/omlibrary/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -88,6 +88,7 @@ pipeline {
               environment {
                 RUNTESTDB = "/cache/runtest/"
                 ASAN = "ON"
+                HOME = "/tmp/"
               }
               steps {
                 buildOMS()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -652,7 +652,7 @@ void buildOMS() {
        cmake --build build/ --parallel ${nproc} --target install -v
        ''')
     } else {
-      sh "cmake -S . -B build/ -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=install/ -DOM_OMS_ENABLE_TESTSUITE:BOOL=ON"
+      sh "cmake -S . -B build/ -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=install/ -DOM_OMS_ENABLE_TESTSUITE:BOOL=ON ${env.ASAN ? '-DASAN=ON': ''}"
       sh "cmake --build build/ --parallel ${nproc} --target install -v"
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -80,7 +80,7 @@ pipeline {
             stage('build') {
               agent {
                 docker {
-                  image 'docker.openmodelica.org/build-deps:v1.13'
+                  image 'docker.openmodelica.org/build-deps:v1.22.2'
                   label 'linux'
                   alwaysPull true
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@ pipeline {
     booleanParam(name: 'MINGW_UCRT64', defaultValue: true, description: 'Build with MINGW/UCRT64')
     booleanParam(name: 'MINGW_UCRT64_CLANG', defaultValue: true, description: 'Build with MINGW/UCRT64 with clang')
     booleanParam(name: 'MACOS_ARM64', defaultValue: false, description: 'Build with macOS-arm64 (M1 mac)')
-    booleanParam(name: 'LINUX64_ASAN', defaultValue: false, description: 'Build with linux64 asan')
+    booleanParam(name: 'LINUX64_ASAN', defaultValue: true, description: 'Build with linux64 asan')
     booleanParam(name: 'SUBMODULE_UPDATE', defaultValue: false, description: 'Allow pull request to update submodules (disabled by default due to common user errors)')
     booleanParam(name: 'UPLOAD_BUILD_OPENMODELICA', defaultValue: false, description: 'Upload install artifacts to build.openmodelica.org/omsimulator. Activates MINGW_UCRT64 as well.')
     string(name: 'RUNTESTS_FLAG', defaultValue: '', description: 'runtests.pl flag')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -55,6 +55,7 @@ pipeline {
           environment {
             RUNTESTDB = "/cache/runtest/"
             NPROC = "${numPhysicalCPU}"
+            HOME = "/tmp/"
           }
           steps {
             buildOMS()
@@ -163,6 +164,7 @@ pipeline {
                 FMIL_FLAGS = '-DFMILIB_FMI_PLATFORM=arm-linux-gnueabihf'
                 detected_OS = 'Linux'
                 VERBOSE = '1'
+                HOME = "/tmp/"
               }
               steps {
                 sh 'printenv'

--- a/README.md
+++ b/README.md
@@ -127,7 +127,6 @@ OMSimulator tests are automatically run on Jenkins, see [latest test reports](ht
    ./runtests.pl -j4
    ```
    - Use `-jN` to specify `N` threads.
-   - Add `-asan` to disable Python tests.
 
 ### Windows (Visual Studio)
 
@@ -144,4 +143,3 @@ Testing requires the OMDev mingw shell:
    ./runtests.pl -j4 -platform=win
    ```
    - Use `-jN` to specify `N` threads.
-   - Add `-asan` to disable Python tests.

--- a/testsuite/api/addExternalResources1.lua
+++ b/testsuite/api/addExternalResources1.lua
@@ -4,6 +4,7 @@
 -- ucrt64: yes
 -- win: yes
 -- mac: no
+-- asan: yes
 
 oms_setCommandLineOption("--suppressPath=true")
 oms_setTempDirectory("./addExternalResources1_lua/")

--- a/testsuite/api/addExternalResources1.lua
+++ b/testsuite/api/addExternalResources1.lua
@@ -4,7 +4,6 @@
 -- ucrt64: yes
 -- win: yes
 -- mac: no
--- asan: yes
 
 oms_setCommandLineOption("--suppressPath=true")
 oms_setTempDirectory("./addExternalResources1_lua/")

--- a/testsuite/api/test_omsExport.lua
+++ b/testsuite/api/test_omsExport.lua
@@ -5,6 +5,7 @@
 -- ucrt64: yes
 -- win: yes
 -- mac: yes
+-- asan: yes
 
 oms_setCommandLineOption("--suppressPath=true")
 oms_setTempDirectory("./test_omsExport-lua/")

--- a/testsuite/partest/runtest.pl
+++ b/testsuite/partest/runtest.pl
@@ -33,6 +33,9 @@ for(@ARGV){
   elsif(/^-platform(.*)$/) {
     $rtest_extra_args = $rtest_extra_args . " " . $_;
   }
+  elsif(/^-asan$/) {
+    $rtest_extra_args = $rtest_extra_args . " " . $_;
+  }
   elsif(/^--with-omc=(.*)$/) {
     $rtest_extra_args = $rtest_extra_args . " --with-omc=$1";
   }
@@ -364,4 +367,3 @@ if ($exit_status == 0) {
   }
   exit $time;
 }
-

--- a/testsuite/partest/runtests.pl
+++ b/testsuite/partest/runtests.pl
@@ -36,7 +36,7 @@ $ENV{GC_MARKERS}="1";
 
 my $use_db = 1;
 my $save_db = 1;
-my $asan = 0;
+my $asan = '';
 my $nocolour = '';
 my $count_tests = 0;
 my $run_failing = 0;
@@ -75,7 +75,7 @@ for(@ARGV){
   if(/^-h|--help$/) {
     print("Usage: runtests.pl [OPTION]\n");
     print("\nOptions are:\n");
-    print("  -asan         Skip all python tests.\n");
+    print("  -asan         Run a subset of tests, intended for use with AddressSanitizer (asan).\n");
     print("  -b            Rebase tests in parallel. Use in conjuction with -file=/path/to/file.\n");
     print("  -counttests   Don't run the test; only count them.\n");
     print("  -failing      Run failing tests instead of working.\n");
@@ -90,7 +90,7 @@ for(@ARGV){
     exit 1;
   }
   if(/^-asan$/) {
-    $asan = 1;
+    $asan = '-asan';
   }
   elsif(/^-b$/) {
     $rebase_test = "-b";
@@ -218,11 +218,7 @@ sub add_tests {
   my @tests = split(/\s|=|\\/, shift);
   my $path = shift;
 
-  if ($asan) {
-    @tests = grep(/\.lua|\.xml/, @tests);
-  } else {
-    @tests = grep(/\.lua|\.py|\.xml/, @tests);
-  }
+  @tests = grep(/\.lua|\.py|\.xml/, @tests);
   @tests = map { $_ = ("$path/$_" =~ s/\/\//\//rg) } @tests;
 
   push @test_list, @tests;
@@ -235,7 +231,7 @@ sub run_tests {
     (my $test_dir, my $test) = $test_full =~ /(.*)\/([^\/]*)$/;
 
     my $t0 = [gettimeofday];
-    my $cmd = "$testscript $test_full $have_dwdiff $nocolour $with_xml_cmd $rebase_test $platform";
+    my $cmd = "$testscript $test_full $have_dwdiff $nocolour $with_xml_cmd $rebase_test $platform $asan";
     my $x = system("$cmd") >> 8;
     my $elapsed = tv_interval ( $t0, [gettimeofday]);
 

--- a/testsuite/rtest
+++ b/testsuite/rtest
@@ -68,6 +68,7 @@ $successes=0;
 $total=0;
 $setbaseline=0;
 $verbose="yes";
+$ASAN="no";
 $returnwitherror=0;
 $pager="cat";
 $diffcmd="diff -U 5 -w";
@@ -353,7 +354,8 @@ sub dofile
         "ucrt64"  => "",
         "mingw32" => "",
         "mingw64" => "",
-        "mac"     => "");
+        "mac"     => "",
+        "asan"    => "");
     $expected = $expectedPrefix . "tmp_expected-" . $f;
     $got = $gotPrefix . "_tmp_got-" . $f;
     $log = "$tmpdir/log-$f";
@@ -449,16 +451,24 @@ sub dofile
       return 1;
     }
 
-    if ($info{$TEST_PLATFORM} eq "yes") {
+    $skip = 0;
+    if ($ASAN eq "yes" && $info{'asan'} ne "yes") {
+      $skip = 1;
+    }
+    if ($info{$TEST_PLATFORM} ne "yes") {
+      $skip = 1;
+    }
+
+    if ($skip) {
+      $status = 0;
+      print "skipped\n";
+    } else {
       if ($setbaseline) {
         setbaselineone $f,%info;
         $status = 0;
       } else {
         $status = runone $f,%info;
       }
-    } else {
-      $status = 0;
-      print "skipped\n";
     }
 
     if ($status == 0) {
@@ -495,6 +505,8 @@ while ($#ARGV >= 0) {
       } else {
         $TEST_PLATFORM="linux32";
       }
+    } elsif ($arg eq "-asan") {
+      $ASAN="yes";
     } elsif ($arg eq "-b") {
       $setbaseline = 1;
     } elsif ($arg eq "-c") {


### PR DESCRIPTION
As mentioned in #917, disabling ASan entirely is not ideal. However, running the full test suite with ASan enabled takes too many resources. This pull request adds a new `asan` option to the test case header, allowing us to specify specific tests to run with ASan, rather than enabling it across the entire suite.

Example usage:

```plaintext
-- status: correct
-- teardown_command: rm -rf addExternalResources1_lua/
-- linux: yes
-- ucrt64: yes
-- win: yes
-- mac: no
-- asan: yes
```

This change helps us identify memory issues without the overhead of testing the entire suite with ASan.