### PR TITLE
Make command line options properly override options from other sources

### DIFF
--- a/src/OMSimulatorLib/Flags.cpp
+++ b/src/OMSimulatorLib/Flags.cpp
@@ -45,10 +45,47 @@
 #include <regex>
 #include <sstream>
 
-oms::Flags::Flags()
+oms::Flags::FlagValues::FlagValues() :
+  addParametersToCSV(false),
+  algLoopSolver(oms_alg_solver_kinsol),
+  cvodeMaxErrTestFails(100),
+  cvodeMaxNLSFails(100),
+  cvodeMaxNLSIterations(5),
+  cvodeMaxSteps(1000),
+  defaultModeIsCS(false),
+  deleteTempFiles(true),
+  directionalDerivatives(true),
+  dumpAlgLoops(false),
+  emitEvents(true),
+  ignoreInitialUnknowns(false),
+  initialStepSize(1e-6),
+  inputExtrapolation(false),
+  intervals(100),
+  masterAlgorithm(oms_solver_wc_ma),
+  maxEventIteration(100),
+  maximumStepSize(1e-3),
+  maxLoopIteration(10),
+  minimumStepSize(1e-12),
+  numProcs(1),
+  progressBar(false),
+  realTime(false),
+  resultFile("<default>"),
+  skipCSVHeader(true),
+  solver(oms_solver_sc_cvode),
+  solverStats(false),
+  startTime(0.0),
+  stopTime(1.0),
+  stripRoot(false),
+  suppressPath(true),
+  timeout(0),
+  tolerance(1e-4),
+  wallTime(false),
+  zeroNominal(false)
 {
-  setDefaults();
+}
 
+oms::Flags::Flags() : flagValues()
+{
   for (unsigned int i=0; i<flags.size(); ++i)
   {
     lookup[flags[i].name] = i;
@@ -63,41 +100,7 @@ oms::Flags::~Flags()
 
 void oms::Flags::setDefaults()
 {
-  addParametersToCSV = false;
-  algLoopSolver = oms_alg_solver_kinsol;
-  cvodeMaxErrTestFails = 100;
-  cvodeMaxNLSFails = 100;
-  cvodeMaxNLSIterations = 5;
-  cvodeMaxSteps = 1000;
-  defaultModeIsCS = false;
-  deleteTempFiles = true;
-  directionalDerivatives = true;
-  dumpAlgLoops = false;
-  emitEvents = true;
-  ignoreInitialUnknowns = false;
-  initialStepSize = 1e-6;
-  inputExtrapolation = false;
-  intervals = 100;
-  masterAlgorithm = oms_solver_wc_ma;
-  maxEventIteration = 100;
-  maximumStepSize = 1e-3;
-  maxLoopIteration = 10;
-  minimumStepSize = 1e-12;
-  numProcs = 1;
-  progressBar = false;
-  realTime = false;
-  resultFile = "<default>";
-  skipCSVHeader = true;
-  solver = oms_solver_sc_cvode;
-  solverStats = false;
-  startTime = 0.0;
-  stopTime = 1.0;
-  stripRoot = false;
-  suppressPath = true;
-  timeout = 0;
-  tolerance = 1e-4;
-  wallTime = false;
-  zeroNominal = false;
+  flagValues = FlagValues();
 }
 
 oms::Flags& oms::Flags::GetInstance()
@@ -186,16 +189,16 @@ oms_status_enu_t oms::Flags::SetCommandLineOption(const std::string& cmd)
 
 oms_status_enu_t oms::Flags::AddParametersToCSV(const std::string& value)
 {
-  GetInstance().addParametersToCSV = (value == "true");
+  GetInstance().flagValues.addParametersToCSV = (value == "true");
   return oms_status_ok;
 }
 
 oms_status_enu_t oms::Flags::AlgLoopSolver(const std::string& value)
 {
   if (value == "fixedpoint")
-    GetInstance().algLoopSolver = oms_alg_solver_fixedpoint;
+    GetInstance().flagValues.algLoopSolver = oms_alg_solver_fixedpoint;
   else if (value == "kinsol")
-    GetInstance().algLoopSolver = oms_alg_solver_kinsol;
+    GetInstance().flagValues.algLoopSolver = oms_alg_solver_kinsol;
   else
     return logError("Invalid solver method");
   return oms_status_ok;
@@ -209,49 +212,49 @@ oms_status_enu_t oms::Flags::ClearAllOptions(const std::string& value)
 
 oms_status_enu_t oms::Flags::CVODEMaxErrTestFails(const std::string& value)
 {
-  GetInstance().cvodeMaxErrTestFails = atoi(value.c_str());
+  GetInstance().flagValues.cvodeMaxErrTestFails = atoi(value.c_str());
   return oms_status_ok;
 }
 
 oms_status_enu_t oms::Flags::CVODEMaxNLSFailures(const std::string& value)
 {
-  GetInstance().cvodeMaxNLSFails = atoi(value.c_str());
+  GetInstance().flagValues.cvodeMaxNLSFails = atoi(value.c_str());
   return oms_status_ok;
 }
 
 oms_status_enu_t oms::Flags::CVODEMaxNLSIterations(const std::string& value)
 {
-  GetInstance().cvodeMaxNLSIterations = atoi(value.c_str());
+  GetInstance().flagValues.cvodeMaxNLSIterations = atoi(value.c_str());
   return oms_status_ok;
 }
 
 oms_status_enu_t oms::Flags::CVODEMaxSteps(const std::string& value)
 {
-  GetInstance().cvodeMaxSteps = atoi(value.c_str());
+  GetInstance().flagValues.cvodeMaxSteps = atoi(value.c_str());
   return oms_status_ok;
 }
 
 oms_status_enu_t oms::Flags::DeleteTempFiles(const std::string& value)
 {
-  GetInstance().deleteTempFiles = (value == "true");
+  GetInstance().flagValues.deleteTempFiles = (value == "true");
   return oms_status_ok;
 }
 
 oms_status_enu_t oms::Flags::DirectionalDerivatives(const std::string& value)
 {
-  GetInstance().directionalDerivatives = (value == "true");
+  GetInstance().flagValues.directionalDerivatives = (value == "true");
   return oms_status_ok;
 }
 
 oms_status_enu_t oms::Flags::DumpAlgLoops(const std::string& value)
 {
-  GetInstance().dumpAlgLoops = (value == "true");
+  GetInstance().flagValues.dumpAlgLoops = (value == "true");
   return oms_status_ok;
 }
 
 oms_status_enu_t oms::Flags::EmitEvents(const std::string& value)
 {
-  GetInstance().emitEvents = (value == "true");
+  GetInstance().flagValues.emitEvents = (value == "true");
   return oms_status_ok;
 }
 
@@ -332,19 +335,19 @@ oms_status_enu_t oms::Flags::Help(const std::string& value)
 
 oms_status_enu_t oms::Flags::IgnoreInitialUnknowns(const std::string& value)
 {
-  GetInstance().ignoreInitialUnknowns = (value == "true");
+  GetInstance().flagValues.ignoreInitialUnknowns = (value == "true");
   return oms_status_ok;
 }
 
 oms_status_enu_t oms::Flags::InputExtrapolation(const std::string& value)
 {
-  GetInstance().inputExtrapolation = (value == "true");
+  GetInstance().flagValues.inputExtrapolation = (value == "true");
   return oms_status_ok;
 }
 
 oms_status_enu_t oms::Flags::Intervals(const std::string& value)
 {
-  GetInstance().intervals = atoi(value.c_str());
+  GetInstance().flagValues.intervals = atoi(value.c_str());
   return oms_status_ok;
 }
 
@@ -362,58 +365,58 @@ oms_status_enu_t oms::Flags::LogLevel(const std::string& value)
 
 oms_status_enu_t oms::Flags::MaxEventIteration(const std::string& value)
 {
-  GetInstance().maxEventIteration = atoi(value.c_str());
+  GetInstance().flagValues.maxEventIteration = atoi(value.c_str());
   return oms_status_ok;
 }
 
 oms_status_enu_t oms::Flags::MaxLoopIteration(const std::string& value)
 {
-  GetInstance().maxLoopIteration = atoi(value.c_str());
+  GetInstance().flagValues.maxLoopIteration = atoi(value.c_str());
   return oms_status_ok;
 }
 
 oms_status_enu_t oms::Flags::Mode(const std::string& value)
 {
-  GetInstance().defaultModeIsCS = (value == "cs");
+  GetInstance().flagValues.defaultModeIsCS = (value == "cs");
   return oms_status_ok;
 }
 
 oms_status_enu_t oms::Flags::NumProcs(const std::string& value)
 {
-  GetInstance().numProcs = atoi(value.c_str());
+  GetInstance().flagValues.numProcs = atoi(value.c_str());
   return oms_status_ok;
 }
 
 oms_status_enu_t oms::Flags::ProgressBar(const std::string& value)
 {
-  GetInstance().progressBar = (value == "true");
+  GetInstance().flagValues.progressBar = (value == "true");
   return oms_status_ok;
 }
 
 oms_status_enu_t oms::Flags::RealTime(const std::string& value)
 {
-  GetInstance().realTime = (value == "true");
+  GetInstance().flagValues.realTime = (value == "true");
   return oms_status_ok;
 }
 
 oms_status_enu_t oms::Flags::ResultFile(const std::string& value)
 {
-  GetInstance().resultFile = value;
+  GetInstance().flagValues.resultFile = value;
   return oms_status_ok;
 }
 
 oms_status_enu_t oms::Flags::SkipCSVHeader(const std::string& value)
 {
-  GetInstance().skipCSVHeader = (value == "true");
+  GetInstance().flagValues.skipCSVHeader = (value == "true");
   return oms_status_ok;
 }
 
 oms_status_enu_t oms::Flags::Solver(const std::string& value)
 {
   if (value == "euler")
-    GetInstance().solver = oms_solver_sc_explicit_euler;
+    GetInstance().flagValues.solver = oms_solver_sc_explicit_euler;
   else if (value == "cvode")
-    GetInstance().solver = oms_solver_sc_cvode;
+    GetInstance().flagValues.solver = oms_solver_sc_cvode;
   else
     return logError("Invalid solver method");
 
@@ -422,13 +425,13 @@ oms_status_enu_t oms::Flags::Solver(const std::string& value)
 
 oms_status_enu_t oms::Flags::SolverStats(const std::string& value)
 {
-  GetInstance().solverStats = (value == "true");
+  GetInstance().flagValues.solverStats = (value == "true");
   return oms_status_ok;
 }
 
 oms_status_enu_t oms::Flags::StartTime(const std::string& value)
 {
-  GetInstance().startTime = atof(value.c_str());
+  GetInstance().flagValues.startTime = atof(value.c_str());
   return oms_status_ok;
 }
 
@@ -454,30 +457,30 @@ oms_status_enu_t oms::Flags::StepSize(const std::string& value)
 
   if (options.size() > 1)
   {
-    GetInstance().initialStepSize = atof(options[0].c_str());
-    GetInstance().minimumStepSize = atof(options[1].c_str());
-    GetInstance().maximumStepSize = atof(options[2].c_str());
+    GetInstance().flagValues.initialStepSize = atof(options[0].c_str());
+    GetInstance().flagValues.minimumStepSize = atof(options[1].c_str());
+    GetInstance().flagValues.maximumStepSize = atof(options[2].c_str());
   }
   else
-    GetInstance().maximumStepSize = atof(options[0].c_str());
+    GetInstance().flagValues.maximumStepSize = atof(options[0].c_str());
   return oms_status_ok;
 }
 
 oms_status_enu_t oms::Flags::StopTime(const std::string& value)
 {
-  GetInstance().stopTime = atof(value.c_str());
+  GetInstance().flagValues.stopTime = atof(value.c_str());
   return oms_status_ok;
 }
 
 oms_status_enu_t oms::Flags::StripRoot(const std::string& value)
 {
-  GetInstance().stripRoot = (value == "true");
+  GetInstance().flagValues.stripRoot = (value == "true");
   return oms_status_ok;
 }
 
 oms_status_enu_t oms::Flags::SuppressPath(const std::string& value)
 {
-  GetInstance().suppressPath = (value == "true");
+  GetInstance().flagValues.suppressPath = (value == "true");
   return oms_status_ok;
 }
 
@@ -489,13 +492,13 @@ oms_status_enu_t oms::Flags::TempDir(const std::string& value)
 
 oms_status_enu_t oms::Flags::Timeout(const std::string& value)
 {
-  GetInstance().timeout = atoi(value.c_str());
+  GetInstance().flagValues.timeout = atoi(value.c_str());
   return oms_status_ok;
 }
 
 oms_status_enu_t oms::Flags::Tolerance(const std::string& value)
 {
-  GetInstance().tolerance = atof(value.c_str());
+  GetInstance().flagValues.tolerance = atof(value.c_str());
   return oms_status_ok;
 }
 
@@ -513,12 +516,12 @@ oms_status_enu_t oms::Flags::WorkingDir(const std::string& value)
 
 oms_status_enu_t oms::Flags::WallTime(const std::string& value)
 {
-  GetInstance().wallTime = (value == "true");
+  GetInstance().flagValues.wallTime = (value == "true");
   return oms_status_ok;
 }
 
 oms_status_enu_t oms::Flags::ZeroNominal(const std::string& value)
 {
-  GetInstance().zeroNominal = (value == "true");
+  GetInstance().flagValues.zeroNominal = (value == "true");
   return oms_status_ok;
 }

--- a/src/OMSimulatorLib/Flags.h
+++ b/src/OMSimulatorLib/Flags.h
@@ -39,6 +39,39 @@
 
 namespace oms
 {
+  template <typename T>
+  class FlagValue
+  {
+  public:
+    bool given;
+    T value;
+
+    FlagValue() = default;
+    FlagValue(const FlagValue&) = default;
+
+    FlagValue& operator=(const FlagValue&) = default;
+
+    FlagValue(const T& defaultValue) : given(false), value(defaultValue)
+    { }
+
+    void operator=(const T& newValue) {
+      given = true;
+      value = newValue;
+    }
+
+    operator const T& () const {
+      return value;
+    }
+
+    bool operator==(const T& v) const {
+      return value == v;
+    }
+
+    bool operator!=(const T& v) const {
+      return value != v;
+    }
+  };
+
   class Flags
   {
   private:
@@ -47,86 +80,92 @@ namespace oms
     void setDefaults();
 
     // stop the compiler generating methods copying the object
-    Flags(Flags const&);            ///< not implemented
-    Flags& operator=(Flags const&); ///< not implemented
+    //Flags(Flags const&);            ///< not implemented
+    Flags& operator=(Flags const&) = default; ///< not implemented
 
     static Flags& GetInstance();
 
   public:
     static oms_status_enu_t SetCommandLineOption(const std::string& cmd);
 
-    static bool AddParametersToCSV() {return GetInstance().addParametersToCSV;}
-    static int CVODEMaxErrTestFails() {return GetInstance().cvodeMaxErrTestFails;}
-    static int CVODEMaxNLSFailures() {return GetInstance().cvodeMaxNLSFails;}
-    static int CVODEMaxNLSIterations() {return GetInstance().cvodeMaxNLSIterations;}
-    static int CVODEMaxSteps() {return GetInstance().cvodeMaxSteps;}
-    static bool DefaultModeIsCS() {return GetInstance().defaultModeIsCS;}
-    static bool DeleteTempFiles() {return GetInstance().deleteTempFiles;}
-    static bool DirectionalDerivatives() {return GetInstance().directionalDerivatives;}
-    static bool DumpAlgLoops() {return GetInstance().dumpAlgLoops;}
-    static bool EmitEvents() {return GetInstance().emitEvents;}
-    static bool IgnoreInitialUnknowns() {return GetInstance().ignoreInitialUnknowns;}
-    static bool InputExtrapolation() {return GetInstance().inputExtrapolation;}
-    static bool ProgressBar() {return GetInstance().progressBar;}
-    static bool RealTime() {return GetInstance().realTime;}
-    static bool SkipCSVHeader() {return GetInstance().skipCSVHeader;}
-    static bool SolverStats() {return GetInstance().solverStats;}
-    static bool StripRoot() {return GetInstance().stripRoot;}
-    static bool SuppressPath() {return GetInstance().suppressPath;}
-    static bool WallTime() {return GetInstance().wallTime;}
-    static bool ZeroNominal() {return GetInstance().zeroNominal;}
-    static double InitialStepSize() {return GetInstance().initialStepSize;}
-    static double MaximumStepSize() {return GetInstance().maximumStepSize;}
-    static double MinimumStepSize() {return GetInstance().minimumStepSize;}
-    static double StartTime() {return GetInstance().startTime;}
-    static double StopTime() {return GetInstance().stopTime;}
-    static double Tolerance() {return GetInstance().tolerance;}
-    static oms_alg_solver_enu_t AlgLoopSolver() {return GetInstance().algLoopSolver;}
-    static oms_solver_enu_t MasterAlgorithm() {return GetInstance().masterAlgorithm;}
-    static oms_solver_enu_t Solver() {return GetInstance().solver;}
-    static std::string ResultFile() {return GetInstance().resultFile;}
-    static unsigned int Intervals() {return GetInstance().intervals;}
-    static unsigned int MaxEventIteration() {return GetInstance().maxEventIteration;}
-    static unsigned int MaxLoopIteration() {return GetInstance().maxLoopIteration;}
-    static unsigned int NumProcs() {return GetInstance().numProcs;}
-    static unsigned int Timeout() {return GetInstance().timeout;}
+    static FlagValue<bool> &AddParametersToCSV() {return GetInstance().flagValues.addParametersToCSV;}
+    static FlagValue<int> &CVODEMaxErrTestFails() {return GetInstance().flagValues.cvodeMaxErrTestFails;}
+    static FlagValue<int> &CVODEMaxNLSFailures() {return GetInstance().flagValues.cvodeMaxNLSFails;}
+    static FlagValue<int> &CVODEMaxNLSIterations() {return GetInstance().flagValues.cvodeMaxNLSIterations;}
+    static FlagValue<int> &CVODEMaxSteps() { return GetInstance().flagValues.cvodeMaxSteps; }
+    static FlagValue<bool> &DefaultModeIsCS() {return GetInstance().flagValues.defaultModeIsCS;}
+    static FlagValue<bool> &DeleteTempFiles() {return GetInstance().flagValues.deleteTempFiles;}
+    static FlagValue<bool> &DirectionalDerivatives() {return GetInstance().flagValues.directionalDerivatives;}
+    static FlagValue<bool> &DumpAlgLoops() {return GetInstance().flagValues.dumpAlgLoops;}
+    static FlagValue<bool> &EmitEvents() {return GetInstance().flagValues.emitEvents;}
+    static FlagValue<bool> &IgnoreInitialUnknowns() {return GetInstance().flagValues.ignoreInitialUnknowns;}
+    static FlagValue<bool> &InputExtrapolation() {return GetInstance().flagValues.inputExtrapolation;}
+    static FlagValue<bool> &ProgressBar() {return GetInstance().flagValues.progressBar;}
+    static FlagValue<bool> &RealTime() {return GetInstance().flagValues.realTime;}
+    static FlagValue<bool> &SkipCSVHeader() {return GetInstance().flagValues.skipCSVHeader;}
+    static FlagValue<bool> &SolverStats() {return GetInstance().flagValues.solverStats;}
+    static FlagValue<bool> &StripRoot() {return GetInstance().flagValues.stripRoot;}
+    static FlagValue<bool> &SuppressPath() {return GetInstance().flagValues.suppressPath;}
+    static FlagValue<bool> &WallTime() {return GetInstance().flagValues.wallTime;}
+    static FlagValue<bool> &ZeroNominal() {return GetInstance().flagValues.zeroNominal;}
+    static FlagValue<double> &InitialStepSize() {return GetInstance().flagValues.initialStepSize;}
+    static FlagValue<double> &MaximumStepSize() {return GetInstance().flagValues.maximumStepSize;}
+    static FlagValue<double> &MinimumStepSize() {return GetInstance().flagValues.minimumStepSize;}
+    static FlagValue<double> &StartTime() {return GetInstance().flagValues.startTime;}
+    static FlagValue<double> &StopTime() {return GetInstance().flagValues.stopTime;}
+    static FlagValue<double> &Tolerance() {return GetInstance().flagValues.tolerance;}
+    static FlagValue<oms_alg_solver_enu_t> &AlgLoopSolver() {return GetInstance().flagValues.algLoopSolver;}
+    static FlagValue<oms_solver_enu_t> &MasterAlgorithm() {return GetInstance().flagValues.masterAlgorithm;}
+    static FlagValue<oms_solver_enu_t> &Solver() {return GetInstance().flagValues.solver;}
+    static FlagValue<std::string> &ResultFile() {return GetInstance().flagValues.resultFile;}
+    static FlagValue<unsigned int> &Intervals() {return GetInstance().flagValues.intervals;}
+    static FlagValue<unsigned int> &MaxEventIteration() {return GetInstance().flagValues.maxEventIteration;}
+    static FlagValue<unsigned int> &MaxLoopIteration() {return GetInstance().flagValues.maxLoopIteration;}
+    static FlagValue<unsigned int> &NumProcs() {return GetInstance().flagValues.numProcs;}
+    static FlagValue<unsigned int> &Timeout() {return GetInstance().flagValues.timeout;}
+
+    struct FlagValues {
+      FlagValues();
+
+      FlagValue<bool> addParametersToCSV;
+      FlagValue<int> cvodeMaxErrTestFails;
+      FlagValue<int> cvodeMaxNLSFails;
+      FlagValue<int> cvodeMaxNLSIterations;
+      FlagValue<int> cvodeMaxSteps;
+      FlagValue<bool> defaultModeIsCS;
+      FlagValue<bool> deleteTempFiles;
+      FlagValue<bool> directionalDerivatives;
+      FlagValue<bool> dumpAlgLoops;
+      FlagValue<bool> emitEvents;
+      FlagValue<bool> ignoreInitialUnknowns;
+      FlagValue<bool> inputExtrapolation;
+      FlagValue<bool> progressBar;
+      FlagValue<bool> realTime;
+      FlagValue<bool> skipCSVHeader;
+      FlagValue<bool> solverStats;
+      FlagValue<bool> stripRoot;
+      FlagValue<bool> suppressPath;
+      FlagValue<bool> wallTime;
+      FlagValue<bool> zeroNominal;
+      FlagValue<double> initialStepSize;
+      FlagValue<double> maximumStepSize;
+      FlagValue<double> minimumStepSize;
+      FlagValue<double> startTime;
+      FlagValue<double> stopTime;
+      FlagValue<double> tolerance;
+      FlagValue<oms_alg_solver_enu_t> algLoopSolver;
+      FlagValue<oms_solver_enu_t> masterAlgorithm;
+      FlagValue<oms_solver_enu_t> solver;
+      FlagValue<std::string> resultFile;
+      FlagValue<unsigned int> intervals;
+      FlagValue<unsigned int> maxEventIteration;
+      FlagValue<unsigned int> maxLoopIteration;
+      FlagValue<unsigned int> numProcs;
+      FlagValue<unsigned int> timeout;
+    };
 
   private:
-    bool addParametersToCSV;
-    int cvodeMaxErrTestFails;
-    int cvodeMaxNLSFails;
-    int cvodeMaxNLSIterations;
-    int cvodeMaxSteps;
-    bool defaultModeIsCS;
-    bool deleteTempFiles;
-    bool directionalDerivatives;
-    bool dumpAlgLoops;
-    bool emitEvents;
-    bool ignoreInitialUnknowns;
-    bool inputExtrapolation;
-    bool progressBar;
-    bool realTime;
-    bool skipCSVHeader;
-    bool solverStats;
-    bool stripRoot;
-    bool suppressPath;
-    bool wallTime;
-    bool zeroNominal;
-    double initialStepSize;
-    double maximumStepSize;
-    double minimumStepSize;
-    double startTime;
-    double stopTime;
-    double tolerance;
-    oms_alg_solver_enu_t algLoopSolver;
-    oms_solver_enu_t masterAlgorithm;
-    oms_solver_enu_t solver;
-    std::string resultFile;
-    unsigned int intervals;
-    unsigned int maxEventIteration;
-    unsigned int maxLoopIteration;
-    unsigned int numProcs;
-    unsigned int timeout;
+    FlagValues flagValues;
 
   private:
     struct Flag


### PR DESCRIPTION
### Related Issues

- #1328
- #1329

### Purpose

This commit changes the storage of command line options so that it is knowable, whether the option was provided at all.

It also changes the way the values form the flags are applied to single FMU and SSP simulations, so that the default values for flags are only used if the corresponding value is not defined by the FMU or SSP, and all values in FMUs or SSPs can be overridden from the flags.

### Approach

The flag values are stored in a class `FlagValue` that stores both the value and a boolean variable `given` that defines whether the flag value was actually provided by the user.

The value of the `given` variable is checked to decide whether the values from FMUs or SSPs should be overridden.
