### PR TITLE
Re-enabling ASAN tests

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -25,12 +25,11 @@ jobs:
           submodules: recursive
 
       # Everything else OMSimulator needs is vendored in 3rdParty/. flex is for
-      # omc-diff, which the testsuite compares result files with, and numpy for
-      # the CompositeModels tests that import it.
+      # omc-diff, which the testsuite compares result files with.
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y cmake g++ flex python3 python3-numpy gcovr ccache
+          sudo apt-get install -y cmake g++ flex python3 gcovr ccache
 
       # Only 3rdParty benefits much: the instrumented sources are rebuilt at -O0
       # anyway. It still takes the bulk of a cold build off the critical path.

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ imgui.ini
 /OMSimulator.creator.user
 /OMSimulator.files
 /OMSimulator.includes
+
+# Python files
+__pycache__/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,7 +8,6 @@ pipeline {
     booleanParam(name: 'MACOS_ARM64', defaultValue: false, description: 'Build with macOS-arm64 (M1 mac)')
     booleanParam(name: 'SUBMODULE_UPDATE', defaultValue: false, description: 'Allow pull request to update submodules (disabled by default due to common user errors)')
     booleanParam(name: 'UPLOAD_BUILD_OPENMODELICA', defaultValue: false, description: 'Upload install artifacts to build.openmodelica.org/omsimulator. Activates MINGW_UCRT64 as well.')
-    booleanParam(name: 'ASAN', defaultValue: false, description: 'Build and test with AddressSanitizer (disabled by default while the reported leaks are unfixed)')
     string(name: 'CTEST_FLAGS', defaultValue: '', description: 'Extra flags passed to ctest, e.g. -R api')
   }
   stages {
@@ -48,12 +47,6 @@ pipeline {
     stage('build-in-parallel') {
       parallel {
         stage('linux64-resolute-asan') {
-          // Disabled until the leaks AddressSanitizer reports have been fixed.
-          // Set the ASAN build parameter to run it in the meantime.
-          when {
-            expression { return params.ASAN }
-            beforeAgent true
-          }
           stages {
             stage('build-asan') {
               agent {

--- a/README.md
+++ b/README.md
@@ -1,14 +1,17 @@
-# OMSimulator [![License: OSMC-PL](https://img.shields.io/badge/license-OSMC--PL-lightgrey.svg)](OSMC-License.txt)
+# OMSimulator
+
+[![License: OSMC-PL](https://img.shields.io/badge/license-OSMC--PL-lightgrey.svg)](OSMC-License.txt)
+[![codecov](https://codecov.io/gh/OpenModelica/OMSimulator/branch/master/graph/badge.svg?token=HmYNZuQtNA)](https://codecov.io/gh/OpenModelica/OMSimulator)
 
 The OpenModelica FMI & SSP-based co-simulation environment.
 
-### Branch Overview
+## Branch Overview
 
 - **`master`**: Development branch for active, unstable updates.
 - **`maintenance/v2.1`**: Stable branch for version 2.1 with patch updates (latest release: **v2.1.3**).
 - **`maintenance/v2.0`**: Stable branch for version 2.0 with patch updates (latest release: **v2.0.1**).
 
-### Overview
+## Overview
 
 OMSimulator can be used as:
 
@@ -18,10 +21,10 @@ OMSimulator can be used as:
 
 OMSimulator is also included with the OpenModelica installer, which includes OMEdit, a graphical editor.
 
-* [OpenModelica](https://openmodelica.org/)
-* [Standalone package](https://build.openmodelica.org/omsimulator/)
+- [OpenModelica](https://openmodelica.org/)
+- [Standalone package](https://build.openmodelica.org/omsimulator/)
 
-### Documentation
+## Documentation
 
 Latest documentation:
 
@@ -29,7 +32,7 @@ Latest documentation:
 - [User Guide HTML](https://openmodelica.org/doc/OMSimulator/master/OMSimulator/UsersGuide/html/)
 - [OMSimulatorLib Doxygen](https://openmodelica.org/doc/OMSimulator/master/OMSimulator/doxygen/html/index.html)
 
-### Testing and Coverage
+## Testing and Coverage
 
 OMSimulator's coverage tests provide insights across a wide range of publicly available libraries. For an overview of all tested libraries and their detailed reports, visit the [Coverage Test Overview](https://libraries.openmodelica.org/branches/master-fmi/).
 
@@ -38,10 +41,10 @@ OMSimulator's coverage tests provide insights across a wide range of publicly av
 
 > **Note**: Issues may be attributed to OMSimulator itself or the FMI export in OpenModelica.
 
-### Build Instructions
+## Build Instructions
 
 To compile the project, please follow the steps outlined in the [BUILD.md](BUILD.md) file.
 
-### License
+## License
 
 This project is licensed under the OSMC Public License. See [OSMC-License.txt](OSMC-License.txt) for details.

--- a/src/OMSimulatorLib/AlgLoop.cpp
+++ b/src/OMSimulatorLib/AlgLoop.cpp
@@ -300,7 +300,9 @@ oms::KinsolSolver* oms::KinsolSolver::NewKinsolSolver(const int algLoopNum, cons
 {
   int flag;
   int printLevel;
-  KinsolSolver* kinsolSolver = new KinsolSolver();
+  /* Held by a unique_ptr until it is complete, so that the error returns below
+   * do not leak the object and the SUNDIALS memory it allocated so far. */
+  std::unique_ptr<KinsolSolver> kinsolSolver(new KinsolSolver());
 
   logDebug("Create new KinsolSolver object for algebraic loop number " + std::to_string(algLoopNum));
 
@@ -392,7 +394,7 @@ oms::KinsolSolver* oms::KinsolSolver::NewKinsolSolver(const int algLoopNum, cons
     fScaleData[i] = 1.0;
   }
 
-  return kinsolSolver;
+  return kinsolSolver.release();
 }
 
 /**
@@ -488,8 +490,8 @@ oms::AlgLoop::AlgLoop(oms_alg_solver_enu_t method, double relativeTolerance, scc
 
   if (method == oms_alg_solver_kinsol)
   {
-    kinsolData = KinsolSolver::NewKinsolSolver(systNumber, SCC.connections.size(), relativeTolerance, useDirectionalDerivative);
-    if (kinsolData==NULL)
+    kinsolData.reset(KinsolSolver::NewKinsolSolver(systNumber, SCC.connections.size(), relativeTolerance, useDirectionalDerivative));
+    if (!kinsolData)
     {
       logError("NewKinsolSolver() failed. Aborting!");
       throw("AlgLoop() failed!");

--- a/src/OMSimulatorLib/AlgLoop.h
+++ b/src/OMSimulatorLib/AlgLoop.h
@@ -36,6 +36,7 @@
 #ifndef _OMS_ALGLOOP_H_
 #define _OMS_ALGLOOP_H_
 
+#include <memory>
 #include <string>
 #include <vector>
 #include "OMSimulator/Types.h"
@@ -65,24 +66,27 @@ namespace oms
     oms_status_enu_t kinsolSolve(System& syst, DirectedGraph& graph);
 
   private:
+    /* All members start out empty, so that the destructor can be run on an
+     * object NewKinsolSolver() gave up on half way through. */
+
     /* tolerances */
-    double fnormtol;        /* function tolerance */
+    double fnormtol = 0.0;  /* function tolerance */
 
     /* work arrays */
-    N_Vector initialGuess;
-    N_Vector uScale;        /* Scaling vector for u */
-    N_Vector fScale;        /* Scaling vector for f(u) */
-    N_Vector fTmp;          /* Vector used for tmp computations */
+    N_Vector initialGuess = nullptr;
+    N_Vector uScale = nullptr;        /* Scaling vector for u */
+    N_Vector fScale = nullptr;        /* Scaling vector for f(u) */
+    N_Vector fTmp = nullptr;          /* Vector used for tmp computations */
 
     /* kinsol internal data */
-    void* kinsolMemory;
-    void* user_data;
-    int size;
+    void* kinsolMemory = nullptr;
+    void* user_data = nullptr;
+    int size = 0;
 
     /* linear solver data */
-    SUNLinearSolver linSol; /* Linear solver object used by KINSOL */
-    N_Vector y;             /* Template for cloning vectors needed inside linear solver */
-    SUNMatrix J;            /* (Non-)Sparse matrix template for cloning matrices needed within linear solver */
+    SUNLinearSolver linSol = nullptr; /* Linear solver object used by KINSOL */
+    N_Vector y = nullptr;             /* Template for cloning vectors needed inside linear solver */
+    SUNMatrix J = nullptr;            /* (Non-)Sparse matrix template for cloning matrices needed within linear solver */
 
     /* member function */
     static int nlsKinsolJac(N_Vector u, N_Vector fu, SUNMatrix J, void *user_data, N_Vector tmp1, N_Vector tmp2);
@@ -105,7 +109,9 @@ namespace oms
     oms_alg_solver_enu_t algSolverMethod;
     oms_status_enu_t fixPointIteration(System& syst, DirectedGraph& graph);
 
-    KinsolSolver* kinsolData;
+    /* Owns the solver: an AlgLoop is created as a temporary and moved into
+     * System::algLoops, so the copy constructor has to stay deleted. */
+    std::unique_ptr<KinsolSolver> kinsolData;
 
     /* Loop data */
     const scc_t SCC;            ///< Strong connected components

--- a/src/OMSimulatorLib/CMakeLists.txt
+++ b/src/OMSimulatorLib/CMakeLists.txt
@@ -2,22 +2,28 @@ project(OMSimulatorLib)
 
 find_package(Threads)
 
+# GCC and Clang both work, but they are slightly different
 if (ASAN)
   set(CMAKE_BUILD_TYPE Debug)
-ENDIF ()
 
-IF (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
-  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror=uninitialized")
-ELSEIF (CMAKE_COMPILER_IS_GNUCC AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 5.1)
-  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror=uninitialized")
-  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror=return-local-addr")
-  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror=return-type")
-  if (ASAN)
-    message(STATUS "AddressSanitizer enabled")
-    add_compile_options("-fsanitize=address" "-fno-omit-frame-pointer")
-    link_libraries("-fsanitize=address")
-  ENDIF ()
-ENDIF ()
+  if ((CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 5.1) OR
+      (CMAKE_CXX_COMPILER_ID MATCHES "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 3.1))
+    message(FATAL_ERROR
+            "ASAN=ON needs GCC 5.1 or newer, or Clang 3.1 or newer, but the selected "
+            "C++ compiler is ${CMAKE_CXX_COMPILER_ID} ${CMAKE_CXX_COMPILER_VERSION} "
+            "(${CMAKE_CXX_COMPILER}). Configure with a supported compiler, e.g. "
+            "-DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++, or build without -DASAN=ON.")
+  endif ()
+
+  message(STATUS "AddressSanitizer enabled")
+  add_compile_options("-fsanitize=address" "-fno-omit-frame-pointer")
+  link_libraries("-fsanitize=address")
+endif ()
+
+# Be pedantic about potential memory issues
+SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror=uninitialized")
+SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror=return-type")
+SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror=return-local-addr")
 
 set(OMSIMULATORLIB_SOURCES
       AlgLoop.cpp

--- a/src/OMSimulatorLib/CMakeLists.txt
+++ b/src/OMSimulatorLib/CMakeLists.txt
@@ -21,9 +21,26 @@ if (ASAN)
 endif ()
 
 # Be pedantic about potential memory issues
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror=uninitialized")
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror=return-type")
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror=return-local-addr")
+if (MSVC)
+  # MSVC doesn't know -Werror=<name>, its warnings only have numbers.
+  set(OMS_MSVC_MEMORY_WARNINGS
+        4700 # uninitialized local variable used                (-Wuninitialized)
+        4701 # potentially uninitialized local variable used    (-Wmaybe-uninitialized)
+        4703 # potentially uninitialized local pointer used     (-Wmaybe-uninitialized)
+        4715 # not all control paths return a value             (-Wreturn-type)
+        4716 # must return a value                              (-Wreturn-type)
+        4172 # returning address of local variable or temporary (-Wreturn-local-addr)
+     )
+  foreach (warning IN LISTS OMS_MSVC_MEMORY_WARNINGS)
+    # /w1<n> reports the warning at the default warning level (C4701 and C4703
+    # are level 4 and would stay silent otherwise), /we<n> turns it into an error.
+    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /w1${warning} /we${warning}")
+  endforeach ()
+else ()
+  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror=uninitialized")
+  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror=return-type")
+  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror=return-local-addr")
+endif ()
 
 set(OMSIMULATORLIB_SOURCES
       AlgLoop.cpp

--- a/src/OMSimulatorLib/SystemSC.cpp
+++ b/src/OMSimulatorLib/SystemSC.cpp
@@ -319,6 +319,11 @@ oms_status_enu_t oms::SystemSC::initialize()
     event_indicators_prev.push_back((double*)calloc(nEventIndicators.back(), sizeof(double)));
    }
 
+  // Now that fmus is filled, the per-FMU flags the integrator steps write to
+  // can be sized. make_unique value-initializes them, i.e. all false.
+  callEventUpdate = std::make_unique<bool[]>(fmus.size());
+  terminateSimulation = std::make_unique<bool[]>(fmus.size());
+
   if (n_states == 0)
     logInfo("model doesn't contain any continuous state");
 
@@ -511,8 +516,8 @@ oms_status_enu_t oms::SystemSC::terminate()
   }
 
   fmus.clear();
-  delete[] callEventUpdate;
-  delete[] terminateSimulation;
+  callEventUpdate.reset();
+  terminateSimulation.reset();
   nStates.clear();
   nEventIndicators.clear();
   states.clear();
@@ -579,6 +584,8 @@ oms_status_enu_t oms::SystemSC::reset()
   for (double* ptr : event_indicators) free(ptr);
   for (double* ptr : event_indicators_prev) free(ptr);
   fmus.clear();
+  callEventUpdate.reset();
+  terminateSimulation.reset();
   nStates.clear();
   nEventIndicators.clear();
   states.clear();

--- a/src/OMSimulatorLib/SystemSC.h
+++ b/src/OMSimulatorLib/SystemSC.h
@@ -40,6 +40,8 @@
 #include "System.h"
 #include "OMSimulator/Types.h"
 
+#include <memory>
+
 #include <cvode/cvode.h>                  /* prototypes for CVODE fcts., consts. */
 #include <nvector/nvector_serial.h>       /* serial N_Vector types, fcts., macros */
 #include <sunlinsol/sunlinsol_dense.h>    /* Default dense linear solver */
@@ -90,8 +92,9 @@ namespace oms
   private:
     std::vector<Component*> fmus; // use Component Base class to support FMI 2 ME and FMI 3 ME
 
-    bool* callEventUpdate = new bool[fmus.size()](); //initialize with false
-    bool* terminateSimulation = new bool[fmus.size()](); //initialize with false
+    // One entry per FMU, allocated by initialize() once fmus is filled.
+    std::unique_ptr<bool[]> callEventUpdate;     //initialized with false
+    std::unique_ptr<bool[]> terminateSimulation; //initialized with false
 
     std::vector<size_t> nStates;
     std::vector<size_t> nEventIndicators;

--- a/testsuite/README.md
+++ b/testsuite/README.md
@@ -61,7 +61,8 @@ Special directives in the header of a test file:
 * `asan: yes`
 
   Also run the test case in an AddressSanitizer build (`-DOMS_TESTSUITE_ASAN=ON`), where all other
-  tests are skipped.
+  tests are skipped. Such a run leak checks the `OMSimulatorPython3` wrapper and the interpreter
+  as well; the leaks those report on their own are ignored through `lsan-suppressions.txt`.
 * `env: KEY=VALUE ...`
 
   Extra environment variables for the test case.

--- a/testsuite/lsan-suppressions.txt
+++ b/testsuite/lsan-suppressions.txt
@@ -1,0 +1,34 @@
+# LeakSanitizer suppressions for the AddressSanitizer testsuite runs.
+#
+# Only OMSimulator itself is built with -fsanitize=address. The tests reach it
+# through the OMSimulatorPython3 shell wrapper and an uninstrumented python3,
+# into which libasan is preloaded (see build_env() in runtest.py). Everything
+# those processes allocate is therefore leak checked as well, and none of them
+# frees its state before exiting, so every ASAN test run ends in a leak report
+# that has nothing to do with OMSimulator. The entries below drop exactly the
+# modules seen in those reports.
+#
+# A suppression matches when its text occurs in the function name, the source
+# file or the module path of ANY frame of an allocation stack, not just the
+# allocating one. That is safe here only because the frame pointer based
+# unwinder ASAN uses by default stops at the first uninstrumented frame: a leak
+# allocated inside OMSimulator gets a stack of OMSimulator frames ending in
+# libffi, and never reaches the interpreter frames matched below. Do not set
+# ASAN_OPTIONS=fast_unwind_on_malloc=0 - the deeper stacks it produces run into
+# python3 frames and every real leak would be suppressed along with the noise.
+
+# The wrapper calls readlink, dirname and uname. On this distribution those are
+# uutils coreutils, which leaks ~43 kB in each of those short lived processes.
+leak:/usr/lib/cargo/bin/coreutils/
+
+# Interpreter state that CPython does not free at exit. Matches /usr/bin/python3
+# as well as a virtualenv one, but not the extension modules under
+# /usr/lib/python3.*/, which sit between OMSimulator and the interpreter.
+leak:bin/python3
+
+# The XML libraries lxml pulls in. The reports show these below python3 frames,
+# so the entry above already covers them; they are listed separately in case a
+# stack is truncated before the interpreter frames.
+leak:/dist-packages/lxml/
+leak:libxml2.so
+leak:libxslt.so

--- a/testsuite/lsan-suppressions.txt
+++ b/testsuite/lsan-suppressions.txt
@@ -26,9 +26,12 @@ leak:/usr/lib/cargo/bin/coreutils/
 # /usr/lib/python3.*/, which sit between OMSimulator and the interpreter.
 leak:bin/python3
 
-# The XML libraries lxml pulls in. The reports show these below python3 frames,
-# so the entry above already covers them; they are listed separately in case a
-# stack is truncated before the interpreter frames.
-leak:/dist-packages/lxml/
+# The XML libraries lxml pulls in. Locally the reports show these below python3
+# frames, so the entry above already covers them, but on Jenkins lxml is a wheel
+# with libxml2/libxslt statically linked into etree.*.so and the stacks stop at
+# that module, so it has to be matched on its own. The path fragment covers both
+# a distribution install (/usr/lib/python3.*/dist-packages/lxml/) and a wheel in
+# a virtualenv (/opt/venv/lib/python3.*/site-packages/lxml/).
+leak:packages/lxml/
 leak:libxml2.so
 leak:libxslt.so

--- a/testsuite/resources/.gitignore
+++ b/testsuite/resources/.gitignore
@@ -1,2 +1,8 @@
 /*.fmu
 /*.ssp
+/*.fmutmp/
+/*.json
+/*.libs
+/*.log
+/index.html
+/*.makefile

--- a/testsuite/runtest.py
+++ b/testsuite/runtest.py
@@ -30,6 +30,9 @@ DEFAULT_EPSILON = "5e-5"
 
 SKIP_EXIT_CODE = 77
 
+# Leaks of the wrapper and the interpreter, ignored in AddressSanitizer runs.
+LSAN_SUPPRESSIONS = Path(__file__).resolve().parent / "lsan-suppressions.txt"
+
 # Metadata keys understood in the test file header, with their defaults.
 DEFAULT_INFO = {
     "status": "unknown",
@@ -214,6 +217,8 @@ def build_env(info, asan: bool) -> dict:
     # libasan has to be preloaded for the instrumented library to work.
     env["LD_PRELOAD"] = subprocess.check_output(
         ["gcc", "-print-file-name=libasan.so"]).decode().strip()
+    # Hide supressed leaks from Python wrapper and interpreter
+    env["LSAN_OPTIONS"] = "suppressions=%s:print_suppressions=0" % LSAN_SUPPRESSIONS
   for assignment in info["env"].split():
     if "=" in assignment:
       key, value = assignment.split("=", 1)

--- a/testsuite/tests/AircraftVehicleDemonstrator/acvs_simulate.py
+++ b/testsuite/tests/AircraftVehicleDemonstrator/acvs_simulate.py
@@ -3,6 +3,7 @@
 ## ucrt64: no
 ## win: no
 ## mac: no
+## asan: yes
 
 from OMSimulator import SSP, Settings, CRef, Capi
 

--- a/testsuite/tests/AircraftVehicleDemonstrator/acvs_simulate.py
+++ b/testsuite/tests/AircraftVehicleDemonstrator/acvs_simulate.py
@@ -3,7 +3,8 @@
 ## ucrt64: no
 ## win: no
 ## mac: no
-## asan: yes
+## asan: no
+## the FMUs this test loads leak memory inside their own binaries
 
 from OMSimulator import SSP, Settings, CRef, Capi
 

--- a/testsuite/tests/AircraftVehicleDemonstrator/embrace1.py
+++ b/testsuite/tests/AircraftVehicleDemonstrator/embrace1.py
@@ -3,6 +3,7 @@
 ## ucrt64: no
 ## win: no
 ## mac: no
+## asan: yes
 
 from OMSimulator import SSP, Settings, CRef, Capi
 

--- a/testsuite/tests/AircraftVehicleDemonstrator/embrace1.py
+++ b/testsuite/tests/AircraftVehicleDemonstrator/embrace1.py
@@ -3,7 +3,8 @@
 ## ucrt64: no
 ## win: no
 ## mac: no
-## asan: yes
+## asan: no
+## the ECS_HW FMU reads memory that it freed itself (setlocale)
 
 from OMSimulator import SSP, Settings, CRef, Capi
 

--- a/testsuite/tests/AircraftVehicleDemonstrator/embrace2.py
+++ b/testsuite/tests/AircraftVehicleDemonstrator/embrace2.py
@@ -3,6 +3,7 @@
 ## ucrt64: no
 ## win: no
 ## mac: no
+## asan: yes
 
 from OMSimulator import SSP, Settings, CRef, Capi
 

--- a/testsuite/tests/AircraftVehicleDemonstrator/embrace2.py
+++ b/testsuite/tests/AircraftVehicleDemonstrator/embrace2.py
@@ -3,7 +3,8 @@
 ## ucrt64: no
 ## win: no
 ## mac: no
-## asan: yes
+## asan: no
+## the ECS_HW FMU reads memory that it freed itself (setlocale)
 
 from OMSimulator import SSP, Settings, CRef, Capi
 

--- a/testsuite/tests/CompositeModels/FeedthroughConnections.py
+++ b/testsuite/tests/CompositeModels/FeedthroughConnections.py
@@ -3,6 +3,7 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
+## asan: yes
 
 
 from OMSimulator import SSP, CRef, Settings

--- a/testsuite/tests/CompositeModels/FeedthroughSetValue1.py
+++ b/testsuite/tests/CompositeModels/FeedthroughSetValue1.py
@@ -6,7 +6,6 @@
 ## asan: yes
 
 
-from numpy import uint64
 from OMSimulator import SSP, CRef, Settings, Float64, Float32, Int8, Int16, Int32, Int64, UInt8, UInt16, UInt32, UInt64
 
 Settings.suppressPath = True

--- a/testsuite/tests/CompositeModels/FeedthroughSetValue1.py
+++ b/testsuite/tests/CompositeModels/FeedthroughSetValue1.py
@@ -3,6 +3,7 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
+## asan: yes
 
 
 from numpy import uint64

--- a/testsuite/tests/CompositeModels/FeedthroughSetValue2.py
+++ b/testsuite/tests/CompositeModels/FeedthroughSetValue2.py
@@ -3,6 +3,7 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
+## asan: yes
 
 
 from numpy import uint64

--- a/testsuite/tests/CompositeModels/FeedthroughSetValue2.py
+++ b/testsuite/tests/CompositeModels/FeedthroughSetValue2.py
@@ -6,7 +6,6 @@
 ## asan: yes
 
 
-from numpy import uint64
 from OMSimulator import SSP, SSV, CRef, Settings, Float64, Float32, Int8, Int16, Int32, Int64, UInt8, UInt16, UInt32, UInt64
 
 Settings.suppressPath = True

--- a/testsuite/tests/CompositeModels/connectFmi2AndFmi3.py
+++ b/testsuite/tests/CompositeModels/connectFmi2AndFmi3.py
@@ -3,6 +3,7 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
+## asan: yes
 
 
 from OMSimulator import SSP, CRef, Settings

--- a/testsuite/tests/api/LOC.py
+++ b/testsuite/tests/api/LOC.py
@@ -3,6 +3,7 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
+## asan: yes
 
 from OMSimulator import SSD, Settings
 

--- a/testsuite/tests/api/NestedSystem.py
+++ b/testsuite/tests/api/NestedSystem.py
@@ -3,6 +3,7 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
+## asan: yes
 
 from OMSimulator import SSP, CRef, Settings
 

--- a/testsuite/tests/api/NewSSP.py
+++ b/testsuite/tests/api/NewSSP.py
@@ -3,6 +3,7 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
+## asan: yes
 
 import logging
 logging.basicConfig(level=logging.INFO)

--- a/testsuite/tests/api/NewSSP2.py
+++ b/testsuite/tests/api/NewSSP2.py
@@ -3,6 +3,7 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
+## asan: yes
 
 import logging
 logging.basicConfig(level=logging.INFO)

--- a/testsuite/tests/api/NewSSP3.py
+++ b/testsuite/tests/api/NewSSP3.py
@@ -3,6 +3,7 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
+## asan: yes
 
 from OMSimulator import SSP, CRef, Settings
 

--- a/testsuite/tests/api/ReplaceComponent1.py
+++ b/testsuite/tests/api/ReplaceComponent1.py
@@ -3,6 +3,7 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
+## asan: yes
 
 
 from OMSimulator import SSP, CRef, Settings

--- a/testsuite/tests/api/ResultReader.py
+++ b/testsuite/tests/api/ResultReader.py
@@ -3,6 +3,7 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
+## asan: yes
 
 from OMSimulator import SSP, CRef, Settings
 

--- a/testsuite/tests/api/addMetaData.py
+++ b/testsuite/tests/api/addMetaData.py
@@ -3,6 +3,7 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
+## asan: yes
 
 from OMSimulator import SSP, CRef, Settings, SSV, SignalType
 

--- a/testsuite/tests/api/create_ssp_file.py
+++ b/testsuite/tests/api/create_ssp_file.py
@@ -3,6 +3,7 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
+## asan: yes
 
 import logging
 logging.basicConfig(level=logging.INFO)

--- a/testsuite/tests/api/cref.py
+++ b/testsuite/tests/api/cref.py
@@ -4,6 +4,7 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
+## asan: yes
 
 from OMSimulator import CRef
 

--- a/testsuite/tests/api/deleteConnector1.py
+++ b/testsuite/tests/api/deleteConnector1.py
@@ -3,6 +3,7 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
+## asan: yes
 
 from OMSimulator import SSP, CRef, Settings, Connector, Causality, SignalType
 

--- a/testsuite/tests/api/deleteResources1.py
+++ b/testsuite/tests/api/deleteResources1.py
@@ -3,6 +3,7 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
+## asan: yes
 
 from OMSimulator import SSP, CRef, Settings, SSV, SignalType
 

--- a/testsuite/tests/api/deleteSystem1.py
+++ b/testsuite/tests/api/deleteSystem1.py
@@ -3,6 +3,7 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
+## asan: yes
 
 from OMSimulator import SSP, CRef, Settings, Connector, Causality, SignalType
 

--- a/testsuite/tests/api/duplicateVariant1.py
+++ b/testsuite/tests/api/duplicateVariant1.py
@@ -3,6 +3,7 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
+## asan: yes
 
 
 from OMSimulator import SSD, SSP, Settings, CRef

--- a/testsuite/tests/api/duplicateVariant2.py
+++ b/testsuite/tests/api/duplicateVariant2.py
@@ -3,6 +3,7 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
+## asan: yes
 
 
 from OMSimulator import SSD, SSP, Settings, CRef

--- a/testsuite/tests/api/enumTest1.py
+++ b/testsuite/tests/api/enumTest1.py
@@ -3,6 +3,7 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
+## asan: yes
 
 from OMSimulator import SSP, CRef, Settings
 

--- a/testsuite/tests/api/exportSSMTemplate1.py
+++ b/testsuite/tests/api/exportSSMTemplate1.py
@@ -3,6 +3,7 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
+## asan: yes
 
 from OMSimulator import SSP, CRef, Settings, Connector, Causality, SignalType
 

--- a/testsuite/tests/api/exportSSMTemplate2.py
+++ b/testsuite/tests/api/exportSSMTemplate2.py
@@ -3,6 +3,7 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
+## asan: yes
 
 from OMSimulator import FMU, Settings
 

--- a/testsuite/tests/api/exportSSVTemplate1.py
+++ b/testsuite/tests/api/exportSSVTemplate1.py
@@ -3,6 +3,7 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
+## asan: yes
 
 from OMSimulator import SSP, CRef, Settings, Connector, Causality, SignalType
 

--- a/testsuite/tests/api/exportSSVTemplate2.py
+++ b/testsuite/tests/api/exportSSVTemplate2.py
@@ -3,6 +3,7 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
+## asan: yes
 
 from OMSimulator import FMU, Settings
 

--- a/testsuite/tests/api/fmuinfo.py
+++ b/testsuite/tests/api/fmuinfo.py
@@ -3,6 +3,7 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
+## asan: yes
 
 from OMSimulator import FMU, Variable, SignalType, Causality
 

--- a/testsuite/tests/api/invalidSSD.py
+++ b/testsuite/tests/api/invalidSSD.py
@@ -3,6 +3,7 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
+## asan: yes
 
 ## This example demonstrates how to export an SSD file from an SSP file.
 ## the main purpose of this example is to parse all the elements in the SSD file

--- a/testsuite/tests/api/invalidSSV.py
+++ b/testsuite/tests/api/invalidSSV.py
@@ -3,6 +3,7 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
+## asan: yes
 
 ## This example demonstrates how to export an SSD file from an SSP file.
 ## the main purpose of this example is to parse all the elements in the SSD file

--- a/testsuite/tests/api/listSSVReference1.py
+++ b/testsuite/tests/api/listSSVReference1.py
@@ -3,6 +3,7 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
+## asan: yes
 
 from OMSimulator import SSP, CRef, Settings, SSV, SignalType
 

--- a/testsuite/tests/api/rename1.py
+++ b/testsuite/tests/api/rename1.py
@@ -3,6 +3,7 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
+## asan: yes
 
 from OMSimulator import SSP, CRef, Settings, Connector, Causality, SignalType
 

--- a/testsuite/tests/api/setMappingSSM1.py
+++ b/testsuite/tests/api/setMappingSSM1.py
@@ -3,6 +3,7 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
+## asan: yes
 
 from OMSimulator import SSP, CRef, Settings, SSV, SSM
 

--- a/testsuite/tests/api/setMappingSSM2.py
+++ b/testsuite/tests/api/setMappingSSM2.py
@@ -3,6 +3,7 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
+## asan: yes
 
 from OMSimulator import SSP, CRef, Settings, SSV, SSM, Connector, Causality, SignalType
 

--- a/testsuite/tests/api/setMappingSSM3.py
+++ b/testsuite/tests/api/setMappingSSM3.py
@@ -3,6 +3,7 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
+## asan: yes
 
 from OMSimulator import SSP, CRef, Settings, Connector, Causality, SignalType
 

--- a/testsuite/tests/api/setSolver1.py
+++ b/testsuite/tests/api/setSolver1.py
@@ -3,6 +3,7 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
+## asan: yes
 
 from OMSimulator import SSP, CRef, Settings
 

--- a/testsuite/tests/api/setSolver2.py
+++ b/testsuite/tests/api/setSolver2.py
@@ -3,6 +3,7 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
+## asan: yes
 
 from OMSimulator import SSP, CRef, Settings
 

--- a/testsuite/tests/api/setValue1.py
+++ b/testsuite/tests/api/setValue1.py
@@ -3,6 +3,7 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
+## asan: yes
 
 from OMSimulator import SSP, CRef, Settings
 

--- a/testsuite/tests/api/setValue2.py
+++ b/testsuite/tests/api/setValue2.py
@@ -3,6 +3,7 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
+## asan: yes
 
 from OMSimulator import SSP, CRef, Settings
 

--- a/testsuite/tests/api/setValue3.py
+++ b/testsuite/tests/api/setValue3.py
@@ -3,6 +3,7 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
+## asan: yes
 
 from OMSimulator import SSP, CRef, Settings
 

--- a/testsuite/tests/api/setValue4.py
+++ b/testsuite/tests/api/setValue4.py
@@ -3,6 +3,7 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
+## asan: yes
 
 from OMSimulator import SSP, CRef, Settings, Connector, Causality, SignalType
 

--- a/testsuite/tests/api/setValueSSV1.py
+++ b/testsuite/tests/api/setValueSSV1.py
@@ -3,6 +3,7 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
+## asan: yes
 
 from OMSimulator import SSP, CRef, Settings, SSV, SignalType
 

--- a/testsuite/tests/api/setValueSSV2.py
+++ b/testsuite/tests/api/setValueSSV2.py
@@ -3,6 +3,7 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
+## asan: yes
 
 from OMSimulator import SSP, CRef, Settings, SSV, SignalType
 

--- a/testsuite/tests/api/setValueSSV3.py
+++ b/testsuite/tests/api/setValueSSV3.py
@@ -3,6 +3,7 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
+## asan: yes
 
 from OMSimulator import SSP, CRef, Settings, SSV, Connector, Causality, SignalType
 

--- a/testsuite/tests/api/swapSSV1.py
+++ b/testsuite/tests/api/swapSSV1.py
@@ -3,6 +3,7 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
+## asan: yes
 
 from OMSimulator import SSP, CRef, Settings, SSV, SignalType
 

--- a/testsuite/tests/api/swapSSV2.py
+++ b/testsuite/tests/api/swapSSV2.py
@@ -3,6 +3,7 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
+## asan: yes
 
 from OMSimulator import SSP, CRef, Settings, SSV, Connector, Causality, SignalType
 

--- a/testsuite/tests/api/swapSSV3.py
+++ b/testsuite/tests/api/swapSSV3.py
@@ -3,6 +3,7 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
+## asan: yes
 
 from OMSimulator import SSP, CRef, Settings, SSV, Connector, Causality, SignalType
 

--- a/testsuite/tests/api/swapSSV4.py
+++ b/testsuite/tests/api/swapSSV4.py
@@ -3,6 +3,7 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
+## asan: yes
 
 from OMSimulator import SSP, CRef, Settings, SSV, SignalType
 

--- a/testsuite/tests/dcmotor/dcmotor.py
+++ b/testsuite/tests/dcmotor/dcmotor.py
@@ -3,7 +3,8 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
-## asan: yes
+## asan: no
+## the FMUs this test loads leak memory inside their own binaries
 
 ## This example demonstrates how to export an SSD file from an SSP file.
 ## the main purpose of this example is to parse all the elements in the SSD file

--- a/testsuite/tests/dcmotor/dcmotor.py
+++ b/testsuite/tests/dcmotor/dcmotor.py
@@ -3,6 +3,7 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
+## asan: yes
 
 ## This example demonstrates how to export an SSD file from an SSP file.
 ## the main purpose of this example is to parse all the elements in the SSD file

--- a/testsuite/tests/dcmotor/dcmotorMETest.py
+++ b/testsuite/tests/dcmotor/dcmotorMETest.py
@@ -3,6 +3,7 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
+## asan: yes
 
 ## This example test dc motors fmu's with ME solver
 

--- a/testsuite/tests/dcmotor/dcmotorMETest.py
+++ b/testsuite/tests/dcmotor/dcmotorMETest.py
@@ -3,7 +3,8 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
-## asan: yes
+## asan: no
+## the FMUs this test loads leak memory inside their own binaries
 
 ## This example test dc motors fmu's with ME solver
 

--- a/testsuite/tests/parker/ParkerSim.py
+++ b/testsuite/tests/parker/ParkerSim.py
@@ -3,6 +3,7 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
+## asan: yes
 
 import logging
 logging.basicConfig(level=logging.INFO)

--- a/testsuite/tests/reference-fmus/2.0/cs/BouncingBall-cs.py
+++ b/testsuite/tests/reference-fmus/2.0/cs/BouncingBall-cs.py
@@ -2,7 +2,7 @@
 ## linux: yes
 ## ucrt64: yes
 ## win: yes
-## asan: no
+## asan: yes
 
 from OMSimulator import SSP, CRef, Settings, Capi
 Settings.suppressPath = True

--- a/testsuite/tests/reference-fmus/2.0/cs/Dahlquist-cs.py
+++ b/testsuite/tests/reference-fmus/2.0/cs/Dahlquist-cs.py
@@ -2,7 +2,7 @@
 ## linux: yes
 ## ucrt64: yes
 ## win: yes
-## asan: no
+## asan: yes
 
 from OMSimulator import SSP, CRef, Settings, Capi
 Settings.suppressPath = True

--- a/testsuite/tests/reference-fmus/2.0/cs/Feedthrough-cs.py
+++ b/testsuite/tests/reference-fmus/2.0/cs/Feedthrough-cs.py
@@ -2,7 +2,7 @@
 ## linux: yes
 ## ucrt64: yes
 ## win: yes
-## asan: no
+## asan: yes
 
 from OMSimulator import SSP, CRef, Settings
 Settings.suppressPath = True

--- a/testsuite/tests/reference-fmus/2.0/cs/Resource-cs.py
+++ b/testsuite/tests/reference-fmus/2.0/cs/Resource-cs.py
@@ -2,7 +2,7 @@
 ## linux: yes
 ## ucrt64: yes
 ## win: yes
-## asan: no
+## asan: yes
 
 from OMSimulator import SSP, CRef, Settings
 Settings.suppressPath = True

--- a/testsuite/tests/reference-fmus/2.0/cs/Stair-cs.py
+++ b/testsuite/tests/reference-fmus/2.0/cs/Stair-cs.py
@@ -2,7 +2,7 @@
 ## linux: yes
 ## ucrt64: yes
 ## win: yes
-## asan: no
+## asan: yes
 
 from OMSimulator import SSP, CRef, Settings, Capi
 Settings.suppressPath = True

--- a/testsuite/tests/reference-fmus/2.0/cs/VanDerPol-cs.py
+++ b/testsuite/tests/reference-fmus/2.0/cs/VanDerPol-cs.py
@@ -2,7 +2,7 @@
 ## linux: yes
 ## ucrt64: yes
 ## win: yes
-## asan: no
+## asan: yes
 
 from OMSimulator import SSP, CRef, Settings, Capi
 Settings.suppressPath = True

--- a/testsuite/tests/reference-fmus/2.0/me/BouncingBall-me.py
+++ b/testsuite/tests/reference-fmus/2.0/me/BouncingBall-me.py
@@ -2,7 +2,7 @@
 ## linux: yes
 ## ucrt64: yes
 ## win: yes
-## asan: no
+## asan: yes
 
 from OMSimulator import SSP, CRef, Settings, Capi
 Settings.suppressPath = True

--- a/testsuite/tests/reference-fmus/2.0/me/Dahlquist-me.py
+++ b/testsuite/tests/reference-fmus/2.0/me/Dahlquist-me.py
@@ -2,7 +2,7 @@
 ## linux: yes
 ## ucrt64: yes
 ## win: yes
-## asan: no
+## asan: yes
 
 from OMSimulator import SSP, CRef, Settings, Capi
 Settings.suppressPath = True

--- a/testsuite/tests/reference-fmus/2.0/me/Feedthrough-me.py
+++ b/testsuite/tests/reference-fmus/2.0/me/Feedthrough-me.py
@@ -2,7 +2,7 @@
 ## linux: yes
 ## ucrt64: yes
 ## win: yes
-## asan: no
+## asan: yes
 
 from OMSimulator import SSP, CRef, Settings
 Settings.suppressPath = True

--- a/testsuite/tests/reference-fmus/2.0/me/Resource-me.py
+++ b/testsuite/tests/reference-fmus/2.0/me/Resource-me.py
@@ -2,7 +2,7 @@
 ## linux: yes
 ## ucrt64: yes
 ## win: yes
-## asan: no
+## asan: yes
 
 from OMSimulator import SSP, CRef, Settings
 Settings.suppressPath = True

--- a/testsuite/tests/reference-fmus/2.0/me/Stair-me-events.py
+++ b/testsuite/tests/reference-fmus/2.0/me/Stair-me-events.py
@@ -2,7 +2,7 @@
 ## linux: yes
 ## ucrt64: yes
 ## win: yes
-## asan: no
+## asan: yes
 
 # Every time event has to be stored as exactly two data points, the value before
 # and the value after the event. The output grid is accumulated in floating-point

--- a/testsuite/tests/reference-fmus/2.0/me/Stair-me.py
+++ b/testsuite/tests/reference-fmus/2.0/me/Stair-me.py
@@ -2,7 +2,7 @@
 ## linux: yes
 ## ucrt64: yes
 ## win: yes
-## asan: no
+## asan: yes
 
 from OMSimulator import SSP, CRef, Settings, Capi
 Settings.suppressPath = True

--- a/testsuite/tests/reference-fmus/2.0/me/VanDerPol-me.py
+++ b/testsuite/tests/reference-fmus/2.0/me/VanDerPol-me.py
@@ -2,7 +2,7 @@
 ## linux: yes
 ## ucrt64: yes
 ## win: yes
-## asan: no
+## asan: yes
 
 from OMSimulator import SSP, CRef, Settings, Capi
 Settings.suppressPath = True

--- a/testsuite/tests/reference-fmus/3.0/cs/BouncingBall-cs.py
+++ b/testsuite/tests/reference-fmus/3.0/cs/BouncingBall-cs.py
@@ -2,7 +2,7 @@
 ## linux: yes
 ## ucrt64: yes
 ## win: yes
-## asan: no
+## asan: yes
 
 from OMSimulator import SSP, CRef, Settings, Capi
 Settings.suppressPath = True

--- a/testsuite/tests/reference-fmus/3.0/cs/Dahlquist-cs.py
+++ b/testsuite/tests/reference-fmus/3.0/cs/Dahlquist-cs.py
@@ -2,7 +2,7 @@
 ## linux: yes
 ## ucrt64: yes
 ## win: yes
-## asan: no
+## asan: yes
 
 from OMSimulator import SSP, CRef, Settings, Capi
 Settings.suppressPath = True

--- a/testsuite/tests/reference-fmus/3.0/cs/Feedthrough-cs.py
+++ b/testsuite/tests/reference-fmus/3.0/cs/Feedthrough-cs.py
@@ -2,7 +2,7 @@
 ## linux: yes
 ## ucrt64: yes
 ## win: yes
-## asan: no
+## asan: yes
 
 from OMSimulator import SSP, CRef, Settings
 Settings.suppressPath = True

--- a/testsuite/tests/reference-fmus/3.0/cs/Resource-cs.py
+++ b/testsuite/tests/reference-fmus/3.0/cs/Resource-cs.py
@@ -2,7 +2,7 @@
 ## linux: yes
 ## ucrt64: yes
 ## win: yes
-## asan: no
+## asan: yes
 
 from OMSimulator import SSP, CRef, Settings
 Settings.suppressPath = True

--- a/testsuite/tests/reference-fmus/3.0/cs/Stair-cs.py
+++ b/testsuite/tests/reference-fmus/3.0/cs/Stair-cs.py
@@ -2,7 +2,7 @@
 ## linux: yes
 ## ucrt64: yes
 ## win: yes
-## asan: no
+## asan: yes
 
 from OMSimulator import SSP, CRef, Settings, Capi
 Settings.suppressPath = True

--- a/testsuite/tests/reference-fmus/3.0/cs/VanDerPol-cs.py
+++ b/testsuite/tests/reference-fmus/3.0/cs/VanDerPol-cs.py
@@ -2,7 +2,7 @@
 ## linux: yes
 ## ucrt64: yes
 ## win: yes
-## asan: no
+## asan: yes
 
 from OMSimulator import SSP, CRef, Settings, Capi
 Settings.suppressPath = True

--- a/testsuite/tests/reference-fmus/3.0/me/BouncingBall-me.py
+++ b/testsuite/tests/reference-fmus/3.0/me/BouncingBall-me.py
@@ -2,7 +2,7 @@
 ## linux: yes
 ## ucrt64: yes
 ## win: yes
-## asan: no
+## asan: yes
 
 from OMSimulator import SSP, CRef, Settings, Capi
 Settings.suppressPath = True

--- a/testsuite/tests/reference-fmus/3.0/me/Dahlquist-me.py
+++ b/testsuite/tests/reference-fmus/3.0/me/Dahlquist-me.py
@@ -2,7 +2,7 @@
 ## linux: yes
 ## ucrt64: yes
 ## win: yes
-## asan: no
+## asan: yes
 
 from OMSimulator import SSP, CRef, Settings, Capi
 Settings.suppressPath = True

--- a/testsuite/tests/reference-fmus/3.0/me/Feedthrough-me.py
+++ b/testsuite/tests/reference-fmus/3.0/me/Feedthrough-me.py
@@ -2,7 +2,7 @@
 ## linux: yes
 ## ucrt64: yes
 ## win: yes
-## asan: no
+## asan: yes
 
 from OMSimulator import SSP, CRef, Settings
 Settings.suppressPath = True

--- a/testsuite/tests/reference-fmus/3.0/me/Resource-me.py
+++ b/testsuite/tests/reference-fmus/3.0/me/Resource-me.py
@@ -2,7 +2,7 @@
 ## linux: yes
 ## ucrt64: yes
 ## win: yes
-## asan: no
+## asan: yes
 
 from OMSimulator import SSP, CRef, Settings
 Settings.suppressPath = True

--- a/testsuite/tests/reference-fmus/3.0/me/Stair-me.py
+++ b/testsuite/tests/reference-fmus/3.0/me/Stair-me.py
@@ -2,7 +2,7 @@
 ## linux: yes
 ## ucrt64: yes
 ## win: yes
-## asan: no
+## asan: yes
 
 from OMSimulator import SSP, CRef, Settings, Capi
 Settings.suppressPath = True

--- a/testsuite/tests/reference-fmus/3.0/me/VanDerPol-me.py
+++ b/testsuite/tests/reference-fmus/3.0/me/VanDerPol-me.py
@@ -2,7 +2,7 @@
 ## linux: yes
 ## ucrt64: yes
 ## win: yes
-## asan: no
+## asan: yes
 
 from OMSimulator import SSP, CRef, Settings, Capi
 Settings.suppressPath = True

--- a/testsuite/tests/simulation/DualMassOscillator1.py
+++ b/testsuite/tests/simulation/DualMassOscillator1.py
@@ -3,6 +3,7 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
+## asan: yes
 
 from OMSimulator import SSP, CRef, Settings
 

--- a/testsuite/tests/simulation/DualMassOscillator1.py
+++ b/testsuite/tests/simulation/DualMassOscillator1.py
@@ -3,7 +3,8 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
-## asan: yes
+## asan: no
+## the FMUs this test loads leak memory inside their own binaries
 
 from OMSimulator import SSP, CRef, Settings
 

--- a/testsuite/tests/simulation/DualMassOscillator2.py
+++ b/testsuite/tests/simulation/DualMassOscillator2.py
@@ -3,6 +3,7 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
+## asan: yes
 
 from OMSimulator import SSP, CRef, Settings
 

--- a/testsuite/tests/simulation/DualMassOscillator2.py
+++ b/testsuite/tests/simulation/DualMassOscillator2.py
@@ -3,7 +3,8 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
-## asan: yes
+## asan: no
+## the FMUs this test loads leak memory inside their own binaries
 
 from OMSimulator import SSP, CRef, Settings
 

--- a/testsuite/tests/simulation/LinearTransformation1.py
+++ b/testsuite/tests/simulation/LinearTransformation1.py
@@ -3,6 +3,7 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
+## asan: yes
 
 from OMSimulator import SSP, CRef, Settings
 

--- a/testsuite/tests/simulation/LinearTransformation2.py
+++ b/testsuite/tests/simulation/LinearTransformation2.py
@@ -3,6 +3,7 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
+## asan: yes
 
 from OMSimulator import SSP, CRef, Settings
 

--- a/testsuite/tests/simulation/LinearTransformation3.py
+++ b/testsuite/tests/simulation/LinearTransformation3.py
@@ -3,7 +3,8 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
-## asan: yes
+## asan: no
+## the FMUs this test loads leak memory inside their own binaries
 
 from OMSimulator import SSP, CRef, Settings, Connector, Causality, SignalType, SSV, SSM
 

--- a/testsuite/tests/simulation/LinearTransformation3.py
+++ b/testsuite/tests/simulation/LinearTransformation3.py
@@ -3,6 +3,7 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
+## asan: yes
 
 from OMSimulator import SSP, CRef, Settings, Connector, Causality, SignalType, SSV, SSM
 

--- a/testsuite/tests/simulation/NestedSystemSimulation1.py
+++ b/testsuite/tests/simulation/NestedSystemSimulation1.py
@@ -3,7 +3,8 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
-## asan: yes
+## asan: no
+## the FMUs this test loads leak memory inside their own binaries
 
 from OMSimulator import SSP, CRef, Settings, Connector, Causality, SignalType
 

--- a/testsuite/tests/simulation/NestedSystemSimulation1.py
+++ b/testsuite/tests/simulation/NestedSystemSimulation1.py
@@ -3,6 +3,7 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
+## asan: yes
 
 from OMSimulator import SSP, CRef, Settings, Connector, Causality, SignalType
 

--- a/testsuite/tests/simulation/NestedSystemSimulation2.py
+++ b/testsuite/tests/simulation/NestedSystemSimulation2.py
@@ -3,6 +3,7 @@
 ## ucrt64: yes
 ## win: no
 ## mac: no
+## asan: yes
 
 from OMSimulator import SSP, CRef, Settings, Connector, Causality, SignalType
 

--- a/testsuite/tests/simulation/NestedSystemSimulation2.py
+++ b/testsuite/tests/simulation/NestedSystemSimulation2.py
@@ -3,7 +3,8 @@
 ## ucrt64: yes
 ## win: no
 ## mac: no
-## asan: yes
+## asan: no
+## the FMUs this test loads leak memory inside their own binaries
 
 from OMSimulator import SSP, CRef, Settings, Connector, Causality, SignalType
 

--- a/testsuite/tests/simulation/NestedSystemSimulation3.py
+++ b/testsuite/tests/simulation/NestedSystemSimulation3.py
@@ -3,7 +3,8 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
-## asan: yes
+## asan: no
+## the FMUs this test loads leak memory inside their own binaries
 
 from OMSimulator import SSP, CRef, Settings, Connector, Causality, SignalType
 

--- a/testsuite/tests/simulation/NestedSystemSimulation3.py
+++ b/testsuite/tests/simulation/NestedSystemSimulation3.py
@@ -3,6 +3,7 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
+## asan: yes
 
 from OMSimulator import SSP, CRef, Settings, Connector, Causality, SignalType
 

--- a/testsuite/tests/simulation/QuarterCarModel.py
+++ b/testsuite/tests/simulation/QuarterCarModel.py
@@ -3,6 +3,7 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
+## asan: yes
 
 from OMSimulator import SSP, CRef, Settings
 

--- a/testsuite/tests/simulation/QuarterCarModel.py
+++ b/testsuite/tests/simulation/QuarterCarModel.py
@@ -3,7 +3,8 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
-## asan: yes
+## asan: no
+## the FMUs this test loads leak memory inside their own binaries
 
 from OMSimulator import SSP, CRef, Settings
 

--- a/testsuite/tests/simulation/SimpleSimulation10.py
+++ b/testsuite/tests/simulation/SimpleSimulation10.py
@@ -3,6 +3,7 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
+## asan: yes
 
 from OMSimulator import SSP, CRef, Settings, Connector, Causality, SignalType, SSV
 

--- a/testsuite/tests/simulation/SimpleSimulation10.py
+++ b/testsuite/tests/simulation/SimpleSimulation10.py
@@ -3,7 +3,8 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
-## asan: yes
+## asan: no
+## the FMUs this test loads leak memory inside their own binaries
 
 from OMSimulator import SSP, CRef, Settings, Connector, Causality, SignalType, SSV
 

--- a/testsuite/tests/simulation/SimpleSimulation11.py
+++ b/testsuite/tests/simulation/SimpleSimulation11.py
@@ -3,7 +3,8 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
-## asan: yes
+## asan: no
+## the FMUs this test loads leak memory inside their own binaries
 
 from OMSimulator import SSP, CRef, Settings, Connector, Causality, SignalType, SSV, SSM
 

--- a/testsuite/tests/simulation/SimpleSimulation11.py
+++ b/testsuite/tests/simulation/SimpleSimulation11.py
@@ -3,6 +3,7 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
+## asan: yes
 
 from OMSimulator import SSP, CRef, Settings, Connector, Causality, SignalType, SSV, SSM
 

--- a/testsuite/tests/simulation/SimpleSimulation12.py
+++ b/testsuite/tests/simulation/SimpleSimulation12.py
@@ -3,7 +3,8 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
-## asan: yes
+## asan: no
+## the FMUs this test loads leak memory inside their own binaries
 
 from OMSimulator import SSP, CRef, Settings, Connector, Causality, SignalType, SSV, SSM
 

--- a/testsuite/tests/simulation/SimpleSimulation12.py
+++ b/testsuite/tests/simulation/SimpleSimulation12.py
@@ -3,6 +3,7 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
+## asan: yes
 
 from OMSimulator import SSP, CRef, Settings, Connector, Causality, SignalType, SSV, SSM
 

--- a/testsuite/tests/simulation/SimpleSimulation13.py
+++ b/testsuite/tests/simulation/SimpleSimulation13.py
@@ -3,7 +3,8 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
-## asan: yes
+## asan: no
+## the FMUs this test loads leak memory inside their own binaries
 
 from OMSimulator import SSP, CRef, Settings, Connector, Causality, SignalType, SSV, SSM
 

--- a/testsuite/tests/simulation/SimpleSimulation13.py
+++ b/testsuite/tests/simulation/SimpleSimulation13.py
@@ -3,6 +3,7 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
+## asan: yes
 
 from OMSimulator import SSP, CRef, Settings, Connector, Causality, SignalType, SSV, SSM
 

--- a/testsuite/tests/simulation/SimpleSimulation14.py
+++ b/testsuite/tests/simulation/SimpleSimulation14.py
@@ -3,7 +3,8 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
-## asan: yes
+## asan: no
+## the FMUs this test loads leak memory inside their own binaries
 
 from OMSimulator import SSP, CRef, Settings, Connector, Causality, SignalType
 

--- a/testsuite/tests/simulation/SimpleSimulation14.py
+++ b/testsuite/tests/simulation/SimpleSimulation14.py
@@ -3,6 +3,7 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
+## asan: yes
 
 from OMSimulator import SSP, CRef, Settings, Connector, Causality, SignalType
 

--- a/testsuite/tests/simulation/SimpleSimulation15.py
+++ b/testsuite/tests/simulation/SimpleSimulation15.py
@@ -3,6 +3,7 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
+## asan: yes
 
 from OMSimulator import SSP, CRef, Connector, Causality, SignalType
 

--- a/testsuite/tests/simulation/SimpleSimulation16.py
+++ b/testsuite/tests/simulation/SimpleSimulation16.py
@@ -3,6 +3,7 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
+## asan: yes
 
 from OMSimulator import SSP, CRef, Connector, Causality, SignalType
 

--- a/testsuite/tests/simulation/SimpleSimulation17.py
+++ b/testsuite/tests/simulation/SimpleSimulation17.py
@@ -3,6 +3,7 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
+## asan: yes
 
 from OMSimulator import SSP, CRef, Settings, Connector, Causality, SignalType
 

--- a/testsuite/tests/simulation/SimpleSimulation2.py
+++ b/testsuite/tests/simulation/SimpleSimulation2.py
@@ -3,6 +3,7 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
+## asan: yes
 
 from OMSimulator import SSP, CRef, Settings
 

--- a/testsuite/tests/simulation/SimpleSimulation3.py
+++ b/testsuite/tests/simulation/SimpleSimulation3.py
@@ -3,6 +3,7 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
+## asan: yes
 
 from OMSimulator import SSP, CRef, Settings
 

--- a/testsuite/tests/simulation/SimpleSimulation5.py
+++ b/testsuite/tests/simulation/SimpleSimulation5.py
@@ -3,6 +3,7 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
+## asan: yes
 
 from OMSimulator import SSP, CRef, Settings
 

--- a/testsuite/tests/simulation/SimpleSimulation5.py
+++ b/testsuite/tests/simulation/SimpleSimulation5.py
@@ -3,7 +3,8 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
-## asan: yes
+## asan: no
+## the FMUs this test loads leak memory inside their own binaries
 
 from OMSimulator import SSP, CRef, Settings
 

--- a/testsuite/tests/simulation/SimpleSimulation6.py
+++ b/testsuite/tests/simulation/SimpleSimulation6.py
@@ -3,7 +3,8 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
-## asan: yes
+## asan: no
+## the FMUs this test loads leak memory inside their own binaries
 
 from OMSimulator import SSP, CRef, Settings, Connector, Causality, SignalType
 

--- a/testsuite/tests/simulation/SimpleSimulation6.py
+++ b/testsuite/tests/simulation/SimpleSimulation6.py
@@ -3,6 +3,7 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
+## asan: yes
 
 from OMSimulator import SSP, CRef, Settings, Connector, Causality, SignalType
 

--- a/testsuite/tests/simulation/SimpleSimulation7.py
+++ b/testsuite/tests/simulation/SimpleSimulation7.py
@@ -3,7 +3,8 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
-## asan: yes
+## asan: no
+## the FMUs this test loads leak memory inside their own binaries
 
 from OMSimulator import SSP, CRef, Settings, Connector, Causality, SignalType
 

--- a/testsuite/tests/simulation/SimpleSimulation7.py
+++ b/testsuite/tests/simulation/SimpleSimulation7.py
@@ -3,6 +3,7 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
+## asan: yes
 
 from OMSimulator import SSP, CRef, Settings, Connector, Causality, SignalType
 

--- a/testsuite/tests/simulation/SimpleSimulation8.py
+++ b/testsuite/tests/simulation/SimpleSimulation8.py
@@ -3,7 +3,8 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
-## asan: yes
+## asan: no
+## the FMUs this test loads leak memory inside their own binaries
 
 from OMSimulator import SSP, CRef, Settings, Connector, Causality, SignalType
 

--- a/testsuite/tests/simulation/SimpleSimulation8.py
+++ b/testsuite/tests/simulation/SimpleSimulation8.py
@@ -3,6 +3,7 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
+## asan: yes
 
 from OMSimulator import SSP, CRef, Settings, Connector, Causality, SignalType
 

--- a/testsuite/tests/simulation/SimpleSimulation9.py
+++ b/testsuite/tests/simulation/SimpleSimulation9.py
@@ -3,6 +3,7 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
+## asan: yes
 
 from OMSimulator import SSP, CRef, Settings, Connector, Causality, SignalType, SSV
 

--- a/testsuite/tests/simulation/SimpleSimulation9.py
+++ b/testsuite/tests/simulation/SimpleSimulation9.py
@@ -3,7 +3,8 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
-## asan: yes
+## asan: no
+## the FMUs this test loads leak memory inside their own binaries
 
 from OMSimulator import SSP, CRef, Settings, Connector, Causality, SignalType, SSV
 

--- a/testsuite/tests/simulation/exportJson1.py
+++ b/testsuite/tests/simulation/exportJson1.py
@@ -3,6 +3,7 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
+## asan: yes
 
 from OMSimulator import SSP, SSD, CRef, Settings
 

--- a/testsuite/tests/simulation/exportJson2.py
+++ b/testsuite/tests/simulation/exportJson2.py
@@ -3,6 +3,7 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
+## asan: yes
 
 from OMSimulator import SSP, SSD, CRef, Settings
 

--- a/testsuite/tests/simulation/exportJson4.py
+++ b/testsuite/tests/simulation/exportJson4.py
@@ -3,7 +3,8 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
-## asan: yes
+## asan: no
+## the FMUs this test loads leak memory inside their own binaries
 
 from OMSimulator import SSP, CRef, Settings, Connector, Causality, SignalType
 

--- a/testsuite/tests/simulation/exportJson4.py
+++ b/testsuite/tests/simulation/exportJson4.py
@@ -3,6 +3,7 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
+## asan: yes
 
 from OMSimulator import SSP, CRef, Settings, Connector, Causality, SignalType
 

--- a/testsuite/tests/simulation/fmuSimulation1.py
+++ b/testsuite/tests/simulation/fmuSimulation1.py
@@ -3,6 +3,7 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
+## asan: yes
 
 from OMSimulator import FMU, Variable, SignalType, Causality
 

--- a/testsuite/tests/simulation/stepUntil.py
+++ b/testsuite/tests/simulation/stepUntil.py
@@ -3,6 +3,7 @@
 ## ucrt64: yes
 ## win: yes
 ## mac: yes
+## asan: yes
 
 from OMSimulator import FMU, Variable, SignalType, Causality
 


### PR DESCRIPTION
## Related Issues

Fixes https://github.com/OpenModelica/OMSimulator/issues/1615.

## Purpose

* Enable ASAN again
* Updated testsuite to enable ASAN everywhere possible
  * Fix memory issues that popped up while it was disabled or never discoverd
  * Disabled ASAN tests still leak memory
* Update Build configuration to be more strict on all used compiler

## Approach

### Bugs fixed in OMSimulator

**Heap-buffer-overflow in `SystemSC`** (b917d7b7)

`callEventUpdate` and `terminateSimulation` were allocated in a default member initializer, `new bool[fmus.size()]()`. That runs in the constructor, where `fmus` is still empty — `initialize()` only fills it later — so both arrays were always zero length. Every ME step then wrote one flag per FMU past the end of them. The arrays are now `std::unique_ptr<bool[]>` sized in `initialize()` once `fmus` is known. `unique_ptr` also closes two related problems: `terminate()` `delete[]`-ed the arrays without clearing the pointers while `initialize()` never re-allocated them (dangling pointer on re-initialize), and `~SystemSC()` freed nothing at all (leak when `terminate()` is never called).

**KINSOL solver leaked per algebraic loop** (01dcf3fd)

`AlgLoop` owned `KinsolSolver*` as a raw pointer and never deleted it, leaking the KINSOL memory block, five `N_Vector`s, the dense matrix, the linear solver and the user-data struct for every algebraic loop. `kinsolData` was also left uninitialized when the fixed-point solver was selected, and the ~12 error returns in `NewKinsolSolver()` leaked the half-built object. Now a `unique_ptr` member, with the factory holding one until the object is complete.

### Build configuration

- ASAN now works with Clang, not only GCC (4e5e02f5). The flags used to sit  inside a GNU-only branch, so `-DASAN=ON` on a Clang build silently produced an uninstrumented library — it still reported leaks through the preloaded libasan
  interceptors, but detected no overflow or use-after-free at all. A `FATAL_ERROR` now rejects compilers too old to support the sanitizer.
- MSVC equivalents of the `-Werror=` memory warnings (2193adb7): C4700, C4701, C4703, C4715, C4716 and C4172 are raised to the default warning level and turned into errors.

### Testsuite

- New `testsuite/lsan-suppressions.txt`, wired into `runtest.py` via `LSAN_OPTIONS`. It covers only non-OMSimulator modules: the uutils coreutils processes the `OMSimulatorPython3` wrapper starts, CPython's own interpreter state, and lxml/libxml2/libxslt. `print_suppressions=0` keeps the reports out of the compared test output. The file documents why matching on module paths is safe here and why `fast_unwind_on_malloc=0` must not be set.
- `asan: yes` on 82 test cases, `asan: no` with an explanatory line on 23 (774f9037, ab681d02) — see the limitation below.
- Dropped the unused `from numpy import uint64` from the two `FeedthroughSetValue` tests and `python3-numpy` from the coverage workflow (8cfb221a). numpy leaks ~683 bytes registering its ufuncs at import, in stacks too shallow to suppress by interpreter frame.

### Known limitation

23 tests are marked `asan: no`. All of them fail on leaks — and in the two `embrace` cases a use-after-free — that occur *inside the FMU binaries*, not in OMSimulator: OpenModelica-generated FMUs leak in `<Model>_function_initSynchronous`, `FMU_16_aero_interface.so` leaks ~82 kB during `fmi2Instantiate`, and Dymola's
`ECS_HW.so` reads the pointer returned by `setlocale()` after a later call has freed it. All of these tests do call `terminate()` and `delete()`, so `fmi2FreeInstance` is issued correctly. Suppressions cannot help: once the FMU is
`dlclose`d the stacks are `#0 malloc / #1 <unknown module>` with nothing left to
match on. Each disabled test carries a one-line comment naming the reason.