### PR TITLE
Change branch condition in setStartValues

### DIFF
--- a/src/OMSimulatorPython/instantiated_model.py
+++ b/src/OMSimulatorPython/instantiated_model.py
@@ -351,7 +351,7 @@ class InstantiatedModel:
       raise KeyError(f"Missing required key: '{systemName}'")
 
     ## apply ssm mapping if exist and apply start values from mapped parameters
-    if ssm and ssm.mappingEntry:
+    if ssm is not None:
       for source, targets in ssm.mappingEntry.items():
         if CRef(source) in value.start_values:
           (source_value, type, _, _) = value.start_values[CRef(source)]


### PR DESCRIPTION
### Related Issues
#1628 
<!-- Link to the issues that are solved with this PR. -->

### Purpose
The SSP standard allows empty SSM files. When an SSM is present, no values except those in the SSM should be applied. This behavior corresponds to the first branch in setStartValues. Previously the condition in this if statement was `ssm and ssm.mappingEntry`. This means empty SSM files caused the other branch to be selected. This is contrary to what the standard requires.
<!--- Describe the problem or feature in addition to a link to the issues. -->

### Approach
 Using `ssm is not None` instead ensures compliance to the SSP standard, by using the SSM branch even if there are no mappings. The effect is that no values are applied if an SSV is referenced through an "empty" SSM, which is what the standard implies.
<!--- How does this change address the problem? -->
