### PR TITLE
ET.parse bug in python 3.11 patched

### DIFF
--- a/src/OMSimulatorPython/ssd.py
+++ b/src/OMSimulatorPython/ssd.py
@@ -36,7 +36,7 @@ class SSD:
     '''Imports an SSD file and parses its contents.'''
     try:
       # Determine input type
-      tree = ET.parse(filename)
+      tree = ET.parse(str(filename))
       root = tree.getroot()
       filename = Path(filename).resolve()
       return SSD.importFromNode(root, filename, resources)

--- a/src/OMSimulatorPython/utils.py
+++ b/src/OMSimulatorPython/utils.py
@@ -139,14 +139,14 @@ def parseParameterBindings(node, obj, resources):
           Unit.importFromNode(param_set, obj, tagname="ssv:Units")
 
 def parseSSV(filename):
-  tree = ET.parse(filename)
+  tree = ET.parse(str(filename))
   root = tree.getroot()
   validateSSP(root, filename, "SystemStructureParameterValues.xsd")
   parameters = root.find("ssv:Parameters", namespaces=namespace.ns)
   return parseParameterBindingHelper(parameters)
 
 def parseSSM(filename):
-  tree = ET.parse(filename)
+  tree = ET.parse(str(filename))
   root = tree.getroot()
   validateSSP(root, filename, "SystemStructureParameterMapping.xsd")
   mappingEntry = defaultdict(list)


### PR DESCRIPTION
### Related Issues

Python api craches when using python 3.11 or ealier

### Approach

function call gets string instead of Path
