### PR TITLE
Fix tmp-dir collision of rtest

### DIFF
--- a/testsuite/rtest
+++ b/testsuite/rtest
@@ -74,7 +74,7 @@ $pager="cat";
 $diffcmd="diff -U 5 -w";
 $dwdiffcmd="dwdiff '-d()' -l -C 3 -c -L";
 $log="";
-$test_id = int(rand(9999));
+$test_id = $$ . "_" . int(rand(9999));
 my $username = ( $^O ne 'MSWin32' ? getpwuid($<) : undef )
           || getlogin()
           || $ENV{'USER'}


### PR DESCRIPTION
## Related Issues

Fixes https://github.com/OpenModelica/OMSimulator/issues/1596.

## Purpose

* Fix temporary directory collision resulting in random failures on Windows: ``The process cannot access the file because it is being used by another process.`

## Approach

* Use process-id to get unique `test_id`
