### PR TITLE
Try to fix runtest.pl

### DIFF
--- a/testsuite/partest/runtest.pl
+++ b/testsuite/partest/runtest.pl
@@ -360,7 +360,9 @@ exit_sandbox() if $sandbox_needed;
 if ($exit_status == 0) {
   exit 0;
 } else {
-  if ($time < 1) {
+  if ($time eq "") {
+    exit 1;
+  } elsif ($time < 1) {
     exit 1;
   } elsif ($time > 100) {
     exit 100;


### PR DESCRIPTION
This pull request addresses an issue in runtest.pl where $time is sometimes assigned an empty string, leading to the following error:

```
[QuarterCarModel.DisplacementDisplacement.lua:]Argument "" isn't numeric in numeric lt (<) at runtest.pl line 363
```

I am unsure why $time is empty in this context. @perost Could you provide insights or suggestions to fix this properly?