### PR TITLE
Fix signal filter regex matching in ComponentTable (v3.0)

### DIFF
--- a/src/OMSimulatorLib/ComponentTable.cpp
+++ b/src/OMSimulatorLib/ComponentTable.cpp
@@ -397,7 +397,7 @@ oms_status_enu_t oms::ComponentTable::addSignalsToResults(const char* regex)
     if (x.second)
       continue;
 
-    if (regex_match(std::string(x.first), exp))
+    if (regex_match(std::string(getFullCref() + x.first), exp))
       x.second = true;
   }
 
@@ -412,7 +412,7 @@ oms_status_enu_t oms::ComponentTable::removeSignalsFromResults(const char* regex
     if (!x.second)
       continue;
 
-    if (regex_match(std::string(x.first), exp))
+    if (regex_match(std::string(getFullCref() + x.first), exp))
       x.second = false;
   }
 


### PR DESCRIPTION
### Related Issues
#1584
<!-- Link to the issues that are solved with this PR. -->

### Purpose
In ComponentFMUCS, ComponentFMUME the regex in addSignalsToResults and removeSignalsFromResults is matched against the full cref of the signal, e.g. model.root.component.signal. In ComponentTable, the regex was matched against the signal name only. 
<!--- Describe the problem or feature in addition to a link to the issues. -->

### Approach
This PR fixes this inconsistency by updating the ComponentTable implementations to match against the full cref of the signal.
<!--- How does this change address the problem? -->
