### PR TITLE
upgrade ssp schema's to 2.0 and export as ssp 2.0

### DIFF
--- a/schema/ssp/SystemStructureCommon.xsd
+++ b/schema/ssp/SystemStructureCommon.xsd
@@ -5,11 +5,11 @@
     <xs:annotation>
         <xs:documentation xml:lang="en">
             This is the normative XML Schema 1.0 schema for the MAP SSP
-            SystemStructure 1.0 common content across formats.
+            SystemStructure 2.0 common content across formats.
             
-            Version: 1.0
+            Version: 2.0
 
-            Copyright 2016 -- 2019 Modelica Association Project "SSP"
+            Copyright 2016 -- 2024 Modelica Association Project "SSP"
 
             Redistribution and use in source and binary forms, with or
             without modification, are permitted provided that the
@@ -116,6 +116,13 @@
         </xs:attribute>
     </xs:attributeGroup>
     
+    <xs:simpleType name="TGenericInteger">
+        <xs:restriction base="xs:integer">
+            <xs:maxInclusive value="18446744073709551615"/>
+            <xs:minInclusive value="-9223372036854775808"/>
+        </xs:restriction>
+    </xs:simpleType>
+    
     <xs:complexType name="TEnumerations">
         <xs:sequence>
             <xs:element name="Enumeration" minOccurs="1" maxOccurs="unbounded" type="ssc:TEnumeration"/>
@@ -221,7 +228,7 @@
     <xs:complexType name="TAnnotations">
         <xs:sequence maxOccurs="unbounded">
             <xs:element name="Annotation">
-                <xs:complexType>
+                <xs:complexType mixed="true">
                     <xs:sequence>
                         <xs:any namespace="##any" processContents="lax" minOccurs="0"/>
                     </xs:sequence>
@@ -248,6 +255,197 @@
         </xs:sequence>
     </xs:complexType>
     
+    <xs:group name="GMetaData">
+        <xs:sequence>
+            <xs:element name="MetaData" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">
+                        This element can specify additional meta data for the given resource. Multiple
+                        (or no) MetaData elements may be present.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="Content" type="ssc:ContentType" minOccurs="0" maxOccurs="1">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">
+                                    This optional element can contain inlined content of the resource meta data. If it
+                                    is present, then the attribute source of the MetaData element must not be present.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:element>
+                        <xs:group ref="ssc:GSignature">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">
+                                    This element can contain digital signature information on the meta data referenced
+                                    by the enclosing MetaData element. It is left unspecified what types of signatures
+                                    are used and/or available for now.  Multiple or no signature elements may be present.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:group>
+                    </xs:sequence>
+                    <xs:attribute name="kind" use="required">
+                        <xs:annotation>
+                            <xs:documentation xml:lang="en">
+                                This attribute indicates the kind of resource meta data that is referenced, i.e.
+                                what role it plays in relation to the resource being described.
+                            </xs:documentation>
+                        </xs:annotation>
+                        <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                                <xs:enumeration value="general"/>
+                                <xs:enumeration value="quality"/>
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:attribute>
+                    <xs:attribute name="type" type="xs:string" use="required">
+                        <xs:annotation>
+                            <xs:documentation xml:lang="en">
+                                This mandatory attribute specifies the MIME type of the resource meta data, which
+                                does not have a default value.  If no specific MIME type can be indicated, then
+                                the type application/octet-stream is to be used.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="source" type="xs:anyURI" use="optional">
+                        <xs:annotation>
+                            <xs:documentation xml:lang="en">
+                                This attribute indicates the source of the resource meta data as a
+                                URI (cf. RFC 3986).  The base URI for the resolution of relative URIs
+                                is determined by the sourceBase attribute.
+
+                                If the source attribute is missing, the meta data is provided inline
+                                as contents of a Content element, which must not be present otherwise.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="sourceBase" use="optional" default="file">
+                        <xs:annotation>
+                            <xs:documentation xml:lang="en">
+                                Defines the base the source URI is resolved against:  If the attribute
+                                is missing or is specified as file, the source is resolved against the
+                                URI of the containing file.  If the containing model element has a
+                                source attribute, the sourceBase attribute can be specified as resource.
+                                In this case the URI is resolved against the (resolved) source URI of
+                                the containing model element.
+
+                                The last option allows the specification of meta data sources that
+                                reside inside a resource (for example an FMU) through relative URIs.
+                            </xs:documentation>
+                        </xs:annotation>
+                        <xs:simpleType>
+                            <xs:restriction base="xs:string">
+                                <xs:enumeration value="file"/>
+                                <xs:enumeration value="resource"/>
+                            </xs:restriction>
+                        </xs:simpleType>
+                    </xs:attribute>
+                    <xs:attributeGroup ref="ssc:ABaseElement"/>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+    </xs:group>
+
+    <xs:group name="GSignature">
+        <xs:sequence>
+            <xs:element name="Signature" type="ssc:SignatureType" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">
+                        This element can contain digital signature information on the data referenced
+                        by the enclosing element. It is left unspecified what types of signatures
+                        are used and/or available for now.  Multiple or no signature elements may be present.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+    </xs:group>
+    
+    <xs:complexType name="SignatureType">
+        <xs:sequence>
+            <xs:element name="Content" type="ssc:ContentType" minOccurs="0" maxOccurs="1"/>
+        </xs:sequence>
+        <xs:attribute name="role" use="required">
+            <xs:annotation>
+                <xs:documentation xml:lang="en">
+                    This mandatory attribute specifies the role this signature has in the overall
+                    process. It indicates whether the digital signature is intended to just convey
+                    the authenticity of the information, or whether a claim for suitability of
+                    the information for certain purposes is made.  In the later case, the digital
+                    signature format should include detailed information about what suitability
+                    claims are being made.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:enumeration value="authenticity"/>
+                    <xs:enumeration value="suitability"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="type" type="xs:string" use="required">
+            <xs:annotation>
+                <xs:documentation xml:lang="en">
+                    This mandatory attribute specifies the MIME type of the resource signature, which
+                    does not have a default value.  If no specific MIME type can be indicated, then
+                    the type application/octet-stream is to be used.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="source" type="xs:anyURI" use="optional">
+            <xs:annotation>
+                <xs:documentation xml:lang="en">
+                    This attribute indicates the source of the digital signature as a
+                    URI (cf. RFC 3986).  The base URI for the resolution of relative URIs
+                    is determined by the sourceBase attribute.
+
+                    If the source attribute is missing, the signature must be provided
+                    inline as contents of a Content element, which must not be present
+                    otherwise.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+        <xs:attribute name="sourceBase" use="optional" default="file">
+            <xs:annotation>
+                <xs:documentation xml:lang="en">
+                    Defines the base the source URI is resolved against:  If the attribute
+                    is missing or is specified as file, the source is resolved against the
+                    URI of the containing file.  If the containing model element has a
+                    source attribute, the sourceBase attribute can be specified as resource.
+                    In this case the URI is resolved against the (resolved) source URI of
+                    the containing model element.  If the Signature element is contained
+                    within a MetaData element, the sourceBase attribute can be specified as
+                    metaData.  In this case the URI is resolved against the (resolved) URI
+                    of the meta data source.
+
+                    The last two options allow the specification of signature sources that
+                    reside inside a resource (for example an FMU), or the meta data
+                    through relative URIs.
+                </xs:documentation>
+            </xs:annotation>
+            <xs:simpleType>
+                <xs:restriction base="xs:string">
+                    <xs:enumeration value="file"/>
+                    <xs:enumeration value="resource"/>
+                    <xs:enumeration value="metaData"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attributeGroup ref="ssc:ABaseElement"/>
+    </xs:complexType>
+
+    <xs:complexType name="ContentType" mixed="true">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                This optional element can contain inlined content of an entity. If it is present,
+                then the attribute source of the enclosing element must not be present.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:choice>
+            <xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+        </xs:choice>
+        <xs:attributeGroup ref="ssc:ABaseElement"/>
+    </xs:complexType>
+
     <xs:group name="GTypeChoice">
         <xs:choice>
             <xs:annotation>
@@ -276,7 +474,79 @@
                     </xs:attribute>
                 </xs:complexType>
             </xs:element>
+            <xs:element name="Float64">
+                <xs:complexType>
+                    <xs:attribute name="unit" type="xs:string" use="optional">
+                        <xs:annotation>
+                            <xs:documentation xml:lang="en">
+                                This attribute gives the unit of the entity and must
+                                reference one of the unit definitions provided in the Units
+                                element of the containing file.
+                                
+                                If a unit is not supplied, the unit is determined through
+                                default mechanisms: For FMU components, the unit of the
+                                underlying variable would be used, for systems the units
+                                of connected underlying connectors could be used if unambiguous.
+                                If a unit cannot be deduced unambinguously, the user should
+                                be informed of this error.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="Float32">
+                <xs:complexType>
+                    <xs:attribute name="unit" type="xs:string" use="optional">
+                        <xs:annotation>
+                            <xs:documentation xml:lang="en">
+                                This attribute gives the unit of the entity and must
+                                reference one of the unit definitions provided in the Units
+                                element of the containing file.
+                                
+                                If a unit is not supplied, the unit is determined through
+                                default mechanisms: For FMU components, the unit of the
+                                underlying variable would be used, for systems the units
+                                of connected underlying connectors could be used if unambiguous.
+                                If a unit cannot be deduced unambinguously, the user should
+                                be informed of this error.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
             <xs:element name="Integer">
+                <xs:complexType>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="Int8">
+                <xs:complexType>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="UInt8">
+                <xs:complexType>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="Int16">
+                <xs:complexType>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="UInt16">
+                <xs:complexType>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="Int32">
+                <xs:complexType>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="UInt32">
+                <xs:complexType>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="Int64">
+                <xs:complexType>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="UInt64">
                 <xs:complexType>
                 </xs:complexType>
             </xs:element>
@@ -319,6 +589,29 @@
                             </xs:documentation>
                         </xs:annotation>
                     </xs:attribute>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="Clock">
+                <xs:complexType>
+                  <xs:attribute name="intervalVariability" use="optional">
+                    <xs:simpleType>
+                      <xs:restriction base="xs:normalizedString">
+                        <xs:enumeration value="constant"/>
+                        <xs:enumeration value="fixed"/>
+                        <xs:enumeration value="tunable"/>
+                        <xs:enumeration value="changing"/>
+                        <xs:enumeration value="countdown"/>
+                        <xs:enumeration value="triggered"/>
+                      </xs:restriction>
+                    </xs:simpleType>
+                  </xs:attribute>
+                  <xs:attribute name="intervalDecimal" type="xs:double" use="optional"/>
+                  <xs:attribute name="shiftDecimal" type="xs:double" default="0"/>
+                  <xs:attribute name="supportsFraction" type="xs:boolean" default="false"/>
+                  <xs:attribute name="resolution" type="xs:unsignedLong" use="optional"/>
+                  <xs:attribute name="intervalCounter" type="xs:unsignedLong" use="optional"/>
+                  <xs:attribute name="shiftCounter" type="xs:unsignedLong" default="0"/>
+                  <xs:attribute name="priority" type="xs:unsignedInt" use="optional"/>
                 </xs:complexType>
             </xs:element>
         </xs:choice>
@@ -408,8 +701,8 @@
                 <xs:annotation>
                     <xs:documentation xml:lang="en">
                         This element provides for a transformation of integer parameter values
-                        based on a mapping table and is valid for parameters of integer and 
-                        enumeration type.  Each mapping table entry is provided by a MapEntry
+                        based on a mapping table and is valid for parameters of all integer and 
+                        enumeration types.  Each mapping table entry is provided by a MapEntry
                         element.
                     </xs:documentation>
                 </xs:annotation>
@@ -417,7 +710,7 @@
                     <xs:sequence>
                         <xs:element name="MapEntry" minOccurs="1" maxOccurs="unbounded">
                             <xs:complexType>
-                                <xs:attribute name="source" type="xs:int" use="required">
+                                <xs:attribute name="source" type="ssc:TGenericInteger" use="required">
                                     <xs:annotation>
                                         <xs:documentation xml:lang="en">
                                             This attribute gives the value of the parameter in the
@@ -425,7 +718,7 @@
                                         </xs:documentation>
                                     </xs:annotation>
                                 </xs:attribute>
-                                <xs:attribute name="target" type="xs:int" use="required">
+                                <xs:attribute name="target" type="ssc:TGenericInteger" use="required">
                                     <xs:annotation>
                                         <xs:documentation xml:lang="en">
                                             This attribute gives the value of the parameter to use
@@ -475,6 +768,50 @@
                 </xs:complexType>
             </xs:element>
         </xs:choice>
+    </xs:group>
+    
+    <xs:group name="GDimensions">
+        <xs:sequence>
+            <xs:element name="Dimension" minOccurs="0" maxOccurs="unbounded">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">
+                        This optional element specifies one dimension of an array connector.
+                        If no dimension elements are present in a connector, it is a scalar
+                        connector. The number of dimension elements in a connector provides
+                        the dimensionality of the array.
+                        
+                        Either the size or the sizeConnector attributes CAN be present
+                        on the element, indicating a fixed size, or a size that depends on
+                        the structural parameter or constant referenced by the sizeConnector
+                        attribute.
+                        
+                        If none of the attributes are present, then the size of the dimension
+                        is unspecified at the SSD level. If both attributes are present this
+                        is considered an error.
+                    </xs:documentation>
+                </xs:annotation>
+                <xs:complexType>
+                    <xs:attribute name="size" type="xs:unsignedLong" use="optional">
+                        <xs:annotation>
+                            <xs:documentation xml:lang="en">
+                                This attribute gives the size of this dimension of the
+                                connector as a fixed, unchangeable number.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                    <xs:attribute name="sizeConnector" type="xs:string" use="optional">
+                        <xs:annotation>
+                            <xs:documentation xml:lang="en">
+                                This attribute references another connector by name, that
+                                gives the size of this dimension of the connector, e.g. a
+                                structural parameter or a constant of the underlying
+                                component that gives the dimension size.
+                            </xs:documentation>
+                        </xs:annotation>
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
     </xs:group>
     
 </xs:schema>

--- a/schema/ssp/SystemStructureDescription.xsd
+++ b/schema/ssp/SystemStructureDescription.xsd
@@ -2,16 +2,15 @@
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified"
     xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription"
     xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
-    targetNamespace="http://ssp-standard.org/SSP1/SystemStructureDescription"
-    attributeFormDefault="unqualified">
+    targetNamespace="http://ssp-standard.org/SSP1/SystemStructureDescription">
     <xs:annotation>
         <xs:documentation xml:lang="en">
             This is the normative XML Schema 1.0 schema for the MAP SSP
-            SystemStructureDescription 1.0 format.
+            SystemStructureDescription 2.0 format.
+            
+            Version: 2.0
 
-            Version: 1.0
-
-            Copyright 2016 -- 2019 Modelica Association Project "SSP"
+            Copyright 2016 -- 2024 Modelica Association Project "SSP"
 
             Redistribution and use in source and binary forms, with or
             without modification, are permitted provided that the
@@ -42,9 +41,9 @@
             POSSIBILITY OF SUCH DAMAGE.
         </xs:documentation>
     </xs:annotation>
-
+    
     <xs:import namespace="http://ssp-standard.org/SSP1/SystemStructureCommon" schemaLocation="SystemStructureCommon.xsd"/>
-
+    
     <xs:element name="SystemStructureDescription">
         <xs:complexType>
             <xs:sequence>
@@ -52,17 +51,20 @@
                 <xs:element name="Enumerations" minOccurs="0" type="ssc:TEnumerations"/>
                 <xs:element name="Units" minOccurs="0" type="ssc:TUnits"/>
                 <xs:element name="DefaultExperiment" minOccurs="0" type="ssd:TDefaultExperiment"/>
+                <xs:group ref="ssc:GMetaData"/>
+                <xs:group ref="ssc:GSignature"/>
                 <xs:element name="Annotations" minOccurs="0" type="ssc:TAnnotations"/>
             </xs:sequence>
             <xs:attribute name="version" use="required">
                 <xs:annotation>
                     <xs:documentation xml:lang="en">
-                        Version of SSD format, 1.0 for this release.
+                        Version of SSD format, 1.0 or 2.0 for this release.
                     </xs:documentation>
                 </xs:annotation>
                 <xs:simpleType>
                     <xs:restriction base="xs:normalizedString">
-                        <xs:pattern value="1[.][0-9]+(-.*)?"/>
+                        <xs:pattern value="1[.]0"/>
+                        <xs:pattern value="2[.]0"/>
                     </xs:restriction>
                 </xs:simpleType>
             </xs:attribute>
@@ -79,7 +81,7 @@
             <xs:attributeGroup ref="ssc:ATopLevelMetaData"/>
         </xs:complexType>
     </xs:element>
-
+        
     <xs:complexType name="TElement">
         <xs:annotation>
             <xs:documentation xml:lang="en">
@@ -92,11 +94,11 @@
                     <xs:documentation xml:lang="en">
                         The set of connectors of this element, which represent
                         the interface of the element to the outside world.
-
+ 
                         For components the set of connectors must match variable/ports
                         of the underlying component implementation, e.g. the referenced
                         FMU, by name.
-
+ 
                         Note that there is no requirement that connectors must
                         be present for all variables/ports of an underlying
                         component implementation.  Only those connectors must
@@ -115,7 +117,7 @@
                         The optional attribute rotation (in degrees) defines an additional rotation
                         (applied after flipping), where positive numbers indicate left rotation (x->y).
                         The coordinate system is oriented: x -> right, y -> up.
-
+                        
                         The optional attribute iconSource defines an icon URI with the same semantics as
                         for the source attribute of the Component element.  If defined, this icon overrides
                         any icon that may be defined e.g. in an .fmu file (as disccused in the FMI group).
@@ -145,6 +147,8 @@
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
+            <xs:group ref="ssc:GMetaData"/>
+            <xs:group ref="ssc:GSignature"/>
         </xs:sequence>
         <xs:attributeGroup ref="ssc:ABaseElement"/>
         <xs:attribute name="name" use="required">
@@ -162,7 +166,7 @@
             </xs:simpleType>
         </xs:attribute>
     </xs:complexType>
-
+    
     <xs:complexType name="TComponent">
         <xs:complexContent>
             <xs:extension base="ssd:TElement">
@@ -180,36 +184,36 @@
                         </xs:documentation>
                     </xs:annotation>
                 </xs:attribute>
-                <xs:attribute name="source" type="xs:anyURI" use="required">
+                <xs:attribute name="source" type="xs:anyURI" use="optional">
                     <xs:annotation>
                         <xs:documentation xml:lang="en">
-                            This attribute indicates the source of the component as an URI
-                            (cf. RFC 3986).  For purposes of the resolution of relative URIs
+                            Optional attribute indicating the source of the component as a URI
+                            (cf. RFC 3986). For purposes of the resolution of relative URIs
                             the base URI is the URI of the SSD.  Therefore for components
                             that are located alongside the SSD, relative URIs without scheme
                             and authority can and should be used to specify the component
                             sources.  For components that are packaged inside an SSP that
                             contains this SSD, this is mandatory (in this way, the SSD URIs
                             remain valid after unpacking the SSP into the filesystem).
-
+                            
                             E.g. for an FMU called MyDemoFMU.fmu, that is located in the
                             resources directory of an SSP, the correct URI would be
                             "resources/MyDemoFMU.fmu".
-
+                            
                             When referencing another SSP, by default the default SSD of the
                             SSP (i.e. SystemStructure.ssd) is referenced.  When a non-default
-                            SSD should be selected, then the name of the non-default SSD must
-                            be given through a fragment identifier, i.e. the URI
+                            SSD should be selected, then the name of the non-default SSD must 
+                            be given through a fragment identifier, i.e. the URI 
                             "resources/SubSSP.ssp#VariantB.ssd" would reference the VariantB.ssd
                             of SubSSP.ssp located in the resources directory relative to this SSD.
-
+                            
                             When the URI is a same-document URI with a fragment identifier, e.g.
                             "#other-system", then the fragment identifier should identify a
                             system element in this SSD document with an id attribute identical
                             to the fragment identifier.  This mechanism can be used to instantiate
                             an embedded system definition multiple times through reference to
                             its definition element.
-
+                            
                             Note that implementations are only required to support relative URIs
                             as specified above, and that especially relative URIs that move beyond
                             the baseURI (e.g. go "up" a level via ..) are not required to be
@@ -217,6 +221,19 @@
                             security or other reasons.  Implementations are also not required to
                             support any absolute URIs and any specific URI schemes (but are of
                             course allowed to support any and all kinds of URIs where useful).
+
+                            If the source attribute is missing, this indicates that there is no
+                            provided source for the component, indicating a simulation
+                            architecture design without complete executable implementation.
+                            Implementations *CAN* take any specified type attribute into account
+                            when handling such components. In any other regard implementations
+                            *CAN* treat such components as equivalent to an empty system with the
+                            same connectors and other properties as specified for the component.
+
+                            Note that not specifying a source attribute is not the same as
+                            specifying a source attribute with an emtpy string value, as that
+                            is considered a valid relative URI. Implementations *MUST NOT*
+                            specify an empty relative URI to indicate a missing implementation.
                         </xs:documentation>
                     </xs:annotation>
                 </xs:attribute>
@@ -228,9 +245,10 @@
                             attribute can be used to determine which FMU implementation should be
                             employed.  If the attribute is missing or uses the default value "any",
                             the importing tool is free to choose what kind of FMU implementation
-                            to use.  If the value is "CoSimulation" or "ModelExchange" the corresponding
-                            FMU implementation must be used.  It is an error if the specified type
-                            of FMU implementation is not present in the FMU.
+                            to use.  If the value is "CoSimulation", "ModelExchange", or
+                            "ScheduledExecution", the corresponding FMU implementation must be used.
+                            It is an error if the specified type of FMU implementation is not present
+                            in the FMU.
                         </xs:documentation>
                     </xs:annotation>
                     <xs:simpleType>
@@ -238,6 +256,7 @@
                             <xs:enumeration value="any"/>
                             <xs:enumeration value="ModelExchange"/>
                             <xs:enumeration value="CoSimulation"/>
+                            <xs:enumeration value="ScheduledExecution"/>
                         </xs:restriction>
                     </xs:simpleType>
                 </xs:attribute>
@@ -252,35 +271,52 @@
                     <xs:documentation xml:lang="en">
                         This element defines a signal dictionary, describing the signal dictionary
                         entries present in the signal dictionary.
-
+                        
                         The contents of the element can be used to provide a signal dictionary
                         inline, in which case the source attribute of the SignalDictionary element
                         must be empty.
-
+                        
                         The contents must be an ssb:SignalDictionary element, if the type attribute
-                        of this element is application/x-ssp-signal-dictionary, or any other valid
+                        of this element is application/x-ssp-signal-dictionary, or any other valid 
                         XML content if the type attribute references another MIME type (in that case
                         there should be a layered specification that defines how embedding the content
                         works for that MIME type).
                     </xs:documentation>
                 </xs:annotation>
                 <xs:complexType>
-                    <xs:choice>
-                        <!-- NOTE: In XML Schema 1.1 this choice would also contain the following entry:
+                    <xs:sequence>
+                        <xs:choice>
+                            <!-- NOTE: In XML Schema 1.1 this choice would also contain the following entry:
 
-                             <xs:element ref="ssb:SignalDictionary"/>
+                                 <xs:element ref="ssb:SignalDictionary"/>
 
-                             which specifies the proper way to directly embed a SignalDictionary inline.
+                                 which specifies the proper way to directly embed a SignalDictionary inline.
+                                 Due to restrictions in XML Schema 1.0, this would lead to a violation of the
+                                 unique particle attribution schema component constraint, since the embedded
+                                 ssb:SignalDictionary element would also be matched by the more generic xs:any
+                                 specification.  Since XML Schema 1.1 validators are still rare compared with
+                                 1.0 validators, the default schema files for SSP are still restricted to 1.0;
+                                 however if you have access to a 1.1 validator/validating parser, you can
+                                 use the 1.1 variant of these stylesheets instead.
+                            -->
+                            <xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+                        </xs:choice>
+                        <!-- NOTE: In XML Schema 1.1 this sequence would also contain the following entries:
+
+                             <xs:group ref="ssc:GMetaData"/>
+                             <xs:group ref="ssc:GSignature"/>
+
+                             which specifies the proper way to add meta data and signatures.
+
                              Due to restrictions in XML Schema 1.0, this would lead to a violation of the
-                             unique particle attribution schema component constraint, since the embedded
-                             ssb:SignalDictionary element would also be matched by the more generic xs:any
-                             specification.  Since XML Schema 1.1 validators are still rare compared with
-                             1.0 validators, the default schema files for SSP are still restricted to 1.0;
-                             however if you have access to a 1.1 validator/validating parser, you can
-                             use the 1.1 variant of these stylesheets instead.
+                             unique particle attribution schema component constraint, since the MetaData
+                             element would also be matched by the more generic xs:any specification.
+                             Since XML Schema 1.1 validators are still rare compared with 1.0 validators,
+                             the default schema files for SSP are still restricted to 1.0; however if you
+                             have access to a 1.1 validator/validating parser, you can use the 1.1 variant
+                             of these stylesheets instead.
                         -->
-                        <xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-                    </xs:choice>
+                    </xs:sequence>
                     <xs:attributeGroup ref="ssc:ABaseElement"/>
                     <xs:attribute name="type" type="xs:string" use="optional" default="application/x-ssp-signal-dictionary"/>
                     <xs:attribute name="source" type="xs:anyURI" use="optional">
@@ -289,13 +325,13 @@
                                 This attribute indicates the source of the signal dictionary as a URI
                                 (cf. RFC 3986).  For purposes of the resolution of relative URIs
                                 the base URI is the URI of the SSD.
-
+                                
                                 If the source attribute is missing, the signal dictionary is provided
                                 inline as contents of the SignalDictionary element, which must be
                                 empty otherwise.
-
+                                
                                 For the default type application/x-ssp-signal-dictionary such inline
-                                content must be an ssb:SignalDictionary element.
+                                content must be an ssb:SignalDictionary element. 
                             </xs:documentation>
                         </xs:annotation>
                     </xs:attribute>
@@ -318,7 +354,7 @@
             </xs:element>
         </xs:sequence>
     </xs:complexType>
-
+    
     <xs:complexType name="TSignalDictionaryReference">
         <xs:complexContent>
             <xs:extension base="ssd:TElement">
@@ -329,7 +365,7 @@
                     <xs:annotation>
                         <xs:documentation xml:lang="en">
                             This attribute gives the name of the signal dictionary that is to
-                            be referenced.  Name lookups occur in hierarchical fashion, i.e.
+                            be referenced.  Name lookups occur in hierarchical fashion, i.e. 
                             the name is first looked up in the system that contains a signal
                             dictionary reference.  If that lookup yields no match, the lookup
                             is performed on the enclosing system, etc., until a match is found.
@@ -340,7 +376,7 @@
             </xs:extension>
         </xs:complexContent>
     </xs:complexType>
-
+    
     <xs:complexType name="TSystem">
         <xs:annotation>
             <xs:documentation xml:lang="en">
@@ -374,14 +410,14 @@
                                             Note that connections between connectors on a system are
                                             allowed, so neither startElement nor endElement has to be
                                             supplied.
-
+                                            
                                             Note also that the terms start and end in the attribute names
                                             of the connector, like startElement or endConnector, do not
                                             denote directionality of the data flow implied by the connector.
                                             That is determined by the combination of the semantics of the
                                             actual connectors (variables/ports) connected and their kind
                                             attributes:
-
+                                            
                                             For component to component connections as well as for connections
                                             between two connectors at the system level, currently the kind of
                                             one connector must be output and of another connector must be
@@ -389,7 +425,7 @@
                                             must be calculatedParameter and the other must be parameter.
                                             Information flows from the output/calculatedParameter to the
                                             input/parameter connector.
-
+                                            
                                             For system to component connections the kinds of the connectors
                                             must match, i.e. either both are input or both output or both
                                             parameter or both calculatedParameter.
@@ -413,10 +449,10 @@
                                                         through the coordinates of the corresponding connectors.  The only relevant
                                                         geometry information provided by the connection geometry is a, by default
                                                         empty, list of intermediate waypoint coordinates, which are to be interpreted
-                                                        as for the svg:polyline primitive, i.e. as waypoints for straight line
+                                                        as for the svg:polyline primitive, i.e. as waypoints for straight line 
                                                         segments, with the first and last points added automatically based on the
                                                         translated coordinates of the start and end connectors.
-
+                                                        
                                                         Note that x and y coordinates are in the coordinate system of the
                                                         enclosing system.
                                                     </xs:documentation>
@@ -458,6 +494,19 @@
                                                 </xs:documentation>
                                             </xs:annotation>
                                         </xs:attribute>
+                                        <xs:attribute name="startIndices" use="optional">
+                                            <xs:annotation>
+                                                <xs:documentation xml:lang="en">
+                                                    This optional attribute gives the list of indices of an
+                                                    array connector that this connection is restricted to.
+                                                    If not supplied this indicates that this connection
+                                                    applies to the whole connector, not just a single element.
+                                                </xs:documentation>
+                                            </xs:annotation>
+                                            <xs:simpleType>
+                                                <xs:list itemType="xs:unsignedLong"/>
+                                            </xs:simpleType>
+                                        </xs:attribute>
                                         <xs:attribute name="endElement" type="xs:string" use="optional">
                                             <xs:annotation>
                                                 <xs:documentation xml:lang="en">
@@ -479,6 +528,19 @@
                                                 </xs:documentation>
                                             </xs:annotation>
                                         </xs:attribute>
+                                        <xs:attribute name="endIndices" use="optional">
+                                            <xs:annotation>
+                                                <xs:documentation xml:lang="en">
+                                                    This optional attribute gives the list of indices of an
+                                                    array connector that this connection is restricted to.
+                                                    If not supplied this indicates that this connection
+                                                    applies to the whole connector, not just a single element.
+                                                </xs:documentation>
+                                            </xs:annotation>
+                                            <xs:simpleType>
+                                                <xs:list itemType="xs:unsignedLong"/>
+                                            </xs:simpleType>
+                                        </xs:attribute>
                                         <xs:attribute name="suppressUnitConversion" type="xs:boolean" use="optional" default="false">
                                             <xs:annotation>
                                                 <xs:documentation xml:lang="en">
@@ -487,7 +549,7 @@
                                                     available for both start and end definitions.  If this attribute is
                                                     supplied and its value is true, then the environment will not perform
                                                     any automatic unit conversions, otherwise automatic unit
-                                                    conversions can be performed.  This is also useful in conjunction with
+                                                    conversions can be performed.  This is also useful in conjunction with 
                                                     the optional linear transformation supplied via the LinearTransformation
                                                     element: With suppressUnitConversion = true, the linear transformation
                                                     is performed instead of any unit conversions, whereas otherwise the
@@ -504,22 +566,22 @@
                     <xs:element name="SystemGeometry" minOccurs="0">
                         <xs:annotation>
                             <xs:documentation xml:lang="en">
-                                This optional element defines the extent of the system canvas.
-                                (x1,y1) and (x2,y2) define the lower-left and upper-right
+                                This optional element defines the extent of the system canvas. 
+                                (x1,y1) and (x2,y2) define the lower-left and upper-right 
                                 corner, respectively.
 
                                 Different from ElementGeometry, where x1>x2 and y1>y2 indicate
                                 flipping, x1 &lt; x2 and y1 &lt; y2 must hold here.
-
+                                
                                 If undefined, the system canvas extent defaults to the bounding
                                 box of all ElementGeometry elements of the child elements of the
                                 system.
-
+                                
                                 When displaying the content of a sub-system together with the
                                 enclosing parent system, the transformation of co-coordinates
                                 inside the sub-system to co-ordinates in the parent system is defined
-                                by the transformation from SystemGeometry.{x1,y1,x2,y2} to
-                                ElementGeometry.{x1', y1', x2', y2'}, where ElementGeometry.z'
+                                by the transformation from SystemGeometry.{x1,y1,x2,y2} to 
+                                ElementGeometry.{x1', y1', x2', y2'}, where ElementGeometry.z' 
                                 is the respective coordinate of the sub-system when instantiated
                                 in the parent system after rotation.
                             </xs:documentation>
@@ -538,7 +600,7 @@
                                 that are contained in the system, e.g. things like notes, which have no
                                 semantic impact on the system but aid in presentation of the system in
                                 graphical user interfaces.
-
+                                
                                 Currently the only graphical element defined is the Note element, which
                                 allows for simple textual notes to be placed into the system diagram, but
                                 in the future more elements might be added as needed for exchange of
@@ -555,7 +617,7 @@
                                                 enclosing system.  It is sized using the attributes so that the coordinates
                                                 (x1,y1) and (x2,y2) define the positions of the lower-left and upper-right
                                                 corners of the note in the coordinate system of the parent.
-
+                                                
                                                 The note text is given by the text attribute.  The presentation expectation
                                                 is that the text is automatically sized ad wrapped in such a way that it
                                                 fits the note area.  If this would lead to too small text, it might be
@@ -591,7 +653,7 @@
                             <xs:annotation>
                                 <xs:documentation xml:lang="en">
                                     This element gives the type of the connector.
-
+                                    
                                     If a type is not supplied, the type is determined through
                                     default mechanisms: For FMU components, the type of the
                                     underlying variable would be used, for systems the types
@@ -603,38 +665,70 @@
                                 </xs:documentation>
                             </xs:annotation>
                         </xs:group>
+                        <xs:group ref="ssc:GDimensions">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">
+                                    This optional sequence of elements specifies the dimensions of an
+                                    array connector.  If no dimension elements are present in a
+                                    connector, it is a scalar connector. The number of dimension
+                                    elements in a connector providesthe dimensionality of the array.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:group>
+                        <xs:element name="Clock" minOccurs="0" maxOccurs="unbounded">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">
+                                    This element associates the connector to a clock of the
+                                    given name, which must be defined on the given element.
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:attribute name="name" type="xs:string" use="required"/>
+                            </xs:complexType>
+                        </xs:element>
                         <xs:element name="ConnectorGeometry" minOccurs="0">
                             <xs:annotation>
                                 <xs:documentation xml:lang="en">
                                     This optional element gives the geometry information of the connector.
-                                    Note that x and y coordinates are in a special coordinate system, where
-                                    0,0 is the lower-left corner of the component/system, and 1,1 is the
-                                    upper-right corner of the component, regardless of aspect ratio.
-
-                                    For systems the placement of connectors for the inside and outside
-                                    view of the system is identical, the special coordinate system is just
+                                    Note that x and y coordinates are in a normalized connector coordinate
+                                    system, where 0,0 is the lower-left corner of the component/system,
+                                    and 1,1 is the upper-right corner of the component, regardless of
+                                    aspect ratio.
+                                    
+                                    By default, the placement of connectors for a system's inside and
+                                    outside views is identical. The connector coordinate system is just
                                     translated to different actual coordinate systems, namely the one
-                                    determined by the ElementGeometry for the outside view, and the
-                                    one determined by SystemGeometry for the inside view.
+                                    determined by ElementGeometry for the outside view and the one
+                                    determined by SystemGeometry for the inside view.
+                                    
+                                    For systems, optionally, different placement of connectors for the
+                                    inside view of the system can be specified with the systemInnerX
+                                    and systemInnerY coordinates. This enables preserving the inside
+                                    system layout when integrating a system in a system structure and
+                                    avoiding unintended changes to the position of the connectors on
+                                    the inside view of the system when making layout changes on the
+                                    outside view and vice versa.
                                 </xs:documentation>
                             </xs:annotation>
                             <xs:complexType>
                                 <xs:attribute name="x" type="xs:double" use="required"/>
                                 <xs:attribute name="y" type="xs:double" use="required"/>
+                                <xs:attribute name="systemInnerX" type="xs:double" use="optional"/>
+                                <xs:attribute name="systemInnerY" type="xs:double" use="optional"/>
                             </xs:complexType>
                         </xs:element>
                         <xs:element name="Annotations" minOccurs="0" type="ssc:TAnnotations"/>
                     </xs:sequence>
                     <xs:attributeGroup ref="ssc:ABaseElement"/>
-                    <xs:attribute name="name" use="required">
+                    <xs:attribute name="name" type="xs:string" use="required">
                         <xs:annotation>
                             <xs:documentation xml:lang="en">
                                 This attribute gives the connector a name, which
                                 shall be unique within the component or system and,
-                                for components, must match the name of a relevant
+                                for components, must match the name of a relevant 
                                 variable/port in the underlying component implementation,
                                 e.g. the referenced FMU.
-
+                                
                                 Note that there is no requirement that connectors must
                                 be present for all variables/ports of an underlying
                                 component implementation.  Only those connectors must
@@ -646,31 +740,48 @@
                     <xs:attribute name="kind" use="required">
                         <xs:annotation>
                             <xs:documentation xml:lang="en">
-                                This attribute specifies the kind of the given connector,
-                                which indicates whether the connector is an input, an
-                                output, both (inout), a parameter or a calculated parameter (i.e.
-                                a parameter that is calculated by the component during initialization).
+                                This attribute specifies the kind of the given connector, which
+                                indicates whether the connector is an input, an output, both
+                                (inout), unspecified, a local variable, a constant, a parameter,
+                                a calculated parameter (i.e. a parameter that is calculated by the
+                                component during initialization), or a structural parameter (i.e.
+                                a parameter that can be set during (re-)configuration mode).
+                                
                                 For components this must match the related kind of the underlying
-                                component implementation, e.g. for referenced FMUs it must match the
-                                combination of variability and causality.
-
-                                For FMI 2.0 this means that the causality of the variable must
-                                match the kind of the connector.
-
+                                component implementation. For referenced FMUs it must match the
+                                combination of variability and causality:
+                                
+                                For FMI 2.0 and 3.0 this means that the causality of the variable
+                                must match the kind of the connector (with the kind inout not being
+                                valid for either FMI 3.0, 2.0, or 1.0).
+                                
                                 For FMI 1.0 this means that for connectors of kind input or output
                                 the causality of the variable must be input or output and the
                                 variability of the variable must be discrete or continuous (for
                                 outputs also constant and parameter are allowable).  For connectors
-                                of kind parameter the causality must be input or internal and the
-                                variablity must be parameter.  For connectors of kind
-                                calculatedParameter the causality must be output and the variablity
-                                must be parameter.
+                                of kind parameter the causality of the FMI 1.0 variable must be
+                                input or internal and the variability must be parameter.  For
+                                connectors of kind calculatedParameter the causality of the FMI 1.0
+                                variable must be output and the variability must be parameter. For
+                                connectors of kind constant the causality of the FMI 1.0 variable
+                                must be output and the variability must be constant.
 
+                                Connectors of kind `local` are used to define variables of the
+                                model element. Such a variable is not intended to be used for
+                                connections. However, if it is connected, the semantics are same as
+                                for an `output`.
+                                
                                 For SignalDictionaryReferences, the kind of a given connector can
                                 additionally be 'inout', which indicates that the semantics of the
                                 connector are derived from the connections going to the connector.
                                 This can be used for example to allow a connector to function as
-                                both an input and output within the same SignaleDictionaryReference.
+                                both an input and output within the same SignalDictionaryReference.
+
+                                Connectors of kind `unspecified` are used to define connectors for
+                                which the flow of information is either not yet specified, or is
+                                determined at runtime, for example for acausal connections of
+                                Modelica models. Such connectors can be connected to any other
+                                connector under the rules of the underlying modeling language.
                             </xs:documentation>
                         </xs:annotation>
                         <xs:simpleType>
@@ -679,7 +790,11 @@
                                 <xs:enumeration value="output"/>
                                 <xs:enumeration value="parameter"/>
                                 <xs:enumeration value="calculatedParameter"/>
+                                <xs:enumeration value="structuralParameter"/>
+                                <xs:enumeration value="constant"/>
+                                <xs:enumeration value="local"/>
                                 <xs:enumeration value="inout"/>
+                                <xs:enumeration value="unspecified"/>
                             </xs:restriction>
                         </xs:simpleType>
                     </xs:attribute>
@@ -699,11 +814,11 @@
                         provided in the parameter source must match the names of the FMU variables, or must be
                         mapped to the names of the FMU variables through a ParameterMapping element, or are
                         ignored if no matching variable is found.
-
+                        
                         For systems the names in the parameter source must either match the hierarchical names
                         of parameters or other variables in the system, or must be mapped to those names through
                         a ParameterMapping element, or are ignored if no matching variable is found.
-
+                        
                         The hierarchical names of the parameters or other variables of a system are formed in the
                         following way: Any variables of the system exposed through connectors of the system have
                         the name of the connector as their name.  For all elements of the system, the hierarchical
@@ -713,14 +828,14 @@
                         a parameter P2, the hierarchical names of the parameters in system A are B.SP1 and B.C.P2
                         respectively.  The hierarchical name of those parameters inside system B are SP1 and C.P2
                         respectively.
-
+                        
                         More than one ParameterBinding can be supplied, in which case all of the parameters found
                         will be used to parametrize the component, with parameter values in ParameterBinding
                         sources appearing at a succeeding position in the element order taking priority over prior
-                        sources at the same hierarchy level, should a parameter be included in more than one
+                        sources at the same hierarchy level, should a parameter be included in more than one 
                         ParameterBinding source.
-
-                        When ParameterBinding sources on multiple levels of the hierarchy supply values for the
+                        
+                        When ParameterBinding sources on multiple levels of the hierarchy supply values for the 
                         same parameter, bindings at a higher hierarchy level take precedence over lower levels,
                         i.e. bindings at a system level take precedence over bindings at a sub-system or component
                         level.
@@ -752,7 +867,7 @@
                                     This optional element can be used to provide parameter values inline
                                     to the parameter binding, in which case the source attribute of the
                                     ParameterBinding element must be empty.
-
+                                    
                                     The contents must be an ssv:ParameterSet element, if the type attribute
                                     of the ParameterBinding element is application/x-ssp-parameter-set, or
                                     any other valid XML content if the type attribute references another
@@ -763,9 +878,9 @@
                             <xs:complexType>
                                 <xs:choice>
                                     <!-- NOTE: In XML Schema 1.1 this choice would also contain the following entry:
-
+                                        
                                          <xs:element ref="ssv:ParameterSet"/>
-
+                                        
                                          which specifies the proper way to directly embed a ParameterSet inline.
                                          Due to restrictions in XML Schema 1.0, this would lead to a violation of the
                                          unique particle attribution schema component constraint, since the embedded
@@ -789,11 +904,11 @@
                                     as is for name matching against the names of parameters in the component
                                     or system and the values of the parameter source are not transformed further
                                     before being applied.
-
+                                    
                                     The contents of the element can be used to provide a parameter mapping
                                     inline, in which case the source attribute of the ParameterMapping element
                                     must be empty.
-
+                                    
                                     The contents must be an ssm:ParameterMapping element, if the type attribute
                                     of this element is application/x-ssp-parameter-mapping, or any other valid
                                     XML content if the type attribute references another MIME type (in that case
@@ -802,35 +917,48 @@
                                 </xs:documentation>
                             </xs:annotation>
                             <xs:complexType>
-                                <xs:choice>
-                                    <!-- NOTE: In XML Schema 1.1 this choice would also contain the following entry:
+                                <xs:sequence>
+                                    <xs:choice>
+                                        <!-- NOTE: In XML Schema 1.1 this choice would also contain the following entry:
 
-                                         <xs:element ref="ssm:ParameterMapping"/>
+                                             <xs:element ref="ssm:ParameterMapping"/>
 
-                                         which specifies the proper way to directly embed a ParameterMapping inline.
+                                             which specifies the proper way to directly embed a ParameterMapping inline.
+                                             Due to restrictions in XML Schema 1.0, this would lead to a violation of the
+                                             unique particle attribution schema component constraint, since the embedded
+                                             ssm:ParameterMapping element would also be matched by the more generic xs:any
+                                             specification.  Since XML Schema 1.1 validators are still rare compared with
+                                             1.0 validators, the default schema files for SSP are still restricted to 1.0;
+                                             however if you have access to a 1.1 validator/validating parser, you can
+                                             use the 1.1 variant of these stylesheets instead.
+                                        -->
+                                        <xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+                                    </xs:choice>
+                                    <!-- NOTE: In XML Schema 1.1 this sequence would also contain the following entries:
+
+                                         <xs:group ref="ssc:GMetaData"/>
+                                         <xs:group ref="ssc:GSignature"/>
+
+                                         which specifies the proper way to add meta data and signatures.
+
                                          Due to restrictions in XML Schema 1.0, this would lead to a violation of the
-                                         unique particle attribution schema component constraint, since the embedded
-                                         ssm:ParameterMapping element would also be matched by the more generic xs:any
-                                         specification.  Since XML Schema 1.1 validators are still rare compared with
-                                         1.0 validators, the default schema files for SSP are still restricted to 1.0;
-                                         however if you have access to a 1.1 validator/validating parser, you can
-                                         use the 1.1 variant of these stylesheets instead.
+                                         unique particle attribution schema component constraint, since the MetaData
+                                         element would also be matched by the more generic xs:any specification.
+                                         Since XML Schema 1.1 validators are still rare compared with 1.0 validators,
+                                         the default schema files for SSP are still restricted to 1.0; however if you
+                                         have access to a 1.1 validator/validating parser, you can use the 1.1 variant
+                                         of these stylesheets instead.
                                     -->
-                                    <xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-                                </xs:choice>
+                                </xs:sequence>
                                 <xs:attributeGroup ref="ssc:ABaseElement"/>
                                 <xs:attribute name="type" type="xs:string" use="optional" default="application/x-ssp-parameter-mapping"/>
                                 <xs:attribute name="source" type="xs:anyURI" use="optional">
                                     <xs:annotation>
                                         <xs:documentation xml:lang="en">
                                             This attribute indicates the source of the parameter mapping as a URI
-                                            (cf. RFC 3986).  For purposes of the resolution of relative URIs
-                                            the base URI is the URI of the SSD, if the sourcebase attribute
-                                            is not specified or is specified as SSD, and the URI of the
-                                            referenced component if the base attribute is specified as component.
-                                            This allows the specification of parameter mapping sources that reside
-                                            inside the component (e.g. an FMU) through relative URIs.
-
+                                            (cf. RFC 3986).  The base URI for the resolution of relative URIs is
+                                            determined by the sourceBase attribute.
+                                            
                                             If the source attribute is missing, the parameter mapping is provided
                                             inline as contents of the ParameterMapping element, which must be
                                             empty otherwise.
@@ -842,8 +970,10 @@
                                         <xs:documentation xml:lang="en">
                                             Defines the base the source URI is resolved against:  If the attribute
                                             is missing or is specified as SSD, the source is resolved against the
-                                            URI of the SSD, if the attribute is specified as component the URI is
-                                            resolved against the (resolved) URI of the component source.
+                                            URI of the containing file.  If the attribute is specified as component
+                                            the URI is resolved against the (resolved) source URI of the component.
+                                            The last option allows the specification of parameter sources that
+                                            reside inside a resource (for example an FMU) through relative URIs.
                                         </xs:documentation>
                                     </xs:annotation>
                                     <xs:simpleType>
@@ -855,6 +985,8 @@
                                 </xs:attribute>
                             </xs:complexType>
                         </xs:element>
+                        <xs:group ref="ssc:GMetaData"/>
+                        <xs:group ref="ssc:GSignature"/>
                         <xs:element name="Annotations" minOccurs="0" type="ssc:TAnnotations"/>
                     </xs:sequence>
                     <xs:attributeGroup ref="ssc:ABaseElement"/>
@@ -872,16 +1004,9 @@
                         <xs:annotation>
                             <xs:documentation xml:lang="en">
                                 This attribute indicates the source of the parameters as a URI
-                                (cf. RFC 3986).  For purposes of the resolution of relative URIs
-                                the base URI is the URI of the SSD, if the sourcebase attribute
-                                is not specified or is specified as SSD, and the URI of the
-                                referenced component if the base attribute is specified as component.
-                                This allows the specification of parameter sources that reside inside
-                                the component (e.g. an FMU) through relative URIs.
-
-                                Access to parameter sets over the SSP Parameter Repository Protocol
-                                is mediated through URIs with the http or https scheme.
-
+                                (cf. RFC 3986).  The base URI for the resolution of relative URIs is
+                                determined by the sourceBase attribute.
+                                
                                 If the source attribute is missing, the parameter mapping is provided
                                 inline as contents of a ParameterValues element, which must not be
                                 present otherwise.
@@ -893,8 +1018,11 @@
                             <xs:documentation xml:lang="en">
                                 Defines the base the source URI is resolved against:  If the attribute
                                 is missing or is specified as SSD, the source is resolved against the
-                                URI of the SSD, if the attribute is specified as component the URI is
-                                resolved against the (resolved) URI of the component source.
+                                URI of the containing file.  If the attribute is specified as component
+                                the URI is resolved against the (resolved) source URI of the component.
+                                The last option allows the specification of parameter mapping sources
+                                that reside inside a resource (for example an FMU) through relative
+                                URIs.
                             </xs:documentation>
                         </xs:annotation>
                         <xs:simpleType>
@@ -924,7 +1052,7 @@
             </xs:element>
         </xs:sequence>
     </xs:complexType>
-
+    
     <xs:complexType name="TDefaultExperiment">
         <xs:annotation>
             <xs:documentation xml:lang="en">
@@ -944,7 +1072,7 @@
         <xs:attribute name="stopTime" type="xs:double" use="optional">
             <xs:annotation>
                 <xs:documentation xml:lang="en">Default stop time of simulation</xs:documentation>
-            </xs:annotation>
+            </xs:annotation>            
         </xs:attribute>
     </xs:complexType>
 </xs:schema>

--- a/schema/ssp/SystemStructureDescription11.xsd
+++ b/schema/ssp/SystemStructureDescription11.xsd
@@ -10,13 +10,13 @@
     <xs:annotation>
         <xs:documentation xml:lang="en">
             This is the XML Schema 1.1 schema for the MAP SSP
-            SystemStructureDescription 1.0 format.  It is provided
+            SystemStructureDescription 2.0 format.  It is provided
             as a non-normative alternative to the XML Schema 1.0 schema
             to support simpler cross-namespace validation of SSD files.
             
-            Version: 1.0
+            Version: 2.0
 
-            Copyright 2016 -- 2019 Modelica Association Project "SSP"
+            Copyright 2016 -- 2024 Modelica Association Project "SSP"
 
             Redistribution and use in source and binary forms, with or
             without modification, are permitted provided that the
@@ -60,17 +60,20 @@
                 <xs:element name="Enumerations" minOccurs="0" type="ssc:TEnumerations"/>
                 <xs:element name="Units" minOccurs="0" type="ssc:TUnits"/>
                 <xs:element name="DefaultExperiment" minOccurs="0" type="ssd:TDefaultExperiment"/>
+                <xs:group ref="ssc:GMetaData"/>
+                <xs:group ref="ssc:GSignature"/>
                 <xs:element name="Annotations" minOccurs="0" type="ssc:TAnnotations"/>
             </xs:sequence>
             <xs:attribute name="version" use="required">
                 <xs:annotation>
                     <xs:documentation xml:lang="en">
-                        Version of SSD format, 1.0 for this release.
+                        Version of SSD format, 1.0 or 2.0 for this release.
                     </xs:documentation>
                 </xs:annotation>
                 <xs:simpleType>
                     <xs:restriction base="xs:normalizedString">
-                        <xs:pattern value="1[.][0-9]+(-.*)?"/>
+                        <xs:pattern value="1[.]0"/>
+                        <xs:pattern value="2[.]0"/>
                     </xs:restriction>
                 </xs:simpleType>
             </xs:attribute>
@@ -153,6 +156,8 @@
                     </xs:documentation>
                 </xs:annotation>
             </xs:element>
+            <xs:group ref="ssc:GMetaData"/>
+            <xs:group ref="ssc:GSignature"/>
         </xs:sequence>
         <xs:attributeGroup ref="ssc:ABaseElement"/>
         <xs:attribute name="name" use="required">
@@ -188,11 +193,11 @@
                         </xs:documentation>
                     </xs:annotation>
                 </xs:attribute>
-                <xs:attribute name="source" type="xs:anyURI" use="required">
+                <xs:attribute name="source" type="xs:anyURI" use="optional">
                     <xs:annotation>
                         <xs:documentation xml:lang="en">
-                            This attribute indicates the source of the component as an URI
-                            (cf. RFC 3986).  For purposes of the resolution of relative URIs
+                            Optional attribute indicating the source of the component as a URI
+                            (cf. RFC 3986). For purposes of the resolution of relative URIs
                             the base URI is the URI of the SSD.  Therefore for components
                             that are located alongside the SSD, relative URIs without scheme
                             and authority can and should be used to specify the component
@@ -225,6 +230,19 @@
                             security or other reasons.  Implementations are also not required to
                             support any absolute URIs and any specific URI schemes (but are of
                             course allowed to support any and all kinds of URIs where useful).
+
+                            If the source attribute is missing, this indicates that there is no
+                            provided source for the component, indicating a simulation
+                            architecture design without complete executable implementation.
+                            Implementations *CAN* take any specified type attribute into account
+                            when handling such components. In any other regard implementations
+                            *CAN* treat such components as equivalent to an empty system with the
+                            same connectors and other properties as specified for the component.
+
+                            Note that not specifying a source attribute is not the same as
+                            specifying a source attribute with an emtpy string value, as that
+                            is considered a valid relative URI. Implementations *MUST NOT*
+                            specify an empty relative URI to indicate a missing implementation.
                         </xs:documentation>
                     </xs:annotation>
                 </xs:attribute>
@@ -236,9 +254,10 @@
                             attribute can be used to determine which FMU implementation should be
                             employed.  If the attribute is missing or uses the default value "any",
                             the importing tool is free to choose what kind of FMU implementation
-                            to use.  If the value is "CoSimulation" or "ModelExchange" the corresponding
-                            FMU implementation must be used.  It is an error if the specified type
-                            of FMU implementation is not present in the FMU.
+                            to use.  If the value is "CoSimulation", "ModelExchange", or
+                            "ScheduledExecution", the corresponding FMU implementation must be used.
+                            It is an error if the specified type of FMU implementation is not present
+                            in the FMU.
                         </xs:documentation>
                     </xs:annotation>
                     <xs:simpleType>
@@ -246,6 +265,7 @@
                             <xs:enumeration value="any"/>
                             <xs:enumeration value="ModelExchange"/>
                             <xs:enumeration value="CoSimulation"/>
+                            <xs:enumeration value="ScheduledExecution"/>
                         </xs:restriction>
                     </xs:simpleType>
                 </xs:attribute>
@@ -273,10 +293,14 @@
                     </xs:documentation>
                 </xs:annotation>
                 <xs:complexType>
-                    <xs:choice>
-                        <xs:element ref="ssb:SignalDictionary"/>
-                        <xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-                    </xs:choice>
+                    <xs:sequence>
+                        <xs:choice>
+                            <xs:element ref="ssb:SignalDictionary"/>
+                            <xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+                        </xs:choice>
+                        <xs:group ref="ssc:GMetaData"/>
+                        <xs:group ref="ssc:GSignature"/>
+                    </xs:sequence>
                     <xs:attributeGroup ref="ssc:ABaseElement"/>
                     <xs:attribute name="type" type="xs:string" use="optional" default="application/x-ssp-signal-dictionary"/>
                     <xs:attribute name="source" type="xs:anyURI" use="optional">
@@ -454,6 +478,19 @@
                                                 </xs:documentation>
                                             </xs:annotation>
                                         </xs:attribute>
+                                        <xs:attribute name="startIndices" use="optional">
+                                            <xs:annotation>
+                                                <xs:documentation xml:lang="en">
+                                                    This optional attribute gives the list of indices of an
+                                                    array connector that this connection is restricted to.
+                                                    If not supplied this indicates that this connection
+                                                    applies to the whole connector, not just a single element.
+                                                </xs:documentation>
+                                            </xs:annotation>
+                                            <xs:simpleType>
+                                                <xs:list itemType="xs:unsignedLong"/>
+                                            </xs:simpleType>
+                                        </xs:attribute>
                                         <xs:attribute name="endElement" type="xs:string" use="optional">
                                             <xs:annotation>
                                                 <xs:documentation xml:lang="en">
@@ -474,6 +511,19 @@
                                                     element.
                                                 </xs:documentation>
                                             </xs:annotation>
+                                        </xs:attribute>
+                                        <xs:attribute name="endIndices" use="optional">
+                                            <xs:annotation>
+                                                <xs:documentation xml:lang="en">
+                                                    This optional attribute gives the list of indices of an
+                                                    array connector that this connection is restricted to.
+                                                    If not supplied this indicates that this connection
+                                                    applies to the whole connector, not just a single element.
+                                                </xs:documentation>
+                                            </xs:annotation>
+                                            <xs:simpleType>
+                                                <xs:list itemType="xs:unsignedLong"/>
+                                            </xs:simpleType>
                                         </xs:attribute>
                                         <xs:attribute name="suppressUnitConversion" type="xs:boolean" use="optional" default="false">
                                             <xs:annotation>
@@ -599,30 +649,62 @@
                                 </xs:documentation>
                             </xs:annotation>
                         </xs:group>
+                        <xs:group ref="ssc:GDimensions">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">
+                                    This optional sequence of elements specifies the dimensions of an
+                                    array connector.  If no dimension elements are present in a
+                                    connector, it is a scalar connector. The number of dimension
+                                    elements in a connector providesthe dimensionality of the array.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:group>
+                        <xs:element name="Clock" minOccurs="0" maxOccurs="unbounded">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">
+                                    This element associates the connector to a clock of the
+                                    given name, which must be defined on the given element.
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:complexType>
+                                <xs:attribute name="name" type="xs:string" use="required"/>
+                            </xs:complexType>
+                        </xs:element>
                         <xs:element name="ConnectorGeometry" minOccurs="0">
                             <xs:annotation>
                                 <xs:documentation xml:lang="en">
                                     This optional element gives the geometry information of the connector.
-                                    Note that x and y coordinates are in a special coordinate system, where
-                                    0,0 is the lower-left corner of the component/system, and 1,1 is the
-                                    upper-right corner of the component, regardless of aspect ratio.
+                                    Note that x and y coordinates are in a normalized connector coordinate
+                                    system, where 0,0 is the lower-left corner of the component/system,
+                                    and 1,1 is the upper-right corner of the component, regardless of
+                                    aspect ratio.
                                     
-                                    For systems the placement of connectors for the inside and outside
-                                    view of the system is identical, the special coordinate system is just
+                                    By default, the placement of connectors for a system's inside and
+                                    outside views is identical. The connector coordinate system is just
                                     translated to different actual coordinate systems, namely the one
-                                    determined by the ElementGeometry for the outside view, and the
-                                    one determined by SystemGeometry for the inside view.
+                                    determined by ElementGeometry for the outside view and the one
+                                    determined by SystemGeometry for the inside view.
+                                    
+                                    For systems, optionally, different placement of connectors for the
+                                    inside view of the system can be specified with the systemInnerX
+                                    and systemInnerY coordinates. This enables preserving the inside
+                                    system layout when integrating a system in a system structure and
+                                    avoiding unintended changes to the position of the connectors on
+                                    the inside view of the system when making layout changes on the
+                                    outside view and vice versa.
                                 </xs:documentation>
                             </xs:annotation>
                             <xs:complexType>
                                 <xs:attribute name="x" type="xs:double" use="required"/>
                                 <xs:attribute name="y" type="xs:double" use="required"/>
+                                <xs:attribute name="systemInnerX" type="xs:double" use="optional"/>
+                                <xs:attribute name="systemInnerY" type="xs:double" use="optional"/>
                             </xs:complexType>
                         </xs:element>
                         <xs:element name="Annotations" minOccurs="0" type="ssc:TAnnotations"/>
                     </xs:sequence>
                     <xs:attributeGroup ref="ssc:ABaseElement"/>
-                    <xs:attribute name="name" use="required">
+                    <xs:attribute name="name" type="xs:string" use="required">
                         <xs:annotation>
                             <xs:documentation xml:lang="en">
                                 This attribute gives the connector a name, which
@@ -642,31 +724,48 @@
                     <xs:attribute name="kind" use="required">
                         <xs:annotation>
                             <xs:documentation xml:lang="en">
-                                This attribute specifies the kind of the given connector,
-                                which indicates whether the connector is an input, an
-                                output, both (inout), a parameter or a calculated parameter (i.e.
-                                a parameter that is calculated by the component during initialization).
-                                For components this must match the related kind of the underlying
-                                component implementation, e.g. for referenced FMUs it must match the
-                                combination of variability and causality.
+                                This attribute specifies the kind of the given connector, which
+                                indicates whether the connector is an input, an output, both
+                                (inout), unspecified, a local variable, a constant, a parameter,
+                                a calculated parameter (i.e. a parameter that is calculated by the
+                                component during initialization), or a structural parameter (i.e.
+                                a parameter that can be set during (re-)configuration mode).
                                 
-                                For FMI 2.0 this means that the causality of the variable must
-                                match the kind of the connector.
+                                For components this must match the related kind of the underlying
+                                component implementation. For referenced FMUs it must match the
+                                combination of variability and causality:
+                                
+                                For FMI 2.0 and 3.0 this means that the causality of the variable
+                                must match the kind of the connector (with the kind inout not being
+                                valid for either FMI 3.0, 2.0, or 1.0).
                                 
                                 For FMI 1.0 this means that for connectors of kind input or output
                                 the causality of the variable must be input or output and the
                                 variability of the variable must be discrete or continuous (for
                                 outputs also constant and parameter are allowable).  For connectors
-                                of kind parameter the causality must be input or internal and the
-                                variablity must be parameter.  For connectors of kind
-                                calculatedParameter the causality must be output and the variablity
-                                must be parameter.
+                                of kind parameter the causality of the FMI 1.0 variable must be
+                                input or internal and the variability must be parameter.  For
+                                connectors of kind calculatedParameter the causality of the FMI 1.0
+                                variable must be output and the variability must be parameter. For
+                                connectors of kind constant the causality of the FMI 1.0 variable
+                                must be output and the variability must be constant.
+
+                                Connectors of kind `local` are used to define variables of the
+                                model element. Such a variable is not intended to be used for
+                                connections. However, if it is connected, the semantics are same as
+                                for an `output`.
                                 
                                 For SignalDictionaryReferences, the kind of a given connector can
                                 additionally be 'inout', which indicates that the semantics of the
                                 connector are derived from the connections going to the connector.
                                 This can be used for example to allow a connector to function as
-                                both an input and output within the same SignaleDictionaryReference.
+                                both an input and output within the same SignalDictionaryReference.
+
+                                Connectors of kind `unspecified` are used to define connectors for
+                                which the flow of information is either not yet specified, or is
+                                determined at runtime, for example for acausal connections of
+                                Modelica models. Such connectors can be connected to any other
+                                connector under the rules of the underlying modeling language.
                             </xs:documentation>
                         </xs:annotation>
                         <xs:simpleType>
@@ -675,7 +774,11 @@
                                 <xs:enumeration value="output"/>
                                 <xs:enumeration value="parameter"/>
                                 <xs:enumeration value="calculatedParameter"/>
+                                <xs:enumeration value="structuralParameter"/>
+                                <xs:enumeration value="constant"/>
+                                <xs:enumeration value="local"/>
                                 <xs:enumeration value="inout"/>
+                                <xs:enumeration value="unspecified"/>
                             </xs:restriction>
                         </xs:simpleType>
                     </xs:attribute>
@@ -786,22 +889,22 @@
                                 </xs:documentation>
                             </xs:annotation>
                             <xs:complexType>
-                                <xs:choice>
-                                    <xs:element ref="ssm:ParameterMapping"/>
-                                    <xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
-                                </xs:choice>
+                                <xs:sequence>
+                                    <xs:choice>
+                                        <xs:element ref="ssm:ParameterMapping"/>
+                                        <xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+                                    </xs:choice>
+                                    <xs:group ref="ssc:GMetaData"/>
+                                    <xs:group ref="ssc:GSignature"/>
+                                </xs:sequence>
                                 <xs:attributeGroup ref="ssc:ABaseElement"/>
                                 <xs:attribute name="type" type="xs:string" use="optional" default="application/x-ssp-parameter-mapping"/>
                                 <xs:attribute name="source" type="xs:anyURI" use="optional">
                                     <xs:annotation>
                                         <xs:documentation xml:lang="en">
                                             This attribute indicates the source of the parameter mapping as a URI
-                                            (cf. RFC 3986).  For purposes of the resolution of relative URIs
-                                            the base URI is the URI of the SSD, if the sourcebase attribute
-                                            is not specified or is specified as SSD, and the URI of the
-                                            referenced component if the base attribute is specified as component.
-                                            This allows the specification of parameter mapping sources that reside
-                                            inside the component (e.g. an FMU) through relative URIs.
+                                            (cf. RFC 3986).  The base URI for the resolution of relative URIs is
+                                            determined by the sourceBase attribute.
                                             
                                             If the source attribute is missing, the parameter mapping is provided
                                             inline as contents of the ParameterMapping element, which must be
@@ -814,8 +917,10 @@
                                         <xs:documentation xml:lang="en">
                                             Defines the base the source URI is resolved against:  If the attribute
                                             is missing or is specified as SSD, the source is resolved against the
-                                            URI of the SSD, if the attribute is specified as component the URI is
-                                            resolved against the (resolved) URI of the component source.
+                                            URI of the containing file.  If the attribute is specified as component
+                                            the URI is resolved against the (resolved) source URI of the component.
+                                            The last option allows the specification of parameter sources that
+                                            reside inside a resource (for example an FMU) through relative URIs.
                                         </xs:documentation>
                                     </xs:annotation>
                                     <xs:simpleType>
@@ -827,6 +932,8 @@
                                 </xs:attribute>
                             </xs:complexType>
                         </xs:element>
+                        <xs:group ref="ssc:GMetaData"/>
+                        <xs:group ref="ssc:GSignature"/>
                         <xs:element name="Annotations" minOccurs="0" type="ssc:TAnnotations"/>
                     </xs:sequence>
                     <xs:attributeGroup ref="ssc:ABaseElement"/>
@@ -844,15 +951,8 @@
                         <xs:annotation>
                             <xs:documentation xml:lang="en">
                                 This attribute indicates the source of the parameters as a URI
-                                (cf. RFC 3986).  For purposes of the resolution of relative URIs
-                                the base URI is the URI of the SSD, if the sourcebase attribute
-                                is not specified or is specified as SSD, and the URI of the
-                                referenced component if the base attribute is specified as component.
-                                This allows the specification of parameter sources that reside inside
-                                the component (e.g. an FMU) through relative URIs.
-                                
-                                Access to parameter sets over the SSP Parameter Repository Protocol
-                                is mediated through URIs with the http or https scheme.
+                                (cf. RFC 3986).  The base URI for the resolution of relative URIs is
+                                determined by the sourceBase attribute.
                                 
                                 If the source attribute is missing, the parameter mapping is provided
                                 inline as contents of a ParameterValues element, which must not be
@@ -865,8 +965,11 @@
                             <xs:documentation xml:lang="en">
                                 Defines the base the source URI is resolved against:  If the attribute
                                 is missing or is specified as SSD, the source is resolved against the
-                                URI of the SSD, if the attribute is specified as component the URI is
-                                resolved against the (resolved) URI of the component source.
+                                URI of the containing file.  If the attribute is specified as component
+                                the URI is resolved against the (resolved) source URI of the component.
+                                The last option allows the specification of parameter mapping sources
+                                that reside inside a resource (for example an FMU) through relative
+                                URIs.
                             </xs:documentation>
                         </xs:annotation>
                         <xs:simpleType>

--- a/schema/ssp/SystemStructureParameterMapping.xsd
+++ b/schema/ssp/SystemStructureParameterMapping.xsd
@@ -6,11 +6,11 @@
     <xs:annotation>
         <xs:documentation xml:lang="en">
             This is the normative XML Schema 1.0 schema for the MAP SSP
-            SystemStructureParameterMapping 1.0 format.
+            SystemStructureParameterMapping 2.0 format.
             
-            Version: 1.0
+            Version: 2.0
 
-            Copyright 2016 -- 2019 Modelica Association Project "SSP"
+            Copyright 2016 -- 2024 Modelica Association Project "SSP"
 
             Redistribution and use in source and binary forms, with or
             without modification, are permitted provided that the
@@ -48,17 +48,20 @@
         <xs:complexType>
             <xs:sequence>
                 <xs:element name="MappingEntry" minOccurs="0" maxOccurs="unbounded" type="ssm:TMappingEntry"/>
+                <xs:group ref="ssc:GMetaData"/>
+                <xs:group ref="ssc:GSignature"/>
                 <xs:element name="Annotations" minOccurs="0" type="ssc:TAnnotations"/>
             </xs:sequence>
             <xs:attribute name="version" use="required">
                 <xs:annotation>
                     <xs:documentation xml:lang="en">
-                        Version of SSM format, 1.0 for this release.
+                        Version of SSM format, 1.0 or 2.0 for this release.
                     </xs:documentation>
                 </xs:annotation>
                 <xs:simpleType>
                     <xs:restriction base="xs:normalizedString">
-                        <xs:pattern value="1[.][0-9]+(-.*)?"/>
+                        <xs:pattern value="1[.]0"/>
+                        <xs:pattern value="2[.]0"/>
                     </xs:restriction>
                 </xs:simpleType>
             </xs:attribute>

--- a/schema/ssp/SystemStructureParameterValues.xsd
+++ b/schema/ssp/SystemStructureParameterValues.xsd
@@ -6,11 +6,11 @@
     <xs:annotation>
         <xs:documentation xml:lang="en">
             This is the normative XML Schema 1.0 schema for the MAP SSP
-            SystemStructureParameterValues 1.0 format.
+            SystemStructureParameterValues 2.0 format.
                         
-            Version: 1.0
+            Version: 2.0
 
-            Copyright 2016 -- 2019 Modelica Association Project "SSP"
+            Copyright 2016 -- 2024 Modelica Association Project "SSP"
 
             Redistribution and use in source and binary forms, with or
             without modification, are permitted provided that the
@@ -50,17 +50,20 @@
                 <xs:element name="Parameters" type="ssv:TParameters"/>
                 <xs:element name="Enumerations" minOccurs="0" type="ssc:TEnumerations"/>
                 <xs:element name="Units" minOccurs="0" type="ssc:TUnits"/>
+                <xs:group ref="ssc:GMetaData"/>
+                <xs:group ref="ssc:GSignature"/>
                 <xs:element name="Annotations" minOccurs="0" type="ssc:TAnnotations"/>
             </xs:sequence>
             <xs:attribute name="version" use="required">
                 <xs:annotation>
                     <xs:documentation xml:lang="en">
-                        Version of SSV format, 1.0 for this release.
+                        Version of SSV format, 1.0 or 2.0 for this release.
                     </xs:documentation>
                 </xs:annotation>
                 <xs:simpleType>
                     <xs:restriction base="xs:normalizedString">
-                        <xs:pattern value="1[.][0-9]+(-.*)?"/>
+                        <xs:pattern value="1[.]0"/>
+                        <xs:pattern value="2[.]0"/>
                     </xs:restriction>
                 </xs:simpleType>
             </xs:attribute>
@@ -87,12 +90,64 @@
             <xs:choice>
                 <xs:element name="Real">
                     <xs:complexType>
-                        <xs:attribute name="value" type="xs:double" use="required">
+                        <xs:attribute name="value" use="required">
                             <xs:annotation>
                                 <xs:documentation xml:lang="en">
-                                    This attribute gives the value of the parameter.
+                                    This attribute gives the value(s) of the parameter. Array
+                                    values are serialized in row-major order, as defined in FMI.
                                 </xs:documentation>
                             </xs:annotation>
+                            <xs:simpleType>
+                                <xs:list itemType="xs:double"/>
+                            </xs:simpleType>
+                        </xs:attribute>
+                        <xs:attribute name="unit" type="xs:string" use="optional">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">
+                                    This attribute gives the unit of the parameter value and must
+                                    reference one of the unit definitions provided in the Units
+                                    element of the enclosing file.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="Float64">
+                    <xs:complexType>
+                        <xs:attribute name="value" use="required">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">
+                                    This attribute gives the value(s) of the parameter. Array
+                                    values are serialized in row-major order, as defined in FMI.
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:simpleType>
+                                <xs:list itemType="xs:double"/>
+                            </xs:simpleType>
+                        </xs:attribute>
+                        <xs:attribute name="unit" type="xs:string" use="optional">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">
+                                    This attribute gives the unit of the parameter value and must
+                                    reference one of the unit definitions provided in the Units
+                                    element of the enclosing file.
+                                </xs:documentation>
+                            </xs:annotation>
+                        </xs:attribute>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="Float32">
+                    <xs:complexType>
+                        <xs:attribute name="value" use="required">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">
+                                    This attribute gives the value(s) of the parameter. Array
+                                    values are serialized in row-major order, as defined in FMI.
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:simpleType>
+                                <xs:list itemType="xs:float"/>
+                            </xs:simpleType>
                         </xs:attribute>
                         <xs:attribute name="unit" type="xs:string" use="optional">
                             <xs:annotation>
@@ -107,32 +162,181 @@
                 </xs:element>
                 <xs:element name="Integer">
                     <xs:complexType>
-                        <xs:attribute name="value" type="xs:int" use="required">
+                        <xs:attribute name="value" use="required">
                             <xs:annotation>
                                 <xs:documentation xml:lang="en">
-                                    This attribute gives the value of the parameter.
+                                    This attribute gives the value(s) of the parameter. Array
+                                    values are serialized in row-major order, as defined in FMI.
                                 </xs:documentation>
                             </xs:annotation>
+                            <xs:simpleType>
+                                <xs:list itemType="xs:int"/>
+                            </xs:simpleType>
+                        </xs:attribute>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="Int8">
+                    <xs:complexType>
+                        <xs:attribute name="value" use="required">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">
+                                    This attribute gives the value(s) of the parameter. Array
+                                    values are serialized in row-major order, as defined in FMI.
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:simpleType>
+                                <xs:list itemType="xs:byte"/>
+                            </xs:simpleType>
+                        </xs:attribute>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="UInt8">
+                    <xs:complexType>
+                        <xs:attribute name="value" use="required">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">
+                                    This attribute gives the value(s) of the parameter. Array
+                                    values are serialized in row-major order, as defined in FMI.
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:simpleType>
+                                <xs:list itemType="xs:unsignedByte"/>
+                            </xs:simpleType>
+                        </xs:attribute>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="Int16">
+                    <xs:complexType>
+                        <xs:attribute name="value" use="required">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">
+                                    This attribute gives the value(s) of the parameter. Array
+                                    values are serialized in row-major order, as defined in FMI.
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:simpleType>
+                                <xs:list itemType="xs:short"/>
+                            </xs:simpleType>
+                        </xs:attribute>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="UInt16">
+                    <xs:complexType>
+                        <xs:attribute name="value" use="required">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">
+                                    This attribute gives the value(s) of the parameter. Array
+                                    values are serialized in row-major order, as defined in FMI.
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:simpleType>
+                                <xs:list itemType="xs:unsignedShort"/>
+                            </xs:simpleType>
+                        </xs:attribute>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="Int32">
+                    <xs:complexType>
+                        <xs:attribute name="value" use="required">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">
+                                    This attribute gives the value(s) of the parameter. Array
+                                    values are serialized in row-major order, as defined in FMI.
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:simpleType>
+                                <xs:list itemType="xs:int"/>
+                            </xs:simpleType>
+                        </xs:attribute>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="UInt32">
+                    <xs:complexType>
+                        <xs:attribute name="value" use="required">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">
+                                    This attribute gives the value(s) of the parameter. Array
+                                    values are serialized in row-major order, as defined in FMI.
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:simpleType>
+                                <xs:list itemType="xs:unsignedInt"/>
+                            </xs:simpleType>
+                        </xs:attribute>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="Int64">
+                    <xs:complexType>
+                        <xs:attribute name="value" use="required">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">
+                                    This attribute gives the value(s) of the parameter. Array
+                                    values are serialized in row-major order, as defined in FMI.
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:simpleType>
+                                <xs:list itemType="xs:long"/>
+                            </xs:simpleType>
+                        </xs:attribute>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="UInt64">
+                    <xs:complexType>
+                        <xs:attribute name="value" use="required">
+                            <xs:annotation>
+                                <xs:documentation xml:lang="en">
+                                    This attribute gives the value(s) of the parameter. Array
+                                    values are serialized in row-major order, as defined in FMI.
+                                </xs:documentation>
+                            </xs:annotation>
+                            <xs:simpleType>
+                                <xs:list itemType="xs:unsignedLong"/>
+                            </xs:simpleType>
                         </xs:attribute>
                     </xs:complexType>
                 </xs:element>
                 <xs:element name="Boolean">
                     <xs:complexType>
-                        <xs:attribute name="value" type="xs:boolean" use="required">
+                        <xs:attribute name="value" use="required">
                             <xs:annotation>
                                 <xs:documentation xml:lang="en">
-                                    This attribute gives the value of the parameter.
+                                    This attribute gives the value(s) of the parameter. Array
+                                    values are serialized in row-major order, as defined in FMI.
                                 </xs:documentation>
                             </xs:annotation>
+                            <xs:simpleType>
+                                <xs:list itemType="xs:boolean"/>
+                            </xs:simpleType>
                         </xs:attribute>
                     </xs:complexType>
                 </xs:element>
                 <xs:element name="String">
                     <xs:complexType>
-                        <xs:attribute name="value" type="xs:string" use="required">
+                        <xs:sequence>
+                            <xs:element name="Value" minOccurs="0" maxOccurs="unbounded">
+                                <xs:annotation>
+                                    <xs:documentation xml:lang="en">
+                                        This element gives the value for one array element of the
+                                        parameter. If any Value element is present, then the value
+                                        attribute on the parent element MUST NOT be used.
+                                        Array values are serialized in row-major order, as defined
+                                        in FMI.
+                                    </xs:documentation>
+                                </xs:annotation>
+                                <xs:complexType>
+                                    <xs:attribute name="value" type="xs:string" use="required"/>
+                                </xs:complexType>
+                            </xs:element>
+                        </xs:sequence>
+                        <xs:attribute name="value" type="xs:string">
                             <xs:annotation>
                                 <xs:documentation xml:lang="en">
-                                    This attribute gives the value of the parameter.
+                                    This attribute gives the value of the parameter, if it is a
+                                    scalar parameter. For array parameters requiring more than
+                                    one element, Value elements MUST be used. For scalar and one
+                                    element array parameters the Value element CAN be used. In
+                                    either case, if Value elements are used, then this value
+                                    attribute MUST NOT be present.
                                 </xs:documentation>
                             </xs:annotation>
                         </xs:attribute>
@@ -140,13 +344,39 @@
                 </xs:element>
                 <xs:element name="Enumeration">
                     <xs:complexType>
-                        <xs:attribute name="value" type="xs:string" use="required">
+                        <xs:sequence>
+                            <xs:element name="Value" minOccurs="0" maxOccurs="unbounded">
+                                <xs:annotation>
+                                    <xs:documentation xml:lang="en">
+                                        This element gives the value for one array element
+                                        of the parameter as the enumeration item name.
+                                        If any Value element is present, then the value
+                                        attribute on the parent element MUST NOT be used.
+                                        Note that the actual numeric value this value is
+                                        mapped to at run time will depend on the item mapping
+                                        of the enumeration type of the variables being
+                                        parameterized.
+                                        Array values are serialized in row-major order, as defined
+                                        in FMI.
+                                    </xs:documentation>
+                                </xs:annotation>
+                                <xs:complexType>
+                                    <xs:attribute name="value" type="xs:string" use="required"/>
+                                </xs:complexType>
+                            </xs:element>
+                        </xs:sequence>
+                        <xs:attribute name="value" type="xs:string">
                             <xs:annotation>
                                 <xs:documentation xml:lang="en">
-                                    This attribute gives the value of the parameter as 
-                                    the enumeration item name.  Note that the actual
-                                    numeric value this value is mapped to at run time
-                                    will depend on the item mapping of the enumeration
+                                    This attribute gives the value of the parameter as the
+                                    enumeration item name, if it is a scalar parameter. For
+                                    array parameters requiring more than one element, Value
+                                    elements MUST be used. For scalar and one element array
+                                    parameters the Value element CAN be used. In either case,
+                                    if Value elements are used, then this value attribute MUST
+                                    NOT be present.
+                                    Note that the actual numeric value this value is mapped to
+                                    at run time will depend on the item mapping of the enumeration
                                     type of the variables being parameterized.
                                 </xs:documentation>
                             </xs:annotation>
@@ -175,6 +405,22 @@
                 </xs:element>
                 <xs:element name="Binary">
                     <xs:complexType>
+                        <xs:sequence>
+                            <xs:element name="Value" minOccurs="0" maxOccurs="unbounded">
+                                <xs:annotation>
+                                    <xs:documentation xml:lang="en">
+                                        This element gives the value for one array element of the
+                                        parameter. If any Value element is present, then the value
+                                        attribute on the parent element MUST NOT be used.
+                                        Array values are serialized in row-major order, as defined
+                                        in FMI.
+                                    </xs:documentation>
+                                </xs:annotation>
+                                <xs:complexType>
+                                    <xs:attribute name="value" type="xs:hexBinary" use="required"/>
+                                </xs:complexType>
+                            </xs:element>
+                        </xs:sequence>
                         <xs:attribute name="mime-type" type="xs:string" default="application/octet-stream">
                             <xs:annotation>
                                 <xs:documentation xml:lang="en">
@@ -191,17 +437,33 @@
                                 </xs:documentation>
                             </xs:annotation>
                         </xs:attribute>
-                        <xs:attribute name="value" type="xs:hexBinary" use="required">
+                        <xs:attribute name="value" type="xs:hexBinary">
                             <xs:annotation>
                                 <xs:documentation xml:lang="en">
-                                    This attribute gives the value of the parameter as a
-                                    hex encoded binary value.
+                                    This attribute gives the value of the parameter as a hex
+                                    encoded binary value, if it is a scalar parameter. For
+                                    array parameters requiring more than one element, Value
+                                    elements MUST be used. For scalar and one element array
+                                    parameters the Value element CAN be used. In either case,
+                                    if Value elements are used, then this value attribute MUST
+                                    NOT be present.
                                 </xs:documentation>
                             </xs:annotation>
                         </xs:attribute>
                     </xs:complexType>
                 </xs:element>
             </xs:choice>
+            <xs:group ref="ssc:GDimensions">
+                <xs:annotation>
+                    <xs:documentation xml:lang="en">
+                        This optional sequence of elements specifies the dimensions of
+                        an array parameter.  If no dimension elements are present in a
+                        parameter, it is a scalar parameter. The number of dimension
+                        elements in a parameter provides the dimensionality of the
+                        parameter.
+                    </xs:documentation>
+                </xs:annotation>
+            </xs:group>
             <xs:element name="Annotations" minOccurs="0" type="ssc:TAnnotations"/>
         </xs:sequence>
         <xs:attributeGroup ref="ssc:ABaseElement"/>

--- a/schema/ssp/SystemStructureSignalDictionary.xsd
+++ b/schema/ssp/SystemStructureSignalDictionary.xsd
@@ -6,11 +6,11 @@
     <xs:annotation>
         <xs:documentation xml:lang="en">
             This is the normative XML Schema 1.0 schema for the MAP SSP
-            SystemStructureSignalDictionary 1.0 format.
+            SystemStructureSignalDictionary 2.0 format.
             
-            Version: 1.0
+            Version: 2.0
 
-            Copyright 2016 -- 2019 Modelica Association Project "SSP"
+            Copyright 2016 -- 2024 Modelica Association Project "SSP"
 
             Redistribution and use in source and binary forms, with or
             without modification, are permitted provided that the
@@ -50,17 +50,20 @@
                 <xs:element name="DictionaryEntry" minOccurs="0" maxOccurs="unbounded" type="ssb:TDictionaryEntry"/>
                 <xs:element name="Enumerations" minOccurs="0" type="ssc:TEnumerations"/>
                 <xs:element name="Units" minOccurs="0" type="ssc:TUnits"/>
+                <xs:group ref="ssc:GMetaData"/>
+                <xs:group ref="ssc:GSignature"/>
                 <xs:element name="Annotations" minOccurs="0" type="ssc:TAnnotations"/>
             </xs:sequence>
             <xs:attribute name="version" use="required">
                 <xs:annotation>
                     <xs:documentation xml:lang="en">
-                        Version of SSB format, 1.0 for this release.
+                        Version of SSB format, 1.0 or 2.0 for this release.
                     </xs:documentation>
                 </xs:annotation>
                 <xs:simpleType>
                     <xs:restriction base="xs:normalizedString">
-                        <xs:pattern value="1[.][0-9]+(-.*)?"/>
+                        <xs:pattern value="1[.]0"/>
+                        <xs:pattern value="2[.]0"/>
                     </xs:restriction>
                 </xs:simpleType>
             </xs:attribute>
@@ -72,6 +75,7 @@
     <xs:complexType name="TDictionaryEntry">
         <xs:sequence>
             <xs:group ref="ssc:GTypeChoice"/>
+            <xs:group ref="ssc:GDimensions"/>
             <xs:element name="Annotations" minOccurs="0" type="ssc:TAnnotations"/>
         </xs:sequence>
         <xs:attributeGroup ref="ssc:ABaseElement"/>

--- a/src/OMSimulatorLib/Connector.cpp
+++ b/src/OMSimulatorLib/Connector.cpp
@@ -181,7 +181,7 @@ std::string oms::Connector::getTypeString(const pugi::xml_node& node, const std:
   {
     return node.attribute("type").as_string();
   }
-  else if (sspVersion == "1.0")
+  else if (sspVersion == "1.0" || sspVersion == "2.0")
   {
     for(pugi::xml_node_iterator it = node.begin(); it != node.end(); ++it)
     {

--- a/src/OMSimulatorLib/Model.cpp
+++ b/src/OMSimulatorLib/Model.cpp
@@ -744,7 +744,7 @@ oms_status_enu_t oms::Model::reduceSSV(const std::string& ssvfile, const std::st
   pugi::xml_document ssvdoc;
   // generate XML declaration for ssm file
   pugi::xml_node ssvDeclarationNode = ssvdoc.append_child(pugi::node_declaration);
-  ssvDeclarationNode.append_attribute("version") = "1.0";
+  ssvDeclarationNode.append_attribute("version") = "2.0";
   ssvDeclarationNode.append_attribute("encoding") = "UTF-8";
 
   std::string savePath = "";

--- a/src/OMSimulatorLib/Model.cpp
+++ b/src/OMSimulatorLib/Model.cpp
@@ -335,7 +335,7 @@ oms_status_enu_t oms::Model::importSnapshot(const char* snapshot_, char** newCre
   if (new_cref != getCref() && Scope::GetInstance().getModel(new_cref))
     return logError("Renaming the model \"" + std::string(getCref()) + "\" to \"" + std::string(new_cref) + "\" failed because another model with the same name already exists in the scope.");
 
-  if (ssdVersion != "Draft20180219" && ssdVersion != "1.0")
+  if (ssdVersion != "Draft20180219" && ssdVersion != "1.0" && ssdVersion != "2.0")
     logWarning("Unknown SSD version: " + ssdVersion);
 
   System* old_root_system = system;
@@ -892,7 +892,7 @@ oms_status_enu_t oms::Model::importFromSnapshot(const Snapshot& snapshot)
       oms_system_enu_t systemType = getSystemType(*it, sspVersion);
 
       if (oms_status_ok != addSystem(systemCref, systemType))
-        return oms_status_error;
+        return logError("Unable to add System \"" + std::string(systemCref.c_str()) + "\"");
 
       System* system = getSystem(systemCref);
       if (!system)
@@ -939,7 +939,7 @@ oms_status_enu_t oms::Model::importFromSnapshot(const Snapshot& snapshot)
         {
           name = itAnnotations->name();
           // check for oms_default_experiment from version 1.0
-          if (std::string(name) == oms::ssp::Version1_0::simulation_information  && sspVersion == "1.0")
+          if (std::string(name) == oms::ssp::Version1_0::simulation_information  && (sspVersion == "1.0" || sspVersion == "2.0"))
           {
             resultFilename = itAnnotations->attribute("resultFile").as_string();
             loggingInterval = itAnnotations->attribute("loggingInterval").as_double();
@@ -971,7 +971,7 @@ oms_system_enu_t oms::Model::getSystemType(const pugi::xml_node& node, const std
     }
 
     /* from Version "1.0" simulationInformation is handled in vendor annotation */
-    if (name == oms::ssp::Draft20180219::ssd::annotations  && sspVersion == "1.0")
+    if (name == oms::ssp::Draft20180219::ssd::annotations  && (sspVersion == "1.0" || sspVersion == "2.0"))
     {
       pugi::xml_node annotation_node;
       annotation_node = itElements->child(oms::ssp::Version1_0::ssc::annotation);

--- a/src/OMSimulatorLib/Model.cpp
+++ b/src/OMSimulatorLib/Model.cpp
@@ -744,7 +744,7 @@ oms_status_enu_t oms::Model::reduceSSV(const std::string& ssvfile, const std::st
   pugi::xml_document ssvdoc;
   // generate XML declaration for ssm file
   pugi::xml_node ssvDeclarationNode = ssvdoc.append_child(pugi::node_declaration);
-  ssvDeclarationNode.append_attribute("version") = "2.0";
+  ssvDeclarationNode.append_attribute("version") = "1.0";
   ssvDeclarationNode.append_attribute("encoding") = "UTF-8";
 
   std::string savePath = "";

--- a/src/OMSimulatorLib/Scope.cpp
+++ b/src/OMSimulatorLib/Scope.cpp
@@ -217,7 +217,7 @@ oms_status_enu_t oms::Scope::importModel(const std::string& filename, char** _cr
   if (!model)
     return oms_status_error;
 
-  if (ssdVersion != "Draft20180219" && ssdVersion != "1.0")
+  if (ssdVersion != "Draft20180219" && ssdVersion != "1.0" && ssdVersion != "2.0")
     logWarning("Unknown SSD version: " + ssdVersion);
 
   // extract the ssp file
@@ -436,8 +436,8 @@ oms_status_enu_t oms::Scope::loadSnapshot(const oms::ComRef& cref, const char* s
     return logError("failed to load snapshot, because it would change the model's name but it already exists in the scope");
 
   std::string ssdVersion = node.attribute("version").as_string();
-  if (ssdVersion != "Draft20180219" && ssdVersion != "1.0")
-    return logError("Unknown SSD version \"" + ssdVersion + "\"; supported version are \"1.0\" and \"Draft20180219\".");
+  if (ssdVersion != "Draft20180219" && ssdVersion != "1.0" && ssdVersion != "2.0")
+    return logError("Unknown SSD version \"" + ssdVersion + "\"; supported version are \"1.0\" and \"2.0\" and\"Draft20180219\".");
 
   oms_status_enu_t status = getModel(cref)->loadSnapshot(node);
 

--- a/src/OMSimulatorLib/Snapshot.cpp
+++ b/src/OMSimulatorLib/Snapshot.cpp
@@ -201,7 +201,7 @@ pugi::xml_node oms::Snapshot::getTemplateResourceNodeSSV(const filesystem::path&
   pugi::xml_node node_parameterset = new_node.append_child(oms::ssp::Version1_0::ssv::parameter_set);
   node_parameterset.append_attribute("xmlns:ssc") = "http://ssp-standard.org/SSP1/SystemStructureCommon";
   node_parameterset.append_attribute("xmlns:ssv") = "http://ssp-standard.org/SSP1/SystemStructureParameterValues";
-  node_parameterset.append_attribute("version") = "1.0";
+  node_parameterset.append_attribute("version") = "2.0";
   node_parameterset.append_attribute("name") = cref.c_str();
   pugi::xml_node node_parameters = node_parameterset.append_child(oms::ssp::Version1_0::ssv::parameters);
 
@@ -214,7 +214,7 @@ pugi::xml_node oms::Snapshot::getTemplateResourceNodeSSM(const filesystem::path&
   pugi::xml_node node_parameterMapping = new_node.append_child(oms::ssp::Version1_0::ssm::parameter_mapping);
   node_parameterMapping.append_attribute("xmlns:ssc") = "http://ssp-standard.org/SSP1/SystemStructureCommon";
   node_parameterMapping.append_attribute("xmlns:ssm") = "http://ssp-standard.org/SSP1/SystemStructureParameterMapping";
-  node_parameterMapping.append_attribute("version") = "1.0";
+  node_parameterMapping.append_attribute("version") = "2.0";
 
   return node_parameterMapping;
 }
@@ -223,7 +223,7 @@ pugi::xml_node oms::Snapshot::getTemplateResourceNodeSignalFilter(const filesyst
 {
   pugi::xml_node new_node = newResourceNode(filename);
   pugi::xml_node oms_signalFilter = new_node.append_child(oms::ssp::Version1_0::oms_signalFilter);
-  oms_signalFilter.append_attribute("version") = "1.0";
+  oms_signalFilter.append_attribute("version") = "2.0";
 
   return oms_signalFilter;
 }
@@ -232,7 +232,7 @@ pugi::xml_node oms::Snapshot::getTemplateResourceNodeSSDVariants()
 {
   pugi::xml_node new_node = newResourceNode("ssdVariants.xml");
   pugi::xml_node oms_variants = new_node.append_child("oms:Variants");
-  oms_variants.append_attribute("version") = "1.0";
+  oms_variants.append_attribute("version") = "2.0";
 
   return oms_variants;
 }

--- a/src/OMSimulatorLib/Snapshot.cpp
+++ b/src/OMSimulatorLib/Snapshot.cpp
@@ -190,7 +190,7 @@ pugi::xml_node oms::Snapshot::getTemplateResourceNodeSSD(const filesystem::path&
   ssdNode.append_attribute("xmlns:ssb") = "http://ssp-standard.org/SSP1/SystemStructureSignalDictionary";
   ssdNode.append_attribute("xmlns:oms") = "https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd";
   ssdNode.append_attribute("name") = cref.c_str();
-  ssdNode.append_attribute("version") = "1.0";
+  ssdNode.append_attribute("version") = "2.0";
 
   return ssdNode;
 }

--- a/src/OMSimulatorLib/System.cpp
+++ b/src/OMSimulatorLib/System.cpp
@@ -862,9 +862,14 @@ oms_status_enu_t oms::System::importFromSnapshot(const pugi::xml_node& node, con
           // allow component type to be empty, as type is optional according to SSP-1.0 and default type is application/x-fmu-sharedlibrary
           if ("application/x-fmu-sharedlibrary" == type || type.empty())
           {
-            if (getType() == oms_system_wc)
+            std::string source = itElements->attribute("source").as_string();
+            filesystem::path modelDescriptionPath = filesystem::path(getModel().getTempDirectory()) / filesystem::path(source);
+            std::string fmiVersion = getFmiVersion(modelDescriptionPath.generic_string());
+            if (getType() == oms_system_wc && fmiVersion == "2.0")
               component = ComponentFMUCS::NewComponent(*itElements, this, sspVersion, snapshot, variantName);
-            else if (getType() == oms_system_sc)
+            else if (getType() == oms_system_wc && fmiVersion == "3.0")
+              component = ComponentFMU3CS::NewComponent(*itElements, this, sspVersion, snapshot, variantName);
+            else if (getType() == oms_system_sc && fmiVersion == "2.0")
               component = ComponentFMUME::NewComponent(*itElements, this, sspVersion, snapshot, variantName);
             else
               return logError("wrong xml schema detected: " + name);
@@ -914,7 +919,7 @@ oms_status_enu_t oms::System::importFromSnapshot(const pugi::xml_node& node, con
           name = itAnnotations->name();
 
           // check for oms:simulationInformation from version 1.0
-          if (std::string(name) == oms::ssp::Version1_0::simulation_information && sspVersion == "1.0")
+          if (std::string(name) == oms::ssp::Version1_0::simulation_information && (sspVersion == "1.0" || sspVersion == "2.0"))
           {
             if (oms_status_ok != importFromSSD_SimulationInformation(*itAnnotations, sspVersion))
               return logError("Failed to import " + std::string(oms::ssp::Version1_0::simulation_information));

--- a/src/OMSimulatorLib/System.cpp
+++ b/src/OMSimulatorLib/System.cpp
@@ -862,9 +862,11 @@ oms_status_enu_t oms::System::importFromSnapshot(const pugi::xml_node& node, con
           // allow component type to be empty, as type is optional according to SSP-1.0 and default type is application/x-fmu-sharedlibrary
           if ("application/x-fmu-sharedlibrary" == type || type.empty())
           {
+            // read the modelDescription.xml in memory to detect the fmiVersion
             std::string source = itElements->attribute("source").as_string();
             filesystem::path modelDescriptionPath = filesystem::path(getModel().getTempDirectory()) / filesystem::path(source);
             std::string fmiVersion = getFmiVersion(modelDescriptionPath.generic_string());
+
             if (getType() == oms_system_wc && fmiVersion == "2.0")
               component = ComponentFMUCS::NewComponent(*itElements, this, sspVersion, snapshot, variantName);
             else if (getType() == oms_system_wc && fmiVersion == "3.0")

--- a/src/OMSimulatorLib/SystemWC.cpp
+++ b/src/OMSimulatorLib/SystemWC.cpp
@@ -133,7 +133,7 @@ oms_status_enu_t oms::SystemWC::importFromSSD_SimulationInformation(const pugi::
   pugi::xml_node fixedStepMaster = node.child(oms::ssp::Version1_0::FixedStepMaster);
   if (fixedStepMaster)
   {
-    if (sspVersion == "1.0")
+    if (sspVersion == "1.0" || sspVersion == "2.0")
     {
       solverName = fixedStepMaster.attribute("description").as_string();
       FixedStepMaster = oms::ssp::Version1_0::FixedStepMaster;
@@ -150,7 +150,7 @@ oms_status_enu_t oms::SystemWC::importFromSSD_SimulationInformation(const pugi::
   pugi::xml_node variableStepMaster = node.child(oms::ssp::Version1_0::VariableStepMaster);
   if (variableStepMaster)
   {
-    if (sspVersion == "1.0")
+    if (sspVersion == "1.0" || sspVersion == "2.0")
     {
       solverName = variableStepMaster.attribute("description").as_string();
       VariableStepMaster = oms::ssp::Version1_0::VariableStepMaster;

--- a/src/OMSimulatorLib/Values.cpp
+++ b/src/OMSimulatorLib/Values.cpp
@@ -820,7 +820,7 @@ oms_status_enu_t oms::Values::exportToSSD(pugi::xml_node& node) const
   pugi::xml_node node_parameter_values = node_parameter_binding.append_child(oms::ssp::Version1_0::ssd::parameter_values);
 
   pugi::xml_node node_parameterset = node_parameter_values.append_child(oms::ssp::Version1_0::ssv::parameter_set);
-  node_parameterset.append_attribute("version") = "1.0";
+  node_parameterset.append_attribute("version") = "2.0";
   node_parameterset.append_attribute("name") = "parameters";
   pugi::xml_node node_parameters = node_parameterset.append_child(oms::ssp::Version1_0::ssv::parameters);
 
@@ -1129,7 +1129,7 @@ void oms::Values::exportParameterBindings(pugi::xml_node &node, Snapshot &snapsh
             pugi::xml_node node_parameter_binding = node_parameters_bindings.append_child(oms::ssp::Version1_0::ssd::parameter_binding);
             pugi::xml_node node_parameter_values = node_parameter_binding.append_child(oms::ssp::Version1_0::ssd::parameter_values);
             pugi::xml_node node_parameterset = node_parameter_values.append_child(oms::ssp::Version1_0::ssv::parameter_set);
-            node_parameterset.append_attribute("version") = "1.0";
+            node_parameterset.append_attribute("version") = "2.0";
             node_parameterset.append_attribute("name") = "parameters";
             pugi::xml_node node_parameters = node_parameterset.append_child(oms::ssp::Version1_0::ssv::parameters);
             res.second.exportStartValuesHelper(node_parameters);

--- a/testsuite/api/addExternalResources1.lua
+++ b/testsuite/api/addExternalResources1.lua
@@ -96,7 +96,7 @@ print(src)
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="addExternalResources"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:Connectors>
@@ -285,7 +285,7 @@ print(src)
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="addExternalResources.root.Input1"
 --         type="Real"
@@ -332,7 +332,7 @@ print(src)
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="addExternalResources"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:Connectors>
@@ -521,7 +521,7 @@ print(src)
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="addExternalResources.root.Input1"
 --         type="Real"

--- a/testsuite/api/addExternalResources1.lua
+++ b/testsuite/api/addExternalResources1.lua
@@ -227,7 +227,7 @@ print(src)
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -248,7 +248,7 @@ print(src)
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -264,7 +264,7 @@ print(src)
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -463,7 +463,7 @@ print(src)
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -484,7 +484,7 @@ print(src)
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -500,7 +500,7 @@ print(src)
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter

--- a/testsuite/api/addExternalResources2.lua
+++ b/testsuite/api/addExternalResources2.lua
@@ -54,7 +54,7 @@ oms_delete("import_parameter_mapping")
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="import_parameter_mapping"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="co_sim">
 --         <ssd:Connectors>
@@ -256,7 +256,7 @@ oms_delete("import_parameter_mapping")
 --     <ssm:ParameterMapping
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping"
---       version="1.0">
+--       version="2.0">
 --       <ssm:MappingEntry
 --         source="cosim_parameters"
 --         target="parameter_1" />
@@ -289,7 +289,7 @@ oms_delete("import_parameter_mapping")
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="import_parameter_mapping.co_sim.Input_1"
 --         type="Real"
@@ -372,7 +372,7 @@ oms_delete("import_parameter_mapping")
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="import_parameter_mapping"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="co_sim">
 --         <ssd:Connectors>
@@ -574,7 +574,7 @@ oms_delete("import_parameter_mapping")
 --     <ssm:ParameterMapping
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping"
---       version="1.0">
+--       version="2.0">
 --       <ssm:MappingEntry
 --         source="cosim_parameters"
 --         target="parameter_1" />
@@ -607,7 +607,7 @@ oms_delete("import_parameter_mapping")
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="import_parameter_mapping.co_sim.Input_1"
 --         type="Real"

--- a/testsuite/api/addExternalResources2.lua
+++ b/testsuite/api/addExternalResources2.lua
@@ -225,7 +225,7 @@ oms_delete("import_parameter_mapping")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -543,7 +543,7 @@ oms_delete("import_parameter_mapping")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter

--- a/testsuite/api/addExternalResources3.py
+++ b/testsuite/api/addExternalResources3.py
@@ -231,7 +231,7 @@ print(src)
 ##     <ssv:ParameterSet
 ##       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 ##       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
-##       version="1.0"
+##       version="2.0"
 ##       name="parameters">
 ##       <ssv:Parameters>
 ##         <ssv:Parameter
@@ -252,7 +252,7 @@ print(src)
 ##     <ssv:ParameterSet
 ##       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 ##       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
-##       version="1.0"
+##       version="2.0"
 ##       name="parameters">
 ##       <ssv:Parameters>
 ##         <ssv:Parameter
@@ -268,7 +268,7 @@ print(src)
 ##     <ssv:ParameterSet
 ##       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 ##       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
-##       version="1.0"
+##       version="2.0"
 ##       name="parameters">
 ##       <ssv:Parameters>
 ##         <ssv:Parameter
@@ -467,7 +467,7 @@ print(src)
 ##     <ssv:ParameterSet
 ##       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 ##       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
-##       version="1.0"
+##       version="2.0"
 ##       name="parameters">
 ##       <ssv:Parameters>
 ##         <ssv:Parameter
@@ -488,7 +488,7 @@ print(src)
 ##     <ssv:ParameterSet
 ##       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 ##       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
-##       version="1.0"
+##       version="2.0"
 ##       name="parameters">
 ##       <ssv:Parameters>
 ##         <ssv:Parameter
@@ -504,7 +504,7 @@ print(src)
 ##     <ssv:ParameterSet
 ##       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 ##       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
-##       version="1.0"
+##       version="2.0"
 ##       name="parameters">
 ##       <ssv:Parameters>
 ##         <ssv:Parameter

--- a/testsuite/api/addExternalResources3.py
+++ b/testsuite/api/addExternalResources3.py
@@ -100,7 +100,7 @@ print(src)
 ##       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 ##       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 ##       name="addExternalResources"
-##       version="1.0">
+##       version="2.0">
 ##       <ssd:System
 ##         name="root">
 ##         <ssd:Connectors>
@@ -289,7 +289,7 @@ print(src)
 ##   <oms:file
 ##     name="resources/signalFilter.xml">
 ##     <oms:SignalFilter
-##       version="1.0">
+##       version="2.0">
 ##       <oms:Variable
 ##         name="addExternalResources.root.Input1"
 ##         type="Real"
@@ -336,7 +336,7 @@ print(src)
 ##       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 ##       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 ##       name="addExternalResources"
-##       version="1.0">
+##       version="2.0">
 ##       <ssd:System
 ##         name="root">
 ##         <ssd:Connectors>
@@ -525,7 +525,7 @@ print(src)
 ##   <oms:file
 ##     name="resources/signalFilter.xml">
 ##     <oms:SignalFilter
-##       version="1.0">
+##       version="2.0">
 ##       <oms:Variable
 ##         name="addExternalResources.root.Input1"
 ##         type="Real"

--- a/testsuite/api/addExternalResources4.py
+++ b/testsuite/api/addExternalResources4.py
@@ -228,7 +228,7 @@ oms.delete("import_parameter_mapping")
 ##     <ssv:ParameterSet
 ##       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 ##       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
-##       version="1.0"
+##       version="2.0"
 ##       name="parameters">
 ##       <ssv:Parameters>
 ##         <ssv:Parameter
@@ -546,7 +546,7 @@ oms.delete("import_parameter_mapping")
 ##     <ssv:ParameterSet
 ##       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 ##       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
-##       version="1.0"
+##       version="2.0"
 ##       name="parameters">
 ##       <ssv:Parameters>
 ##         <ssv:Parameter

--- a/testsuite/api/addExternalResources4.py
+++ b/testsuite/api/addExternalResources4.py
@@ -57,7 +57,7 @@ oms.delete("import_parameter_mapping")
 ##       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 ##       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 ##       name="import_parameter_mapping"
-##       version="1.0">
+##       version="2.0">
 ##       <ssd:System
 ##         name="co_sim">
 ##         <ssd:Connectors>
@@ -259,7 +259,7 @@ oms.delete("import_parameter_mapping")
 ##     <ssm:ParameterMapping
 ##       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 ##       xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping"
-##       version="1.0">
+##       version="2.0">
 ##       <ssm:MappingEntry
 ##         source="cosim_parameters"
 ##         target="parameter_1" />
@@ -292,7 +292,7 @@ oms.delete("import_parameter_mapping")
 ##   <oms:file
 ##     name="resources/signalFilter.xml">
 ##     <oms:SignalFilter
-##       version="1.0">
+##       version="2.0">
 ##       <oms:Variable
 ##         name="import_parameter_mapping.co_sim.Input_1"
 ##         type="Real"
@@ -375,7 +375,7 @@ oms.delete("import_parameter_mapping")
 ##       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 ##       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 ##       name="import_parameter_mapping"
-##       version="1.0">
+##       version="2.0">
 ##       <ssd:System
 ##         name="co_sim">
 ##         <ssd:Connectors>
@@ -577,7 +577,7 @@ oms.delete("import_parameter_mapping")
 ##     <ssm:ParameterMapping
 ##       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 ##       xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping"
-##       version="1.0">
+##       version="2.0">
 ##       <ssm:MappingEntry
 ##         source="cosim_parameters"
 ##         target="parameter_1" />
@@ -610,7 +610,7 @@ oms.delete("import_parameter_mapping")
 ##   <oms:file
 ##     name="resources/signalFilter.xml">
 ##     <oms:SignalFilter
-##       version="1.0">
+##       version="2.0">
 ##       <oms:Variable
 ##         name="import_parameter_mapping.co_sim.Input_1"
 ##         type="Real"

--- a/testsuite/api/addExternalResources5.lua
+++ b/testsuite/api/addExternalResources5.lua
@@ -105,7 +105,7 @@ oms_delete("addExternalResources")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter

--- a/testsuite/api/addExternalResources5.lua
+++ b/testsuite/api/addExternalResources5.lua
@@ -46,7 +46,7 @@ oms_delete("addExternalResources")
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="addExternalResources"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:Connectors>
@@ -136,7 +136,7 @@ oms_delete("addExternalResources")
 --     <ssm:ParameterMapping
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping"
---       version="1.0">
+--       version="2.0">
 --       <ssm:MappingEntry
 --         source="cosim_parameters"
 --         target="parameter_1" />
@@ -169,7 +169,7 @@ oms_delete("addExternalResources")
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="addExternalResources.root.Input1"
 --         type="Real"

--- a/testsuite/api/deleteReferencesInSSD1.lua
+++ b/testsuite/api/deleteReferencesInSSD1.lua
@@ -213,7 +213,7 @@ oms_delete("deleteResources")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -234,7 +234,7 @@ oms_delete("deleteResources")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -250,7 +250,7 @@ oms_delete("deleteResources")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -437,7 +437,7 @@ oms_delete("deleteResources")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -458,7 +458,7 @@ oms_delete("deleteResources")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -474,7 +474,7 @@ oms_delete("deleteResources")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter

--- a/testsuite/api/deleteReferencesInSSD1.lua
+++ b/testsuite/api/deleteReferencesInSSD1.lua
@@ -82,7 +82,7 @@ oms_delete("deleteResources")
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="deleteResources"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:Connectors>
@@ -271,7 +271,7 @@ oms_delete("deleteResources")
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="deleteResources.root.Input1"
 --         type="Real"
@@ -318,7 +318,7 @@ oms_delete("deleteResources")
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="deleteResources"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:Connectors>
@@ -495,7 +495,7 @@ oms_delete("deleteResources")
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="deleteResources.root.Input1"
 --         type="Real"

--- a/testsuite/api/deleteResourcesInSSP1.lua
+++ b/testsuite/api/deleteResourcesInSSP1.lua
@@ -210,7 +210,7 @@ oms_delete("deleteResources")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -231,7 +231,7 @@ oms_delete("deleteResources")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -247,7 +247,7 @@ oms_delete("deleteResources")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter

--- a/testsuite/api/deleteResourcesInSSP1.lua
+++ b/testsuite/api/deleteResourcesInSSP1.lua
@@ -79,7 +79,7 @@ oms_delete("deleteResources")
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="deleteResources"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:Connectors>
@@ -268,7 +268,7 @@ oms_delete("deleteResources")
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="deleteResources.root.Input1"
 --         type="Real"
@@ -315,7 +315,7 @@ oms_delete("deleteResources")
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="deleteResources"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:Connectors>
@@ -432,7 +432,7 @@ oms_delete("deleteResources")
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="deleteResources.root.Input1"
 --         type="Real"

--- a/testsuite/api/importExportAllResources.lua
+++ b/testsuite/api/importExportAllResources.lua
@@ -62,7 +62,7 @@ oms_delete("import_parameter_mapping")
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="import_parameter_mapping"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="co_sim">
 --         <ssd:Connectors>
@@ -264,7 +264,7 @@ oms_delete("import_parameter_mapping")
 --     <ssm:ParameterMapping
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping"
---       version="1.0">
+--       version="2.0">
 --       <ssm:MappingEntry
 --         source="cosim_parameters"
 --         target="parameter_1" />
@@ -297,7 +297,7 @@ oms_delete("import_parameter_mapping")
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="import_parameter_mapping.co_sim.Input_1"
 --         type="Real"
@@ -380,7 +380,7 @@ oms_delete("import_parameter_mapping")
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="import_parameter_mapping"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="co_sim">
 --         <ssd:Connectors>
@@ -582,7 +582,7 @@ oms_delete("import_parameter_mapping")
 --     <ssm:ParameterMapping
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping"
---       version="1.0">
+--       version="2.0">
 --       <ssm:MappingEntry
 --         source="cosim_parameters"
 --         target="parameter_1" />
@@ -615,7 +615,7 @@ oms_delete("import_parameter_mapping")
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="import_parameter_mapping.co_sim.Input_1"
 --         type="Real"

--- a/testsuite/api/importExportAllResources.lua
+++ b/testsuite/api/importExportAllResources.lua
@@ -233,7 +233,7 @@ oms_delete("import_parameter_mapping")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -551,7 +551,7 @@ oms_delete("import_parameter_mapping")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter

--- a/testsuite/api/import_export_units1.lua
+++ b/testsuite/api/import_export_units1.lua
@@ -45,7 +45,7 @@ print(src)
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -90,7 +90,7 @@ print(src)
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter

--- a/testsuite/api/import_export_units2.lua
+++ b/testsuite/api/import_export_units2.lua
@@ -50,7 +50,7 @@ print(src)
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="model"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:Elements>
@@ -178,7 +178,7 @@ print(src)
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="model.root.sine.y"
 --         type="Real"
@@ -221,7 +221,7 @@ print(src)
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="model"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:Elements>
@@ -349,7 +349,7 @@ print(src)
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="model.root.sine.y"
 --         type="Real"

--- a/testsuite/api/import_export_units2.lua
+++ b/testsuite/api/import_export_units2.lua
@@ -100,7 +100,7 @@ print(src)
 --               <ssd:ParameterBinding>
 --                 <ssd:ParameterValues>
 --                   <ssv:ParameterSet
---                     version="1.0"
+--                     version="2.0"
 --                     name="parameters">
 --                     <ssv:Parameters>
 --                       <ssv:Parameter
@@ -271,7 +271,7 @@ print(src)
 --               <ssd:ParameterBinding>
 --                 <ssd:ParameterValues>
 --                   <ssv:ParameterSet
---                     version="1.0"
+--                     version="2.0"
 --                     name="parameters">
 --                     <ssv:Parameters>
 --                       <ssv:Parameter

--- a/testsuite/api/reduceSSV.lua
+++ b/testsuite/api/reduceSSV.lua
@@ -27,7 +27,7 @@ readFile("reduced.ssv")
 
 -- Result:
 -- <?xml version="1.0" encoding="UTF-8"?>
--- <ssv:ParameterSet xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" version="1.0" name="parameters">
+-- <ssv:ParameterSet xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" version="2.0" name="parameters">
 --     <ssv:Parameters>
 --         <ssv:Parameter name="cosim_input">
 --             <ssv:Real value="20" />
@@ -48,7 +48,7 @@ readFile("reduced.ssv")
 -- <ssv:ParameterSet
 --   xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --   xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---   version="1.0"
+--   version="2.0"
 --   name="reducedSSV">
 --   <ssv:Parameters>
 --     <ssv:Parameter

--- a/testsuite/api/reduceSSV.lua
+++ b/testsuite/api/reduceSSV.lua
@@ -27,7 +27,7 @@ readFile("reduced.ssv")
 
 -- Result:
 -- <?xml version="1.0" encoding="UTF-8"?>
--- <ssv:ParameterSet xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" version="2.0" name="parameters">
+-- <ssv:ParameterSet xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" version="1.0" name="parameters">
 --     <ssv:Parameters>
 --         <ssv:Parameter name="cosim_input">
 --             <ssv:Real value="20" />

--- a/testsuite/api/reduceSSV.py
+++ b/testsuite/api/reduceSSV.py
@@ -31,7 +31,7 @@ readFile("reduced.ssv")
 
 ## Result:
 ## <?xml version="1.0" encoding="UTF-8"?>
-## <ssv:ParameterSet xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" version="2.0" name="parameters">
+## <ssv:ParameterSet xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" version="1.0" name="parameters">
 ##     <ssv:Parameters>
 ##         <ssv:Parameter name="cosim_input">
 ##             <ssv:Real value="20" />

--- a/testsuite/api/reduceSSV.py
+++ b/testsuite/api/reduceSSV.py
@@ -31,7 +31,7 @@ readFile("reduced.ssv")
 
 ## Result:
 ## <?xml version="1.0" encoding="UTF-8"?>
-## <ssv:ParameterSet xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" version="1.0" name="parameters">
+## <ssv:ParameterSet xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" version="2.0" name="parameters">
 ##     <ssv:Parameters>
 ##         <ssv:Parameter name="cosim_input">
 ##             <ssv:Real value="20" />
@@ -52,7 +52,7 @@ readFile("reduced.ssv")
 ## <ssv:ParameterSet
 ##   xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 ##   xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
-##   version="1.0"
+##   version="2.0"
 ##   name="reducedSSV">
 ##   <ssv:Parameters>
 ##     <ssv:Parameter

--- a/testsuite/api/setUnits1.lua
+++ b/testsuite/api/setUnits1.lua
@@ -49,7 +49,7 @@ oms_delete("model")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -94,7 +94,7 @@ oms_delete("model")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter

--- a/testsuite/api/setUnits2.lua
+++ b/testsuite/api/setUnits2.lua
@@ -101,7 +101,7 @@ oms_delete("model")
 --               <ssd:ParameterBinding>
 --                 <ssd:ParameterValues>
 --                   <ssv:ParameterSet
---                     version="1.0"
+--                     version="2.0"
 --                     name="parameters">
 --                     <ssv:Parameters>
 --                       <ssv:Parameter
@@ -273,7 +273,7 @@ oms_delete("model")
 --               <ssd:ParameterBinding>
 --                 <ssd:ParameterValues>
 --                   <ssv:ParameterSet
---                     version="1.0"
+--                     version="2.0"
 --                     name="parameters">
 --                     <ssv:Parameters>
 --                       <ssv:Parameter

--- a/testsuite/api/setUnits2.lua
+++ b/testsuite/api/setUnits2.lua
@@ -51,7 +51,7 @@ oms_delete("model")
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="model"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:Elements>
@@ -179,7 +179,7 @@ oms_delete("model")
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="model.root.sine.y"
 --         type="Real"
@@ -222,7 +222,7 @@ oms_delete("model")
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="model"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:Elements>
@@ -352,7 +352,7 @@ oms_delete("model")
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="model.root.sine.y"
 --         type="Real"

--- a/testsuite/api/setUnits3.py
+++ b/testsuite/api/setUnits3.py
@@ -50,7 +50,7 @@ oms.delete("model")
 ##     <ssv:ParameterSet
 ##       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 ##       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
-##       version="1.0"
+##       version="2.0"
 ##       name="parameters">
 ##       <ssv:Parameters>
 ##         <ssv:Parameter
@@ -95,7 +95,7 @@ oms.delete("model")
 ##     <ssv:ParameterSet
 ##       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 ##       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
-##       version="1.0"
+##       version="2.0"
 ##       name="parameters">
 ##       <ssv:Parameters>
 ##         <ssv:Parameter

--- a/testsuite/api/test01.lua
+++ b/testsuite/api/test01.lua
@@ -82,7 +82,7 @@ printStatus(status, 3)
 -- error:   [NewSystem] A WC system must be the root system.
 -- status:  [correct] error
 -- <?xml version="1.0"?>
--- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="test01lua" version="1.0">
+-- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="test01lua" version="2.0">
 -- 	<ssd:System name="foo">
 -- 		<ssd:Elements>
 -- 			<ssd:System name="goo">
@@ -165,7 +165,7 @@ printStatus(status, 3)
 -- status:  [correct] ok
 -- status:  [correct] ok
 -- <?xml version="1.0"?>
--- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="test01lua" version="1.0">
+-- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="test01lua" version="2.0">
 -- 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
 -- 		<ssd:Annotations>
 -- 			<ssc:Annotation type="org.openmodelica">

--- a/testsuite/api/test01.py
+++ b/testsuite/api/test01.py
@@ -82,7 +82,7 @@ printStatus(status, 3)
 ## error:   [NewSystem] A WC system must be the root system.
 ## status:  [correct] error
 ## <?xml version="1.0"?>
-## <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="test01py" version="1.0">
+## <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="test01py" version="2.0">
 ## 	<ssd:System name="foo">
 ## 		<ssd:Elements>
 ## 			<ssd:System name="goo">
@@ -165,7 +165,7 @@ printStatus(status, 3)
 ## status:  [correct] ok
 ## status:  [correct] ok
 ## <?xml version="1.0"?>
-## <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="test01py" version="1.0">
+## <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="test01py" version="2.0">
 ## 	<ssd:DefaultExperiment startTime="0.000000" stopTime="1.000000">
 ## 		<ssd:Annotations>
 ## 			<ssc:Annotation type="org.openmodelica">

--- a/testsuite/api/test03.lua
+++ b/testsuite/api/test03.lua
@@ -66,7 +66,7 @@ oms_delete("test03lua")
 
 -- Result:
 -- <?xml version="1.0"?>
--- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="test03lua" version="1.0">
+-- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="test03lua" version="2.0">
 -- 	<ssd:System name="eoo">
 -- 		<ssd:Elements>
 -- 			<ssd:Component name="source" type="application/x-fmu-sharedlibrary" source="resources/0001_source.fmu">
@@ -128,7 +128,7 @@ oms_delete("test03lua")
 -- error:   [getResourceNode] Failed to find node "resources/signalFilter.xml"
 -- status:  [correct] ok
 -- <?xml version="1.0"?>
--- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="test03lua" version="1.0">
+-- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="test03lua" version="2.0">
 -- 	<ssd:System name="eoo">
 -- 		<ssd:Elements>
 -- 			<ssd:Component name="source" type="application/x-fmu-sharedlibrary" source="resources/0001_source.fmu">

--- a/testsuite/api/test03.py
+++ b/testsuite/api/test03.py
@@ -60,7 +60,7 @@ oms.delete("test03py")
 
 ## Result:
 ## <?xml version="1.0"?>
-## <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="test03py" version="1.0">
+## <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="test03py" version="2.0">
 ## 	<ssd:System name="eoo">
 ## 		<ssd:Elements>
 ## 			<ssd:Component name="source" type="application/x-fmu-sharedlibrary" source="resources/0001_source.fmu">
@@ -122,7 +122,7 @@ oms.delete("test03py")
 ## error:   [getResourceNode] Failed to find node "resources/signalFilter.xml"
 ## status:  [correct] ok
 ## <?xml version="1.0"?>
-## <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="test03py" version="1.0">
+## <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="test03py" version="2.0">
 ## 	<ssd:System name="eoo">
 ## 		<ssd:Elements>
 ## 			<ssd:Component name="source" type="application/x-fmu-sharedlibrary" source="resources/0001_source.fmu">

--- a/testsuite/api/test_omsExport.lua
+++ b/testsuite/api/test_omsExport.lua
@@ -64,7 +64,7 @@ printStatus(status, 0)
 -- status:  [correct] ok
 -- status:  [correct] ok
 -- <?xml version="1.0"?>
--- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="model" version="1.0">
+-- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="model" version="2.0">
 -- 	<ssd:System name="sc">
 -- 		<ssd:Annotations>
 -- 			<ssc:Annotation type="org.openmodelica">
@@ -91,7 +91,7 @@ printStatus(status, 0)
 -- status:  [correct] ok
 -- status:  [correct] ok
 -- <?xml version="1.0"?>
--- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="model" version="1.0">
+-- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="model" version="2.0">
 -- 	<ssd:System name="sc">
 -- 		<ssd:Annotations>
 -- 			<ssc:Annotation type="org.openmodelica">

--- a/testsuite/api/test_omsExport.py
+++ b/testsuite/api/test_omsExport.py
@@ -65,7 +65,7 @@ printStatus(status, 0)
 ## status:  [correct] ok
 ## status:  [correct] ok
 ## <?xml version="1.0"?>
-## <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="model" version="1.0">
+## <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="model" version="2.0">
 ## 	<ssd:System name="sc">
 ## 		<ssd:Annotations>
 ## 			<ssc:Annotation type="org.openmodelica">
@@ -92,7 +92,7 @@ printStatus(status, 0)
 ## status:  [correct] ok
 ## status:  [correct] ok
 ## <?xml version="1.0"?>
-## <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="model" version="1.0">
+## <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="model" version="2.0">
 ## 	<ssd:System name="sc">
 ## 		<ssd:Annotations>
 ## 			<ssc:Annotation type="org.openmodelica">

--- a/testsuite/export/exportSSVTemplate1.lua
+++ b/testsuite/export/exportSSVTemplate1.lua
@@ -52,7 +52,7 @@ oms_delete("exportSSVTemplate")
 -- <ssv:ParameterSet
 --   xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --   xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---   version="1.0"
+--   version="2.0"
 --   name="modelDescriptionStartValues">
 --   <ssv:Parameters>
 --     <ssv:Parameter
@@ -141,7 +141,7 @@ oms_delete("exportSSVTemplate")
 -- <ssv:ParameterSet
 --   xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --   xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---   version="1.0"
+--   version="2.0"
 --   name="modelDescriptionStartValues">
 --   <ssv:Parameters>
 --     <ssv:Parameter
@@ -171,7 +171,7 @@ oms_delete("exportSSVTemplate")
 -- <ssv:ParameterSet
 --   xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --   xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---   version="1.0"
+--   version="2.0"
 --   name="modelDescriptionStartValues">
 --   <ssv:Parameters>
 --     <ssv:Parameter
@@ -198,7 +198,7 @@ oms_delete("exportSSVTemplate")
 -- <ssv:ParameterSet
 --   xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --   xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---   version="1.0"
+--   version="2.0"
 --   name="modelDescriptionStartValues">
 --   <ssv:Parameters>
 --     <ssv:Parameter

--- a/testsuite/export/exportSSVTemplate2.py
+++ b/testsuite/export/exportSSVTemplate2.py
@@ -40,7 +40,7 @@ model.delete()
 ## <ssv:ParameterSet
 ##   xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 ##   xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
-##   version="1.0"
+##   version="2.0"
 ##   name="modelDescriptionStartValues">
 ##   <ssv:Parameters>
 ##     <ssv:Parameter
@@ -87,7 +87,7 @@ model.delete()
 ## <ssv:ParameterSet
 ##   xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 ##   xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
-##   version="1.0"
+##   version="2.0"
 ##   name="modelDescriptionStartValues">
 ##   <ssv:Parameters>
 ##     <ssv:Parameter
@@ -117,7 +117,7 @@ model.delete()
 ## <ssv:ParameterSet
 ##   xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 ##   xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
-##   version="1.0"
+##   version="2.0"
 ##   name="modelDescriptionStartValues">
 ##   <ssv:Parameters>
 ##     <ssv:Parameter

--- a/testsuite/export/exportSSVTemplate3.lua
+++ b/testsuite/export/exportSSVTemplate3.lua
@@ -82,7 +82,7 @@ oms_delete("model")
 -- <ssv:ParameterSet
 --   xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --   xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---   version="1.0"
+--   version="2.0"
 --   name="modelDescriptionStartValues">
 --   <ssv:Parameters>
 --     <ssv:Parameter
@@ -190,7 +190,7 @@ oms_delete("model")
 -- <ssv:ParameterSet
 --   xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --   xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---   version="1.0"
+--   version="2.0"
 --   name="modelDescriptionStartValues">
 --   <ssv:Parameters>
 --     <ssv:Parameter
@@ -244,7 +244,7 @@ oms_delete("model")
 -- <ssv:ParameterSet
 --   xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --   xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---   version="1.0"
+--   version="2.0"
 --   name="modelDescriptionStartValues">
 --   <ssv:Parameters>
 --     <ssv:Parameter
@@ -271,7 +271,7 @@ oms_delete("model")
 -- <ssv:ParameterSet
 --   xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --   xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---   version="1.0"
+--   version="2.0"
 --   name="modelDescriptionStartValues">
 --   <ssv:Parameters>
 --     <ssv:Parameter
@@ -340,7 +340,7 @@ oms_delete("model")
 -- <ssv:ParameterSet
 --   xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --   xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---   version="1.0"
+--   version="2.0"
 --   name="modelDescriptionStartValues">
 --   <ssv:Parameters>
 --     <ssv:Parameter
@@ -394,7 +394,7 @@ oms_delete("model")
 -- <ssv:ParameterSet
 --   xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --   xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---   version="1.0"
+--   version="2.0"
 --   name="modelDescriptionStartValues">
 --   <ssv:Parameters>
 --     <ssv:Parameter

--- a/testsuite/import/importStartValues.py
+++ b/testsuite/import/importStartValues.py
@@ -33,7 +33,7 @@ model.delete()
 ##       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 ##       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 ##       name="importStartValues"
-##       version="1.0">
+##       version="2.0">
 ##       <ssd:System
 ##         name="root">
 ##         <ssd:Connectors>
@@ -158,7 +158,7 @@ model.delete()
 ##   <oms:file
 ##     name="resources/signalFilter.xml">
 ##     <oms:SignalFilter
-##       version="1.0">
+##       version="2.0">
 ##       <oms:Variable
 ##         name="importStartValues.root.C1"
 ##         type="Real"

--- a/testsuite/import/importStartValues.py
+++ b/testsuite/import/importStartValues.py
@@ -123,7 +123,7 @@ model.delete()
 ##     <ssv:ParameterSet
 ##       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 ##       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
-##       version="1.0"
+##       version="2.0"
 ##       name="parameters">
 ##       <ssv:Parameters>
 ##         <ssv:Parameter
@@ -139,7 +139,7 @@ model.delete()
 ##     <ssv:ParameterSet
 ##       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 ##       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
-##       version="1.0"
+##       version="2.0"
 ##       name="parameters">
 ##       <ssv:Parameters>
 ##         <ssv:Parameter

--- a/testsuite/simulation/activateVariant1.lua
+++ b/testsuite/simulation/activateVariant1.lua
@@ -72,7 +72,7 @@ oms_delete("varB")
 --   <oms:file
 --     name="ssdVariants.xml">
 --     <oms:Variants
---       version="1.0">
+--       version="2.0">
 --       <oms:variant
 --         name="model" />
 --       <oms:variant
@@ -100,7 +100,7 @@ oms_delete("varB")
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="model"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:Elements>
@@ -136,7 +136,7 @@ oms_delete("varB")
 --               <ssd:ParameterBinding>
 --                 <ssd:ParameterValues>
 --                   <ssv:ParameterSet
---                     version="1.0"
+--                     version="2.0"
 --                     name="parameters">
 --                     <ssv:Parameters>
 --                       <ssv:Parameter
@@ -193,7 +193,7 @@ oms_delete("varB")
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="model.root.A.u"
 --         type="Real"
@@ -227,7 +227,7 @@ oms_delete("varB")
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="varA"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:Elements>
@@ -263,7 +263,7 @@ oms_delete("varB")
 --               <ssd:ParameterBinding>
 --                 <ssd:ParameterValues>
 --                   <ssv:ParameterSet
---                     version="1.0"
+--                     version="2.0"
 --                     name="parameters">
 --                     <ssv:Parameters>
 --                       <ssv:Parameter
@@ -325,7 +325,7 @@ oms_delete("varB")
 --   <oms:file
 --     name="resources/signalFilter_varA.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="varA.root.A.u"
 --         type="Real"
@@ -359,7 +359,7 @@ oms_delete("varB")
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="varB"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:Elements>
@@ -395,7 +395,7 @@ oms_delete("varB")
 --               <ssd:ParameterBinding>
 --                 <ssd:ParameterValues>
 --                   <ssv:ParameterSet
---                     version="1.0"
+--                     version="2.0"
 --                     name="parameters">
 --                     <ssv:Parameters>
 --                       <ssv:Parameter
@@ -457,7 +457,7 @@ oms_delete("varB")
 --   <oms:file
 --     name="resources/signalFilter_varB.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="varB.root.A.u"
 --         type="Real"

--- a/testsuite/simulation/activateVariant2.lua
+++ b/testsuite/simulation/activateVariant2.lua
@@ -87,7 +87,7 @@ oms_delete("varB")
 --   <oms:file
 --     name="ssdVariants.xml">
 --     <oms:Variants
---       version="1.0">
+--       version="2.0">
 --       <oms:variant
 --         name="model" />
 --       <oms:variant
@@ -114,7 +114,7 @@ oms_delete("varB")
 --   <oms:file
 --     name="ssdVariants.xml">
 --     <oms:Variants
---       version="1.0">
+--       version="2.0">
 --       <oms:variant
 --         name="model" />
 --       <oms:variant
@@ -139,7 +139,7 @@ oms_delete("varB")
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="model"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:Elements>
@@ -175,7 +175,7 @@ oms_delete("varB")
 --               <ssd:ParameterBinding>
 --                 <ssd:ParameterValues>
 --                   <ssv:ParameterSet
---                     version="1.0"
+--                     version="2.0"
 --                     name="parameters">
 --                     <ssv:Parameters>
 --                       <ssv:Parameter
@@ -237,7 +237,7 @@ oms_delete("varB")
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="model.root.A.u"
 --         type="Real"
@@ -268,7 +268,7 @@ oms_delete("varB")
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="varA"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:Elements>
@@ -304,7 +304,7 @@ oms_delete("varB")
 --               <ssd:ParameterBinding>
 --                 <ssd:ParameterValues>
 --                   <ssv:ParameterSet
---                     version="1.0"
+--                     version="2.0"
 --                     name="parameters">
 --                     <ssv:Parameters>
 --                       <ssv:Parameter
@@ -366,7 +366,7 @@ oms_delete("varB")
 --   <oms:file
 --     name="resources/signalFilter_varA.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="varA.root.A.u"
 --         type="Real"
@@ -397,7 +397,7 @@ oms_delete("varB")
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="varB"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:Elements>
@@ -433,7 +433,7 @@ oms_delete("varB")
 --               <ssd:ParameterBinding>
 --                 <ssd:ParameterValues>
 --                   <ssv:ParameterSet
---                     version="1.0"
+--                     version="2.0"
 --                     name="parameters">
 --                     <ssv:Parameters>
 --                       <ssv:Parameter
@@ -495,7 +495,7 @@ oms_delete("varB")
 --   <oms:file
 --     name="resources/signalFilter_varB.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="varB.root.A.u"
 --         type="Real"

--- a/testsuite/simulation/activateVariant3.lua
+++ b/testsuite/simulation/activateVariant3.lua
@@ -95,7 +95,7 @@ oms_delete("varB")
 --   <oms:file
 --     name="ssdVariants.xml">
 --     <oms:Variants
---       version="1.0">
+--       version="2.0">
 --       <oms:variant
 --         name="model" />
 --       <oms:variant
@@ -122,7 +122,7 @@ oms_delete("varB")
 --   <oms:file
 --     name="ssdVariants.xml">
 --     <oms:Variants
---       version="1.0">
+--       version="2.0">
 --       <oms:variant
 --         name="model" />
 --       <oms:variant
@@ -147,7 +147,7 @@ oms_delete("varB")
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="model"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:ParameterBindings>
@@ -228,7 +228,7 @@ oms_delete("varB")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -247,7 +247,7 @@ oms_delete("varB")
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="model.root.A.u"
 --         type="Real"
@@ -278,7 +278,7 @@ oms_delete("varB")
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="varA"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:ParameterBindings>
@@ -359,7 +359,7 @@ oms_delete("varB")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -378,7 +378,7 @@ oms_delete("varB")
 --   <oms:file
 --     name="resources/signalFilter_varA.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="varA.root.A.u"
 --         type="Real"
@@ -409,7 +409,7 @@ oms_delete("varB")
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="varB"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:ParameterBindings>
@@ -490,7 +490,7 @@ oms_delete("varB")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -509,7 +509,7 @@ oms_delete("varB")
 --   <oms:file
 --     name="resources/signalFilter_varB.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="varB.root.A.u"
 --         type="Real"

--- a/testsuite/simulation/addResources1.lua
+++ b/testsuite/simulation/addResources1.lua
@@ -225,7 +225,7 @@ oms_delete("addResources")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -246,7 +246,7 @@ oms_delete("addResources")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -262,7 +262,7 @@ oms_delete("addResources")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter

--- a/testsuite/simulation/addResources1.lua
+++ b/testsuite/simulation/addResources1.lua
@@ -101,7 +101,7 @@ oms_delete("addResources")
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="addResources"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:Connectors>
@@ -276,7 +276,7 @@ oms_delete("addResources")
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="addResources.root.Input1"
 --         type="Real"

--- a/testsuite/simulation/addResources2.lua
+++ b/testsuite/simulation/addResources2.lua
@@ -210,7 +210,7 @@ oms_delete("addResources")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter

--- a/testsuite/simulation/addResources2.lua
+++ b/testsuite/simulation/addResources2.lua
@@ -94,7 +94,7 @@ oms_delete("addResources")
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="addResources"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:Connectors>
@@ -239,7 +239,7 @@ oms_delete("addResources")
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="addResources.root.Input1"
 --         type="Real"

--- a/testsuite/simulation/addResources3.lua
+++ b/testsuite/simulation/addResources3.lua
@@ -92,7 +92,7 @@ oms_delete("addResources")
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="addResources"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:Elements>
@@ -338,7 +338,7 @@ oms_delete("addResources")
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="addResources.root.system2.C1"
 --         type="Real"

--- a/testsuite/simulation/addResources3.lua
+++ b/testsuite/simulation/addResources3.lua
@@ -288,7 +288,7 @@ oms_delete("addResources")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -314,7 +314,7 @@ oms_delete("addResources")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter

--- a/testsuite/simulation/addResources4.lua
+++ b/testsuite/simulation/addResources4.lua
@@ -283,7 +283,7 @@ oms_delete("addResources")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter

--- a/testsuite/simulation/addResources4.lua
+++ b/testsuite/simulation/addResources4.lua
@@ -91,7 +91,7 @@ oms_delete("addResources")
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="addResources"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:ParameterBindings>
@@ -322,7 +322,7 @@ oms_delete("addResources")
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="addResources.root.system2.C1"
 --         type="Real"

--- a/testsuite/simulation/addResources5.lua
+++ b/testsuite/simulation/addResources5.lua
@@ -110,7 +110,7 @@ oms_delete("addResources")
 --               <ssd:ParameterBinding>
 --                 <ssd:ParameterValues>
 --                   <ssv:ParameterSet
---                     version="1.0"
+--                     version="2.0"
 --                     name="parameters">
 --                     <ssv:Parameters>
 --                       <ssv:Parameter
@@ -173,7 +173,7 @@ oms_delete("addResources")
 --                   <ssd:ParameterBinding>
 --                     <ssd:ParameterValues>
 --                       <ssv:ParameterSet
---                         version="1.0"
+--                         version="2.0"
 --                         name="parameters">
 --                         <ssv:Parameters>
 --                           <ssv:Parameter
@@ -222,7 +222,7 @@ oms_delete("addResources")
 --               <ssd:ParameterBinding>
 --                 <ssd:ParameterValues>
 --                   <ssv:ParameterSet
---                     version="1.0"
+--                     version="2.0"
 --                     name="parameters">
 --                     <ssv:Parameters>
 --                       <ssv:Parameter
@@ -285,7 +285,7 @@ oms_delete("addResources")
 --                   <ssd:ParameterBinding>
 --                     <ssd:ParameterValues>
 --                       <ssv:ParameterSet
---                         version="1.0"
+--                         version="2.0"
 --                         name="parameters">
 --                         <ssv:Parameters>
 --                           <ssv:Parameter

--- a/testsuite/simulation/addResources5.lua
+++ b/testsuite/simulation/addResources5.lua
@@ -88,7 +88,7 @@ oms_delete("addResources")
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="addResources"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:Elements>
@@ -352,7 +352,7 @@ oms_delete("addResources")
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="addResources.root.system2.C1"
 --         type="Real"

--- a/testsuite/simulation/addResources6.lua
+++ b/testsuite/simulation/addResources6.lua
@@ -92,7 +92,7 @@ oms_delete("addResources")
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="addResources"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:Elements>
@@ -347,7 +347,7 @@ oms_delete("addResources")
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="addResources.root.system2.C1"
 --         type="Real"

--- a/testsuite/simulation/addResources6.lua
+++ b/testsuite/simulation/addResources6.lua
@@ -114,7 +114,7 @@ oms_delete("addResources")
 --               <ssd:ParameterBinding>
 --                 <ssd:ParameterValues>
 --                   <ssv:ParameterSet
---                     version="1.0"
+--                     version="2.0"
 --                     name="parameters">
 --                     <ssv:Parameters>
 --                       <ssv:Parameter
@@ -177,7 +177,7 @@ oms_delete("addResources")
 --                   <ssd:ParameterBinding>
 --                     <ssd:ParameterValues>
 --                       <ssv:ParameterSet
---                         version="1.0"
+--                         version="2.0"
 --                         name="parameters">
 --                         <ssv:Parameters>
 --                           <ssv:Parameter
@@ -323,7 +323,7 @@ oms_delete("addResources")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter

--- a/testsuite/simulation/addResources7.lua
+++ b/testsuite/simulation/addResources7.lua
@@ -98,7 +98,7 @@ oms_delete("addResources")
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="addResources"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:Elements>
@@ -374,7 +374,7 @@ oms_delete("addResources")
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="addResources.root.system2.C1"
 --         type="Real"

--- a/testsuite/simulation/addResources7.lua
+++ b/testsuite/simulation/addResources7.lua
@@ -302,7 +302,7 @@ oms_delete("addResources")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -323,7 +323,7 @@ oms_delete("addResources")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -339,7 +339,7 @@ oms_delete("addResources")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -360,7 +360,7 @@ oms_delete("addResources")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter

--- a/testsuite/simulation/deleteConnector.lua
+++ b/testsuite/simulation/deleteConnector.lua
@@ -57,7 +57,7 @@ print(src)
 
 -- Result:
 -- <?xml version="1.0"?>
--- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="deleteConnector" version="1.0">
+-- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="deleteConnector" version="2.0">
 -- 	<ssd:System name="Root">
 -- 		<ssd:Connectors>
 -- 			<ssd:Connector name="C1" kind="input">
@@ -80,7 +80,7 @@ print(src)
 -- 				<ssd:ParameterBindings>
 -- 					<ssd:ParameterBinding>
 -- 						<ssd:ParameterValues>
--- 							<ssv:ParameterSet version="1.0" name="parameters">
+-- 							<ssv:ParameterSet version="2.0" name="parameters">
 -- 								<ssv:Parameters>
 -- 									<ssv:Parameter name="C4">
 -- 										<ssv:Real value="30" />
@@ -130,7 +130,7 @@ print(src)
 -- 						<ssd:ParameterBindings>
 -- 							<ssd:ParameterBinding>
 -- 								<ssd:ParameterValues>
--- 									<ssv:ParameterSet version="1.0" name="parameters">
+-- 									<ssv:ParameterSet version="2.0" name="parameters">
 -- 										<ssv:Parameters>
 -- 											<ssv:Parameter name="k">
 -- 												<ssv:Real value="30" unit="1" />
@@ -182,7 +182,7 @@ print(src)
 -- warning: failed to delete object "deleteConnector.Root.System2.C6" because the identifier couldn't be resolved to any connector, component, system, or model
 -- warning: failed to delete object "deleteConnector.Root.System3" because the identifier couldn't be resolved to any connector, component, system, or model
 -- <?xml version="1.0"?>
--- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="deleteConnector" version="1.0">
+-- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="deleteConnector" version="2.0">
 -- 	<ssd:System name="Root">
 -- 		<ssd:Connectors>
 -- 			<ssd:Connector name="C2" kind="output">
@@ -199,7 +199,7 @@ print(src)
 -- 				<ssd:ParameterBindings>
 -- 					<ssd:ParameterBinding>
 -- 						<ssd:ParameterValues>
--- 							<ssv:ParameterSet version="1.0" name="parameters">
+-- 							<ssv:ParameterSet version="2.0" name="parameters">
 -- 								<ssv:Parameters>
 -- 									<ssv:Parameter name="C4">
 -- 										<ssv:Real value="30" />

--- a/testsuite/simulation/deleteConnector1.lua
+++ b/testsuite/simulation/deleteConnector1.lua
@@ -80,7 +80,7 @@ oms_delete("deleteConnector")
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="deleteConnector"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="Root">
 --         <ssd:Connectors>
@@ -246,7 +246,7 @@ oms_delete("deleteConnector")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -275,7 +275,7 @@ oms_delete("deleteConnector")
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="deleteConnector.Root.C1"
 --         type="Real"
@@ -327,7 +327,7 @@ oms_delete("deleteConnector")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter

--- a/testsuite/simulation/deleteReferencesAndStartValues.lua
+++ b/testsuite/simulation/deleteReferencesAndStartValues.lua
@@ -117,7 +117,7 @@ oms_delete("deleteResources")
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="deleteResources"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:Connectors>
@@ -236,7 +236,7 @@ oms_delete("deleteResources")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -257,7 +257,7 @@ oms_delete("deleteResources")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -273,7 +273,7 @@ oms_delete("deleteResources")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -294,7 +294,7 @@ oms_delete("deleteResources")
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="deleteResources.root.Input1"
 --         type="Real"

--- a/testsuite/simulation/deleteRootSystem.lua
+++ b/testsuite/simulation/deleteRootSystem.lua
@@ -39,7 +39,7 @@ oms_importSnapshot("model", src)
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="model"
---       version="1.0">
+--       version="2.0">
 --       <ssd:DefaultExperiment
 --         startTime="0.000000"
 --         stopTime="1.000000">

--- a/testsuite/simulation/deleteStartValues.lua
+++ b/testsuite/simulation/deleteStartValues.lua
@@ -56,7 +56,7 @@ print(src)
 
 -- Result:
 -- <?xml version="1.0"?>
--- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="deleteStartValues" version="1.0">
+-- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="deleteStartValues" version="2.0">
 -- 	<ssd:System name="Root">
 -- 		<ssd:Connectors>
 -- 			<ssd:Connector name="C1" kind="input">
@@ -72,7 +72,7 @@ print(src)
 -- 		<ssd:ParameterBindings>
 -- 			<ssd:ParameterBinding>
 -- 				<ssd:ParameterValues>
--- 					<ssv:ParameterSet version="1.0" name="parameters">
+-- 					<ssv:ParameterSet version="2.0" name="parameters">
 -- 						<ssv:Parameters>
 -- 							<ssv:Parameter name="C3">
 -- 								<ssv:Real value="10" />
@@ -95,7 +95,7 @@ print(src)
 -- 				<ssd:ParameterBindings>
 -- 					<ssd:ParameterBinding>
 -- 						<ssd:ParameterValues>
--- 							<ssv:ParameterSet version="1.0" name="parameters">
+-- 							<ssv:ParameterSet version="2.0" name="parameters">
 -- 								<ssv:Parameters>
 -- 									<ssv:Parameter name="C4">
 -- 										<ssv:Real value="30" />
@@ -130,7 +130,7 @@ print(src)
 -- 				<ssd:ParameterBindings>
 -- 					<ssd:ParameterBinding>
 -- 						<ssd:ParameterValues>
--- 							<ssv:ParameterSet version="1.0" name="parameters">
+-- 							<ssv:ParameterSet version="2.0" name="parameters">
 -- 								<ssv:Parameters>
 -- 									<ssv:Parameter name="C2">
 -- 										<ssv:Real value="-30" />
@@ -195,7 +195,7 @@ print(src)
 -- warning: failed to delete object "deleteStartValues.Root.System3.C4:start" because the identifier couldn't be resolved to any connector, component, system, or model
 -- warning: failed to delete start value "deleteStartValues.Root.System1.Gain.k:start" because the identifier couldn't be resolved to any component signal
 -- <?xml version="1.0"?>
--- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="deleteStartValues" version="1.0">
+-- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="deleteStartValues" version="2.0">
 -- 	<ssd:System name="Root">
 -- 		<ssd:Connectors>
 -- 			<ssd:Connector name="C1" kind="input">

--- a/testsuite/simulation/deleteStartValuesInSSV.lua
+++ b/testsuite/simulation/deleteStartValuesInSSV.lua
@@ -60,7 +60,7 @@ oms_delete("deleteStartValuesInSSV")
 
 -- Result:
 -- <?xml version="1.0"?>
--- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="deleteStartValuesInSSV" version="1.0">
+-- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="deleteStartValuesInSSV" version="2.0">
 -- 	<ssd:System name="Root">
 -- 		<ssd:Connectors>
 -- 			<ssd:Connector name="C1" kind="input">

--- a/testsuite/simulation/deleteStartValuesInSSV1.lua
+++ b/testsuite/simulation/deleteStartValuesInSSV1.lua
@@ -74,7 +74,7 @@ oms_delete("deleteStartValuesInSSV")
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="deleteStartValuesInSSV"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="Root">
 --         <ssd:Connectors>
@@ -197,7 +197,7 @@ oms_delete("deleteStartValuesInSSV")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -218,7 +218,7 @@ oms_delete("deleteStartValuesInSSV")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -242,7 +242,7 @@ oms_delete("deleteStartValuesInSSV")
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="deleteStartValuesInSSV.Root.C1"
 --         type="Real"
@@ -284,7 +284,7 @@ oms_delete("deleteStartValuesInSSV")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -306,7 +306,7 @@ oms_delete("deleteStartValuesInSSV")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter

--- a/testsuite/simulation/deleteStartValuesInSSV2.lua
+++ b/testsuite/simulation/deleteStartValuesInSSV2.lua
@@ -83,7 +83,7 @@ oms_delete("deleteStartValuesInSSV")
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="deleteStartValuesInSSV"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="Root">
 --         <ssd:Connectors>
@@ -214,7 +214,7 @@ oms_delete("deleteStartValuesInSSV")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -235,7 +235,7 @@ oms_delete("deleteStartValuesInSSV")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -256,7 +256,7 @@ oms_delete("deleteStartValuesInSSV")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -277,7 +277,7 @@ oms_delete("deleteStartValuesInSSV")
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="deleteStartValuesInSSV.Root.C1"
 --         type="Real"
@@ -319,7 +319,7 @@ oms_delete("deleteStartValuesInSSV")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -341,7 +341,7 @@ oms_delete("deleteStartValuesInSSV")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -363,7 +363,7 @@ oms_delete("deleteStartValuesInSSV")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters />
 --       <ssv:Units>

--- a/testsuite/simulation/duplicateActivateVariant1.lua
+++ b/testsuite/simulation/duplicateActivateVariant1.lua
@@ -82,10 +82,10 @@ oms_delete("varB")
 -- info:    Activate Variant varB
 -- info:      varB.root.A.u      : -13.0
 -- info:      varB.root.A.k      : -100.0
--- info:    Reactivate Variant varB to varA 
+-- info:    Reactivate Variant varB to varA
 -- info:      varA.root.A.u      : -10.0
 -- info:      varA.root.A.k      : 10.0
--- info:    Reactivate Variant varA to model 
+-- info:    Reactivate Variant varA to model
 -- info:      model.root.A.u      : 0.0
 -- info:      model.root.A.k      : 10.0
 -- <?xml version="1.0"?>
@@ -95,7 +95,7 @@ oms_delete("varB")
 --   <oms:file
 --     name="ssdVariants.xml">
 --     <oms:Variants
---       version="1.0">
+--       version="2.0">
 --       <oms:variant
 --         name="model" />
 --       <oms:variant
@@ -120,7 +120,7 @@ oms_delete("varB")
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="model"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:Elements>
@@ -156,7 +156,7 @@ oms_delete("varB")
 --               <ssd:ParameterBinding>
 --                 <ssd:ParameterValues>
 --                   <ssv:ParameterSet
---                     version="1.0"
+--                     version="2.0"
 --                     name="parameters">
 --                     <ssv:Parameters>
 --                       <ssv:Parameter
@@ -213,7 +213,7 @@ oms_delete("varB")
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="model.root.A.u"
 --         type="Real"
@@ -244,7 +244,7 @@ oms_delete("varB")
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="varA"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:Elements>
@@ -280,7 +280,7 @@ oms_delete("varB")
 --               <ssd:ParameterBinding>
 --                 <ssd:ParameterValues>
 --                   <ssv:ParameterSet
---                     version="1.0"
+--                     version="2.0"
 --                     name="parameters">
 --                     <ssv:Parameters>
 --                       <ssv:Parameter
@@ -342,7 +342,7 @@ oms_delete("varB")
 --   <oms:file
 --     name="resources/signalFilter_varA.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="varA.root.A.u"
 --         type="Real"
@@ -373,7 +373,7 @@ oms_delete("varB")
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="varB"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:Elements>
@@ -409,7 +409,7 @@ oms_delete("varB")
 --               <ssd:ParameterBinding>
 --                 <ssd:ParameterValues>
 --                   <ssv:ParameterSet
---                     version="1.0"
+--                     version="2.0"
 --                     name="parameters">
 --                     <ssv:Parameters>
 --                       <ssv:Parameter
@@ -471,7 +471,7 @@ oms_delete("varB")
 --   <oms:file
 --     name="resources/signalFilter_varB.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="varB.root.A.u"
 --         type="Real"

--- a/testsuite/simulation/duplicateActivateVariant2.py
+++ b/testsuite/simulation/duplicateActivateVariant2.py
@@ -159,7 +159,7 @@ oms.delete("varB")
 ##               <ssd:ParameterBinding>
 ##                 <ssd:ParameterValues>
 ##                   <ssv:ParameterSet
-##                     version="1.0"
+##                     version="2.0"
 ##                     name="parameters">
 ##                     <ssv:Parameters>
 ##                       <ssv:Parameter
@@ -283,7 +283,7 @@ oms.delete("varB")
 ##               <ssd:ParameterBinding>
 ##                 <ssd:ParameterValues>
 ##                   <ssv:ParameterSet
-##                     version="1.0"
+##                     version="2.0"
 ##                     name="parameters">
 ##                     <ssv:Parameters>
 ##                       <ssv:Parameter
@@ -412,7 +412,7 @@ oms.delete("varB")
 ##               <ssd:ParameterBinding>
 ##                 <ssd:ParameterValues>
 ##                   <ssv:ParameterSet
-##                     version="1.0"
+##                     version="2.0"
 ##                     name="parameters">
 ##                     <ssv:Parameters>
 ##                       <ssv:Parameter

--- a/testsuite/simulation/duplicateActivateVariant2.py
+++ b/testsuite/simulation/duplicateActivateVariant2.py
@@ -85,10 +85,10 @@ oms.delete("varB")
 ## info:    Activate Variant varB
 ## info:      varB.root.A.u      :  -13.0
 ## info:      varB.root.A.k      :  -100.0
-## info:    Reactivate Variant varB to varA 
+## info:    Reactivate Variant varB to varA
 ## info:      varA.root.A.u      :  -10.0
 ## info:      varA.root.A.k      :  10.0
-## info:    Reactivate Variant varA to model 
+## info:    Reactivate Variant varA to model
 ## info:      model.root.A.u      :  0.0
 ## info:      model.root.A.k      :  10.0
 ## <?xml version="1.0"?>
@@ -98,7 +98,7 @@ oms.delete("varB")
 ##   <oms:file
 ##     name="ssdVariants.xml">
 ##     <oms:Variants
-##       version="1.0">
+##       version="2.0">
 ##       <oms:variant
 ##         name="model" />
 ##       <oms:variant
@@ -123,7 +123,7 @@ oms.delete("varB")
 ##       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 ##       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 ##       name="model"
-##       version="1.0">
+##       version="2.0">
 ##       <ssd:System
 ##         name="root">
 ##         <ssd:Elements>
@@ -216,7 +216,7 @@ oms.delete("varB")
 ##   <oms:file
 ##     name="resources/signalFilter.xml">
 ##     <oms:SignalFilter
-##       version="1.0">
+##       version="2.0">
 ##       <oms:Variable
 ##         name="model.root.A.u"
 ##         type="Real"
@@ -247,7 +247,7 @@ oms.delete("varB")
 ##       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 ##       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 ##       name="varA"
-##       version="1.0">
+##       version="2.0">
 ##       <ssd:System
 ##         name="root">
 ##         <ssd:Elements>
@@ -345,7 +345,7 @@ oms.delete("varB")
 ##   <oms:file
 ##     name="resources/signalFilter_varA.xml">
 ##     <oms:SignalFilter
-##       version="1.0">
+##       version="2.0">
 ##       <oms:Variable
 ##         name="varA.root.A.u"
 ##         type="Real"
@@ -376,7 +376,7 @@ oms.delete("varB")
 ##       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 ##       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 ##       name="varB"
-##       version="1.0">
+##       version="2.0">
 ##       <ssd:System
 ##         name="root">
 ##         <ssd:Elements>
@@ -474,7 +474,7 @@ oms.delete("varB")
 ##   <oms:file
 ##     name="resources/signalFilter_varB.xml">
 ##     <oms:SignalFilter
-##       version="1.0">
+##       version="2.0">
 ##       <oms:Variable
 ##         name="varB.root.A.u"
 ##         type="Real"

--- a/testsuite/simulation/duplicateVariant1.lua
+++ b/testsuite/simulation/duplicateVariant1.lua
@@ -92,7 +92,7 @@ oms_delete("varB")
 --               <ssd:ParameterBinding>
 --                 <ssd:ParameterValues>
 --                   <ssv:ParameterSet
---                     version="1.0"
+--                     version="2.0"
 --                     name="parameters">
 --                     <ssv:Parameters>
 --                       <ssv:Parameter
@@ -216,7 +216,7 @@ oms_delete("varB")
 --               <ssd:ParameterBinding>
 --                 <ssd:ParameterValues>
 --                   <ssv:ParameterSet
---                     version="1.0"
+--                     version="2.0"
 --                     name="parameters">
 --                     <ssv:Parameters>
 --                       <ssv:Parameter
@@ -345,7 +345,7 @@ oms_delete("varB")
 --               <ssd:ParameterBinding>
 --                 <ssd:ParameterValues>
 --                   <ssv:ParameterSet
---                     version="1.0"
+--                     version="2.0"
 --                     name="parameters">
 --                     <ssv:Parameters>
 --                       <ssv:Parameter

--- a/testsuite/simulation/duplicateVariant1.lua
+++ b/testsuite/simulation/duplicateVariant1.lua
@@ -56,7 +56,7 @@ oms_delete("varB")
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="model"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:Elements>
@@ -149,7 +149,7 @@ oms_delete("varB")
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="model.root.A.u"
 --         type="Real"
@@ -180,7 +180,7 @@ oms_delete("varB")
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="varA"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:Elements>
@@ -278,7 +278,7 @@ oms_delete("varB")
 --   <oms:file
 --     name="resources/signalFilter_varA.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="varA.root.A.u"
 --         type="Real"
@@ -309,7 +309,7 @@ oms_delete("varB")
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="varB"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:Elements>
@@ -407,7 +407,7 @@ oms_delete("varB")
 --   <oms:file
 --     name="resources/signalFilter_varB.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="varB.root.A.u"
 --         type="Real"

--- a/testsuite/simulation/duplicateVariant2.lua
+++ b/testsuite/simulation/duplicateVariant2.lua
@@ -95,7 +95,7 @@ oms_delete("varB")
 --               <ssd:ParameterBinding>
 --                 <ssd:ParameterValues>
 --                   <ssv:ParameterSet
---                     version="1.0"
+--                     version="2.0"
 --                     name="parameters">
 --                     <ssv:Parameters>
 --                       <ssv:Parameter
@@ -219,7 +219,7 @@ oms_delete("varB")
 --               <ssd:ParameterBinding>
 --                 <ssd:ParameterValues>
 --                   <ssv:ParameterSet
---                     version="1.0"
+--                     version="2.0"
 --                     name="parameters">
 --                     <ssv:Parameters>
 --                       <ssv:Parameter
@@ -348,7 +348,7 @@ oms_delete("varB")
 --               <ssd:ParameterBinding>
 --                 <ssd:ParameterValues>
 --                   <ssv:ParameterSet
---                     version="1.0"
+--                     version="2.0"
 --                     name="parameters">
 --                     <ssv:Parameters>
 --                       <ssv:Parameter

--- a/testsuite/simulation/duplicateVariant2.lua
+++ b/testsuite/simulation/duplicateVariant2.lua
@@ -59,7 +59,7 @@ oms_delete("varB")
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="model"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:Elements>
@@ -152,7 +152,7 @@ oms_delete("varB")
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="model.root.A.u"
 --         type="Real"
@@ -183,7 +183,7 @@ oms_delete("varB")
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="varA"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:Elements>
@@ -281,7 +281,7 @@ oms_delete("varB")
 --   <oms:file
 --     name="resources/signalFilter_varA.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="varA.root.A.u"
 --         type="Real"
@@ -312,7 +312,7 @@ oms_delete("varB")
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="varB"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:Elements>
@@ -410,7 +410,7 @@ oms_delete("varB")
 --   <oms:file
 --     name="resources/signalFilter_varB.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="varB.root.A.k"
 --         type="Real"

--- a/testsuite/simulation/duplicateVariant3.lua
+++ b/testsuite/simulation/duplicateVariant3.lua
@@ -140,7 +140,7 @@ oms_delete("varB")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -266,7 +266,7 @@ oms_delete("varB")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -397,7 +397,7 @@ oms_delete("varB")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter

--- a/testsuite/simulation/duplicateVariant3.lua
+++ b/testsuite/simulation/duplicateVariant3.lua
@@ -59,7 +59,7 @@ oms_delete("varB")
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="model"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:ParameterBindings>
@@ -154,7 +154,7 @@ oms_delete("varB")
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="model.root.A.u"
 --         type="Real"
@@ -185,7 +185,7 @@ oms_delete("varB")
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="varA"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:ParameterBindings>
@@ -285,7 +285,7 @@ oms_delete("varB")
 --   <oms:file
 --     name="resources/signalFilter_varA.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="varA.root.A.u"
 --         type="Real"
@@ -316,7 +316,7 @@ oms_delete("varB")
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="varB"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:ParameterBindings>
@@ -416,7 +416,7 @@ oms_delete("varB")
 --   <oms:file
 --     name="resources/signalFilter_varB.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="varB.root.A.u"
 --         type="Real"

--- a/testsuite/simulation/duplicateVariant4.py
+++ b/testsuite/simulation/duplicateVariant4.py
@@ -62,7 +62,7 @@ oms.delete("varB")
 ##       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 ##       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 ##       name="model"
-##       version="1.0">
+##       version="2.0">
 ##       <ssd:System
 ##         name="root">
 ##         <ssd:Elements>
@@ -155,7 +155,7 @@ oms.delete("varB")
 ##   <oms:file
 ##     name="resources/signalFilter.xml">
 ##     <oms:SignalFilter
-##       version="1.0">
+##       version="2.0">
 ##       <oms:Variable
 ##         name="model.root.A.u"
 ##         type="Real"
@@ -186,7 +186,7 @@ oms.delete("varB")
 ##       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 ##       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 ##       name="varA"
-##       version="1.0">
+##       version="2.0">
 ##       <ssd:System
 ##         name="root">
 ##         <ssd:Elements>
@@ -284,7 +284,7 @@ oms.delete("varB")
 ##   <oms:file
 ##     name="resources/signalFilter_varA.xml">
 ##     <oms:SignalFilter
-##       version="1.0">
+##       version="2.0">
 ##       <oms:Variable
 ##         name="varA.root.A.u"
 ##         type="Real"
@@ -315,7 +315,7 @@ oms.delete("varB")
 ##       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 ##       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 ##       name="varB"
-##       version="1.0">
+##       version="2.0">
 ##       <ssd:System
 ##         name="root">
 ##         <ssd:Elements>
@@ -413,7 +413,7 @@ oms.delete("varB")
 ##   <oms:file
 ##     name="resources/signalFilter_varB.xml">
 ##     <oms:SignalFilter
-##       version="1.0">
+##       version="2.0">
 ##       <oms:Variable
 ##         name="varB.root.A.u"
 ##         type="Real"

--- a/testsuite/simulation/duplicateVariant4.py
+++ b/testsuite/simulation/duplicateVariant4.py
@@ -98,7 +98,7 @@ oms.delete("varB")
 ##               <ssd:ParameterBinding>
 ##                 <ssd:ParameterValues>
 ##                   <ssv:ParameterSet
-##                     version="1.0"
+##                     version="2.0"
 ##                     name="parameters">
 ##                     <ssv:Parameters>
 ##                       <ssv:Parameter
@@ -222,7 +222,7 @@ oms.delete("varB")
 ##               <ssd:ParameterBinding>
 ##                 <ssd:ParameterValues>
 ##                   <ssv:ParameterSet
-##                     version="1.0"
+##                     version="2.0"
 ##                     name="parameters">
 ##                     <ssv:Parameters>
 ##                       <ssv:Parameter
@@ -351,7 +351,7 @@ oms.delete("varB")
 ##               <ssd:ParameterBinding>
 ##                 <ssd:ParameterValues>
 ##                   <ssv:ParameterSet
-##                     version="1.0"
+##                     version="2.0"
 ##                     name="parameters">
 ##                     <ssv:Parameters>
 ##                       <ssv:Parameter

--- a/testsuite/simulation/exportConnectorsToResultFile.lua
+++ b/testsuite/simulation/exportConnectorsToResultFile.lua
@@ -90,7 +90,7 @@ oms_delete("exportConnectors")
 -- info:      exportConnectors.Root.C3                    : 4.5
 -- info:      exportConnectors.Root.Gain.u                : 10.5
 -- <?xml version="1.0"?>
--- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="exportConnectors" version="1.0">
+-- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="exportConnectors" version="2.0">
 -- 	<ssd:System name="Root">
 -- 		<ssd:Connectors>
 -- 			<ssd:Connector name="C1" kind="input">
@@ -106,7 +106,7 @@ oms_delete("exportConnectors")
 -- 		<ssd:ParameterBindings>
 -- 			<ssd:ParameterBinding>
 -- 				<ssd:ParameterValues>
--- 					<ssv:ParameterSet version="1.0" name="parameters">
+-- 					<ssv:ParameterSet version="2.0" name="parameters">
 -- 						<ssv:Parameters>
 -- 							<ssv:Parameter name="C3">
 -- 								<ssv:Real value="4.5" />
@@ -137,7 +137,7 @@ oms_delete("exportConnectors")
 -- 				<ssd:ParameterBindings>
 -- 					<ssd:ParameterBinding>
 -- 						<ssd:ParameterValues>
--- 							<ssv:ParameterSet version="1.0" name="parameters">
+-- 							<ssv:ParameterSet version="2.0" name="parameters">
 -- 								<ssv:Parameters>
 -- 									<ssv:Parameter name="u">
 -- 										<ssv:Real value="7.5" />

--- a/testsuite/simulation/exportSSMTemplate.lua
+++ b/testsuite/simulation/exportSSMTemplate.lua
@@ -40,7 +40,7 @@ readFile("gain1.ssm")
 -- <ssm:ParameterMapping
 --   xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --   xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping"
---   version="1.0">
+--   version="2.0">
 --   <ssm:MappingEntry
 --     source=""
 --     target="add.u2" />
@@ -65,7 +65,7 @@ readFile("gain1.ssm")
 -- <ssm:ParameterMapping
 --   xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --   xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping"
---   version="1.0">
+--   version="2.0">
 --   <ssm:MappingEntry
 --     source=""
 --     target="add.u2" />
@@ -84,7 +84,7 @@ readFile("gain1.ssm")
 -- <ssm:ParameterMapping
 --   xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --   xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping"
---   version="1.0">
+--   version="2.0">
 --   <ssm:MappingEntry
 --     source=""
 --     target="Gain.u" />

--- a/testsuite/simulation/exportSSMTemplate.py
+++ b/testsuite/simulation/exportSSMTemplate.py
@@ -43,7 +43,7 @@ readFile("gain2.ssm")
 ## <ssm:ParameterMapping
 ##   xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 ##   xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping"
-##   version="1.0">
+##   version="2.0">
 ##   <ssm:MappingEntry
 ##     source=""
 ##     target="add.u2" />
@@ -68,7 +68,7 @@ readFile("gain2.ssm")
 ## <ssm:ParameterMapping
 ##   xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 ##   xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping"
-##   version="1.0">
+##   version="2.0">
 ##   <ssm:MappingEntry
 ##     source=""
 ##     target="add.u2" />
@@ -87,7 +87,7 @@ readFile("gain2.ssm")
 ## <ssm:ParameterMapping
 ##   xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 ##   xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping"
-##   version="1.0">
+##   version="2.0">
 ##   <ssm:MappingEntry
 ##     source=""
 ##     target="Gain.u" />

--- a/testsuite/simulation/exportSnapshotSSP.lua
+++ b/testsuite/simulation/exportSnapshotSSP.lua
@@ -51,7 +51,7 @@ print(src)
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="exportSnapshotSSP"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:Connectors>
@@ -139,7 +139,7 @@ print(src)
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -158,7 +158,7 @@ print(src)
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="exportSnapshotSSP.root.Input1"
 --         type="Real"

--- a/testsuite/simulation/fmiattributes19.lua
+++ b/testsuite/simulation/fmiattributes19.lua
@@ -63,7 +63,7 @@ oms_delete("model")
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="model"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:Elements>
@@ -127,7 +127,7 @@ oms_delete("model")
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="model.root.A.x"
 --         type="Real"

--- a/testsuite/simulation/importExportEnumerationDefinition.lua
+++ b/testsuite/simulation/importExportEnumerationDefinition.lua
@@ -41,7 +41,7 @@ print(snapshot_)
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="model"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="co_sim">
 --         <ssd:Elements>
@@ -142,7 +142,7 @@ print(snapshot_)
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="model.co_sim.limiter.u"
 --         type="Real"

--- a/testsuite/simulation/importPartialSnapshot.lua
+++ b/testsuite/simulation/importPartialSnapshot.lua
@@ -87,7 +87,7 @@ print(snapshot)
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="snapshot"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:Connectors>
@@ -181,7 +181,7 @@ print(snapshot)
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -205,7 +205,7 @@ print(snapshot)
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="snapshot.root.C1"
 --         type="Real"
@@ -249,7 +249,7 @@ print(snapshot)
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="snapshot"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:Connectors>
@@ -343,7 +343,7 @@ print(snapshot)
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -367,7 +367,7 @@ print(snapshot)
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="snapshot.root.C1"
 --         type="Real"
@@ -411,7 +411,7 @@ print(snapshot)
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="snapshot"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:Connectors>
@@ -505,7 +505,7 @@ print(snapshot)
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -529,7 +529,7 @@ print(snapshot)
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="snapshot.root.C1"
 --         type="Real"
@@ -553,7 +553,7 @@ print(snapshot)
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="snapshot"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:Connectors>
@@ -647,7 +647,7 @@ print(snapshot)
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -671,7 +671,7 @@ print(snapshot)
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="snapshot.root.C1"
 --         type="Real"
@@ -695,7 +695,7 @@ print(snapshot)
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="snapshot"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:Connectors>
@@ -789,7 +789,7 @@ print(snapshot)
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -813,7 +813,7 @@ print(snapshot)
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="snapshot.root.C1"
 --         type="Real"
@@ -837,7 +837,7 @@ print(snapshot)
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="snapshot"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:Connectors>
@@ -931,7 +931,7 @@ print(snapshot)
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -955,7 +955,7 @@ print(snapshot)
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="snapshot.root.C1"
 --         type="Real"

--- a/testsuite/simulation/importStartValues.lua
+++ b/testsuite/simulation/importStartValues.lua
@@ -31,7 +31,7 @@ oms_delete("importStartValues")
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="importStartValues"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:Connectors>
@@ -121,7 +121,7 @@ oms_delete("importStartValues")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -137,7 +137,7 @@ oms_delete("importStartValues")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -156,7 +156,7 @@ oms_delete("importStartValues")
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="importStartValues.root.C1"
 --         type="Real"

--- a/testsuite/simulation/importStartValues1.lua
+++ b/testsuite/simulation/importStartValues1.lua
@@ -48,7 +48,7 @@ oms_delete("importStartValues")
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="importStartValues"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:Connectors>
@@ -67,7 +67,7 @@ oms_delete("importStartValues")
 --           <ssd:ParameterBinding>
 --             <ssd:ParameterValues>
 --               <ssv:ParameterSet
---                 version="1.0"
+--                 version="2.0"
 --                 name="parameters">
 --                 <ssv:Parameters>
 --                   <ssv:Parameter
@@ -115,7 +115,7 @@ oms_delete("importStartValues")
 --               <ssd:ParameterBinding>
 --                 <ssd:ParameterValues>
 --                   <ssv:ParameterSet
---                     version="1.0"
+--                     version="2.0"
 --                     name="parameters">
 --                     <ssv:Parameters>
 --                       <ssv:Parameter
@@ -182,7 +182,7 @@ oms_delete("importStartValues")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -198,7 +198,7 @@ oms_delete("importStartValues")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -217,7 +217,7 @@ oms_delete("importStartValues")
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="importStartValues.root.C1"
 --         type="Real"

--- a/testsuite/simulation/importSuppressUnitConversion.lua
+++ b/testsuite/simulation/importSuppressUnitConversion.lua
@@ -69,7 +69,7 @@ oms_delete("model")
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="model"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:Elements>
@@ -242,7 +242,7 @@ oms_delete("model")
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="model.root.B.u"
 --         type="Real"

--- a/testsuite/simulation/import_export_parameters1.lua
+++ b/testsuite/simulation/import_export_parameters1.lua
@@ -357,7 +357,7 @@ oms_delete("import_export_parameters")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter

--- a/testsuite/simulation/import_export_parameters1.lua
+++ b/testsuite/simulation/import_export_parameters1.lua
@@ -114,7 +114,7 @@ oms_delete("import_export_parameters")
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="import_export_parameters"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="co_sim">
 --         <ssd:Connectors>
@@ -411,7 +411,7 @@ oms_delete("import_export_parameters")
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="import_export_parameters.co_sim.Input_cref"
 --         type="Real"

--- a/testsuite/simulation/import_export_parameters2.lua
+++ b/testsuite/simulation/import_export_parameters2.lua
@@ -114,7 +114,7 @@ oms_delete("import_export_parameters")
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="import_export_parameters"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="co_sim">
 --         <ssd:Connectors>
@@ -456,7 +456,7 @@ oms_delete("import_export_parameters")
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="import_export_parameters.co_sim.Input_cref"
 --         type="Real"

--- a/testsuite/simulation/import_export_parameters2.lua
+++ b/testsuite/simulation/import_export_parameters2.lua
@@ -369,7 +369,7 @@ oms_delete("import_export_parameters")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -400,7 +400,7 @@ oms_delete("import_export_parameters")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -416,7 +416,7 @@ oms_delete("import_export_parameters")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -442,7 +442,7 @@ oms_delete("import_export_parameters")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter

--- a/testsuite/simulation/import_export_parameters3.lua
+++ b/testsuite/simulation/import_export_parameters3.lua
@@ -147,7 +147,7 @@ oms_delete("import_export_parameters")
 --           <ssd:ParameterBinding>
 --             <ssd:ParameterValues>
 --               <ssv:ParameterSet
---                 version="1.0"
+--                 version="2.0"
 --                 name="parameters">
 --                 <ssv:Parameters>
 --                   <ssv:Parameter
@@ -189,7 +189,7 @@ oms_delete("import_export_parameters")
 --               <ssd:ParameterBinding>
 --                 <ssd:ParameterValues>
 --                   <ssv:ParameterSet
---                     version="1.0"
+--                     version="2.0"
 --                     name="parameters">
 --                     <ssv:Parameters>
 --                       <ssv:Parameter
@@ -262,7 +262,7 @@ oms_delete("import_export_parameters")
 --               <ssd:ParameterBinding>
 --                 <ssd:ParameterValues>
 --                   <ssv:ParameterSet
---                     version="1.0"
+--                     version="2.0"
 --                     name="parameters">
 --                     <ssv:Parameters>
 --                       <ssv:Parameter
@@ -343,7 +343,7 @@ oms_delete("import_export_parameters")
 --               <ssd:ParameterBinding>
 --                 <ssd:ParameterValues>
 --                   <ssv:ParameterSet
---                     version="1.0"
+--                     version="2.0"
 --                     name="parameters">
 --                     <ssv:Parameters>
 --                       <ssv:Parameter

--- a/testsuite/simulation/import_export_parameters3.lua
+++ b/testsuite/simulation/import_export_parameters3.lua
@@ -113,7 +113,7 @@ oms_delete("import_export_parameters")
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="import_export_parameters"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="co_sim">
 --         <ssd:Connectors>
@@ -443,7 +443,7 @@ oms_delete("import_export_parameters")
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="import_export_parameters.co_sim.Input_cref"
 --         type="Real"

--- a/testsuite/simulation/import_export_parameters4.lua
+++ b/testsuite/simulation/import_export_parameters4.lua
@@ -118,7 +118,7 @@ oms_delete("import_export_parameters")
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="import_export_parameters"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="co_sim">
 --         <ssd:Connectors>
@@ -152,7 +152,7 @@ oms_delete("import_export_parameters")
 --           <ssd:ParameterBinding>
 --             <ssd:ParameterValues>
 --               <ssv:ParameterSet
---                 version="1.0"
+--                 version="2.0"
 --                 name="parameters">
 --                 <ssv:Parameters>
 --                   <ssv:Parameter
@@ -189,7 +189,7 @@ oms_delete("import_export_parameters")
 --               <ssd:ParameterBinding>
 --                 <ssd:ParameterValues>
 --                   <ssv:ParameterSet
---                     version="1.0"
+--                     version="2.0"
 --                     name="parameters">
 --                     <ssv:Parameters>
 --                       <ssv:Parameter
@@ -262,7 +262,7 @@ oms_delete("import_export_parameters")
 --               <ssd:ParameterBinding>
 --                 <ssd:ParameterValues>
 --                   <ssv:ParameterSet
---                     version="1.0"
+--                     version="2.0"
 --                     name="parameters">
 --                     <ssv:Parameters>
 --                       <ssv:Parameter
@@ -317,7 +317,7 @@ oms_delete("import_export_parameters")
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="import_export_parameters.co_sim.Input_cref"
 --         type="Real"

--- a/testsuite/simulation/import_export_parameters_inline.lua
+++ b/testsuite/simulation/import_export_parameters_inline.lua
@@ -121,7 +121,7 @@ oms_delete("import_export_parameters")
 -- Result:
 -- error:   [addConnection] Connector addP.k1 is already connected to k_cref
 -- <?xml version="1.0"?>
--- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="import_export_parameters" version="1.0">
+-- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="import_export_parameters" version="2.0">
 -- 	<ssd:System name="co_sim">
 -- 		<ssd:Connectors>
 -- 			<ssd:Connector name="Input_cref" kind="input">
@@ -140,7 +140,7 @@ oms_delete("import_export_parameters")
 -- 		<ssd:ParameterBindings>
 -- 			<ssd:ParameterBinding>
 -- 				<ssd:ParameterValues>
--- 					<ssv:ParameterSet version="1.0" name="parameters">
+-- 					<ssv:ParameterSet version="2.0" name="parameters">
 -- 						<ssv:Parameters>
 -- 							<ssv:Parameter name="k_cref">
 -- 								<ssv:Real value="30" />
@@ -166,7 +166,7 @@ oms_delete("import_export_parameters")
 -- 				<ssd:ParameterBindings>
 -- 					<ssd:ParameterBinding>
 -- 						<ssd:ParameterValues>
--- 							<ssv:ParameterSet version="1.0" name="parameters">
+-- 							<ssv:ParameterSet version="2.0" name="parameters">
 -- 								<ssv:Parameters>
 -- 									<ssv:Parameter name="F_cref">
 -- 										<ssv:Real value="40" />
@@ -210,7 +210,7 @@ oms_delete("import_export_parameters")
 -- 				<ssd:ParameterBindings>
 -- 					<ssd:ParameterBinding>
 -- 						<ssd:ParameterValues>
--- 							<ssv:ParameterSet version="1.0" name="parameters">
+-- 							<ssv:ParameterSet version="2.0" name="parameters">
 -- 								<ssv:Parameters>
 -- 									<ssv:Parameter name="k2">
 -- 										<ssv:Real value="-1" />
@@ -255,7 +255,7 @@ oms_delete("import_export_parameters")
 -- 				<ssd:ParameterBindings>
 -- 					<ssd:ParameterBinding>
 -- 						<ssd:ParameterValues>
--- 							<ssv:ParameterSet version="1.0" name="parameters">
+-- 							<ssv:ParameterSet version="2.0" name="parameters">
 -- 								<ssv:Parameters>
 -- 									<ssv:Parameter name="k2">
 -- 										<ssv:Real value="2" />

--- a/testsuite/simulation/import_export_parameters_to_ssv.lua
+++ b/testsuite/simulation/import_export_parameters_to_ssv.lua
@@ -124,7 +124,7 @@ oms_delete("import_export_parameters")
 -- Result:
 -- error:   [addConnection] Connector addP.k1 is already connected to k_cref
 -- <?xml version="1.0"?>
--- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="import_export_parameters" version="1.0">
+-- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="import_export_parameters" version="2.0">
 -- 	<ssd:System name="co_sim">
 -- 		<ssd:Connectors>
 -- 			<ssd:Connector name="Input_cref" kind="input">

--- a/testsuite/simulation/import_export_signalFilter.lua
+++ b/testsuite/simulation/import_export_signalFilter.lua
@@ -90,7 +90,7 @@ oms_delete("model")
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="model"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:ParameterBindings>
@@ -231,7 +231,7 @@ oms_delete("model")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -260,7 +260,7 @@ oms_delete("model")
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="model.root.Gain.u"
 --         type="Real"

--- a/testsuite/simulation/import_export_signalFilter2.lua
+++ b/testsuite/simulation/import_export_signalFilter2.lua
@@ -56,7 +56,7 @@ oms_delete("model")
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="model"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:Elements>
@@ -100,7 +100,7 @@ oms_delete("model")
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="model.root.testArray.x"
 --         type="Real"

--- a/testsuite/simulation/import_export_snapshot.lua
+++ b/testsuite/simulation/import_export_snapshot.lua
@@ -54,7 +54,7 @@ oms_delete("import_export_snapshot")
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="import_export_snapshot"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:Connectors>
@@ -148,7 +148,7 @@ oms_delete("import_export_snapshot")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -172,7 +172,7 @@ oms_delete("import_export_snapshot")
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="import_export_snapshot.root.C1"
 --         type="Real"

--- a/testsuite/simulation/import_hierarchical_ssv_sources1.lua
+++ b/testsuite/simulation/import_hierarchical_ssv_sources1.lua
@@ -64,7 +64,7 @@ oms_delete(model)
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="import_hierarchical_ssv_sources"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:Elements>
@@ -128,7 +128,7 @@ oms_delete(model)
 --               <ssd:ParameterBinding>
 --                 <ssd:ParameterValues>
 --                   <ssv:ParameterSet
---                     version="1.0"
+--                     version="2.0"
 --                     name="parameters">
 --                     <ssv:Parameters>
 --                       <ssv:Parameter
@@ -231,7 +231,7 @@ oms_delete(model)
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -247,7 +247,7 @@ oms_delete(model)
 --     <ssm:ParameterMapping
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping"
---       version="1.0">
+--       version="2.0">
 --       <ssm:MappingEntry
 --         source="system3_start_values"
 --         target="Input_1" />
@@ -261,7 +261,7 @@ oms_delete(model)
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -282,7 +282,7 @@ oms_delete(model)
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -301,7 +301,7 @@ oms_delete(model)
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="import_hierarchical_ssv_sources.root.System3.Input_1"
 --         type="Real"

--- a/testsuite/simulation/import_parameter_mapping_from_ssm.lua
+++ b/testsuite/simulation/import_parameter_mapping_from_ssm.lua
@@ -89,7 +89,7 @@ oms_delete("import_parameter_mapping")
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="import_parameter_mapping"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="co_sim">
 --         <ssd:Connectors>
@@ -260,7 +260,7 @@ oms_delete("import_parameter_mapping")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -291,7 +291,7 @@ oms_delete("import_parameter_mapping")
 --     <ssm:ParameterMapping
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping"
---       version="1.0">
+--       version="2.0">
 --       <ssm:MappingEntry
 --         source="cosim_parameters"
 --         target="parameter_1" />
@@ -324,7 +324,7 @@ oms_delete("import_parameter_mapping")
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="import_parameter_mapping.co_sim.Input_1"
 --         type="Real"

--- a/testsuite/simulation/import_parameter_mapping_inline.lua
+++ b/testsuite/simulation/import_parameter_mapping_inline.lua
@@ -77,7 +77,7 @@ oms_delete("import_parameter_mapping")
 
 -- Result:
 -- <?xml version="1.0"?>
--- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="import_parameter_mapping" version="1.0">
+-- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="import_parameter_mapping" version="2.0">
 -- 	<ssd:System name="co_sim">
 -- 		<ssd:Connectors>
 -- 			<ssd:Connector name="Input_1" kind="input">
@@ -102,7 +102,7 @@ oms_delete("import_parameter_mapping")
 -- 		<ssd:ParameterBindings>
 -- 			<ssd:ParameterBinding>
 -- 				<ssd:ParameterValues>
--- 					<ssv:ParameterSet version="1.0" name="parameters">
+-- 					<ssv:ParameterSet version="2.0" name="parameters">
 -- 						<ssv:Parameters>
 -- 							<ssv:Parameter name="parameter_2">
 -- 								<ssv:Real value="-40" />
@@ -150,7 +150,7 @@ oms_delete("import_parameter_mapping")
 -- 				<ssd:ParameterBindings>
 -- 					<ssd:ParameterBinding>
 -- 						<ssd:ParameterValues>
--- 							<ssv:ParameterSet version="1.0" name="parameters">
+-- 							<ssv:ParameterSet version="2.0" name="parameters">
 -- 								<ssv:Parameters>
 -- 									<ssv:Parameter name="system2_inputs">
 -- 										<ssv:Real value="70" />
@@ -199,7 +199,7 @@ oms_delete("import_parameter_mapping")
 -- 				<ssd:ParameterBindings>
 -- 					<ssd:ParameterBinding>
 -- 						<ssd:ParameterValues>
--- 							<ssv:ParameterSet version="1.0" name="parameters">
+-- 							<ssv:ParameterSet version="2.0" name="parameters">
 -- 								<ssv:Parameters>
 -- 									<ssv:Parameter name="system1_parameters">
 -- 										<ssv:Real value="-50" />

--- a/testsuite/simulation/listVariants1.lua
+++ b/testsuite/simulation/listVariants1.lua
@@ -52,7 +52,7 @@ oms_delete("model")
 --   <oms:file
 --     name="ssdVariants.xml">
 --     <oms:Variants
---       version="1.0">
+--       version="2.0">
 --       <oms:variant
 --         name="varB" />
 --       <oms:variant
@@ -71,7 +71,7 @@ oms_delete("model")
 --   <oms:file
 --     name="ssdVariants.xml">
 --     <oms:Variants
---       version="1.0">
+--       version="2.0">
 --       <oms:variant
 --         name="model" />
 --       <oms:variant

--- a/testsuite/simulation/multipleInstance.lua
+++ b/testsuite/simulation/multipleInstance.lua
@@ -191,7 +191,7 @@ oms_delete("model")
 --               <ssd:ParameterBinding>
 --                 <ssd:ParameterValues>
 --                   <ssv:ParameterSet
---                     version="1.0"
+--                     version="2.0"
 --                     name="parameters">
 --                     <ssv:Parameters>
 --                       <ssv:Parameter
@@ -254,7 +254,7 @@ oms_delete("model")
 --               <ssd:ParameterBinding>
 --                 <ssd:ParameterValues>
 --                   <ssv:ParameterSet
---                     version="1.0"
+--                     version="2.0"
 --                     name="parameters">
 --                     <ssv:Parameters>
 --                       <ssv:Parameter

--- a/testsuite/simulation/multipleInstance.lua
+++ b/testsuite/simulation/multipleInstance.lua
@@ -61,7 +61,7 @@ oms_delete("model")
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="model"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:Elements>
@@ -323,7 +323,7 @@ oms_delete("model")
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="model.root.ypipe.der(_D_outputAlias_outputRate)"
 --         type="Real"

--- a/testsuite/simulation/partialSnapshot.lua
+++ b/testsuite/simulation/partialSnapshot.lua
@@ -66,7 +66,7 @@ print(snapshot)
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="snapshot"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:Connectors>
@@ -160,7 +160,7 @@ print(snapshot)
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -184,7 +184,7 @@ print(snapshot)
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="snapshot.root.C1"
 --         type="Real"
@@ -227,7 +227,7 @@ print(snapshot)
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="snapshot"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:Connectors>
@@ -327,7 +327,7 @@ print(snapshot)
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter

--- a/testsuite/simulation/referenceResources1.lua
+++ b/testsuite/simulation/referenceResources1.lua
@@ -132,7 +132,7 @@ oms_delete("referenceResources1")
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="referenceResources1"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:Connectors>
@@ -263,7 +263,7 @@ oms_delete("referenceResources1")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -284,7 +284,7 @@ oms_delete("referenceResources1")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -305,7 +305,7 @@ oms_delete("referenceResources1")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -321,7 +321,7 @@ oms_delete("referenceResources1")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -337,7 +337,7 @@ oms_delete("referenceResources1")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -354,7 +354,7 @@ oms_delete("referenceResources1")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -375,7 +375,7 @@ oms_delete("referenceResources1")
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="referenceResources1.root.Input1"
 --         type="Real"

--- a/testsuite/simulation/referenceResources2.lua
+++ b/testsuite/simulation/referenceResources2.lua
@@ -318,7 +318,7 @@ oms_delete("import_parameter_mapping")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -384,7 +384,7 @@ oms_delete("import_parameter_mapping")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter

--- a/testsuite/simulation/referenceResources2.lua
+++ b/testsuite/simulation/referenceResources2.lua
@@ -147,7 +147,7 @@ oms_delete("import_parameter_mapping")
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="import_parameter_mapping"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="co_sim">
 --         <ssd:Connectors>
@@ -349,7 +349,7 @@ oms_delete("import_parameter_mapping")
 --     <ssm:ParameterMapping
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping"
---       version="1.0">
+--       version="2.0">
 --       <ssm:MappingEntry
 --         source="cosim_parameters"
 --         target="parameter_1" />
@@ -415,7 +415,7 @@ oms_delete("import_parameter_mapping")
 --     <ssm:ParameterMapping
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping"
---       version="1.0">
+--       version="2.0">
 --       <ssm:MappingEntry
 --         source="cosim_parameters"
 --         target="parameter_1" />
@@ -448,7 +448,7 @@ oms_delete("import_parameter_mapping")
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="import_parameter_mapping.co_sim.Input_1"
 --         type="Real"

--- a/testsuite/simulation/rename.lua
+++ b/testsuite/simulation/rename.lua
@@ -77,7 +77,7 @@ print("info:      model.root_1.add_1.u2           : " .. oms_getReal("model.root
 
 -- Result:
 -- <?xml version="1.0"?>
--- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="model" version="1.0">
+-- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="model" version="2.0">
 -- 	<ssd:System name="root">
 -- 		<ssd:Connectors>
 -- 			<ssd:Connector name="input1" kind="input">
@@ -90,7 +90,7 @@ print("info:      model.root_1.add_1.u2           : " .. oms_getReal("model.root
 -- 		<ssd:ParameterBindings>
 -- 			<ssd:ParameterBinding>
 -- 				<ssd:ParameterValues>
--- 					<ssv:ParameterSet version="1.0" name="parameters">
+-- 					<ssv:ParameterSet version="2.0" name="parameters">
 -- 						<ssv:Parameters>
 -- 							<ssv:Parameter name="input1">
 -- 								<ssv:Real value="10" />
@@ -180,7 +180,7 @@ print("info:      model.root_1.add_1.u2           : " .. oms_getReal("model.root
 -- info:    maximum step size for 'model.root_1.System_2': 0.001000
 -- info:    Result file: model_res.mat (bufferSize=10)
 -- <?xml version="1.0"?>
--- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="model" version="1.0">
+-- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="model" version="2.0">
 -- 	<ssd:System name="root_1">
 -- 		<ssd:Connectors>
 -- 			<ssd:Connector name="input1" kind="input">
@@ -193,7 +193,7 @@ print("info:      model.root_1.add_1.u2           : " .. oms_getReal("model.root
 -- 		<ssd:ParameterBindings>
 -- 			<ssd:ParameterBinding>
 -- 				<ssd:ParameterValues>
--- 					<ssv:ParameterSet version="1.0" name="parameters">
+-- 					<ssv:ParameterSet version="2.0" name="parameters">
 -- 						<ssv:Parameters>
 -- 							<ssv:Parameter name="output">
 -- 								<ssv:Real value="10" />
@@ -219,7 +219,7 @@ print("info:      model.root_1.add_1.u2           : " .. oms_getReal("model.root
 -- 				<ssd:ParameterBindings>
 -- 					<ssd:ParameterBinding>
 -- 						<ssd:ParameterValues>
--- 							<ssv:ParameterSet version="1.0" name="parameters">
+-- 							<ssv:ParameterSet version="2.0" name="parameters">
 -- 								<ssv:Parameters>
 -- 									<ssv:Parameter name="input1">
 -- 										<ssv:Real value="10" />

--- a/testsuite/simulation/renameModel.lua
+++ b/testsuite/simulation/renameModel.lua
@@ -41,7 +41,7 @@ print(src)
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="model_3"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:Connectors>
@@ -159,7 +159,7 @@ print(src)
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="model_3.root.input1"
 --         type="Real"

--- a/testsuite/simulation/renameNewCref_2.lua
+++ b/testsuite/simulation/renameNewCref_2.lua
@@ -160,7 +160,7 @@ print(snapshot)
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="model_7"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:Annotations>
@@ -198,7 +198,7 @@ print(snapshot)
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0" />
+--       version="2.0" />
 --   </oms:file>
 -- </oms:snapshot>
 --

--- a/testsuite/simulation/renameNewCref_2.lua
+++ b/testsuite/simulation/renameNewCref_2.lua
@@ -68,7 +68,7 @@ errormodelSnapshot = [[
     <oms:file
       name="resources/signalFilter.xml">
       <oms:SignalFilter
-        version="1.0" />
+        version="2.0" />
     </oms:file>
   </oms:snapshot>
 ]]
@@ -130,7 +130,7 @@ correctedModelSnapshot = [[
     <oms:file
       name="resources/signalFilter.xml">
       <oms:SignalFilter
-        version="1.0" />
+        version="2.0" />
     </oms:file>
   </oms:snapshot>
 ]]

--- a/testsuite/simulation/renameNewCref_2.lua
+++ b/testsuite/simulation/renameNewCref_2.lua
@@ -30,7 +30,7 @@ errormodelSnapshot = [[
         xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
         xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
         name="model_4"
-        version="1.0">
+        version="2.0">
         <ssd:System
           name="root">
           <ssd:Annotations>
@@ -92,7 +92,7 @@ correctedModelSnapshot = [[
         xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
         xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
         name="model_5"
-        version="1.0">
+        version="2.0">
         <ssd:System
           name="root">
           <ssd:Annotations>

--- a/testsuite/simulation/renameSnapshot.lua
+++ b/testsuite/simulation/renameSnapshot.lua
@@ -71,7 +71,7 @@ print(snapshot)
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="renameSnapshot"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:Connectors>
@@ -190,7 +190,7 @@ print(snapshot)
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -219,7 +219,7 @@ print(snapshot)
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="renameSnapshot.root.C1"
 --         type="Real"
@@ -267,7 +267,7 @@ print(snapshot)
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="renameSnapshot"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root_1">
 --         <ssd:Connectors>
@@ -386,7 +386,7 @@ print(snapshot)
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -415,7 +415,7 @@ print(snapshot)
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="renameSnapshot.root_1.C1"
 --         type="Real"
@@ -463,7 +463,7 @@ print(snapshot)
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="renameSnapshot"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root_1">
 --         <ssd:Connectors>
@@ -582,7 +582,7 @@ print(snapshot)
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -611,7 +611,7 @@ print(snapshot)
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="renameSnapshot.root_1.C1"
 --         type="Real"
@@ -659,7 +659,7 @@ print(snapshot)
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="renameSnapshot"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root_1">
 --         <ssd:Connectors>
@@ -778,7 +778,7 @@ print(snapshot)
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -807,7 +807,7 @@ print(snapshot)
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="renameSnapshot.root_1.C1"
 --         type="Real"

--- a/testsuite/simulation/renameValues1.lua
+++ b/testsuite/simulation/renameValues1.lua
@@ -78,7 +78,7 @@ print("info:      renameValues1.root.add_3.u1       : " .. oms_getReal("renameVa
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="renameValues1"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:ParameterBindings>
@@ -238,7 +238,7 @@ print("info:      renameValues1.root.add_3.u1       : " .. oms_getReal("renameVa
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -267,7 +267,7 @@ print("info:      renameValues1.root.add_3.u1       : " .. oms_getReal("renameVa
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="renameValues1.root.add_3.u1"
 --         type="Real"

--- a/testsuite/simulation/renameValues2.lua
+++ b/testsuite/simulation/renameValues2.lua
@@ -77,7 +77,7 @@ print("info:      renameValues2.root.add_3.u1       : " .. oms_getReal("renameVa
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="renameValues2"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:Elements>
@@ -94,7 +94,7 @@ print("info:      renameValues2.root.add_3.u1       : " .. oms_getReal("renameVa
 --               <ssd:ParameterBinding>
 --                 <ssd:ParameterValues>
 --                   <ssv:ParameterSet
---                     version="1.0"
+--                     version="2.0"
 --                     name="parameters">
 --                     <ssv:Parameters>
 --                       <ssv:Parameter
@@ -167,7 +167,7 @@ print("info:      renameValues2.root.add_3.u1       : " .. oms_getReal("renameVa
 --               <ssd:ParameterBinding>
 --                 <ssd:ParameterValues>
 --                   <ssv:ParameterSet
---                     version="1.0"
+--                     version="2.0"
 --                     name="parameters">
 --                     <ssv:Parameters>
 --                       <ssv:Parameter
@@ -275,7 +275,7 @@ print("info:      renameValues2.root.add_3.u1       : " .. oms_getReal("renameVa
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="renameValues2.root.add_3.u1"
 --         type="Real"

--- a/testsuite/simulation/replaceSubmodel1.lua
+++ b/testsuite/simulation/replaceSubmodel1.lua
@@ -89,7 +89,7 @@ oms_delete("model")
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="model"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:Elements>
@@ -132,7 +132,7 @@ oms_delete("model")
 --               <ssd:ParameterBinding>
 --                 <ssd:ParameterValues>
 --                   <ssv:ParameterSet
---                     version="1.0"
+--                     version="2.0"
 --                     name="parameters">
 --                     <ssv:Parameters>
 --                       <ssv:Parameter
@@ -190,7 +190,7 @@ oms_delete("model")
 --               <ssd:ParameterBinding>
 --                 <ssd:ParameterValues>
 --                   <ssv:ParameterSet
---                     version="1.0"
+--                     version="2.0"
 --                     name="parameters">
 --                     <ssv:Parameters>
 --                       <ssv:Parameter
@@ -257,7 +257,7 @@ oms_delete("model")
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="model.root.B.u"
 --         type="Real"
@@ -324,7 +324,7 @@ oms_delete("model")
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="model"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:Elements>
@@ -367,7 +367,7 @@ oms_delete("model")
 --               <ssd:ParameterBinding>
 --                 <ssd:ParameterValues>
 --                   <ssv:ParameterSet
---                     version="1.0"
+--                     version="2.0"
 --                     name="parameters">
 --                     <ssv:Parameters>
 --                       <ssv:Parameter
@@ -425,7 +425,7 @@ oms_delete("model")
 --               <ssd:ParameterBinding>
 --                 <ssd:ParameterValues>
 --                   <ssv:ParameterSet
---                     version="1.0"
+--                     version="2.0"
 --                     name="parameters">
 --                     <ssv:Parameters>
 --                       <ssv:Parameter
@@ -482,7 +482,7 @@ oms_delete("model")
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="model.root.B.u"
 --         type="Real"

--- a/testsuite/simulation/replaceSubmodel10.lua
+++ b/testsuite/simulation/replaceSubmodel10.lua
@@ -93,7 +93,7 @@ oms_delete("model")
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="model"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:ParameterBindings>
@@ -223,7 +223,7 @@ oms_delete("model")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -252,7 +252,7 @@ oms_delete("model")
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="model.root.B.u"
 --         type="Real"
@@ -319,7 +319,7 @@ oms_delete("model")
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="model"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:ParameterBindings>
@@ -449,7 +449,7 @@ oms_delete("model")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -478,7 +478,7 @@ oms_delete("model")
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="model.root.B.u"
 --         type="Real"

--- a/testsuite/simulation/replaceSubmodel11.py
+++ b/testsuite/simulation/replaceSubmodel11.py
@@ -58,7 +58,7 @@ oms.delete("model")
 ##       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 ##       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 ##       name="model"
-##       version="1.0">
+##       version="2.0">
 ##       <ssd:System
 ##         name="root">
 ##         <ssd:Elements>
@@ -197,7 +197,7 @@ oms.delete("model")
 ##   <oms:file
 ##     name="resources/signalFilter.xml">
 ##     <oms:SignalFilter
-##       version="1.0">
+##       version="2.0">
 ##       <oms:Variable
 ##         name="model.root.B.u"
 ##         type="Real"
@@ -252,7 +252,7 @@ oms.delete("model")
 ##       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 ##       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 ##       name="model"
-##       version="1.0">
+##       version="2.0">
 ##       <ssd:System
 ##         name="root">
 ##         <ssd:Elements>
@@ -391,7 +391,7 @@ oms.delete("model")
 ##   <oms:file
 ##     name="resources/signalFilter.xml">
 ##     <oms:SignalFilter
-##       version="1.0">
+##       version="2.0">
 ##       <oms:Variable
 ##         name="model.root.B.u"
 ##         type="Real"

--- a/testsuite/simulation/replaceSubmodel12.py
+++ b/testsuite/simulation/replaceSubmodel12.py
@@ -60,7 +60,7 @@ oms.delete("model")
 ##       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 ##       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 ##       name="model"
-##       version="1.0">
+##       version="2.0">
 ##       <ssd:System
 ##         name="root">
 ##         <ssd:Elements>
@@ -199,7 +199,7 @@ oms.delete("model")
 ##   <oms:file
 ##     name="resources/signalFilter.xml">
 ##     <oms:SignalFilter
-##       version="1.0">
+##       version="2.0">
 ##       <oms:Variable
 ##         name="model.root.B.u"
 ##         type="Real"
@@ -254,7 +254,7 @@ oms.delete("model")
 ##       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 ##       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 ##       name="model"
-##       version="1.0">
+##       version="2.0">
 ##       <ssd:System
 ##         name="root">
 ##         <ssd:Elements>
@@ -384,7 +384,7 @@ oms.delete("model")
 ##   <oms:file
 ##     name="resources/signalFilter.xml">
 ##     <oms:SignalFilter
-##       version="1.0">
+##       version="2.0">
 ##       <oms:Variable
 ##         name="model.root.B.y"
 ##         type="Real"

--- a/testsuite/simulation/replaceSubmodel2.lua
+++ b/testsuite/simulation/replaceSubmodel2.lua
@@ -92,7 +92,7 @@ oms_delete("model")
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="model"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:ParameterBindings>
@@ -222,7 +222,7 @@ oms_delete("model")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -251,7 +251,7 @@ oms_delete("model")
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="model.root.B.u"
 --         type="Real"
@@ -318,7 +318,7 @@ oms_delete("model")
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="model"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:ParameterBindings>
@@ -443,7 +443,7 @@ oms_delete("model")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -467,7 +467,7 @@ oms_delete("model")
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="model.root.B.u"
 --         type="Real"

--- a/testsuite/simulation/replaceSubmodel3.lua
+++ b/testsuite/simulation/replaceSubmodel3.lua
@@ -93,7 +93,7 @@ oms_delete("model")
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="model"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:Elements>
@@ -227,7 +227,7 @@ oms_delete("model")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -248,7 +248,7 @@ oms_delete("model")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -267,7 +267,7 @@ oms_delete("model")
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="model.root.B.u"
 --         type="Real"
@@ -334,7 +334,7 @@ oms_delete("model")
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="model"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:Elements>
@@ -463,7 +463,7 @@ oms_delete("model")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -484,7 +484,7 @@ oms_delete("model")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -498,7 +498,7 @@ oms_delete("model")
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="model.root.B.u"
 --         type="Real"

--- a/testsuite/simulation/replaceSubmodel4.lua
+++ b/testsuite/simulation/replaceSubmodel4.lua
@@ -64,7 +64,7 @@ oms_delete("model")
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="model"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:ParameterBindings>
@@ -197,7 +197,7 @@ oms_delete("model")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -223,7 +223,7 @@ oms_delete("model")
 --     <ssm:ParameterMapping
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping"
---       version="1.0">
+--       version="2.0">
 --       <ssm:MappingEntry
 --         source="paramA"
 --         target="A.t" />
@@ -241,7 +241,7 @@ oms_delete("model")
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="model.root.B.u"
 --         type="Real"
@@ -310,7 +310,7 @@ oms_delete("model")
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="model"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:ParameterBindings>
@@ -438,7 +438,7 @@ oms_delete("model")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -464,7 +464,7 @@ oms_delete("model")
 --     <ssm:ParameterMapping
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping"
---       version="1.0">
+--       version="2.0">
 --       <ssm:MappingEntry
 --         source="paramA"
 --         target="B.z" />
@@ -479,7 +479,7 @@ oms_delete("model")
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="model.root.B.u"
 --         type="Real"

--- a/testsuite/simulation/replaceSubmodel5.lua
+++ b/testsuite/simulation/replaceSubmodel5.lua
@@ -64,7 +64,7 @@ oms_delete("model")
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="model"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:Elements>
@@ -197,7 +197,7 @@ oms_delete("model")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -218,7 +218,7 @@ oms_delete("model")
 --     <ssm:ParameterMapping
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping"
---       version="1.0">
+--       version="2.0">
 --       <ssm:MappingEntry
 --         source="paramA"
 --         target="t" />
@@ -233,7 +233,7 @@ oms_delete("model")
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="model.root.B.u"
 --         type="Real"
@@ -302,7 +302,7 @@ oms_delete("model")
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="model"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:Elements>
@@ -430,7 +430,7 @@ oms_delete("model")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -451,7 +451,7 @@ oms_delete("model")
 --     <ssm:ParameterMapping
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping"
---       version="1.0">
+--       version="2.0">
 --       <ssm:MappingEntry
 --         source="paramA"
 --         target="foo" />
@@ -463,7 +463,7 @@ oms_delete("model")
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="model.root.B.u"
 --         type="Real"

--- a/testsuite/simulation/replaceSubmodel6.py
+++ b/testsuite/simulation/replaceSubmodel6.py
@@ -98,7 +98,7 @@ oms.delete("model")
 ##       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 ##       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 ##       name="model"
-##       version="1.0">
+##       version="2.0">
 ##       <ssd:System
 ##         name="root">
 ##         <ssd:Elements>
@@ -266,7 +266,7 @@ oms.delete("model")
 ##   <oms:file
 ##     name="resources/signalFilter.xml">
 ##     <oms:SignalFilter
-##       version="1.0">
+##       version="2.0">
 ##       <oms:Variable
 ##         name="model.root.B.u"
 ##         type="Real"
@@ -330,7 +330,7 @@ oms.delete("model")
 ##       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 ##       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 ##       name="model"
-##       version="1.0">
+##       version="2.0">
 ##       <ssd:System
 ##         name="root">
 ##         <ssd:Elements>
@@ -488,7 +488,7 @@ oms.delete("model")
 ##   <oms:file
 ##     name="resources/signalFilter.xml">
 ##     <oms:SignalFilter
-##       version="1.0">
+##       version="2.0">
 ##       <oms:Variable
 ##         name="model.root.B.u"
 ##         type="Real"

--- a/testsuite/simulation/replaceSubmodel6.py
+++ b/testsuite/simulation/replaceSubmodel6.py
@@ -141,7 +141,7 @@ oms.delete("model")
 ##               <ssd:ParameterBinding>
 ##                 <ssd:ParameterValues>
 ##                   <ssv:ParameterSet
-##                     version="1.0"
+##                     version="2.0"
 ##                     name="parameters">
 ##                     <ssv:Parameters>
 ##                       <ssv:Parameter
@@ -199,7 +199,7 @@ oms.delete("model")
 ##               <ssd:ParameterBinding>
 ##                 <ssd:ParameterValues>
 ##                   <ssv:ParameterSet
-##                     version="1.0"
+##                     version="2.0"
 ##                     name="parameters">
 ##                     <ssv:Parameters>
 ##                       <ssv:Parameter
@@ -373,7 +373,7 @@ oms.delete("model")
 ##               <ssd:ParameterBinding>
 ##                 <ssd:ParameterValues>
 ##                   <ssv:ParameterSet
-##                     version="1.0"
+##                     version="2.0"
 ##                     name="parameters">
 ##                     <ssv:Parameters>
 ##                       <ssv:Parameter
@@ -431,7 +431,7 @@ oms.delete("model")
 ##               <ssd:ParameterBinding>
 ##                 <ssd:ParameterValues>
 ##                   <ssv:ParameterSet
-##                     version="1.0"
+##                     version="2.0"
 ##                     name="parameters">
 ##                     <ssv:Parameters>
 ##                       <ssv:Parameter

--- a/testsuite/simulation/replaceSubmodel7.py
+++ b/testsuite/simulation/replaceSubmodel7.py
@@ -99,7 +99,7 @@ oms.delete("model")
 ##       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 ##       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 ##       name="model"
-##       version="1.0">
+##       version="2.0">
 ##       <ssd:System
 ##         name="root">
 ##         <ssd:ParameterBindings>
@@ -258,7 +258,7 @@ oms.delete("model")
 ##   <oms:file
 ##     name="resources/signalFilter.xml">
 ##     <oms:SignalFilter
-##       version="1.0">
+##       version="2.0">
 ##       <oms:Variable
 ##         name="model.root.B.u"
 ##         type="Real"
@@ -322,7 +322,7 @@ oms.delete("model")
 ##       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 ##       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 ##       name="model"
-##       version="1.0">
+##       version="2.0">
 ##       <ssd:System
 ##         name="root">
 ##         <ssd:ParameterBindings>
@@ -471,7 +471,7 @@ oms.delete("model")
 ##   <oms:file
 ##     name="resources/signalFilter.xml">
 ##     <oms:SignalFilter
-##       version="1.0">
+##       version="2.0">
 ##       <oms:Variable
 ##         name="model.root.B.u"
 ##         type="Real"

--- a/testsuite/simulation/replaceSubmodel7.py
+++ b/testsuite/simulation/replaceSubmodel7.py
@@ -229,7 +229,7 @@ oms.delete("model")
 ##     <ssv:ParameterSet
 ##       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 ##       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
-##       version="1.0"
+##       version="2.0"
 ##       name="parameters">
 ##       <ssv:Parameters>
 ##         <ssv:Parameter
@@ -447,7 +447,7 @@ oms.delete("model")
 ##     <ssv:ParameterSet
 ##       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 ##       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
-##       version="1.0"
+##       version="2.0"
 ##       name="parameters">
 ##       <ssv:Parameters>
 ##         <ssv:Parameter

--- a/testsuite/simulation/replaceSubmodel8.lua
+++ b/testsuite/simulation/replaceSubmodel8.lua
@@ -84,7 +84,7 @@ oms_delete("model")
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="model"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:Elements>
@@ -208,7 +208,7 @@ oms_delete("model")
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="model.root.B.u"
 --         type="Real"
@@ -274,7 +274,7 @@ oms_delete("model")
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="model"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:Elements>
@@ -393,7 +393,7 @@ oms_delete("model")
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="model.root.B.u"
 --         type="Real"

--- a/testsuite/simulation/replaceSubmodel9.lua
+++ b/testsuite/simulation/replaceSubmodel9.lua
@@ -90,7 +90,7 @@ oms_delete("model")
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="model"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:Elements>
@@ -133,7 +133,7 @@ oms_delete("model")
 --               <ssd:ParameterBinding>
 --                 <ssd:ParameterValues>
 --                   <ssv:ParameterSet
---                     version="1.0"
+--                     version="2.0"
 --                     name="parameters">
 --                     <ssv:Parameters>
 --                       <ssv:Parameter
@@ -191,7 +191,7 @@ oms_delete("model")
 --               <ssd:ParameterBinding>
 --                 <ssd:ParameterValues>
 --                   <ssv:ParameterSet
---                     version="1.0"
+--                     version="2.0"
 --                     name="parameters">
 --                     <ssv:Parameters>
 --                       <ssv:Parameter
@@ -258,7 +258,7 @@ oms_delete("model")
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="model.root.B.u"
 --         type="Real"
@@ -325,7 +325,7 @@ oms_delete("model")
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="model"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:Elements>
@@ -368,7 +368,7 @@ oms_delete("model")
 --               <ssd:ParameterBinding>
 --                 <ssd:ParameterValues>
 --                   <ssv:ParameterSet
---                     version="1.0"
+--                     version="2.0"
 --                     name="parameters">
 --                     <ssv:Parameters>
 --                       <ssv:Parameter
@@ -426,7 +426,7 @@ oms_delete("model")
 --               <ssd:ParameterBinding>
 --                 <ssd:ParameterValues>
 --                   <ssv:ParameterSet
---                     version="1.0"
+--                     version="2.0"
 --                     name="parameters">
 --                     <ssv:Parameters>
 --                       <ssv:Parameter
@@ -493,7 +493,7 @@ oms_delete("model")
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="model.root.B.u"
 --         type="Real"

--- a/testsuite/simulation/setExternalInputs.lua
+++ b/testsuite/simulation/setExternalInputs.lua
@@ -48,7 +48,7 @@ oms_delete("setExternalInputs")
 -- info:      setExternalInputs.Root.Gain.u at time 3.0: 5.0
 -- info:      setExternalInputs.Root.Gain.u at time 5.0: 10.0
 -- <?xml version="1.0"?>
--- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="setExternalInputs" version="1.0">
+-- <ssd:SystemStructureDescription xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon" xmlns:ssd="http://ssp-standard.org/SSP1/SystemStructureDescription" xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues" xmlns:ssm="http://ssp-standard.org/SSP1/SystemStructureParameterMapping" xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary" xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd" name="setExternalInputs" version="2.0">
 -- 	<ssd:System name="Root">
 -- 		<ssd:Elements>
 -- 			<ssd:Component name="Gain" type="application/x-fmu-sharedlibrary" source="resources/0001_Gain.fmu">

--- a/testsuite/simulation/snapshot.lua
+++ b/testsuite/simulation/snapshot.lua
@@ -48,7 +48,7 @@ oms_delete("snapshot")
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="snapshot"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:Connectors>
@@ -142,7 +142,7 @@ oms_delete("snapshot")
 --     <ssv:ParameterSet
 --       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 --       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
---       version="1.0"
+--       version="2.0"
 --       name="parameters">
 --       <ssv:Parameters>
 --         <ssv:Parameter
@@ -166,7 +166,7 @@ oms_delete("snapshot")
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="snapshot.root.C1"
 --         type="Real"

--- a/testsuite/simulation/snapshot.py
+++ b/testsuite/simulation/snapshot.py
@@ -146,7 +146,7 @@ oms.delete("snapshot")
 ##     <ssv:ParameterSet
 ##       xmlns:ssc="http://ssp-standard.org/SSP1/SystemStructureCommon"
 ##       xmlns:ssv="http://ssp-standard.org/SSP1/SystemStructureParameterValues"
-##       version="1.0"
+##       version="2.0"
 ##       name="parameters">
 ##       <ssv:Parameters>
 ##         <ssv:Parameter

--- a/testsuite/simulation/snapshot.py
+++ b/testsuite/simulation/snapshot.py
@@ -52,7 +52,7 @@ oms.delete("snapshot")
 ##       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 ##       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 ##       name="snapshot"
-##       version="1.0">
+##       version="2.0">
 ##       <ssd:System
 ##         name="root">
 ##         <ssd:Connectors>
@@ -170,7 +170,7 @@ oms.delete("snapshot")
 ##   <oms:file
 ##     name="resources/signalFilter.xml">
 ##     <oms:SignalFilter
-##       version="1.0">
+##       version="2.0">
 ##       <oms:Variable
 ##         name="snapshot.root.C1"
 ##         type="Real"

--- a/testsuite/simulation/suppressUnitConversion.lua
+++ b/testsuite/simulation/suppressUnitConversion.lua
@@ -62,7 +62,7 @@ oms_delete("model")
 --       xmlns:ssb="http://ssp-standard.org/SSP1/SystemStructureSignalDictionary"
 --       xmlns:oms="https://raw.githubusercontent.com/OpenModelica/OMSimulator/master/schema/oms.xsd"
 --       name="model"
---       version="1.0">
+--       version="2.0">
 --       <ssd:System
 --         name="root">
 --         <ssd:Elements>
@@ -235,7 +235,7 @@ oms_delete("model")
 --   <oms:file
 --     name="resources/signalFilter.xml">
 --     <oms:SignalFilter
---       version="1.0">
+--       version="2.0">
 --       <oms:Variable
 --         name="model.root.B.u"
 --         type="Real"


### PR DESCRIPTION
### Related Issues

https://github.com/OpenModelica/OMSimulator/issues/1409

### Purpose

Upgrade ssp schema to `SSP-2.0` and also export ssp to `version 2.0 `

