### PR TITLE
Update FMI schema files

### DIFF
--- a/schema/fmi2/fmi2Annotation.xsd
+++ b/schema/fmi2/fmi2Annotation.xsd
@@ -3,10 +3,10 @@
 	<xs:annotation>
 		<xs:documentation>
 Copyright(c) 2008-2011 MODELISAR consortium,
-             2012-2020 Modelica Association Project "FMI".
+             2012-2024 Modelica Association Project "FMI".
              All rights reserved.
 
-This schema file is part of the FMI 2.0.2 standard.
+This schema file is part of the FMI 2.0.5 standard.
 
 This file is licensed by the copyright holders under the 2-Clause BSD License
 (https://opensource.org/licenses/BSD-2-Clause):

--- a/schema/fmi2/fmi2AttributeGroups.xsd
+++ b/schema/fmi2/fmi2AttributeGroups.xsd
@@ -3,10 +3,10 @@
 	<xs:annotation>
 		<xs:documentation>
 Copyright(c) 2008-2011 MODELISAR consortium,
-             2012-2020 Modelica Association Project "FMI".
+             2012-2024 Modelica Association Project "FMI".
              All rights reserved.
 
-This schema file is part of the FMI 2.0.2 standard.
+This schema file is part of the FMI 2.0.5 standard.
 
 This file is licensed by the copyright holders under the 2-Clause BSD License
 (https://opensource.org/licenses/BSD-2-Clause):

--- a/schema/fmi2/fmi2ModelDescription.xsd
+++ b/schema/fmi2/fmi2ModelDescription.xsd
@@ -7,10 +7,10 @@
 	<xs:annotation>
 		<xs:documentation>
 Copyright(c) 2008-2011 MODELISAR consortium,
-             2012-2020 Modelica Association Project "FMI".
+             2012-2024 Modelica Association Project "FMI".
              All rights reserved.
 
-This schema file is part of the FMI 2.0.2 standard.
+This schema file is part of the FMI 2.0.5 standard.
 
 This file is licensed by the copyright holders under the 2-Clause BSD License
 (https://opensource.org/licenses/BSD-2-Clause):

--- a/schema/fmi2/fmi2ScalarVariable.xsd
+++ b/schema/fmi2/fmi2ScalarVariable.xsd
@@ -5,10 +5,10 @@
 	<xs:annotation>
 		<xs:documentation>
 Copyright(c) 2008-2011 MODELISAR consortium,
-             2012-2020 Modelica Association Project "FMI".
+             2012-2024 Modelica Association Project "FMI".
              All rights reserved.
 
-This schema file is part of the FMI 2.0.2 standard.
+This schema file is part of the FMI 2.0.5 standard.
 
 This file is licensed by the copyright holders under the 2-Clause BSD License
 (https://opensource.org/licenses/BSD-2-Clause):

--- a/schema/fmi2/fmi2Type.xsd
+++ b/schema/fmi2/fmi2Type.xsd
@@ -4,10 +4,10 @@
 	<xs:annotation>
 		<xs:documentation>
 Copyright(c) 2008-2011 MODELISAR consortium,
-             2012-2020 Modelica Association Project "FMI".
+             2012-2024 Modelica Association Project "FMI".
              All rights reserved.
 
-This schema file is part of the FMI 2.0.2 standard.
+This schema file is part of the FMI 2.0.5 standard.
 
 This file is licensed by the copyright holders under the 2-Clause BSD License
 (https://opensource.org/licenses/BSD-2-Clause):

--- a/schema/fmi2/fmi2Unit.xsd
+++ b/schema/fmi2/fmi2Unit.xsd
@@ -3,10 +3,10 @@
 	<xs:annotation>
 		<xs:documentation>
 Copyright(c) 2008-2011 MODELISAR consortium,
-             2012-2020 Modelica Association Project "FMI".
+             2012-2024 Modelica Association Project "FMI".
              All rights reserved.
 
-This schema file is part of the FMI 2.0.2 standard.
+This schema file is part of the FMI 2.0.5 standard.
 
 This file is licensed by the copyright holders under the 2-Clause BSD License
 (https://opensource.org/licenses/BSD-2-Clause):

--- a/schema/fmi2/fmi2VariableDependency.xsd
+++ b/schema/fmi2/fmi2VariableDependency.xsd
@@ -3,10 +3,10 @@
 	<xs:annotation>
 		<xs:documentation>
 Copyright(c) 2008-2011 MODELISAR consortium,
-             2012-2020 Modelica Association Project "FMI".
+             2012-2024 Modelica Association Project "FMI".
              All rights reserved.
 
-This schema file is part of the FMI 2.0.2 standard.
+This schema file is part of the FMI 2.0.5 standard.
 
 This file is licensed by the copyright holders under the 2-Clause BSD License
 (https://opensource.org/licenses/BSD-2-Clause):

--- a/schema/fmi3/fmi3Annotation.xsd
+++ b/schema/fmi3/fmi3Annotation.xsd
@@ -1,24 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified">
-	<xs:annotation>
-		<xs:documentation>
+    <xs:annotation>
+        <xs:documentation>
 Copyright(c) 2008-2011 MODELISAR consortium,
-             2012-2018 Modelica Association Project "FMI".
+             2012-2024 Modelica Association Project "FMI".
              All rights reserved.
-This file is licensed by the copyright holders under the BSD 2-Clause License
-(http://www.opensource.org/licenses/bsd-license.html):
+
+This file is licensed by the copyright holders under the 2-Clause BSD License
+(https://opensource.org/licenses/BSD-2-Clause):
+
 ----------------------------------------------------------------------------
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
 
 - Redistributions of source code must retain the above copyright notice,
-  this list of conditions and the following disclaimer.
+this list of conditions and the following disclaimer.
+
 - Redistributions in binary form must reproduce the above copyright notice,
-  this list of conditions and the following disclaimer in the documentation
-  and/or other materials provided with the distribution.
-- Neither the name of the copyright holders nor the names of its
-  contributors may be used to endorse or promote products derived
-  from this software without specific prior written permission.
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
@@ -32,32 +32,20 @@ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
 OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
 ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ----------------------------------------------------------------------------
-
-with the extension:
-
-You may distribute or publicly perform any modification only under the
-terms of this license.
-(Note, this means that if you distribute a modified file,
-the modified file must also be provided under this license).
-		</xs:documentation>
-	</xs:annotation>
-	<xs:complexType name="fmi3Annotation">
-		<xs:sequence maxOccurs="unbounded">
-			<xs:element name="Tool">
-				<xs:annotation>
-					<xs:documentation>Tool specific annotation (ignored by other tools).</xs:documentation>
-				</xs:annotation>
-				<xs:complexType>
-					<xs:sequence>
-						<xs:any namespace="##any" processContents="lax" minOccurs="0"/>
-					</xs:sequence>
-					<xs:attribute name="name" type="xs:normalizedString" use="required">
-						<xs:annotation>
-							<xs:documentation>Name of tool that can interpret the annotation. "name" must be unique with respect to all other elements of the VendorAnnotation list.</xs:documentation>
-						</xs:annotation>
-					</xs:attribute>
-				</xs:complexType>
-			</xs:element>
-		</xs:sequence>
-	</xs:complexType>
+        </xs:documentation>
+    </xs:annotation>
+    <xs:complexType name="fmi3Annotations">
+        <xs:sequence maxOccurs="unbounded">
+            <xs:element name="Annotation">
+                <xs:complexType mixed="true">
+                    <xs:sequence>
+                        <xs:any namespace="##any" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+                    </xs:sequence>
+                    <xs:attribute name="type" type="xs:normalizedString" use="required">
+                    </xs:attribute>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:element name="Annotations" type="fmi3Annotations"/>
 </xs:schema>

--- a/schema/fmi3/fmi3AttributeGroups.xsd
+++ b/schema/fmi3/fmi3AttributeGroups.xsd
@@ -1,24 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified">
-	<xs:annotation>
-		<xs:documentation>
+    <xs:annotation>
+        <xs:documentation>
 Copyright(c) 2008-2011 MODELISAR consortium,
-             2012-2018 Modelica Association Project "FMI".
+             2012-2024 Modelica Association Project "FMI".
              All rights reserved.
-This file is licensed by the copyright holders under the BSD 2-Clause License
-(http://www.opensource.org/licenses/bsd-license.html):
+
+This file is licensed by the copyright holders under the 2-Clause BSD License
+(https://opensource.org/licenses/BSD-2-Clause):
+
 ----------------------------------------------------------------------------
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
 
 - Redistributions of source code must retain the above copyright notice,
-  this list of conditions and the following disclaimer.
+ this list of conditions and the following disclaimer.
+
 - Redistributions in binary form must reproduce the above copyright notice,
-  this list of conditions and the following disclaimer in the documentation
-  and/or other materials provided with the distribution.
-- Neither the name of the copyright holders nor the names of its
-  contributors may be used to endorse or promote products derived
-  from this software without specific prior written permission.
+ this list of conditions and the following disclaimer in the documentation
+ and/or other materials provided with the distribution.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
@@ -32,52 +32,88 @@ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
 OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
 ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ----------------------------------------------------------------------------
-
-with the extension:
-
-You may distribute or publicly perform any modification only under the
-terms of this license.
-(Note, this means that if you distribute a modified file,
-the modified file must also be provided under this license).
-		</xs:documentation>
-	</xs:annotation>
-	<xs:attributeGroup name="fmi3RealAttributes">
-		<xs:attribute name="quantity" type="xs:normalizedString"/>
-		<xs:attribute name="unit" type="xs:normalizedString"/>
-		<xs:attribute name="displayUnit" type="xs:normalizedString">
-			<xs:annotation>
-				<xs:documentation>Default display unit, provided the conversion of values in "unit" to values in "displayUnit" is defined in UnitDefinitions / Unit / DisplayUnit.</xs:documentation>
-			</xs:annotation>
-		</xs:attribute>
-		<xs:attribute name="relativeQuantity" type="xs:boolean" default="false">
-			<xs:annotation>
-				<xs:documentation>If relativeQuantity=true, offset for displayUnit must be ignored.</xs:documentation>
-			</xs:annotation>
-		</xs:attribute>
-		<xs:attribute name="min" type="xs:double"/>
-		<xs:attribute name="max" type="xs:double">
-			<xs:annotation>
-				<xs:documentation>max >= min required</xs:documentation>
-			</xs:annotation>
-		</xs:attribute>
-		<xs:attribute name="nominal" type="xs:double">
-			<xs:annotation>
-				<xs:documentation>nominal > 0.0 required</xs:documentation>
-			</xs:annotation>
-		</xs:attribute>
-		<xs:attribute name="unbounded" type="xs:boolean" default="false">
-			<xs:annotation>
-				<xs:documentation>Set to true, e.g., for crank angle. If true and variable is a state, relative tolerance should be zero on this variable.</xs:documentation>
-			</xs:annotation>
-		</xs:attribute>
-	</xs:attributeGroup>
-	<xs:attributeGroup name="fmi3IntegerAttributes">
-		<xs:attribute name="quantity" type="xs:normalizedString"/>
-		<xs:attribute name="min" type="xs:int"/>
-		<xs:attribute name="max" type="xs:int">
-			<xs:annotation>
-				<xs:documentation>max >= min required</xs:documentation>
-			</xs:annotation>
-		</xs:attribute>
-	</xs:attributeGroup>
+        </xs:documentation>
+    </xs:annotation>
+    <xs:attributeGroup name="fmi3RealBaseAttributes">
+        <xs:attribute name="quantity" type="xs:normalizedString"/>
+        <xs:attribute name="unit" type="xs:normalizedString"/>
+        <xs:attribute name="displayUnit" type="xs:normalizedString"/>
+        <xs:attribute name="relativeQuantity" type="xs:boolean" default="false"/>
+        <xs:attribute name="unbounded" type="xs:boolean" default="false"/>
+    </xs:attributeGroup>
+    <xs:attributeGroup name="fmi3Float64Attributes">
+        <xs:attribute name="min" type="xs:double"/>
+        <xs:attribute name="max" type="xs:double"/>
+        <xs:attribute name="nominal" type="xs:double"/>
+    </xs:attributeGroup>
+    <xs:attributeGroup name="fmi3Float32Attributes">
+        <xs:attribute name="min" type="xs:float"/>
+        <xs:attribute name="max" type="xs:float"/>
+        <xs:attribute name="nominal" type="xs:float"/>
+    </xs:attributeGroup>
+    <xs:attributeGroup name="fmi3IntegerBaseAttributes">
+        <xs:attribute name="quantity" type="xs:normalizedString"/>
+    </xs:attributeGroup>
+    <xs:attributeGroup name="fmi3Int8Attributes">
+        <xs:attribute name="min" type="xs:byte"/>
+        <xs:attribute name="max" type="xs:byte"/>
+    </xs:attributeGroup>
+    <xs:attributeGroup name="fmi3UInt8Attributes">
+        <xs:attribute name="min" type="xs:unsignedByte"/>
+        <xs:attribute name="max" type="xs:unsignedByte"/>
+    </xs:attributeGroup>
+    <xs:attributeGroup name="fmi3Int16Attributes">
+        <xs:attribute name="min" type="xs:short"/>
+        <xs:attribute name="max" type="xs:short"/>
+    </xs:attributeGroup>
+    <xs:attributeGroup name="fmi3UInt16Attributes">
+        <xs:attribute name="min" type="xs:unsignedShort"/>
+        <xs:attribute name="max" type="xs:unsignedShort"/>
+    </xs:attributeGroup>
+    <xs:attributeGroup name="fmi3Int32Attributes">
+        <xs:attribute name="min" type="xs:int"/>
+        <xs:attribute name="max" type="xs:int"/>
+    </xs:attributeGroup>
+    <xs:attributeGroup name="fmi3UInt32Attributes">
+        <xs:attribute name="min" type="xs:unsignedInt"/>
+        <xs:attribute name="max" type="xs:unsignedInt"/>
+    </xs:attributeGroup>
+    <xs:attributeGroup name="fmi3Int64Attributes">
+        <xs:attribute name="min" type="xs:long"/>
+        <xs:attribute name="max" type="xs:long"/>
+    </xs:attributeGroup>
+    <xs:attributeGroup name="fmi3UInt64Attributes">
+        <xs:attribute name="min" type="xs:unsignedLong"/>
+        <xs:attribute name="max" type="xs:unsignedLong"/>
+    </xs:attributeGroup>
+    <xs:attributeGroup name="fmi3RealVariableAttributes">
+        <xs:attribute name="derivative" type="xs:unsignedInt"/>
+        <xs:attribute name="reinit" type="xs:boolean" default="false"/>
+    </xs:attributeGroup>
+    <xs:attributeGroup name="fmi3EnumerationAttributes">
+        <xs:attribute name="min" type="xs:long"/>
+        <xs:attribute name="max" type="xs:long"/>
+    </xs:attributeGroup>
+    <xs:attributeGroup name="fmi3ClockAttributes">
+        <xs:attribute name="canBeDeactivated" type="xs:boolean" default="false"/>
+        <xs:attribute name="priority" type="xs:unsignedInt" use="optional"/>
+        <xs:attribute name="intervalVariability" use="required">
+            <xs:simpleType>
+                <xs:restriction base="xs:normalizedString">
+                    <xs:enumeration value="constant"/>
+                    <xs:enumeration value="fixed"/>
+                    <xs:enumeration value="tunable"/>
+                    <xs:enumeration value="changing"/>
+                    <xs:enumeration value="countdown"/>
+                    <xs:enumeration value="triggered"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="intervalDecimal" type="xs:double" use="optional"/>
+        <xs:attribute name="shiftDecimal" type="xs:double" default="0"/>
+        <xs:attribute name="supportsFraction" type="xs:boolean" default="false"/>
+        <xs:attribute name="resolution" type="xs:unsignedLong" use="optional"/>
+        <xs:attribute name="intervalCounter" type="xs:unsignedLong" use="optional"/>
+        <xs:attribute name="shiftCounter" type="xs:unsignedLong" default="0"/>
+    </xs:attributeGroup>
 </xs:schema>

--- a/schema/fmi3/fmi3BuildDescription.xsd
+++ b/schema/fmi3/fmi3BuildDescription.xsd
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified">
+    <xs:include schemaLocation="fmi3Annotation.xsd"/>
+    <xs:annotation>
+        <xs:documentation>
+Copyright(c) 2008-2011 MODELISAR consortium,
+             2012-2024 Modelica Association Project "FMI".
+             All rights reserved.
+
+This file is licensed by the copyright holders under the 2-Clause BSD License
+(https://opensource.org/licenses/BSD-2-Clause):
+
+----------------------------------------------------------------------------
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+- Redistributions of source code must retain the above copyright notice,
+ this list of conditions and the following disclaimer.
+
+- Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation
+ and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+----------------------------------------------------------------------------
+        </xs:documentation>
+    </xs:annotation>
+    <xs:element name="fmiBuildDescription">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="BuildConfiguration" maxOccurs="unbounded">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element name="SourceFileSet" minOccurs="0" maxOccurs="unbounded">
+                                <xs:complexType>
+                                    <xs:sequence>
+                                        <xs:element name="SourceFile" maxOccurs="unbounded">
+                                            <xs:complexType>
+                                                <xs:sequence>
+                                                    <xs:element ref="Annotations" minOccurs="0"/>
+                                                </xs:sequence>
+                                                <xs:attribute name="name" type="xs:normalizedString" use="required"/>
+                                            </xs:complexType>
+                                        </xs:element>
+                                        <xs:element name="PreprocessorDefinition" minOccurs="0" maxOccurs="unbounded">
+                                            <xs:complexType>
+                                                <xs:sequence>
+                                                    <xs:element name="Option" minOccurs="0" maxOccurs="unbounded">
+                                                        <xs:complexType>
+                                                            <xs:attribute name="value" type="xs:normalizedString"/>
+                                                            <xs:attribute name="description" type="xs:string"/>
+                                                        </xs:complexType>
+                                                    </xs:element>
+                                                    <xs:element ref="Annotations" minOccurs="0"/>
+                                                </xs:sequence>
+                                                <xs:attribute name="name" type="xs:normalizedString" use="required"/>
+                                                <xs:attribute name="optional" type="xs:boolean" default="false"/>
+                                                <xs:attribute name="value" type="xs:normalizedString"/>
+                                                <xs:attribute name="description" type="xs:string"/>
+                                            </xs:complexType>
+                                        </xs:element>
+                                        <xs:element name="IncludeDirectory" minOccurs="0" maxOccurs="unbounded">
+                                            <xs:complexType>
+                                                <xs:sequence>
+                                                    <xs:element ref="Annotations" minOccurs="0"/>
+                                                </xs:sequence>
+                                                <xs:attribute name="name" type="xs:normalizedString" use="required"/>
+                                            </xs:complexType>
+                                        </xs:element>
+                                        <xs:element ref="Annotations" minOccurs="0"/>
+                                    </xs:sequence>
+                                    <xs:attribute name="name" type="xs:normalizedString"/>
+                                    <xs:attribute name="language" type="xs:normalizedString"/>
+                                    <xs:attribute name="compiler" type="xs:normalizedString"/>
+                                    <xs:attribute name="compilerOptions" type="xs:string"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="Library" minOccurs="0" maxOccurs="unbounded">
+                                <xs:complexType>
+                                    <xs:sequence>
+                                        <xs:element ref="Annotations" minOccurs="0"/>
+                                    </xs:sequence>
+                                    <xs:attribute name="name" type="xs:normalizedString" use="required"/>
+                                    <xs:attribute name="version" type="xs:normalizedString"/>
+                                    <xs:attribute name="external" type="xs:boolean" default="false"/>
+                                    <xs:attribute name="description" type="xs:string"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element ref="Annotations" minOccurs="0"/>
+                        </xs:sequence>
+                        <xs:attribute name="modelIdentifier" type="xs:normalizedString" use="required"/>
+                        <xs:attribute name="platform" type="xs:normalizedString"/>
+                        <xs:attribute name="description" type="xs:string"/>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element ref="Annotations" minOccurs="0"/>
+            </xs:sequence>
+            <xs:attribute name="fmiVersion" use="required">
+                <xs:simpleType>
+                    <xs:restriction base="xs:normalizedString">
+                        <xs:pattern value="3[.](0|[1-9][0-9]*)([.](0|[1-9][0-9]*))?(-.+)?"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:attribute>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/schema/fmi3/fmi3InterfaceType.xsd
+++ b/schema/fmi3/fmi3InterfaceType.xsd
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified">
+    <xs:annotation>
+        <xs:documentation>
+Copyright(c) 2008-2011 MODELISAR consortium,
+             2012-2024 Modelica Association Project "FMI".
+             All rights reserved.
+
+This file is licensed by the copyright holders under the 2-Clause BSD License
+(https://opensource.org/licenses/BSD-2-Clause):
+
+----------------------------------------------------------------------------
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+- Redistributions of source code must retain the above copyright notice,
+ this list of conditions and the following disclaimer.
+
+- Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation
+ and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+----------------------------------------------------------------------------
+        </xs:documentation>
+    </xs:annotation>
+    <xs:include schemaLocation="fmi3Annotation.xsd"/>
+    <xs:complexType name="fmi3InterfaceType" abstract="true">
+        <xs:sequence minOccurs="0">
+            <xs:element ref="Annotations" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="modelIdentifier" type="xs:normalizedString" use="required"/>
+        <xs:attribute name="needsExecutionTool" type="xs:boolean" default="false"/>
+        <xs:attribute name="canBeInstantiatedOnlyOncePerProcess" type="xs:boolean" default="false"/>
+        <xs:attribute name="canGetAndSetFMUState" type="xs:boolean" default="false"/>
+        <xs:attribute name="canSerializeFMUState" type="xs:boolean" default="false"/>
+        <xs:attribute name="providesDirectionalDerivatives" type="xs:boolean" default="false"/>
+        <xs:attribute name="providesAdjointDerivatives" type="xs:boolean" default="false"/>
+        <xs:attribute name="providesPerElementDependencies" type="xs:boolean" default="false"/>
+        <xs:anyAttribute processContents="lax"/>
+    </xs:complexType>
+    <xs:complexType name="fmi3ModelExchange">
+        <xs:complexContent>
+            <xs:extension base="fmi3InterfaceType">
+                <xs:attribute name="needsCompletedIntegratorStep" type="xs:boolean" default="false"/>
+                <xs:attribute name="providesEvaluateDiscreteStates" type="xs:boolean" default="false"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:complexType name="fmi3CoSimulation">
+        <xs:complexContent>
+            <xs:extension base="fmi3InterfaceType">
+                <xs:attribute name="canHandleVariableCommunicationStepSize" type="xs:boolean" default="false"/>
+                <xs:attribute name="fixedInternalStepSize" type="xs:double"/>
+                <xs:attribute name="maxOutputDerivativeOrder" type="xs:unsignedInt" default="0"/>
+                <xs:attribute name="recommendedIntermediateInputSmoothness" type="xs:int" default="0"/>
+                <xs:attribute name="providesIntermediateUpdate" type="xs:boolean" default="false"/>
+                <xs:attribute name="mightReturnEarlyFromDoStep" type="xs:boolean" default="false"/>
+                <xs:attribute name="canReturnEarlyAfterIntermediateUpdate" type="xs:boolean" default="false"/>
+                <xs:attribute name="hasEventMode" type="xs:boolean" default="false"/>
+                <xs:attribute name="providesEvaluateDiscreteStates" type="xs:boolean" default="false"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:complexType name="fmi3ScheduledExecution">
+        <xs:complexContent>
+            <xs:extension base="fmi3InterfaceType"/>
+        </xs:complexContent>
+    </xs:complexType>
+</xs:schema>

--- a/schema/fmi3/fmi3LayeredStandardManifest.xsd
+++ b/schema/fmi3/fmi3LayeredStandardManifest.xsd
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+    elementFormDefault="qualified" attributeFormDefault="qualified"
+    xmlns:fmi-ls="http://fmi-standard.org/fmi-ls-manifest"
+    targetNamespace="http://fmi-standard.org/fmi-ls-manifest">
+    <xs:annotation>
+        <xs:documentation>
+Copyright(c) 2024 Modelica Association Project "FMI".
+             All rights reserved.
+
+This file is licensed by the copyright holders under the 2-Clause BSD License
+(https://opensource.org/licenses/BSD-2-Clause):
+
+----------------------------------------------------------------------------
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+- Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+- Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation
+and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+----------------------------------------------------------------------------
+        </xs:documentation>
+    </xs:annotation>
+    
+    <xs:attribute name="fmi-ls-name" type="xs:normalizedString">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                This attribute gives the name, in reverse domain name notation,
+                of the layered standard.
+            </xs:documentation>
+        </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="fmi-ls-version" type="xs:normalizedString">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                This attribute gives the version of the layered standard. The use
+                of semantic versioning is highly recommended. In case of semantic
+                versioning it is up to the layered standard to define whether only
+                major and minor version are included in the version attribute,
+                or the full version is to be included.
+            </xs:documentation>
+        </xs:annotation>
+    </xs:attribute>
+    <xs:attribute name="fmi-ls-description" type="xs:normalizedString">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                This attribute gives a string with a brief description of the
+                layered standard that is suitable for display to users.
+            </xs:documentation>
+        </xs:annotation>
+    </xs:attribute>
+    
+    <xs:attributeGroup name="ALayeredStandardManifest">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                This attribute group specifies the required root element attributes
+                of the fmi-ls-manifest.xml file in the sub-directory of extra
+                mandated by a layered standard.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:attribute ref="fmi-ls:fmi-ls-name" use="required"/>
+        <xs:attribute ref="fmi-ls:fmi-ls-version" use="required"/>
+        <xs:attribute ref="fmi-ls:fmi-ls-description" use="required"/>
+    </xs:attributeGroup>
+
+    <xs:element name="fmiLayeredStandardManifest">
+        <xs:annotation>
+            <xs:documentation xml:lang="en">
+                This is the default root element to use in a layered standard for the mandated
+                fmi-ls-manifest.xml file, if no other suitable root element definition is provided
+                in the layered standard.
+            </xs:documentation>
+        </xs:annotation>
+        <xs:complexType>
+            <xs:attributeGroup ref="fmi-ls:ALayeredStandardManifest"/>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/schema/fmi3/fmi3ModelDescription.xsd
+++ b/schema/fmi3/fmi3ModelDescription.xsd
@@ -1,28 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified">
-	<xs:include schemaLocation="fmi3VariableDependency.xsd"/>
-	<xs:include schemaLocation="fmi3Unit.xsd"/>
-	<xs:include schemaLocation="fmi3Variable.xsd"/>
-	<xs:include schemaLocation="fmi3Type.xsd"/>
-	<xs:annotation>
-		<xs:documentation>
+    <xs:include schemaLocation="fmi3VariableDependency.xsd"/>
+    <xs:include schemaLocation="fmi3Unit.xsd"/>
+    <xs:include schemaLocation="fmi3Variable.xsd"/>
+    <xs:include schemaLocation="fmi3Type.xsd"/>
+    <xs:include schemaLocation="fmi3Annotation.xsd"/>
+    <xs:include schemaLocation="fmi3InterfaceType.xsd"/>
+    <xs:annotation>
+        <xs:documentation>
 Copyright(c) 2008-2011 MODELISAR consortium,
-             2012-2018 Modelica Association Project "FMI".
+             2012-2024 Modelica Association Project "FMI".
              All rights reserved.
-This file is licensed by the copyright holders under the BSD 2-Clause License
-(http://www.opensource.org/licenses/bsd-license.html):
+
+This file is licensed by the copyright holders under the 2-Clause BSD License
+(https://opensource.org/licenses/BSD-2-Clause):
+
 ----------------------------------------------------------------------------
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
 
 - Redistributions of source code must retain the above copyright notice,
-  this list of conditions and the following disclaimer.
+ this list of conditions and the following disclaimer.
+
 - Redistributions in binary form must reproduce the above copyright notice,
-  this list of conditions and the following disclaimer in the documentation
-  and/or other materials provided with the distribution.
-- Neither the name of the copyright holders nor the names of its
-  contributors may be used to endorse or promote products derived
-  from this software without specific prior written permission.
+ this list of conditions and the following disclaimer in the documentation
+ and/or other materials provided with the distribution.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
@@ -36,334 +38,94 @@ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
 OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
 ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ----------------------------------------------------------------------------
-
-with the extension:
-
-You may distribute or publicly perform any modification only under the
-terms of this license.
-(Note, this means that if you distribute a modified file,
-the modified file must also be provided under this license).
-		</xs:documentation>
-	</xs:annotation>
-	<xs:element name="fmiModelDescription">
-		<xs:complexType>
-			<xs:sequence>
-				<xs:sequence maxOccurs="2">
-					<xs:annotation>
-						<xs:documentation>At least one of the elements must be present</xs:documentation>
-					</xs:annotation>
-					<xs:element name="ModelExchange" minOccurs="0">
-						<xs:annotation>
-							<xs:documentation>The FMU includes a model or the communication to a tool that provides a model. The environment provides the simulation engine for the model.</xs:documentation>
-						</xs:annotation>
-						<xs:complexType>
-							<xs:annotation>
-								<xs:documentation>List of capability flags that an FMI3 Model Exchange interface can provide</xs:documentation>
-							</xs:annotation>
-							<xs:sequence>
-								<xs:element name="SourceFiles" minOccurs="0">
-									<xs:annotation>
-										<xs:documentation>List of source file names that are present in the "sources" directory of the FMU and need to be compiled in order to generate the binary of the FMU (only meaningful for source code FMUs).</xs:documentation>
-									</xs:annotation>
-									<xs:complexType>
-										<xs:sequence maxOccurs="unbounded">
-											<xs:element name="File">
-												<xs:complexType>
-													<xs:attribute name="name" type="xs:normalizedString" use="required">
-														<xs:annotation>
-															<xs:documentation>Name of the file including the path relative to the sources directory, using the forward slash as separator (for example: name = "myFMU.c"; name = "modelExchange/solve.c") </xs:documentation>
-														</xs:annotation>
-													</xs:attribute>
-												</xs:complexType>
-											</xs:element>
-										</xs:sequence>
-									</xs:complexType>
-								</xs:element>
-							</xs:sequence>
-							<xs:attribute name="modelIdentifier" type="xs:normalizedString" use="required">
-								<xs:annotation>
-									<xs:documentation>Short class name according to C-syntax, e.g. "A_B_C". Used as prefix for FMI3 functions if the functions are provided in C source code or in static libraries, but not if the functions are provided by a DLL/SharedObject. modelIdentifier is also used as name of the static library or DLL/SharedObject.</xs:documentation>
-								</xs:annotation>
-							</xs:attribute>
-							<xs:attribute name="needsExecutionTool" type="xs:boolean" default="false">
-								<xs:annotation>
-									<xs:documentation>If true, a tool is needed to execute the model and the FMU just contains the communication to this tool.</xs:documentation>
-								</xs:annotation>
-							</xs:attribute>
-							<xs:attribute name="completedIntegratorStepNotNeeded" type="xs:boolean" default="false"/>
-							<xs:attribute name="canBeInstantiatedOnlyOncePerProcess" type="xs:boolean" default="false"/>
-							<xs:attribute name="canNotUseMemoryManagementFunctions" type="xs:boolean" default="false"/>
-							<xs:attribute name="canGetAndSetFMUstate" type="xs:boolean" default="false"/>
-							<xs:attribute name="canSerializeFMUstate" type="xs:boolean" default="false"/>
-							<xs:attribute name="providesDirectionalDerivative" type="xs:boolean" default="false"/>
-							<xs:attribute name="providesPerElementDependencies" type="xs:boolean" default="false"/>
-						</xs:complexType>
-					</xs:element>
-					<xs:element name="CoSimulation" minOccurs="0">
-						<xs:annotation>
-							<xs:documentation>The FMU includes a model and the simulation engine, or the communication to a tool that provides this. The environment provides the master algorithm for the Co-Simulation coupling.</xs:documentation>
-						</xs:annotation>
-						<xs:complexType>
-							<xs:sequence>
-								<xs:element name="SourceFiles" minOccurs="0">
-									<xs:annotation>
-										<xs:documentation>List of source file names that are present in the "sources" directory of the FMU and need to be compiled in order to generate the binary of the FMU (only meaningful for source code FMUs).</xs:documentation>
-									</xs:annotation>
-									<xs:complexType>
-										<xs:sequence maxOccurs="unbounded">
-											<xs:element name="File">
-												<xs:complexType>
-													<xs:attribute name="name" type="xs:normalizedString" use="required">
-														<xs:annotation>
-															<xs:documentation>Name of the file including the path relative to the sources directory, using the forward slash as separator (for example: name = "myFMU.c"; name = "coSimulation/solve.c") </xs:documentation>
-														</xs:annotation>
-													</xs:attribute>
-												</xs:complexType>
-											</xs:element>
-										</xs:sequence>
-									</xs:complexType>
-								</xs:element>
-							</xs:sequence>
-							<xs:attribute name="modelIdentifier" type="xs:normalizedString" use="required">
-								<xs:annotation>
-									<xs:documentation>Short class name according to C-syntax, e.g. "A_B_C". Used as prefix for FMI3 functions if the functions are provided in C source code or in static libraries, but not if the functions are provided by a DLL/SharedObject. modelIdentifier is also used as name of the static library or DLL/SharedObject.</xs:documentation>
-								</xs:annotation>
-							</xs:attribute>
-							<xs:attribute name="needsExecutionTool" type="xs:boolean" default="false">
-								<xs:annotation>
-									<xs:documentation>If true, a tool is needed to execute the model and the FMU just contains the communication to this tool.</xs:documentation>
-								</xs:annotation>
-							</xs:attribute>
-							<xs:attribute name="canHandleVariableCommunicationStepSize" type="xs:boolean" default="false"/>
-							<xs:attribute name="canInterpolateInputs" type="xs:boolean" default="false"/>
-							<xs:attribute name="maxOutputDerivativeOrder" type="xs:unsignedInt" default="0"/>
-							<xs:attribute name="canRunAsynchronuously" type="xs:boolean" default="false"/>
-							<xs:attribute name="canBeInstantiatedOnlyOncePerProcess" type="xs:boolean" default="false"/>
-							<xs:attribute name="canNotUseMemoryManagementFunctions" type="xs:boolean" default="false"/>
-							<xs:attribute name="canGetAndSetFMUstate" type="xs:boolean" default="false"/>
-							<xs:attribute name="canSerializeFMUstate" type="xs:boolean" default="false"/>
-							<xs:attribute name="providesDirectionalDerivative" type="xs:boolean" default="false">
-								<xs:annotation>
-									<xs:documentation>Directional derivatives at communication points</xs:documentation>
-								</xs:annotation>
-							</xs:attribute>
-							<xs:attribute name="providesPerElementDependencies" type="xs:boolean" default="false"/>
-						</xs:complexType>
-					</xs:element>
-				</xs:sequence>
-				<xs:element name="UnitDefinitions" minOccurs="0">
-					<xs:complexType>
-						<xs:sequence maxOccurs="unbounded">
-							<xs:element name="Unit" type="fmi3Unit"/>
-						</xs:sequence>
-					</xs:complexType>
-				</xs:element>
-				<xs:element name="TypeDefinitions" minOccurs="0">
-					<xs:complexType>
-						<xs:sequence maxOccurs="unbounded">
-							<xs:element name="SimpleType" type="fmi3SimpleType"/>
-						</xs:sequence>
-					</xs:complexType>
-				</xs:element>
-				<xs:element name="LogCategories" minOccurs="0">
-					<xs:annotation>
-						<xs:documentation>Log categories available in FMU</xs:documentation>
-					</xs:annotation>
-					<xs:complexType>
-						<xs:sequence maxOccurs="unbounded">
-							<xs:element name="Category">
-								<xs:complexType>
-									<xs:attribute name="name" type="xs:normalizedString" use="required">
-										<xs:annotation>
-											<xs:documentation>Name of Category element. "name" must be unique with respect to all other elements of the LogCategories list. Standardized names: "logEvents", "logSingularLinearSystems", "logNonlinearSystems", "logDynamicStateSelection", "logStatusWarning", "logStatusDiscard", "logStatusError", "logStatusFatal", "logStatusPending", "logAll"</xs:documentation>
-										</xs:annotation>
-									</xs:attribute>
-									<xs:attribute name="description" type="xs:string">
-										<xs:annotation>
-											<xs:documentation>Description of the log category</xs:documentation>
-										</xs:annotation>
-									</xs:attribute>
-								</xs:complexType>
-							</xs:element>
-						</xs:sequence>
-					</xs:complexType>
-				</xs:element>
-				<xs:element name="DefaultExperiment" minOccurs="0">
-					<xs:complexType>
-						<xs:attribute name="startTime" type="xs:double">
-							<xs:annotation>
-								<xs:documentation>Default start time of simulation</xs:documentation>
-							</xs:annotation>
-						</xs:attribute>
-						<xs:attribute name="stopTime" type="xs:double">
-							<xs:annotation>
-								<xs:documentation>Default stop time of simulation</xs:documentation>
-							</xs:annotation>
-						</xs:attribute>
-						<xs:attribute name="tolerance" type="xs:double">
-							<xs:annotation>
-								<xs:documentation>Default relative integration tolerance</xs:documentation>
-							</xs:annotation>
-						</xs:attribute>
-						<xs:attribute name="stepSize" type="xs:double">
-							<xs:annotation>
-								<xs:documentation>ModelExchange: Default step size for fixed step integrators.
-CoSimulation: Preferred communicationStepSize.</xs:documentation>
-							</xs:annotation>
-						</xs:attribute>
-					</xs:complexType>
-				</xs:element>
-				<xs:element name="VendorAnnotations" type="fmi3Annotation" minOccurs="0">
-					<xs:annotation>
-						<xs:documentation>Tool specific data (ignored by other tools)</xs:documentation>
-					</xs:annotation>
-				</xs:element>
-				<xs:element name="ModelVariables">
-					<xs:annotation>
-						<xs:documentation>Ordered list of all variables (first definition has index = 1).</xs:documentation>
-					</xs:annotation>
-					<xs:complexType>
-						<xs:sequence maxOccurs="unbounded">
-							<xs:element name="Variable" type="fmi3Variable"/>
-						</xs:sequence>
-					</xs:complexType>
-				</xs:element>
-				<xs:element name="ModelStructure">
-					<xs:annotation>
-						<xs:documentation>Ordered lists of outputs, exposed state derivatives,
-and the initial unknowns. Optionally, the functional
-dependency of these variables can be defined.</xs:documentation>
-					</xs:annotation>
-					<xs:complexType>
-						<xs:sequence>
-							<xs:element name="Outputs" type="fmi3VariableDependency" minOccurs="0">
-								<xs:annotation>
-									<xs:documentation>Ordered list of all outputs. Exactly all variables with causality="output" must be in this list. The dependency definition holds for Continuous-Time and for Event Mode (ModelExchange) and for Communication Points (CoSimulation).</xs:documentation>
-								</xs:annotation>
-							</xs:element>
-							<xs:element name="Derivatives" type="fmi3VariableDependency" minOccurs="0">
-								<xs:annotation>
-									<xs:documentation>Ordered list of all exposed state derivatives (and therefore implicitely associated continuous-time states). Exactly all state derivatives of a ModelExchange FMU must be in this list. A CoSimulation FMU need not expose its state derivatives. If a model has dynamic state selection, introduce dummy state variables. The dependency definition holds for Continuous-Time and for Event Mode (ModelExchange) and for Communication Points (CoSimulation).</xs:documentation>
-								</xs:annotation>
-							</xs:element>
-							<xs:element name="InitialUnknowns" minOccurs="0">
-								<xs:annotation>
-									<xs:documentation>Ordered list of all exposed Unknowns in Initialization Mode. This list consists of all variables with (1) causality = "output" and (initial="approx" or calculated"), (2) causality = "calculatedParameter", and (3) all continuous-time states and all state derivatives (defined with element Derivatives from ModelStructure) with initial=("approx" or "calculated"). The resulting list is not allowed to have duplicates (e.g. if a state is also an output, it is included only once in the list). The Unknowns in this list must be ordered according to their Variable index (e.g. if for two variables A and B the Variable index of A is less than the index of B, then A must appear before B in InitialUnknowns).</xs:documentation>
-								</xs:annotation>
-								<xs:complexType>
-									<xs:sequence maxOccurs="unbounded">
-										<xs:element name="Unknown">
-											<xs:annotation>
-												<xs:documentation>Dependency of Unknown from Knowns:
-    Unknown=f(Known_1, Known_2, ...).
-The Knowns are "inputs",
-"variables with initial=exact", and
-"independent variable".</xs:documentation>
-											</xs:annotation>
-											<xs:complexType>
-												<xs:attribute name="valueReference" type="xs:unsignedInt" use="required">
-													<xs:annotation>
-														<xs:documentation>Variable valueReference of Unknown</xs:documentation>
-													</xs:annotation>
-												</xs:attribute>
-												<xs:attribute name="dependencies">
-													<xs:annotation>
-														<xs:documentation>Defines the dependency of the Unknown (directly or indirectly via auxiliary variables) on the Knowns in the Initialization Mode. If not present, it must be assumed that the Unknown depends on all Knowns. If present as empty list, the Unknown depends on none of the Knowns. Otherwise the Unknown depends on the Knowns defined by the given Variable valueReferences. The valueReferences are ordered according to the size of the index of the variable in the Variable list, starting with the smallest index.</xs:documentation>
-													</xs:annotation>
-													<xs:simpleType>
-														<xs:list itemType="xs:unsignedInt"/>
-													</xs:simpleType>
-												</xs:attribute>
-												<xs:attribute name="dependenciesKind">
-													<xs:annotation>
-														<xs:documentation>If not present, it must be assumed that the Unknown depends on the Knowns without a particular structure. Otherwise, the corresponding Known v enters the equation as:
-= "dependent": no particular structure, f(v)
-= "constant"   : constant factor, c*v (only for Real variables)
-If "dependenciesKind" is present, "dependencies" must be present and must have the same number of list elements.</xs:documentation>
-													</xs:annotation>
-													<xs:simpleType>
-														<xs:list>
-															<xs:simpleType>
-																<xs:restriction base="xs:normalizedString">
-																	<xs:enumeration value="dependent"/>
-																	<xs:enumeration value="constant"/>
-																	<xs:enumeration value="fixed"/>
-																	<xs:enumeration value="tunable"/>
-																	<xs:enumeration value="discrete"/>
-																</xs:restriction>
-															</xs:simpleType>
-														</xs:list>
-													</xs:simpleType>
-												</xs:attribute>
-											</xs:complexType>
-										</xs:element>
-									</xs:sequence>
-								</xs:complexType>
-							</xs:element>
-							<xs:element name="NumberOfEventIndicators" minOccurs="0">
-								<xs:complexType>
-									<xs:attribute name="dependencies" use="required">
-										<xs:simpleType>
-											<xs:list itemType="xs:unsignedInt"/>
-										</xs:simpleType>
-									</xs:attribute>
-								</xs:complexType>
-							</xs:element>
-						</xs:sequence>
-					</xs:complexType>
-				</xs:element>
-			</xs:sequence>
-			<xs:attribute name="fmiVersion" use="required">
-				<xs:annotation>
-					<xs:documentation>Version of FMI (FMI 3.0 revision is defined as "3.0"; future minor revisions are denoted as 3.0.1, 3.0.2 etc).
-						For now only pre-release versions of the form 3.0-... are allowed, which should use a pattern of 3.0-wg003.1 or 3.0-fcp004.1,
-						i.e. should include the working group or FCP number as part of the pre-release version.
-					</xs:documentation>
-				</xs:annotation>
-				<xs:simpleType>
-					<xs:restriction base="xs:normalizedString">
-						<xs:pattern value="3[.](0-.*)"/>
-					</xs:restriction>
-				</xs:simpleType>
-			</xs:attribute>
-			<xs:attribute name="modelName" type="xs:string" use="required">
-				<xs:annotation>
-					<xs:documentation>Class name of FMU, e.g. "A.B.C" (several FMU instances are possible)</xs:documentation>
-				</xs:annotation>
-			</xs:attribute>
-			<xs:attribute name="guid" type="xs:normalizedString" use="required">
-				<xs:annotation>
-					<xs:documentation>Fingerprint of xml-file content to verify that xml-file and C-functions are compatible to each other</xs:documentation>
-				</xs:annotation>
-			</xs:attribute>
-			<xs:attribute name="description" type="xs:string"/>
-			<xs:attribute name="author" type="xs:string"/>
-			<xs:attribute name="version" type="xs:normalizedString">
-				<xs:annotation>
-					<xs:documentation>Version of FMU, e.g., "1.4.1"</xs:documentation>
-				</xs:annotation>
-			</xs:attribute>
-			<xs:attribute name="copyright" type="xs:string">
-				<xs:annotation>
-					<xs:documentation>Information on intellectual property copyright for this FMU, such as “© MyCompany 2011“</xs:documentation>
-				</xs:annotation>
-			</xs:attribute>
-			<xs:attribute name="license" type="xs:string">
-				<xs:annotation>
-					<xs:documentation>Information on intellectual property licensing for this FMU, such as “BSD license”, "Proprietary", or "Public Domain"</xs:documentation>
-				</xs:annotation>
-			</xs:attribute>
-			<xs:attribute name="generationTool" type="xs:normalizedString"/>
-			<xs:attribute name="generationDateAndTime" type="xs:dateTime"/>
-			<xs:attribute name="variableNamingConvention" use="optional" default="flat">
-				<xs:simpleType>
-					<xs:restriction base="xs:normalizedString">
-						<xs:enumeration value="flat"/>
-						<xs:enumeration value="structured"/>
-					</xs:restriction>
-				</xs:simpleType>
-			</xs:attribute>
-			<xs:attribute name="numberOfEventIndicators" type="xs:unsignedInt"/>
-		</xs:complexType>
-	</xs:element>
+        </xs:documentation>
+    </xs:annotation>
+    <xs:element name="fmiModelDescription">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="ModelExchange" type="fmi3ModelExchange" minOccurs="0"/>
+                <xs:element name="CoSimulation" type="fmi3CoSimulation" minOccurs="0"/>
+                <xs:element name="ScheduledExecution" type="fmi3ScheduledExecution" minOccurs="0"/>
+                <xs:element name="UnitDefinitions" minOccurs="0">
+                    <xs:complexType>
+                        <xs:sequence maxOccurs="unbounded">
+                            <xs:element name="Unit" type="fmi3Unit"/>
+                        </xs:sequence>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="TypeDefinitions" minOccurs="0">
+                    <xs:complexType>
+                        <xs:group ref="fmi3TypeDefinition" maxOccurs="unbounded"/>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="LogCategories" minOccurs="0">
+                    <xs:complexType>
+                        <xs:sequence maxOccurs="unbounded">
+                            <xs:element name="Category">
+                                <xs:complexType>
+                                    <xs:sequence>
+                                        <xs:element ref="Annotations" minOccurs="0"/>
+                                    </xs:sequence>
+                                    <xs:attribute name="name" type="xs:normalizedString" use="required"/>
+                                    <xs:attribute name="description" type="xs:string"/>
+                                </xs:complexType>
+                            </xs:element>
+                        </xs:sequence>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="DefaultExperiment" minOccurs="0">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element ref="Annotations" minOccurs="0"/>
+                        </xs:sequence>
+                        <xs:attribute name="startTime" type="xs:double"/>
+                        <xs:attribute name="stopTime" type="xs:double"/>
+                        <xs:attribute name="tolerance" type="xs:double"/>
+                        <xs:attribute name="stepSize" type="xs:double"/>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="ModelVariables">
+                    <xs:complexType>
+                        <xs:group ref="fmi3Variable" maxOccurs="unbounded"/>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="ModelStructure">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element name="Output" type="fmi3Unknown" minOccurs="0" maxOccurs="unbounded"/>
+                            <xs:element name="ContinuousStateDerivative" type="fmi3Unknown" minOccurs="0" maxOccurs="unbounded"/>
+                            <xs:element name="ClockedState" type="fmi3Unknown" minOccurs="0" maxOccurs="unbounded"/>
+                            <xs:element name="InitialUnknown" type="fmi3Unknown" minOccurs="0" maxOccurs="unbounded"/>
+                            <xs:element name="EventIndicator" type="fmi3Unknown" minOccurs="0" maxOccurs="unbounded"/>
+                        </xs:sequence>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element ref="Annotations" minOccurs="0"/>
+            </xs:sequence>
+            <xs:attribute name="fmiVersion" use="required">
+                <xs:simpleType>
+                    <xs:restriction base="xs:normalizedString">
+                        <xs:pattern value="3[.](0|[1-9][0-9]*)([.](0|[1-9][0-9]*))?(-.+)?"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:attribute>
+            <xs:attribute name="modelName" type="xs:string" use="required"/>
+            <xs:attribute name="instantiationToken" type="xs:normalizedString" use="required"/>
+            <xs:attribute name="description" type="xs:string"/>
+            <xs:attribute name="author" type="xs:string"/>
+            <xs:attribute name="version" type="xs:normalizedString"/>
+            <xs:attribute name="copyright" type="xs:string"/>
+            <xs:attribute name="license" type="xs:string"/>
+            <xs:attribute name="generationTool" type="xs:normalizedString"/>
+            <xs:attribute name="generationDateAndTime" type="xs:dateTime"/>
+            <xs:attribute name="variableNamingConvention" default="flat">
+                <xs:simpleType>
+                    <xs:restriction base="xs:normalizedString">
+                        <xs:enumeration value="flat"/>
+                        <xs:enumeration value="structured"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:attribute>
+        </xs:complexType>
+    </xs:element>
 </xs:schema>

--- a/schema/fmi3/fmi3Terminal.xsd
+++ b/schema/fmi3/fmi3Terminal.xsd
@@ -35,35 +35,53 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ----------------------------------------------------------------------------
         </xs:documentation>
     </xs:annotation>
-    <xs:complexType name="fmi3Unit">
+    <xs:complexType name="fmi3Terminal">
         <xs:sequence>
-            <xs:element name="BaseUnit" minOccurs="0">
-                <xs:complexType>
-                    <xs:attribute name="kg" type="xs:int" default="0"/>
-                    <xs:attribute name="m" type="xs:int" default="0"/>
-                    <xs:attribute name="s" type="xs:int" default="0"/>
-                    <xs:attribute name="A" type="xs:int" default="0"/>
-                    <xs:attribute name="K" type="xs:int" default="0"/>
-                    <xs:attribute name="mol" type="xs:int" default="0"/>
-                    <xs:attribute name="cd" type="xs:int" default="0"/>
-                    <xs:attribute name="rad" type="xs:int" default="0"/>
-                    <xs:attribute name="factor" type="xs:double" default="1"/>
-                    <xs:attribute name="offset" type="xs:double" default="0"/>
-                </xs:complexType>
-            </xs:element>
-            <xs:element name="DisplayUnit" minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="TerminalMemberVariable" minOccurs="0" maxOccurs="unbounded">
                 <xs:complexType>
                     <xs:sequence>
                         <xs:element ref="Annotations" minOccurs="0"/>
                     </xs:sequence>
-                    <xs:attribute name="name" type="xs:normalizedString" use="required"/>
-                    <xs:attribute name="factor" type="xs:double" default="1"/>
-                    <xs:attribute name="offset" type="xs:double" default="0"/>
-                    <xs:attribute name="inverse" type="xs:boolean" default="false"/>
+                    <xs:attribute name="variableName" type="xs:normalizedString" use="required"/>
+                    <xs:attribute name="memberName" type="xs:normalizedString"/>
+                    <xs:attribute name="variableKind" type="xs:normalizedString" use="required"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="TerminalStreamMemberVariable" minOccurs="0" maxOccurs="unbounded">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element ref="Annotations" minOccurs="0"/>
+                    </xs:sequence>
+                    <xs:attribute name="inStreamMemberName" type="xs:normalizedString" use="required"/>
+                    <xs:attribute name="outStreamMemberName" type="xs:normalizedString" use="required"/>
+                    <xs:attribute name="inStreamVariableName" type="xs:normalizedString" use="required"/>
+                    <xs:attribute name="outStreamVariableName" type="xs:normalizedString" use="required"/>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="Terminal" type="fmi3Terminal" minOccurs="0" maxOccurs="unbounded"/>
+            <xs:element name="TerminalGraphicalRepresentation" minOccurs="0">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element ref="Annotations" minOccurs="0"/>
+                    </xs:sequence>
+                    <xs:attribute name="defaultConnectionColor">
+                        <xs:simpleType>
+                            <xs:list itemType="xs:unsignedByte"/>
+                        </xs:simpleType>
+                    </xs:attribute>
+                    <xs:attribute name="defaultConnectionStrokeSize" type="xs:double"/>
+                    <xs:attribute name="x1" type="xs:double" use="required"/>
+                    <xs:attribute name="y1" type="xs:double" use="required"/>
+                    <xs:attribute name="x2" type="xs:double" use="required"/>
+                    <xs:attribute name="y2" type="xs:double" use="required"/>
+                    <xs:attribute name="iconBaseName" type="xs:string" use="required"/>
                 </xs:complexType>
             </xs:element>
             <xs:element ref="Annotations" minOccurs="0"/>
         </xs:sequence>
         <xs:attribute name="name" type="xs:normalizedString" use="required"/>
+        <xs:attribute name="matchingRule" type="xs:normalizedString" use="required"/>
+        <xs:attribute name="terminalKind" type="xs:normalizedString"/>
+        <xs:attribute name="description" type="xs:string"/>
     </xs:complexType>
 </xs:schema>

--- a/schema/fmi3/fmi3TerminalsAndIcons.xsd
+++ b/schema/fmi3/fmi3TerminalsAndIcons.xsd
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified">
+    <xs:include schemaLocation="fmi3Terminal.xsd"/>
+    <xs:include schemaLocation="fmi3Annotation.xsd"/>
+    <xs:annotation>
+        <xs:documentation>
+Copyright(c) 2008-2011 MODELISAR consortium,
+             2012-2024 Modelica Association Project "FMI".
+             All rights reserved.
+
+This file is licensed by the copyright holders under the 2-Clause BSD License
+(https://opensource.org/licenses/BSD-2-Clause):
+
+----------------------------------------------------------------------------
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+- Redistributions of source code must retain the above copyright notice,
+ this list of conditions and the following disclaimer.
+
+- Redistributions in binary form must reproduce the above copyright notice,
+ this list of conditions and the following disclaimer in the documentation
+ and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+----------------------------------------------------------------------------
+        </xs:documentation>
+    </xs:annotation>
+    <xs:element name="fmiTerminalsAndIcons">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element name="GraphicalRepresentation" minOccurs="0">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element name="CoordinateSystem" minOccurs="0">
+                                <xs:complexType>
+                                    <xs:attribute name="x1" type="xs:double" use="required"/>
+                                    <xs:attribute name="y1" type="xs:double" use="required"/>
+                                    <xs:attribute name="x2" type="xs:double" use="required"/>
+                                    <xs:attribute name="y2" type="xs:double" use="required"/>
+                                    <xs:attribute name="suggestedScalingFactorTo_mm" type="xs:double" use="required"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element name="Icon" minOccurs="0">
+                                <xs:complexType>
+                                    <xs:attribute name="x1" type="xs:double" use="required"/>
+                                    <xs:attribute name="y1" type="xs:double" use="required"/>
+                                    <xs:attribute name="x2" type="xs:double" use="required"/>
+                                    <xs:attribute name="y2" type="xs:double" use="required"/>
+                                </xs:complexType>
+                            </xs:element>
+                            <xs:element ref="Annotations" minOccurs="0"/>
+                        </xs:sequence>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element name="Terminals" minOccurs="0">
+                    <xs:complexType>
+                        <xs:sequence>
+                            <xs:element name="Terminal" type="fmi3Terminal" maxOccurs="unbounded"/>
+                        </xs:sequence>
+                    </xs:complexType>
+                </xs:element>
+                <xs:element ref="Annotations" minOccurs="0"/>
+            </xs:sequence>
+            <xs:attribute name="fmiVersion" use="required">
+                <xs:simpleType>
+                    <xs:restriction base="xs:normalizedString">
+                        <xs:pattern value="3[.](0|[1-9][0-9]*)([.](0|[1-9][0-9]*))?(-.+)?"/>
+                    </xs:restriction>
+                </xs:simpleType>
+            </xs:attribute>
+        </xs:complexType>
+    </xs:element>
+</xs:schema>

--- a/schema/fmi3/fmi3Type.xsd
+++ b/schema/fmi3/fmi3Type.xsd
@@ -1,25 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified">
-	<xs:include schemaLocation="fmi3AttributeGroups.xsd"/>
-	<xs:annotation>
-		<xs:documentation>
+    <xs:include schemaLocation="fmi3Annotation.xsd"/>
+    <xs:include schemaLocation="fmi3AttributeGroups.xsd"/>
+    <xs:annotation>
+        <xs:documentation>
 Copyright(c) 2008-2011 MODELISAR consortium,
-             2012-2018 Modelica Association Project "FMI".
+             2012-2024 Modelica Association Project "FMI".
              All rights reserved.
-This file is licensed by the copyright holders under the BSD 2-Clause License
-(http://www.opensource.org/licenses/bsd-license.html):
+
+This file is licensed by the copyright holders under the 2-Clause BSD License
+(https://opensource.org/licenses/BSD-2-Clause):
+
 ----------------------------------------------------------------------------
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
 
 - Redistributions of source code must retain the above copyright notice,
-  this list of conditions and the following disclaimer.
+ this list of conditions and the following disclaimer.
+
 - Redistributions in binary form must reproduce the above copyright notice,
-  this list of conditions and the following disclaimer in the documentation
-  and/or other materials provided with the distribution.
-- Neither the name of the copyright holders nor the names of its
-  contributors may be used to endorse or promote products derived
-  from this software without specific prior written permission.
+ this list of conditions and the following disclaimer in the documentation
+ and/or other materials provided with the distribution.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
@@ -33,80 +34,174 @@ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
 OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
 ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ----------------------------------------------------------------------------
+        </xs:documentation>
+    </xs:annotation>
 
-with the extension:
+    <xs:complexType name="fmi3TypeDefinitionBase" abstract="true">
+        <xs:sequence>
+            <xs:element ref="Annotations" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:normalizedString" use="required"/>
+        <xs:attribute name="description" type="xs:string"/>
+    </xs:complexType>
 
-You may distribute or publicly perform any modification only under the
-terms of this license.
-(Note, this means that if you distribute a modified file,
-the modified file must also be provided under this license).
-		</xs:documentation>
-	</xs:annotation>
-	<xs:complexType name="fmi3SimpleType">
-		<xs:annotation>
-			<xs:documentation>Type attributes of a scalar variable</xs:documentation>
-		</xs:annotation>
-		<xs:sequence>
-			<xs:choice>
-				<xs:element name="Real">
-					<xs:complexType>
-						<xs:attributeGroup ref="fmi3RealAttributes"/>
-					</xs:complexType>
-				</xs:element>
-				<xs:element name="Integer">
-					<xs:complexType>
-						<xs:attributeGroup ref="fmi3IntegerAttributes"/>
-					</xs:complexType>
-				</xs:element>
-				<xs:element name="Boolean"/>
-				<xs:element name="String"/>
-				<xs:element name="Binary">
-					<xs:complexType>
-						<xs:attribute name="mimeType" type="xs:normalizedString" use="optional" default="application/octet-stream">
-							<xs:annotation>
-								<xs:documentation>Should indicate the type of data passed as a binary. Defaults to application/octet-stream,
-									which is unspecific.  Implementations can use this information to provide guidance to the user about
-									valid/useful connections.</xs:documentation>
-							</xs:annotation>
-						</xs:attribute>
-						<xs:attribute name="maxSize" type="xs:nonNegativeInteger" use="optional">
-							<xs:annotation>
-								<xs:documentation>If present, limits the maximum size of the binary to the indicated value.
-									All variable accesses, both getting and setting of values must guarantee that the returned
-									size of the binary is strictly equal or less than this maximum size.</xs:documentation>
-							</xs:annotation>
-						</xs:attribute>
-					</xs:complexType>
-				</xs:element>
-				<xs:element name="Enumeration">
-					<xs:complexType>
-						<xs:sequence maxOccurs="unbounded">
-							<xs:element name="Item">
-								<xs:complexType>
-									<xs:attribute name="name" type="xs:normalizedString" use="required"/>
-									<xs:attribute name="value" type="xs:int" use="required">
-										<xs:annotation>
-											<xs:documentation>Must be a unique number in the same enumeration</xs:documentation>
-										</xs:annotation>
-									</xs:attribute>
-									<xs:attribute name="description" type="xs:string"/>
-								</xs:complexType>
-							</xs:element>
-						</xs:sequence>
-						<xs:attribute name="quantity" type="xs:normalizedString"/>
-					</xs:complexType>
-				</xs:element>
-			</xs:choice>
-		</xs:sequence>
-		<xs:attribute name="name" type="xs:normalizedString" use="required">
-			<xs:annotation>
-				<xs:documentation>Name of SimpleType element. "name" must be unique with respect to all other elements of the TypeDefinitions list. Furthermore,  "name" of a SimpleType must be different to all "name"s of ScalarVariable.</xs:documentation>
-			</xs:annotation>
-		</xs:attribute>
-		<xs:attribute name="description" type="xs:string">
-			<xs:annotation>
-				<xs:documentation>Description of the SimpleType</xs:documentation>
-			</xs:annotation>
-		</xs:attribute>
-	</xs:complexType>
+    <xs:group name="fmi3TypeDefinition">
+        <xs:choice>
+            <xs:element name="Float32Type">
+                <xs:complexType>
+                    <xs:complexContent>
+                        <xs:extension base="fmi3TypeDefinitionBase">
+                            <xs:attributeGroup ref="fmi3RealBaseAttributes"/>
+                            <xs:attributeGroup ref="fmi3Float32Attributes"/>
+                        </xs:extension>
+                    </xs:complexContent>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="Float64Type">
+                <xs:complexType>
+                    <xs:complexContent>
+                        <xs:extension base="fmi3TypeDefinitionBase">
+                            <xs:attributeGroup ref="fmi3RealBaseAttributes"/>
+                            <xs:attributeGroup ref="fmi3Float64Attributes"/>
+                        </xs:extension>
+                    </xs:complexContent>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="Int8Type">
+                <xs:complexType>
+                    <xs:complexContent>
+                        <xs:extension base="fmi3TypeDefinitionBase">
+                            <xs:attributeGroup ref="fmi3IntegerBaseAttributes"/>
+                            <xs:attributeGroup ref="fmi3Int8Attributes"/>
+                        </xs:extension>
+                    </xs:complexContent>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="UInt8Type">
+                <xs:complexType>
+                    <xs:complexContent>
+                        <xs:extension base="fmi3TypeDefinitionBase">
+                            <xs:attributeGroup ref="fmi3IntegerBaseAttributes"/>
+                            <xs:attributeGroup ref="fmi3UInt8Attributes"/>
+                        </xs:extension>
+                    </xs:complexContent>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="Int16Type">
+                <xs:complexType>
+                    <xs:complexContent>
+                        <xs:extension base="fmi3TypeDefinitionBase">
+                            <xs:attributeGroup ref="fmi3IntegerBaseAttributes"/>
+                            <xs:attributeGroup ref="fmi3Int16Attributes"/>
+                        </xs:extension>
+                    </xs:complexContent>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="UInt16Type">
+                <xs:complexType>
+                    <xs:complexContent>
+                        <xs:extension base="fmi3TypeDefinitionBase">
+                            <xs:attributeGroup ref="fmi3IntegerBaseAttributes"/>
+                            <xs:attributeGroup ref="fmi3UInt16Attributes"/>
+                        </xs:extension>
+                    </xs:complexContent>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="Int32Type">
+                <xs:complexType>
+                    <xs:complexContent>
+                        <xs:extension base="fmi3TypeDefinitionBase">
+                            <xs:attributeGroup ref="fmi3IntegerBaseAttributes"/>
+                            <xs:attributeGroup ref="fmi3Int32Attributes"/>
+                        </xs:extension>
+                    </xs:complexContent>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="UInt32Type">
+                <xs:complexType>
+                    <xs:complexContent>
+                        <xs:extension base="fmi3TypeDefinitionBase">
+                            <xs:attributeGroup ref="fmi3IntegerBaseAttributes"/>
+                            <xs:attributeGroup ref="fmi3UInt32Attributes"/>
+                        </xs:extension>
+                    </xs:complexContent>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="Int64Type">
+                <xs:complexType>
+                    <xs:complexContent>
+                        <xs:extension base="fmi3TypeDefinitionBase">
+                            <xs:attributeGroup ref="fmi3IntegerBaseAttributes"/>
+                            <xs:attributeGroup ref="fmi3Int64Attributes"/>
+                        </xs:extension>
+                    </xs:complexContent>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="UInt64Type">
+                <xs:complexType>
+                    <xs:complexContent>
+                        <xs:extension base="fmi3TypeDefinitionBase">
+                            <xs:attributeGroup ref="fmi3IntegerBaseAttributes"/>
+                            <xs:attributeGroup ref="fmi3UInt64Attributes"/>
+                        </xs:extension>
+                    </xs:complexContent>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="BooleanType">
+                <xs:complexType>
+                    <xs:complexContent>
+                        <xs:extension base="fmi3TypeDefinitionBase"/>
+                    </xs:complexContent>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="StringType">
+                <xs:complexType>
+                    <xs:complexContent>
+                        <xs:extension base="fmi3TypeDefinitionBase"/>
+                    </xs:complexContent>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="BinaryType">
+                <xs:complexType>
+                    <xs:complexContent>
+                        <xs:extension base="fmi3TypeDefinitionBase">
+                            <xs:attribute name="mimeType" type="xs:normalizedString" default="application/octet-stream"/>
+                            <xs:attribute name="maxSize" type="xs:nonNegativeInteger"/>
+                        </xs:extension>
+                    </xs:complexContent>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="EnumerationType">
+                <xs:complexType>
+                    <xs:complexContent>
+                        <xs:extension base="fmi3TypeDefinitionBase">
+                            <xs:sequence maxOccurs="unbounded">
+                                <xs:element name="Item">
+                                    <xs:complexType>
+                                        <xs:sequence>
+                                            <xs:element ref="Annotations" minOccurs="0"/>
+                                        </xs:sequence>
+                                        <xs:attribute name="name" type="xs:normalizedString" use="required"/>
+                                        <xs:attribute name="value" type="xs:long" use="required"/>
+                                        <xs:attribute name="description" type="xs:string"/>
+                                    </xs:complexType>
+                                </xs:element>
+                            </xs:sequence>
+                            <xs:attributeGroup ref="fmi3IntegerBaseAttributes"/>
+                            <xs:attributeGroup ref="fmi3EnumerationAttributes"/>
+                        </xs:extension>
+                    </xs:complexContent>
+                </xs:complexType>
+            </xs:element>
+            <xs:element name="ClockType">
+                <xs:complexType>
+                    <xs:complexContent>
+                        <xs:extension base="fmi3TypeDefinitionBase">
+                            <xs:attributeGroup ref="fmi3ClockAttributes"/>
+                        </xs:extension>
+                    </xs:complexContent>
+                </xs:complexType>
+            </xs:element>
+        </xs:choice>
+    </xs:group>
 </xs:schema>

--- a/schema/fmi3/fmi3Variable.xsd
+++ b/schema/fmi3/fmi3Variable.xsd
@@ -1,26 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified">
-	<xs:include schemaLocation="fmi3Annotation.xsd"/>
-	<xs:include schemaLocation="fmi3AttributeGroups.xsd"/>
-	<xs:annotation>
-		<xs:documentation>
+    <xs:include schemaLocation="fmi3Annotation.xsd"/>
+    <xs:include schemaLocation="fmi3AttributeGroups.xsd"/>
+    <xs:annotation>
+        <xs:documentation>
 Copyright(c) 2008-2011 MODELISAR consortium,
-             2012-2018 Modelica Association Project "FMI".
+             2012-2024 Modelica Association Project "FMI".
              All rights reserved.
-This file is licensed by the copyright holders under the BSD 2-Clause License
-(http://www.opensource.org/licenses/bsd-license.html):
+
+This file is licensed by the copyright holders under the 2-Clause BSD License
+(https://opensource.org/licenses/BSD-2-Clause):
+
 ----------------------------------------------------------------------------
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
 
 - Redistributions of source code must retain the above copyright notice,
-  this list of conditions and the following disclaimer.
+ this list of conditions and the following disclaimer.
+
 - Redistributions in binary form must reproduce the above copyright notice,
-  this list of conditions and the following disclaimer in the documentation
-  and/or other materials provided with the distribution.
-- Neither the name of the copyright holders nor the names of its
-  contributors may be used to endorse or promote products derived
-  from this software without specific prior written permission.
+ this list of conditions and the following disclaimer in the documentation
+ and/or other materials provided with the distribution.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
@@ -34,279 +34,380 @@ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
 OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
 ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ----------------------------------------------------------------------------
-
-with the extension:
-
-You may distribute or publicly perform any modification only under the
-terms of this license.
-(Note, this means that if you distribute a modified file,
-the modified file must also be provided under this license).
-		</xs:documentation>
-	</xs:annotation>
-	<xs:complexType name="fmi3Variable">
-		<xs:annotation>
-			<xs:documentation>Properties of a variable</xs:documentation>
-		</xs:annotation>
-		<xs:sequence>
-			<xs:choice>
-				<xs:element name="Real">
-					<xs:complexType>
-						<xs:attribute name="declaredType" type="xs:normalizedString">
-							<xs:annotation>
-								<xs:documentation>If present, name of type defined with TypeDefinitions / SimpleType providing defaults.</xs:documentation>
-							</xs:annotation>
-						</xs:attribute>
-						<xs:attributeGroup ref="fmi3RealAttributes"/>
-						<xs:attribute name="start">
-							<xs:annotation>
-								<xs:documentation>List of start values. Value before initialization, if initial=exact or approx.
-max >= start[i] >= min required</xs:documentation>
-							</xs:annotation>
-							<xs:simpleType>
-								<xs:list>
-									<xs:simpleType>
-										<xs:restriction base="xs:double"/>
-									</xs:simpleType>
-								</xs:list>
-							</xs:simpleType>
-						</xs:attribute>
-						<xs:attribute name="derivative" type="xs:unsignedInt">
-							<xs:annotation>
-								<xs:documentation>If present, this variable is the derivative of variable with Variable index "derivative".</xs:documentation>
-							</xs:annotation>
-						</xs:attribute>
-						<xs:attribute name="reinit" type="xs:boolean" use="optional" default="false">
-							<xs:annotation>
-								<xs:documentation>Only for ModelExchange and if variable is a continuous-time state:
-If true, state can be reinitialized at an event by the FMU
-If false, state will never be reinitialized at an event by the FMU</xs:documentation>
-							</xs:annotation>
-						</xs:attribute>
-					</xs:complexType>
-				</xs:element>
-				<xs:element name="Integer">
-					<xs:complexType>
-						<xs:attribute name="declaredType" type="xs:normalizedString">
-							<xs:annotation>
-								<xs:documentation>If present, name of type defined with TypeDefinitions / SimpleType providing defaults.</xs:documentation>
-							</xs:annotation>
-						</xs:attribute>
-						<xs:attributeGroup ref="fmi3IntegerAttributes"/>
-						<xs:attribute name="start">
-							<xs:annotation>
-								<xs:documentation>Value before initialization, if initial=exact or approx.
-max >= start[i] >= min required</xs:documentation>
-							</xs:annotation>
-							<xs:simpleType>
-								<xs:list>
-									<xs:simpleType>
-										<xs:restriction base="xs:int"/>
-									</xs:simpleType>
-								</xs:list>
-							</xs:simpleType>
-						</xs:attribute>
-					</xs:complexType>
-				</xs:element>
-				<xs:element name="Boolean">
-					<xs:complexType>
-						<xs:attribute name="declaredType" type="xs:normalizedString">
-							<xs:annotation>
-								<xs:documentation>If present, name of type defined with TypeDefinitions / SimpleType providing defaults.</xs:documentation>
-							</xs:annotation>
-						</xs:attribute>
-						<xs:attribute name="start">
-							<xs:annotation>
-								<xs:documentation>Value before initialization, if initial=exact or approx</xs:documentation>
-							</xs:annotation>
-							<xs:simpleType>
-								<xs:list>
-									<xs:simpleType>
-										<xs:restriction base="xs:boolean"/>
-									</xs:simpleType>
-								</xs:list>
-							</xs:simpleType>
-						</xs:attribute>
-					</xs:complexType>
-				</xs:element>
-				<xs:element name="String">
-					<xs:complexType>
-						<xs:attribute name="declaredType" type="xs:normalizedString">
-							<xs:annotation>
-								<xs:documentation>If present, name of type defined with TypeDefinitions / SimpleType providing defaults.</xs:documentation>
-							</xs:annotation>
-						</xs:attribute>
-						<xs:attribute name="start">
-							<xs:annotation>
-								<xs:documentation>Value before initialization, if initial=exact or approx</xs:documentation>
-							</xs:annotation>
-							<xs:simpleType>
-								<xs:list>
-									<xs:simpleType>
-										<xs:restriction base="xs:string"/>
-									</xs:simpleType>
-								</xs:list>
-							</xs:simpleType>
-						</xs:attribute>
-					</xs:complexType>
-				</xs:element>
-				<xs:element name="Binary">
-					<xs:complexType>
-						<xs:attribute name="declaredType" type="xs:normalizedString">
-							<xs:annotation>
-								<xs:documentation>If present, name of type defined with TypeDefinitions / SimpleType providing defaults.</xs:documentation>
-							</xs:annotation>
-						</xs:attribute>
-						<xs:attribute name="mimeType" type="xs:normalizedString" use="optional" default="application/octet-stream">
-							<xs:annotation>
-								<xs:documentation>Should indicate the type of data passed as a binary. Defaults to application/octet-stream,
-									which is unspecific.  Implementations can use this information to provide guidance to the user about
-									valid/useful connections.</xs:documentation>
-							</xs:annotation>
-						</xs:attribute>
-						<xs:attribute name="maxSize" type="xs:nonNegativeInteger" use="optional">
-							<xs:annotation>
-								<xs:documentation>If present, limits the maximum size of the binary to the indicated value.
-									All variable accesses, both getting and setting of values must guarantee that the returned
-									size of the binary is strictly equal or less than this maximum size.</xs:documentation>
-							</xs:annotation>
-						</xs:attribute>
-						<xs:attribute name="start">
-							<xs:annotation>
-								<xs:documentation>Value before initialization, if initial=exact or approx</xs:documentation>
-							</xs:annotation>
-							<xs:simpleType>
-								<xs:list itemType="xs:hexBinary"/>
-							</xs:simpleType>
-						</xs:attribute>
-					</xs:complexType>
-				</xs:element>
-				<xs:element name="Enumeration">
-					<xs:complexType>
-						<xs:attribute name="declaredType" type="xs:normalizedString" use="required">
-							<xs:annotation>
-								<xs:documentation>Name of type defined with TypeDefinitions / SimpleType </xs:documentation>
-							</xs:annotation>
-						</xs:attribute>
-						<xs:attribute name="quantity" type="xs:normalizedString"/>
-						<xs:attribute name="min" type="xs:int"/>
-						<xs:attribute name="max" type="xs:int">
-							<xs:annotation>
-								<xs:documentation>max >= min required</xs:documentation>
-							</xs:annotation>
-						</xs:attribute>
-						<xs:attribute name="start">
-							<xs:annotation>
-								<xs:documentation>Value before initialization, if initial=exact or approx.
-max >= start >= min required</xs:documentation>
-							</xs:annotation>
-							<xs:simpleType>
-								<xs:list>
-									<xs:simpleType>
-										<xs:restriction base="xs:int"/>
-									</xs:simpleType>
-								</xs:list>
-							</xs:simpleType>
-						</xs:attribute>
-					</xs:complexType>
-				</xs:element>
-			</xs:choice>
-			<xs:element name="Dimensions" minOccurs="0">
-				<xs:complexType>
-					<xs:sequence maxOccurs="unbounded">
-						<xs:element name="Dimension">
-							<xs:complexType>
-								<xs:attribute name="start" type="xs:unsignedInt">
-									<xs:annotation>
-										<xs:documentation>If start value is defined, the size is constant.
-start value must only be defined if index to structuralParameter is not given.</xs:documentation>
-									</xs:annotation>
-								</xs:attribute>
-								<xs:attribute name="valueReference" type="xs:unsignedInt">
-									<xs:annotation>
-										<xs:documentation>Link to structuralParameter element. Must be defined if no start value exist.</xs:documentation>
-									</xs:annotation>
-								</xs:attribute>
-							</xs:complexType>
-						</xs:element>
-					</xs:sequence>
-				</xs:complexType>
-			</xs:element>
-			<xs:element name="Annotations" type="fmi3Annotation" minOccurs="0">
-				<xs:annotation>
-					<xs:documentation>Additional data of the variable, e.g., for the dialog menu or the graphical layout</xs:documentation>
-				</xs:annotation>
-			</xs:element>
-		</xs:sequence>
-		<xs:attribute name="name" type="xs:normalizedString" use="required">
-			<xs:annotation>
-				<xs:documentation>Identifier of variable, e.g. "A_Matrix.", "abc'.d". "name" must be unique with respect to all other elements of the ModelVariables list</xs:documentation>
-			</xs:annotation>
-		</xs:attribute>
-		<xs:attribute name="valueReference" type="xs:unsignedInt" use="required">
-			<xs:annotation>
-				<xs:documentation>Identifier for variable value in FMI3 function calls (not necessarily unique with respect to all variables)</xs:documentation>
-			</xs:annotation>
-		</xs:attribute>
-		<xs:attribute name="description" type="xs:string"/>
-		<xs:attribute name="causality" default="local">
-			<xs:annotation>
-				<xs:documentation>parameter: independent parameter
-calculatedParameter: calculated parameter
-input/output: can be used in connections
-local: variable calculated from other variables
-independent: independent variable (usually time)
-structuralParameter: structural parameter usually used for sizes</xs:documentation>
-			</xs:annotation>
-			<xs:simpleType>
-				<xs:restriction base="xs:normalizedString">
-					<xs:enumeration value="parameter"/>
-					<xs:enumeration value="calculatedParameter"/>
-					<xs:enumeration value="input"/>
-					<xs:enumeration value="output"/>
-					<xs:enumeration value="local"/>
-					<xs:enumeration value="independent"/>
-					<xs:enumeration value="structuralParameter"/>
-				</xs:restriction>
-			</xs:simpleType>
-		</xs:attribute>
-		<xs:attribute name="variability" default="continuous">
-			<xs:annotation>
-				<xs:documentation>constant: value never changes
-fixed: value fixed after initialization
-tunable: value constant between external events
-discrete: value constant between internal events
-continuous: no restriction on value changes</xs:documentation>
-			</xs:annotation>
-			<xs:simpleType>
-				<xs:restriction base="xs:normalizedString">
-					<xs:enumeration value="constant"/>
-					<xs:enumeration value="fixed"/>
-					<xs:enumeration value="tunable"/>
-					<xs:enumeration value="discrete"/>
-					<xs:enumeration value="continuous"/>
-				</xs:restriction>
-			</xs:simpleType>
-		</xs:attribute>
-		<xs:attribute name="initial">
-			<xs:annotation>
-				<xs:documentation>exact: initialized with start value
-approx: iteration variable that starts with start value
-calculated: calculated from other variables.
-If not provided, initial is deduced from causality and variability (details see specification)</xs:documentation>
-			</xs:annotation>
-			<xs:simpleType>
-				<xs:restriction base="xs:normalizedString">
-					<xs:enumeration value="exact"/>
-					<xs:enumeration value="approx"/>
-					<xs:enumeration value="calculated"/>
-				</xs:restriction>
-			</xs:simpleType>
-		</xs:attribute>
-		<xs:attribute name="canHandleMultipleSetPerTimeInstant" type="xs:boolean">
-			<xs:annotation>
-				<xs:documentation>Only for ModelExchange and only for variables with variability = "input":
-If present with value = false, then only one fmi3SetXXX call is allowed at one super dense time instant. In other words, this input is not allowed to appear in an algebraic loop.</xs:documentation>
-			</xs:annotation>
-		</xs:attribute>
-	</xs:complexType>
+        </xs:documentation>
+    </xs:annotation>
+    <xs:complexType name="fmi3AbstractVariable" abstract="true">
+        <xs:sequence>
+            <xs:element ref="Annotations" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:normalizedString" use="required"/>
+        <xs:attribute name="valueReference" type="xs:unsignedInt" use="required"/>
+        <xs:attribute name="description" type="xs:string"/>
+        <xs:attribute name="causality" default="local">
+            <xs:simpleType>
+                <xs:restriction base="xs:normalizedString">
+                    <xs:enumeration value="parameter"/>
+                    <xs:enumeration value="calculatedParameter"/>
+                    <xs:enumeration value="input"/>
+                    <xs:enumeration value="output"/>
+                    <xs:enumeration value="local"/>
+                    <xs:enumeration value="independent"/>
+                    <xs:enumeration value="structuralParameter"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="variability">
+            <xs:simpleType>
+                <xs:restriction base="xs:normalizedString">
+                    <xs:enumeration value="constant"/>
+                    <xs:enumeration value="fixed"/>
+                    <xs:enumeration value="tunable"/>
+                    <xs:enumeration value="discrete"/>
+                    <xs:enumeration value="continuous"/>
+                </xs:restriction>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="canHandleMultipleSetPerTimeInstant" type="xs:boolean"/>
+        <xs:attribute name="clocks">
+            <xs:simpleType>
+                <xs:list itemType="xs:unsignedInt"/>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
+    <xs:group name="fmi3Dimensions">
+        <xs:sequence>
+            <xs:element name="Dimension" minOccurs="0" maxOccurs="unbounded">
+                <xs:complexType>
+                    <xs:attribute name="start" type="xs:unsignedLong"/>
+                    <xs:attribute name="valueReference" type="xs:unsignedInt"/>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+    </xs:group>
+    <xs:complexType name="fmi3ArrayableVariable" abstract="true">
+        <xs:complexContent>
+            <xs:extension base="fmi3AbstractVariable">
+                <xs:group ref="fmi3Dimensions"/>
+                <xs:attribute name="intermediateUpdate" type="xs:boolean"/>
+                <xs:attribute name="previous" type="xs:unsignedInt"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:complexType name="fmi3TypedVariable" abstract="true">
+        <xs:complexContent>
+            <xs:extension base="fmi3AbstractVariable">
+                <xs:attribute name="declaredType" type="xs:normalizedString"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:complexType name="fmi3TypedArrayableVariable" abstract="true">
+        <xs:complexContent>
+            <xs:extension base="fmi3ArrayableVariable">
+                <xs:attribute name="declaredType" type="xs:normalizedString"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:complexType name="fmi3MandatorilyTypedArrayableVariable" abstract="true">
+        <xs:complexContent>
+            <xs:restriction base="fmi3TypedArrayableVariable">
+                <xs:sequence>
+                    <xs:element ref="Annotations" minOccurs="0"/>
+                    <xs:group ref="fmi3Dimensions"/>
+                </xs:sequence>
+                <xs:attribute name="declaredType" type="xs:normalizedString" use="required"/>
+            </xs:restriction>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:complexType name="fmi3InitializableVariable" abstract="true">
+        <xs:complexContent>
+            <xs:extension base="fmi3TypedArrayableVariable">
+                <xs:attribute name="initial">
+                    <xs:simpleType>
+                        <xs:restriction base="xs:normalizedString">
+                            <xs:enumeration value="exact"/>
+                            <xs:enumeration value="approx"/>
+                            <xs:enumeration value="calculated"/>
+                        </xs:restriction>
+                    </xs:simpleType>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:complexType name="fmi3MandatorilyTypedInitializableVariable">
+        <xs:complexContent>
+            <xs:extension base="fmi3MandatorilyTypedArrayableVariable">
+                <xs:attribute name="initial">
+                    <xs:simpleType>
+                        <xs:restriction base="xs:normalizedString">
+                            <xs:enumeration value="exact"/>
+                            <xs:enumeration value="approx"/>
+                            <xs:enumeration value="calculated"/>
+                        </xs:restriction>
+                    </xs:simpleType>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:complexType name="fmi3Float32">
+        <xs:complexContent>
+            <xs:extension base="fmi3InitializableVariable">
+                <xs:sequence>
+                    <xs:element name="Alias" type="fmi3FloatVariableAlias" minOccurs="0" maxOccurs="unbounded"/>
+                </xs:sequence>
+                <xs:attributeGroup ref="fmi3RealBaseAttributes"/>
+                <xs:attributeGroup ref="fmi3Float32Attributes"/>
+                <xs:attribute name="start">
+                    <xs:simpleType>
+                        <xs:list itemType="xs:float"/>
+                    </xs:simpleType>
+                </xs:attribute>
+                <xs:attributeGroup ref="fmi3RealVariableAttributes"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:complexType name="fmi3Float64">
+        <xs:complexContent>
+            <xs:extension base="fmi3InitializableVariable">
+                <xs:sequence>
+                    <xs:element name="Alias" type="fmi3FloatVariableAlias" minOccurs="0" maxOccurs="unbounded"/>
+                </xs:sequence>
+                <xs:attributeGroup ref="fmi3RealBaseAttributes"/>
+                <xs:attributeGroup ref="fmi3Float64Attributes"/>
+                <xs:attribute name="start">
+                    <xs:simpleType>
+                        <xs:list itemType="xs:double"/>
+                    </xs:simpleType>
+                </xs:attribute>
+                <xs:attributeGroup ref="fmi3RealVariableAttributes"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:complexType name="fmi3Int8">
+        <xs:complexContent>
+            <xs:extension base="fmi3InitializableVariable">
+                <xs:sequence>
+                    <xs:element name="Alias" type="fmi3VariableAlias" minOccurs="0" maxOccurs="unbounded"/>
+                </xs:sequence>
+                <xs:attributeGroup ref="fmi3IntegerBaseAttributes"/>
+                <xs:attributeGroup ref="fmi3Int8Attributes"/>
+                <xs:attribute name="start">
+                    <xs:simpleType>
+                        <xs:list itemType="xs:byte"/>
+                    </xs:simpleType>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:complexType name="fmi3UInt8">
+        <xs:complexContent>
+            <xs:extension base="fmi3InitializableVariable">
+                <xs:sequence>
+                    <xs:element name="Alias" type="fmi3VariableAlias" minOccurs="0" maxOccurs="unbounded"/>
+                </xs:sequence>
+                <xs:attributeGroup ref="fmi3IntegerBaseAttributes"/>
+                <xs:attributeGroup ref="fmi3UInt8Attributes"/>
+                <xs:attribute name="start">
+                    <xs:simpleType>
+                        <xs:list itemType="xs:unsignedByte"/>
+                    </xs:simpleType>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:complexType name="fmi3Int16">
+        <xs:complexContent>
+            <xs:extension base="fmi3InitializableVariable">
+                <xs:sequence>
+                    <xs:element name="Alias" type="fmi3VariableAlias" minOccurs="0" maxOccurs="unbounded"/>
+                </xs:sequence>
+                <xs:attributeGroup ref="fmi3IntegerBaseAttributes"/>
+                <xs:attributeGroup ref="fmi3Int16Attributes"/>
+                <xs:attribute name="start">
+                    <xs:simpleType>
+                        <xs:list itemType="xs:short"/>
+                    </xs:simpleType>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:complexType name="fmi3UInt16">
+        <xs:complexContent>
+            <xs:extension base="fmi3InitializableVariable">
+                <xs:sequence>
+                    <xs:element name="Alias" type="fmi3VariableAlias" minOccurs="0" maxOccurs="unbounded"/>
+                </xs:sequence>
+                <xs:attributeGroup ref="fmi3IntegerBaseAttributes"/>
+                <xs:attributeGroup ref="fmi3UInt16Attributes"/>
+                <xs:attribute name="start">
+                    <xs:simpleType>
+                        <xs:list itemType="xs:unsignedShort"/>
+                    </xs:simpleType>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:complexType name="fmi3Int32">
+        <xs:complexContent>
+            <xs:extension base="fmi3InitializableVariable">
+                <xs:sequence>
+                    <xs:element name="Alias" type="fmi3VariableAlias" minOccurs="0" maxOccurs="unbounded"/>
+                </xs:sequence>
+                <xs:attributeGroup ref="fmi3IntegerBaseAttributes"/>
+                <xs:attributeGroup ref="fmi3Int32Attributes"/>
+                <xs:attribute name="start">
+                    <xs:simpleType>
+                        <xs:list itemType="xs:int"/>
+                    </xs:simpleType>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:complexType name="fmi3UInt32">
+        <xs:complexContent>
+            <xs:extension base="fmi3InitializableVariable">
+                <xs:sequence>
+                    <xs:element name="Alias" type="fmi3VariableAlias" minOccurs="0" maxOccurs="unbounded"/>
+                </xs:sequence>
+                <xs:attributeGroup ref="fmi3IntegerBaseAttributes"/>
+                <xs:attributeGroup ref="fmi3UInt32Attributes"/>
+                <xs:attribute name="start">
+                    <xs:simpleType>
+                        <xs:list itemType="xs:unsignedInt"/>
+                    </xs:simpleType>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:complexType name="fmi3Int64">
+        <xs:complexContent>
+            <xs:extension base="fmi3InitializableVariable">
+                <xs:sequence>
+                    <xs:element name="Alias" type="fmi3VariableAlias" minOccurs="0" maxOccurs="unbounded"/>
+                </xs:sequence>
+                <xs:attributeGroup ref="fmi3IntegerBaseAttributes"/>
+                <xs:attributeGroup ref="fmi3Int64Attributes"/>
+                <xs:attribute name="start">
+                    <xs:simpleType>
+                        <xs:list itemType="xs:long"/>
+                    </xs:simpleType>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:complexType name="fmi3UInt64">
+        <xs:complexContent>
+            <xs:extension base="fmi3InitializableVariable">
+                <xs:sequence>
+                    <xs:element name="Alias" type="fmi3VariableAlias" minOccurs="0" maxOccurs="unbounded"/>
+                </xs:sequence>
+                <xs:attributeGroup ref="fmi3IntegerBaseAttributes"/>
+                <xs:attributeGroup ref="fmi3UInt64Attributes"/>
+                <xs:attribute name="start">
+                    <xs:simpleType>
+                        <xs:list itemType="xs:unsignedLong"/>
+                    </xs:simpleType>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:complexType name="fmi3Boolean">
+        <xs:complexContent>
+            <xs:extension base="fmi3InitializableVariable">
+                <xs:sequence>
+                    <xs:element name="Alias" type="fmi3VariableAlias" minOccurs="0" maxOccurs="unbounded"/>
+                </xs:sequence>
+                <xs:attribute name="start">
+                    <xs:simpleType>
+                        <xs:list itemType="xs:boolean"/>
+                    </xs:simpleType>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:complexType name="fmi3String">
+        <xs:complexContent>
+            <xs:extension base="fmi3InitializableVariable">
+                <xs:sequence>
+                    <xs:element name="Start" minOccurs="0" maxOccurs="unbounded">
+                        <xs:complexType>
+                            <xs:attribute name="value" type="xs:string"/>
+                        </xs:complexType>
+                    </xs:element>
+                    <xs:element name="Alias" type="fmi3VariableAlias" minOccurs="0" maxOccurs="unbounded"/>
+                </xs:sequence>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:complexType name="fmi3Binary">
+        <xs:complexContent>
+            <xs:extension base="fmi3InitializableVariable">
+                <xs:sequence>
+                    <xs:element name="Start" minOccurs="0" maxOccurs="unbounded">
+                        <xs:complexType>
+                            <xs:attribute name="value" type="xs:hexBinary"/>
+                        </xs:complexType>
+                    </xs:element>
+                    <xs:element name="Alias" type="fmi3VariableAlias" minOccurs="0" maxOccurs="unbounded"/>
+                </xs:sequence>
+                <xs:attribute name="mimeType" type="xs:normalizedString" default="application/octet-stream"/>
+                <xs:attribute name="maxSize" type="xs:nonNegativeInteger"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:complexType name="fmi3Enumeration">
+        <xs:complexContent>
+            <xs:extension base="fmi3MandatorilyTypedInitializableVariable">
+                <xs:sequence>
+                    <xs:element name="Alias" type="fmi3VariableAlias" minOccurs="0" maxOccurs="unbounded"/>
+                </xs:sequence>
+                <xs:attributeGroup ref="fmi3IntegerBaseAttributes"/>
+                <xs:attributeGroup ref="fmi3EnumerationAttributes"/>
+                <xs:attribute name="start">
+                    <xs:simpleType>
+                        <xs:list itemType="xs:long"/>
+                    </xs:simpleType>
+                </xs:attribute>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:complexType name="fmi3Clock">
+        <xs:complexContent>
+            <xs:extension base="fmi3TypedVariable">
+                <xs:sequence>
+                    <xs:element name="Alias" type="fmi3VariableAlias" minOccurs="0" maxOccurs="unbounded"/>
+                </xs:sequence>
+                <xs:attributeGroup ref="fmi3ClockAttributes"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:complexType name="fmi3VariableAlias">
+        <xs:attribute name="name" type="xs:normalizedString" use="required"/>
+        <xs:attribute name="description" type="xs:string"/>
+    </xs:complexType>
+    <xs:complexType name="fmi3FloatVariableAlias">
+        <xs:complexContent>
+            <xs:extension base="fmi3VariableAlias">
+                <xs:attribute name="displayUnit" type="xs:normalizedString"/>
+            </xs:extension>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:group name="fmi3Variable">
+        <xs:choice>
+            <xs:element name="Float32" type="fmi3Float32"/>
+            <xs:element name="Float64" type="fmi3Float64"/>
+            <xs:element name="Int8" type="fmi3Int8"/>
+            <xs:element name="UInt8" type="fmi3UInt8"/>
+            <xs:element name="Int16" type="fmi3Int16"/>
+            <xs:element name="UInt16" type="fmi3UInt16"/>
+            <xs:element name="Int32" type="fmi3Int32"/>
+            <xs:element name="UInt32" type="fmi3UInt32"/>
+            <xs:element name="Int64" type="fmi3Int64"/>
+            <xs:element name="UInt64" type="fmi3UInt64"/>
+            <xs:element name="Boolean" type="fmi3Boolean"/>
+            <xs:element name="String" type="fmi3String"/>
+            <xs:element name="Binary" type="fmi3Binary"/>
+            <xs:element name="Enumeration" type="fmi3Enumeration"/>
+            <xs:element name="Clock" type="fmi3Clock"/>
+        </xs:choice>
+    </xs:group>
 </xs:schema>

--- a/schema/fmi3/fmi3VariableDependency.xsd
+++ b/schema/fmi3/fmi3VariableDependency.xsd
@@ -1,24 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified">
-	<xs:annotation>
-		<xs:documentation>
+    <xs:include schemaLocation="fmi3Annotation.xsd"/>
+    <xs:annotation>
+        <xs:documentation>
 Copyright(c) 2008-2011 MODELISAR consortium,
-             2012-2018 Modelica Association Project "FMI".
+             2012-2024 Modelica Association Project "FMI".
              All rights reserved.
-This file is licensed by the copyright holders under the BSD 2-Clause License
-(http://www.opensource.org/licenses/bsd-license.html):
+
+This file is licensed by the copyright holders under the 2-Clause BSD License
+(https://opensource.org/licenses/BSD-2-Clause):
+
 ----------------------------------------------------------------------------
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
 
 - Redistributions of source code must retain the above copyright notice,
-  this list of conditions and the following disclaimer.
+ this list of conditions and the following disclaimer.
+
 - Redistributions in binary form must reproduce the above copyright notice,
-  this list of conditions and the following disclaimer in the documentation
-  and/or other materials provided with the distribution.
-- Neither the name of the copyright holders nor the names of its
-  contributors may be used to endorse or promote products derived
-  from this software without specific prior written permission.
+ this list of conditions and the following disclaimer in the documentation
+ and/or other materials provided with the distribution.
 
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
@@ -32,66 +33,32 @@ WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
 OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
 ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ----------------------------------------------------------------------------
-
-with the extension:
-
-You may distribute or publicly perform any modification only under the
-terms of this license.
-(Note, this means that if you distribute a modified file,
-the modified file must also be provided under this license).
-		</xs:documentation>
-	</xs:annotation>
-	<xs:complexType name="fmi3VariableDependency">
-		<xs:sequence maxOccurs="unbounded">
-			<xs:element name="Unknown">
-				<xs:annotation>
-					<xs:documentation>Dependency of scalar Unknown from Knowns
-in Continuous-Time and Event Mode (ModelExchange),
-and at Communication Points (CoSimulation):
-    Unknown=f(Known_1, Known_2, ...).
-The Knowns are "inputs", "continuous states" and
-"independent variable" (usually time)".</xs:documentation>
-				</xs:annotation>
-				<xs:complexType>
-					<xs:attribute name="valueReference" type="xs:unsignedInt" use="required">
-						<xs:annotation>
-							<xs:documentation>Variable valueReference of Unknown</xs:documentation>
-						</xs:annotation>
-					</xs:attribute>
-					<xs:attribute name="dependencies">
-						<xs:annotation>
-							<xs:documentation>Defines the dependency of the Unknown (directly or indirectly via auxiliary variables) on the Knowns in Continuous-Time and Event Mode (ModelExchange) and at Communication Points (CoSimulation). If not present, it must be assumed that the Unknown depends on all Knowns. If present as empty list, the Unknown depends on none of the Knowns. Otherwise the Unknown depends on the Knowns defined by the given Variable valueReference. The valueReferences are ordered according to the size of the index of the variable in the Variable list, starting with the smallest index.</xs:documentation>
-						</xs:annotation>
-						<xs:simpleType>
-							<xs:list itemType="xs:unsignedInt"/>
-						</xs:simpleType>
-					</xs:attribute>
-					<xs:attribute name="dependenciesKind">
-						<xs:annotation>
-							<xs:documentation>If not present, it must be assumed that the Unknown depends on the Knowns without a particular structure. Otherwise, the corresponding Known v enters the equation as:
-= "dependent": no particular structure, f(v)
-= "constant"   : constant factor, c*v (only for Real variablse)
-= "fixed"        : fixed factor, p*v (only for Real variables)
-= "tunable"    : tunable factor, p*v (only for Real variables)
-= "discrete"    : discrete factor, d*v (only for Real variables)
-If "dependenciesKind" is present, "dependencies" must be present and must have the same number of list elements.</xs:documentation>
-						</xs:annotation>
-						<xs:simpleType>
-							<xs:list>
-								<xs:simpleType>
-									<xs:restriction base="xs:normalizedString">
-										<xs:enumeration value="dependent"/>
-										<xs:enumeration value="constant"/>
-										<xs:enumeration value="fixed"/>
-										<xs:enumeration value="tunable"/>
-										<xs:enumeration value="discrete"/>
-									</xs:restriction>
-								</xs:simpleType>
-							</xs:list>
-						</xs:simpleType>
-					</xs:attribute>
-				</xs:complexType>
-			</xs:element>
-		</xs:sequence>
-	</xs:complexType>
+        </xs:documentation>
+    </xs:annotation>
+    <xs:complexType name="fmi3Unknown">
+        <xs:sequence>
+            <xs:element ref="Annotations" minOccurs="0"/>
+        </xs:sequence>
+        <xs:attribute name="valueReference" type="xs:unsignedInt" use="required"/>
+        <xs:attribute name="dependencies">
+            <xs:simpleType>
+                <xs:list itemType="xs:unsignedInt"/>
+            </xs:simpleType>
+        </xs:attribute>
+        <xs:attribute name="dependenciesKind">
+            <xs:simpleType>
+                <xs:list>
+                    <xs:simpleType>
+                        <xs:restriction base="xs:normalizedString">
+                            <xs:enumeration value="dependent"/>
+                            <xs:enumeration value="constant"/>
+                            <xs:enumeration value="fixed"/>
+                            <xs:enumeration value="tunable"/>
+                            <xs:enumeration value="discrete"/>
+                        </xs:restriction>
+                    </xs:simpleType>
+                </xs:list>
+            </xs:simpleType>
+        </xs:attribute>
+    </xs:complexType>
 </xs:schema>


### PR DESCRIPTION
### Related Issues

Our FMI 3 schema files are outdated.
See e.g. discussion in https://github.com/OpenModelica/OpenModelica/pull/15970 about `canRunAsynchronuously` in FMI 3, which isn't a thing.

### Purpose

* Update schema/fmi2 to FMI 2.0.5
* Update schema/fmi3 to FMI 3.0.2

Update 3rd-party FMI4C FMI headers

* Update FMI2 headers to FMI 2.0.5
* Update FMI3 headers to FMI 3.0.2

### Approach

Copy-and-paste the released files.
