### PR TITLE
Quote signal names in CSV output

### DIFF
--- a/src/OMSimulatorLib/CSVWriter.cpp
+++ b/src/OMSimulatorLib/CSVWriter.cpp
@@ -66,16 +66,16 @@ bool oms::CSVWriter::createFile(const std::string& filename, double startTime, d
     fputs("\"sep=,\"\n", pFile);
 
   // first signal is always 'time'
-  fputs("time", pFile);
+  fputs("\"time\"", pFile);
 
   // write signal names to csv file
   for (int i = 0; i < signals.size(); ++i)
-    fprintf(pFile, ",%s", signals[i].name.c_str());
+    fprintf(pFile, ",\"%s\"", signals[i].name.c_str());
 
   // write parameter headers to csv file
   if (Flags::AddParametersToCSV())
     for (int i = 0; i < parameters.size(); ++i)
-      fprintf(pFile, ",%s", parameters[i].signal.name.c_str());
+      fprintf(pFile, ",\"%s\"", parameters[i].signal.name.c_str());
 
   fputs("\n", pFile);
   return true;


### PR DESCRIPTION


### Related Issues
#1197
<!-- Link to the issues that are solved with this PR. -->

### Purpose
FMUs with the structured variable naming convention may contain comma signs in the signal names. For example:
* `system.root.example.x[1,1]`, or
* `system.root.example.der(y, 2)`.

If these signal names are not quoted, the output CSV files can not be parsed by other tools, e.g. OMEdit. Therefore, OMSimulator should quote signal names in CSV output, ensuring that CSV output is correct.
<!--- Describe the problem or feature in addition to a link to the issues. -->

### Approach
This PR updates CSVWriter to quote signal names when writing the header.
<!--- How does this change address the problem? -->
