### PR TITLE
Fix logging of unsupported version

### DIFF
--- a/src/OMSimulatorLib/ComponentFMU3CS.cpp
+++ b/src/OMSimulatorLib/ComponentFMU3CS.cpp
@@ -150,7 +150,29 @@ oms::Component* oms::ComponentFMU3CS::NewComponent(const oms::ComRef& cref, oms:
   fmiVersion_t version = fmi4c_getFmiVersion(component->fmu);
   if (fmiVersion3 != version)
   {
-    logError("Unsupported FMI version: " + version);
+    switch (version)
+    {
+      case fmiVersionUnknown:
+      {
+        logError("Unsupported FMI version: unknown");
+        break;
+      }
+      case fmiVersion1:
+      {
+        logError("Unsupported FMI version: 1");
+        break;
+      }
+      case fmiVersion2:
+      {
+        logError("Unsupported FMI version: 2");
+        break;
+      }
+      default:
+      {
+        logError("Unsupported FMI version");
+        break;
+      }
+    }
     delete component;
     return NULL;
   }

--- a/src/OMSimulatorLib/ComponentFMUCS.cpp
+++ b/src/OMSimulatorLib/ComponentFMUCS.cpp
@@ -151,7 +151,29 @@ oms::Component* oms::ComponentFMUCS::NewComponent(const oms::ComRef& cref, oms::
   fmiVersion_t version = fmi4c_getFmiVersion(component->fmu);
   if (fmiVersion2 != version)
   {
-    logError("Unsupported FMI version: " + version);
+    switch (version)
+    {
+      case fmiVersionUnknown:
+      {
+        logError("Unsupported FMI version: unknown");
+        break;
+      }
+      case fmiVersion1:
+      {
+        logError("Unsupported FMI version: 1");
+        break;
+      }
+      case fmiVersion3:
+      {
+        logError("Unsupported FMI version: 3");
+        break;
+      }
+      default:
+      {
+        logError("Unsupported FMI version");
+        break;
+      }
+    }
     delete component;
     return NULL;
   }

--- a/src/OMSimulatorLib/ComponentFMUME.cpp
+++ b/src/OMSimulatorLib/ComponentFMUME.cpp
@@ -149,7 +149,29 @@ oms::Component* oms::ComponentFMUME::NewComponent(const oms::ComRef& cref, oms::
   fmiVersion_t version = fmi4c_getFmiVersion(component->fmu);
   if (fmiVersion2 != version)
   {
-    logError("Unsupported FMI version: " + version);
+    switch (version)
+    {
+      case fmiVersionUnknown:
+      {
+        logError("Unsupported FMI version: unknown");
+        break;
+      }
+      case fmiVersion1:
+      {
+        logError("Unsupported FMI version: 1");
+        break;
+      }
+      case fmiVersion3:
+      {
+        logError("Unsupported FMI version: 3");
+        break;
+      }
+      default:
+      {
+        logError("Unsupported FMI version");
+        break;
+      }
+    }
     delete component;
     return NULL;
   }


### PR DESCRIPTION
Adding 'fmiVersion_t' to a string does not append to the string.

Maybe this can be made prettier in the future, but at least this fixes the error.