### PR TITLE
Add setString to procedural API

### DIFF
--- a/src/OMSimulatorPython/OMSimulator.py
+++ b/src/OMSimulatorPython/OMSimulator.py
@@ -136,6 +136,7 @@ class OMSimulator:
     self.setSolver = Scope._capi.setSolver
     self.setStartTime = Scope._capi.setStartTime
     self.setStopTime = Scope._capi.setStopTime
+    self.setString = Scope._capi.setString
     self.setTempDirectory = Scope._capi.setTempDirectory
     self.setTLMPositionAndOrientation = Scope._capi.setTLMPositionAndOrientation
     self.setTLMSocketData = Scope._capi.setTLMSocketData


### PR DESCRIPTION
### Related Issues
setString is missing from the procedural Python API.

### Purpose
To enable setting string parameters using the procedural API, add the missing setString method to the procedural API. The method was already implemented in the object oriented API and implemented in the capi wrapper.
<!--- Describe the problem or feature in addition to a link to the issues. -->

### Approach
```diff
+    self.setString = Scope._capi.setString
```
<!--- How does this change address the problem? -->
