### PR TITLE
Change table component MIME type to "text/csv" 

### DIFF
--- a/src/OMSimulatorLib/ComponentTable.cpp
+++ b/src/OMSimulatorLib/ComponentTable.cpp
@@ -110,7 +110,8 @@ oms::Component* oms::ComponentTable::NewComponent(const pugi::xml_node& node, om
   std::string type = node.attribute("type").as_string();
   std::string source = node.attribute("source").as_string();
 
-  if (type != "application/table")
+  // Support both "legacy" application/table MIME type and text/csv according to MA-CSV proposal
+  if (type != "application/table" && type != "text/csv")
   {
     logError("Unexpected component type: " + type);
     return NULL;
@@ -164,7 +165,7 @@ oms::Component* oms::ComponentTable::NewComponent(const pugi::xml_node& node, om
 oms_status_enu_t oms::ComponentTable::exportToSSD(pugi::xml_node& node, Snapshot& snapshot, std::string variantName) const
 {
   node.append_attribute("name") = this->getCref().c_str();
-  node.append_attribute("type") = "application/table";
+  node.append_attribute("type") = "text/csv";
   node.append_attribute("source") = getPath().c_str();
   pugi::xml_node node_connectors = node.append_child(oms::ssp::Draft20180219::ssd::connectors);
 

--- a/src/OMSimulatorLib/System.cpp
+++ b/src/OMSimulatorLib/System.cpp
@@ -907,7 +907,7 @@ oms_status_enu_t oms::System::importFromSnapshot(const pugi::xml_node& node, con
             else
               return logError("wrong xml schema detected: " + name);
           }
-          else if ("application/table" == type)
+          else if ("application/table" == type || "text/csv" == type)
             component = ComponentTable::NewComponent(*itElements, this, sspVersion, snapshot);
 #if !defined(NO_TLM)
           else if (itElements->attribute("type") == nullptr && getType() == oms_system_tlm) {


### PR DESCRIPTION
### Related Issues
This PR resolves #1473 

### Purpose
The purpose of this PR is to support a subset of the proposed MA CSV standard for stimuli data.

### Approach
With this PR, the "correct" MIME type is used for export. Both MIME types ("legacy" application/table, and text/csv) are supported for import, which preserves compatibility with SSPs exported in previous versions of OMSimulator.

Import of SSPs with both MIME types has been tested and work as expected.
