### PR TITLE
Adapt to fmi4c instance handles

### DIFF
--- a/src/OMSimulatorLib/Component.h
+++ b/src/OMSimulatorLib/Component.h
@@ -130,7 +130,7 @@ namespace oms
     virtual oms_status_enu_t getEventindicators(double* eventindicators) {return logError_NotImplemented;}
     virtual oms_status_enu_t getEventindicators(double* eventindicators, size_t size) {return logError_NotImplemented;}
 
-    virtual fmiHandle* getFMU() {return nullptr;  }
+    virtual fmuHandle* getFMU() {return nullptr;  }
     virtual fmi2EventInfo* getEventInfo() {return nullptr;}
     virtual oms_status_enu_t doEventIteration() {return logError_NotImplemented;}
     virtual oms_status_enu_t completedIntegratorStep(bool noSetFMUStatePriorToCurrentPoint, bool& enterEventMode, bool& terminateSimulation) {return logError_NotImplemented;}

--- a/src/OMSimulatorLib/ComponentFMU3CS.cpp
+++ b/src/OMSimulatorLib/ComponentFMU3CS.cpp
@@ -58,8 +58,8 @@ oms::ComponentFMU3CS::ComponentFMU3CS(const ComRef& cref, System* parentSystem, 
 
 oms::ComponentFMU3CS::~ComponentFMU3CS()
 {
-  if (oms_modelState_virgin != getModel().getModelState())
-    fmi3_freeInstance(fmu);
+  if (instance && oms_modelState_virgin != getModel().getModelState())
+    fmi3_freeInstance(instance);
 
   fmi4c_freeFmu(fmu);
 }
@@ -643,7 +643,8 @@ oms_status_enu_t oms::ComponentFMU3CS::setExportName(const std::string& exportNa
 oms_status_enu_t oms::ComponentFMU3CS::instantiate()
 {
   // TODO investigate fmi3IntermediateUpdateCallback = NULL
-  if(!fmi3_instantiateCoSimulation(fmu, fmi3False, fmi3True, fmi3False, fmi3False, NULL, 0, fmu, omsfmi3logger, NULL))
+  instance = fmi3_instantiateCoSimulation(fmu, fmi3False, fmi3True, fmi3False, fmi3False, NULL, 0, fmu, omsfmi3logger, NULL);
+  if (!instance)
   {
     logInfo("fmi3Instantiate() failed");
     exit(1);
@@ -690,7 +691,7 @@ oms_status_enu_t oms::ComponentFMU3CS::instantiate()
   double relativeTolerance = 0.0;
   getParentSystem()->getTolerance(&relativeTolerance);
 
-  fmi3Status status_ = fmi3_enterInitializationMode(fmu, fmi3False, relativeTolerance, time, fmi3False, getModel().getStopTime());
+  fmi3Status status_ = fmi3_enterInitializationMode(instance, fmi3False, relativeTolerance, time, fmi3False, getModel().getStopTime());
 
   if (fmi3OK != status_) return logError_FMUCall("fmi3_enterInitializationMode", this);
 
@@ -852,7 +853,7 @@ oms_status_enu_t oms::ComponentFMU3CS::initialize()
   CallClock callClock(clock);
 
   // exitInitialization
-  fmi3Status status = fmi3_exitInitializationMode(fmu);
+  fmi3Status status = fmi3_exitInitializationMode(instance);
 
   if (fmi3OK != status) return logError_FMUCall("fmi3_exitInitializationMode", this);
 
@@ -864,18 +865,19 @@ oms_status_enu_t oms::ComponentFMU3CS::initialize()
 oms_status_enu_t oms::ComponentFMU3CS::terminate()
 {
   freeState();
-  fmi3Status fmistatus = fmi3_terminate(fmu);
+  fmi3Status fmistatus = fmi3_terminate(instance);
   if (fmi3OK != fmistatus)
     return logError_Termination(getCref());
 
-  fmi3_freeInstance(fmu);
+  fmi3_freeInstance(instance);
+  instance = NULL;
 
   return oms_status_ok;
 }
 
 oms_status_enu_t oms::ComponentFMU3CS::reset()
 {
-  fmi3Status fmistatus = fmi3_reset(fmu);
+  fmi3Status fmistatus = fmi3_reset(instance);
   if (fmi3OK != fmistatus)
     return logError_ResetFailed(getCref());
 
@@ -884,7 +886,7 @@ oms_status_enu_t oms::ComponentFMU3CS::reset()
   double relativeTolerance = 0.0;
   getParentSystem()->getTolerance(&relativeTolerance);
 
-  fmi3Status status_ = fmi3_enterInitializationMode(fmu, fmi3False, relativeTolerance, time, fmi3True, getModel().getStopTime());
+  fmi3Status status_ = fmi3_enterInitializationMode(instance, fmi3False, relativeTolerance, time, fmi3True, getModel().getStopTime());
   if (fmi3OK != fmistatus) return logError_FMUCall("fmi3_enterInitializationMode", this);
 
   return oms_status_ok;
@@ -901,7 +903,7 @@ oms_status_enu_t oms::ComponentFMU3CS::stepUntil(double stopTime)
 
   while (time < stopTime)
   {
-    fmi3Status status = fmi3_doStep(fmu,  time, hdef, fmi3True, &eventEncountered, &terminateSimulation, &earlyReturn, &lastT);
+    fmi3Status status = fmi3_doStep(instance,  time, hdef, fmi3True, &eventEncountered, &terminateSimulation, &earlyReturn, &lastT);
     time += hdef;
 
     if (status == fmi3Discard)
@@ -922,7 +924,7 @@ oms_status_enu_t oms::ComponentFMU3CS::getBoolean(const fmi3ValueReference& vr, 
   CallClock callClock(clock);
 
   // bool value_;
-  if (fmi3OK != fmi3_getBoolean(fmu, &vr, 1, &value, 1))
+  if (fmi3OK != fmi3_getBoolean(instance, &vr, 1, &value, 1))
     return oms_status_error;
 
   // value = value_ ? true : false;
@@ -1018,7 +1020,7 @@ oms_status_enu_t oms::ComponentFMU3CS::getInteger(const fmi3ValueReference& vr, 
     case oms_signal_numeric_type_INT64:
     {
       int64_t v64;
-      if (fmi3OK != fmi3_getInt64(fmu, &vr, 1, &v64, 1))
+      if (fmi3OK != fmi3_getInt64(instance, &vr, 1, &v64, 1))
         return oms_status_error;
       if (v64 < INT_MIN || v64 > INT_MAX)
         return oms_status_error; // out of int range
@@ -1028,7 +1030,7 @@ oms_status_enu_t oms::ComponentFMU3CS::getInteger(const fmi3ValueReference& vr, 
     case oms_signal_numeric_type_INT32:
     {
       int32_t v32;
-      if (fmi3OK != fmi3_getInt32(fmu, &vr, 1, &v32, 1))
+      if (fmi3OK != fmi3_getInt32(instance, &vr, 1, &v32, 1))
         return oms_status_error;
       value = static_cast<int>(v32); // safe
       break;
@@ -1036,7 +1038,7 @@ oms_status_enu_t oms::ComponentFMU3CS::getInteger(const fmi3ValueReference& vr, 
     case oms_signal_numeric_type_INT16:
     {
       int16_t v16;
-      if (fmi3OK != fmi3_getInt16(fmu, &vr, 1, &v16, 1))
+      if (fmi3OK != fmi3_getInt16(instance, &vr, 1, &v16, 1))
         return oms_status_error;
       value = static_cast<int>(v16); // safe
       break;
@@ -1044,7 +1046,7 @@ oms_status_enu_t oms::ComponentFMU3CS::getInteger(const fmi3ValueReference& vr, 
     case oms_signal_numeric_type_INT8:
     {
       int8_t v8;
-      if (fmi3OK != fmi3_getInt8(fmu, &vr, 1, &v8, 1))
+      if (fmi3OK != fmi3_getInt8(instance, &vr, 1, &v8, 1))
         return oms_status_error;
       value = static_cast<int>(v8); // safe
       break;
@@ -1052,7 +1054,7 @@ oms_status_enu_t oms::ComponentFMU3CS::getInteger(const fmi3ValueReference& vr, 
     case oms_signal_numeric_type_UINT64:
     {
       uint64_t vU64;
-      if (fmi3OK != fmi3_getUInt64(fmu, &vr, 1, &vU64, 1))
+      if (fmi3OK != fmi3_getUInt64(instance, &vr, 1, &vU64, 1))
         return oms_status_error;
       if (vU64 > static_cast<uint64_t>(INT_MAX))
         return oms_status_error; // cannot fit in int
@@ -1062,7 +1064,7 @@ oms_status_enu_t oms::ComponentFMU3CS::getInteger(const fmi3ValueReference& vr, 
     case oms_signal_numeric_type_UINT32:
     {
       uint32_t vU32;
-      if (fmi3OK != fmi3_getUInt32(fmu, &vr, 1, &vU32, 1))
+      if (fmi3OK != fmi3_getUInt32(instance, &vr, 1, &vU32, 1))
         return oms_status_error;
       if (vU32 > static_cast<uint32_t>(INT_MAX))
         return oms_status_error; // cannot fit in int
@@ -1072,7 +1074,7 @@ oms_status_enu_t oms::ComponentFMU3CS::getInteger(const fmi3ValueReference& vr, 
     case oms_signal_numeric_type_UINT16:
     {
       uint16_t vU16;
-      if (fmi3OK != fmi3_getUInt16(fmu, &vr, 1, &vU16, 1))
+      if (fmi3OK != fmi3_getUInt16(instance, &vr, 1, &vU16, 1))
         return oms_status_error;
       value = static_cast<int>(vU16); // safe
       break;
@@ -1080,7 +1082,7 @@ oms_status_enu_t oms::ComponentFMU3CS::getInteger(const fmi3ValueReference& vr, 
     case oms_signal_numeric_type_UINT8:
     {
       uint8_t vU8;
-      if (fmi3OK != fmi3_getUInt8(fmu, &vr, 1, &vU8, 1))
+      if (fmi3OK != fmi3_getUInt8(instance, &vr, 1, &vU8, 1))
         return oms_status_error;
       value = static_cast<int>(vU8); // safe
       break;
@@ -1190,14 +1192,14 @@ oms_status_enu_t oms::ComponentFMU3CS::getReal(const fmi3ValueReference& vr, dou
   {
     case oms_signal_numeric_type_FLOAT64:
     {
-      if (fmi3OK != fmi3_getFloat64(fmu, &vr, 1, &value, 1))
+      if (fmi3OK != fmi3_getFloat64(instance, &vr, 1, &value, 1))
         return oms_status_error;
       break;
     }
     case oms_signal_numeric_type_FLOAT32:
     {
       float value_;
-      if (fmi3OK != fmi3_getFloat32(fmu, &vr, 1, &value_, 1))
+      if (fmi3OK != fmi3_getFloat32(instance, &vr, 1, &value_, 1))
         return oms_status_error;
       // Convert the float to double and assign to 'value'
       value = static_cast<double>(value_);
@@ -1300,7 +1302,7 @@ oms_status_enu_t oms::ComponentFMU3CS::getString(const fmi3ValueReference& vr, s
   CallClock callClock(clock);
   fmi3String str;
 
-  if (fmi3OK != fmi3_getString(fmu, &vr, 1, &str, 1))
+  if (fmi3OK != fmi3_getString(instance, &vr, 1, &str, 1))
     return oms_status_error;
 
   value = std::string(str);
@@ -1497,7 +1499,7 @@ oms_status_enu_t oms::ComponentFMU3CS::getDirectionalDerivativeHeper(const int u
       dvknown[i] = 0.0;
   }
 
-  fmi3_getDirectionalDerivative(fmu, &vr_unknown, 1, vr_known, dependencyList.size(), dvknown, 1, &value, 1);
+  fmi3_getDirectionalDerivative(instance, &vr_unknown, 1, vr_known, dependencyList.size(), dvknown, 1, &value, 1);
 
   free(vr_known);
   free(dvknown);
@@ -1522,7 +1524,7 @@ oms_status_enu_t oms::ComponentFMU3CS::getRealOutputDerivative(const ComRef& cre
   if (!fmu || j < 0)
     return logError_UnknownSignal(getFullCref() + cref);
 
-  der = SignalDerivative(getFMUInfo()->getMaxOutputDerivativeOrder(), fmu, allVariables[j].getValueReferenceFMI3());
+  der = SignalDerivative(getFMUInfo()->getMaxOutputDerivativeOrder(), instance, allVariables[j].getValueReferenceFMI3());
   return oms_status_ok;
 }
 
@@ -1551,8 +1553,8 @@ oms_status_enu_t oms::ComponentFMU3CS::setRealInputDerivative(const ComRef& cref
   if (!fmu || j < 0)
     return logError_UnknownSignal(getFullCref() + cref);
 
-  fmi3ValueReference vr = allVariables[j].getValueReferenceFMI3();
-  return der.setRealInputDerivatives(fmu, vr);
+  // FMI 3.0 dropped fmi2SetRealInputDerivatives, so there is nothing to set here
+  return logError_NotImplemented;
 }
 
 oms_status_enu_t oms::ComponentFMU3CS::setBoolean(const ComRef& cref, bool value)
@@ -1599,7 +1601,7 @@ oms_status_enu_t oms::ComponentFMU3CS::setBoolean(const ComRef& cref, bool value
   {
     fmi3ValueReference vr = allVariables[j].getValueReferenceFMI3();
     // int value_ = value ? 1 : 0;
-    if (fmi3OK != fmi3_setBoolean(fmu, &vr, 1, &value, 1))
+    if (fmi3OK != fmi3_setBoolean(instance, &vr, 1, &value, 1))
       return oms_status_error;
   }
 
@@ -1655,56 +1657,56 @@ oms_status_enu_t oms::ComponentFMU3CS::setInteger(const ComRef& cref, int value)
       case oms_signal_numeric_type_INT64:
       {
         int64_t v = static_cast<int64_t>(value);
-        if (fmi3OK != fmi3_setInt64(fmu, &vr, 1, &v, 1))
+        if (fmi3OK != fmi3_setInt64(instance, &vr, 1, &v, 1))
           return oms_status_error;
         break;
       }
       case oms_signal_numeric_type_INT32:
       {
         int32_t v = static_cast<int32_t>(value);
-        if (fmi3OK != fmi3_setInt32(fmu, &vr, 1, &v, 1))
+        if (fmi3OK != fmi3_setInt32(instance, &vr, 1, &v, 1))
           return oms_status_error;
         break;
       }
       case oms_signal_numeric_type_INT16:
       {
         int16_t v = static_cast<int16_t>(value);
-        if (fmi3OK != fmi3_setInt16(fmu, &vr, 1, &v, 1))
+        if (fmi3OK != fmi3_setInt16(instance, &vr, 1, &v, 1))
           return oms_status_error;
         break;
       }
       case oms_signal_numeric_type_INT8:
       {
         int8_t v = static_cast<int8_t>(value);
-        if (fmi3OK != fmi3_setInt8(fmu, &vr, 1, &v, 1))
+        if (fmi3OK != fmi3_setInt8(instance, &vr, 1, &v, 1))
           return oms_status_error;
         break;
       }
       case oms_signal_numeric_type_UINT64:
       {
         uint64_t v = static_cast<uint64_t>(value);
-        if (fmi3OK != fmi3_setUInt64(fmu, &vr, 1, &v, 1))
+        if (fmi3OK != fmi3_setUInt64(instance, &vr, 1, &v, 1))
           return oms_status_error;
         break;
       }
       case oms_signal_numeric_type_UINT32:
       {
         uint32_t v = static_cast<uint32_t>(value);
-        if (fmi3OK != fmi3_setUInt32(fmu, &vr, 1, &v, 1))
+        if (fmi3OK != fmi3_setUInt32(instance, &vr, 1, &v, 1))
           return oms_status_error;
         break;
       }
       case oms_signal_numeric_type_UINT16:
       {
         uint16_t v = static_cast<uint16_t>(value);
-        if (fmi3OK != fmi3_setUInt16(fmu, &vr, 1, &v, 1))
+        if (fmi3OK != fmi3_setUInt16(instance, &vr, 1, &v, 1))
           return oms_status_error;
         break;
       }
       case oms_signal_numeric_type_UINT8:
       {
         uint8_t v = static_cast<uint8_t>(value);
-        if (fmi3OK != fmi3_setUInt8(fmu, &vr, 1, &v, 1))
+        if (fmi3OK != fmi3_setUInt8(instance, &vr, 1, &v, 1))
           return oms_status_error;
         break;
       }
@@ -1771,14 +1773,14 @@ oms_status_enu_t oms::ComponentFMU3CS::setReal(const ComRef& cref, double value)
     {
       case oms_signal_numeric_type_FLOAT64:
       {
-        if (fmi3OK != fmi3_setFloat64(fmu, &vr, 1, &value, 1))
+        if (fmi3OK != fmi3_setFloat64(instance, &vr, 1, &value, 1))
           return oms_status_error;
         break;
       }
       case oms_signal_numeric_type_FLOAT32:
       {
         float value_= static_cast<float>(value);
-        if (fmi3OK != fmi3_setFloat32(fmu, &vr, 1, &value_, 1))
+        if (fmi3OK != fmi3_setFloat32(instance, &vr, 1, &value_, 1))
           return oms_status_error;
         break;
       }
@@ -1838,7 +1840,7 @@ oms_status_enu_t oms::ComponentFMU3CS::setString(const ComRef& cref, const std::
   {
     fmi3ValueReference vr = allVariables[j].getValueReferenceFMI3();
     fmi3String value_ = value.c_str();
-    if (fmi3OK != fmi3_setString(fmu, &vr, 1, &value_, 1))
+    if (fmi3OK != fmi3_setString(instance, &vr, 1, &value_, 1))
       return oms_status_error;
   }
 
@@ -2118,7 +2120,7 @@ oms_status_enu_t oms::ComponentFMU3CS::removeSignalsFromResults(const char* rege
 
 oms_status_enu_t oms::ComponentFMU3CS::saveState()
 {
-  fmi3Status fmistatus = fmi3_getFMUState(fmu, &fmuState);
+  fmi3Status fmistatus = fmi3_getFMUState(instance, &fmuState);
   if (fmi3OK != fmistatus) return logError_FMUCall("fmi3_getFMUState", this);
   fmuStateTime = time;
 
@@ -2130,7 +2132,7 @@ oms_status_enu_t oms::ComponentFMU3CS::freeState()
   if (!fmuState)
     return oms_status_warning;
 
-  fmi3Status fmistatus = fmi3_freeFMUState(fmu, &fmuState);
+  fmi3Status fmistatus = fmi3_freeFMUState(instance, &fmuState);
   fmuState = NULL;
   if (fmi3OK != fmistatus) return logError_FMUCall("fmi3_freeFMUstate", this);
 
@@ -2139,7 +2141,7 @@ oms_status_enu_t oms::ComponentFMU3CS::freeState()
 
 oms_status_enu_t oms::ComponentFMU3CS::restoreState()
 {
-  fmi3Status fmistatus = fmi3_setFMUState(fmu, fmuState);
+  fmi3Status fmistatus = fmi3_setFMUState(instance, fmuState);
   if (fmi3OK != fmistatus) return logError_FMUCall("fmi3_setFMUstate", this);
   time = fmuStateTime;
 

--- a/src/OMSimulatorLib/ComponentFMU3CS.h
+++ b/src/OMSimulatorLib/ComponentFMU3CS.h
@@ -106,7 +106,7 @@ namespace oms
     oms_status_enu_t updateOrDeleteStartValueInReplacedComponent(std::vector<std::string>& warningList);
 
     oms_status_enu_t setFmuTime(double time) {this->time = time; return oms_status_ok;}
-    fmiHandle* getFMU() {return fmu;}
+    fmuHandle* getFMU() {return fmu;}
     std::vector<Variable> getAllVariables() {return allVariables;}
 
     oms_status_enu_t getRealOutputDerivative(const ComRef& cref, SignalDerivative& der);
@@ -146,7 +146,8 @@ namespace oms
 
   private:
     fmi3LogMessageCallback omsfmi3logger;
-    fmiHandle *fmu = NULL;
+    fmuHandle *fmu = NULL;
+    fmi3InstanceHandle *instance = NULL;
     FMUInfo fmuInfo;
 
     std::vector<Variable> allVariables;

--- a/src/OMSimulatorLib/ComponentFMU3ME.cpp
+++ b/src/OMSimulatorLib/ComponentFMU3ME.cpp
@@ -57,8 +57,8 @@ oms::ComponentFMU3ME::ComponentFMU3ME(const ComRef& cref, System* parentSystem, 
 
 oms::ComponentFMU3ME::~ComponentFMU3ME()
 {
-  if (oms_modelState_virgin != getModel().getModelState())
-    fmi3_freeInstance(fmu);
+  if (instance && oms_modelState_virgin != getModel().getModelState())
+    fmi3_freeInstance(instance);
 
   fmi4c_freeFmu(fmu);
 }
@@ -628,7 +628,8 @@ oms_status_enu_t oms::ComponentFMU3ME::initializeDependencyGraph_outputs()
 
 oms_status_enu_t oms::ComponentFMU3ME::instantiate()
 {
-  if (!fmi3_instantiateModelExchange(fmu, fmi3False, fmi3True, NULL, omsfmi3logger))
+  instance = fmi3_instantiateModelExchange(fmu, fmi3False, fmi3True, NULL, omsfmi3logger);
+  if (!instance)
   {
     logInfo("fmi3Instantiate() failed");
     exit(1);
@@ -676,7 +677,7 @@ oms_status_enu_t oms::ComponentFMU3ME::instantiate()
   double relativeTolerance = 0.0;
   getParentSystem()->getTolerance(&relativeTolerance);
 
-  fmi3Status status_ = fmi3_enterInitializationMode(fmu, fmi3False, relativeTolerance, startTime, fmi3False, getModel().getStopTime());
+  fmi3Status status_ = fmi3_enterInitializationMode(instance, fmi3False, relativeTolerance, startTime, fmi3False, getModel().getStopTime());
 
   if (fmi3OK != status_) return logError_FMUCall("fmi3_enterInitializationMode", this);
 
@@ -792,7 +793,7 @@ oms_status_enu_t oms::ComponentFMU3ME::doEventIteration()
   terminateSimulation = fmi3False;
   while (newDiscreteStatesNeeded && !terminateSimulation)
   {
-    fmistatus = fmi3_updateDiscreteStates(fmu,
+    fmistatus = fmi3_updateDiscreteStates(instance,
                                           &newDiscreteStatesNeeded,
                                           &terminateSimulation,
                                           &nominalsOfContinuousStatesChanged,
@@ -871,22 +872,22 @@ oms_status_enu_t oms::ComponentFMU3ME::initialize()
   fmi3Status fmistatus;
 
   // exitInitialization
-  fmistatus = fmi3_exitInitializationMode(fmu);
+  fmistatus = fmi3_exitInitializationMode(instance);
   if (fmi3OK != fmistatus) return logError_FMUCall("fmi3_exitInitializationMode", this);
 
   // get number of continuous state after initialize
-  fmistatus = fmi3_getNumberOfContinuousStates(fmu, &nContinuousStates);
+  fmistatus = fmi3_getNumberOfContinuousStates(instance, &nContinuousStates);
   if (fmi3OK != fmistatus) return logError_FMUCall("fmi3_getNumberOfContinuousStates", this);
 
   // get number of event indicators after initialize
-  fmistatus = fmi3_getNumberOfEventIndicators(fmu, &nEventIndicators);
+  fmistatus = fmi3_getNumberOfEventIndicators(instance, &nEventIndicators);
   if (fmi3OK != fmistatus) return logError_FMUCall("fmi3_getNumberOfEventIndicators", this);
 
   // fmi3_exitInitialization_mode leaves FMU in event mode
   if (oms_status_ok != doEventIteration())
     return oms_status_error;
 
-  fmistatus = fmi3_enterContinuousTimeMode(fmu);
+  fmistatus = fmi3_enterContinuousTimeMode(instance);
   if (fmi3OK != fmistatus) return logError_FMUCall("fmi3_enterContinuousTimeMode", this);
 
   return oms_status_ok;
@@ -894,18 +895,19 @@ oms_status_enu_t oms::ComponentFMU3ME::initialize()
 
 oms_status_enu_t oms::ComponentFMU3ME::terminate()
 {
-  fmi3Status fmistatus = fmi3_terminate(fmu);
+  fmi3Status fmistatus = fmi3_terminate(instance);
   if (fmi3OK != fmistatus)
     return logError_Termination(getCref());
 
-  fmi3_freeInstance(fmu);
+  fmi3_freeInstance(instance);
+  instance = NULL;
 
   return oms_status_ok;
 }
 
 oms_status_enu_t oms::ComponentFMU3ME::reset()
 {
-  fmi3Status fmistatus = fmi3_reset(fmu);
+  fmi3Status fmistatus = fmi3_reset(instance);
   if (fmi3OK != fmistatus)
     return logError_ResetFailed(getCref());
 
@@ -914,7 +916,7 @@ oms_status_enu_t oms::ComponentFMU3ME::reset()
   double relativeTolerance = 0.0;
   getParentSystem()->getTolerance(&relativeTolerance);
 
-  fmi3Status status_ = fmi3_enterInitializationMode(fmu, fmi3False, relativeTolerance, startTime, fmi3True, getModel().getStopTime());
+  fmi3Status status_ = fmi3_enterInitializationMode(instance, fmi3False, relativeTolerance, startTime, fmi3True, getModel().getStopTime());
   if (fmi3OK != fmistatus) return logError_FMUCall("fmi3_enterInitializationMode", this);
 
   newDiscreteStatesNeeded = fmi3False;
@@ -931,7 +933,7 @@ oms_status_enu_t oms::ComponentFMU3ME::getBoolean(const fmi3ValueReference& vr, 
 {
   CallClock callClock(clock);
 
-  if (fmi3OK != fmi3_getBoolean(fmu, &vr, 1, &value, 1))
+  if (fmi3OK != fmi3_getBoolean(instance, &vr, 1, &value, 1))
     return oms_status_error;
 
   return oms_status_ok;
@@ -1026,7 +1028,7 @@ oms_status_enu_t oms::ComponentFMU3ME::getInteger(const fmi3ValueReference& vr, 
     case oms_signal_numeric_type_INT64:
     {
       int64_t v64;
-      if (fmi3OK != fmi3_getInt64(fmu, &vr, 1, &v64, 1))
+      if (fmi3OK != fmi3_getInt64(instance, &vr, 1, &v64, 1))
         return oms_status_error;
       if (v64 < INT_MIN || v64 > INT_MAX)
         return oms_status_error; // out of int range
@@ -1036,7 +1038,7 @@ oms_status_enu_t oms::ComponentFMU3ME::getInteger(const fmi3ValueReference& vr, 
     case oms_signal_numeric_type_INT32:
     {
       int32_t v32;
-      if (fmi3OK != fmi3_getInt32(fmu, &vr, 1, &v32, 1))
+      if (fmi3OK != fmi3_getInt32(instance, &vr, 1, &v32, 1))
         return oms_status_error;
       value = static_cast<int>(v32); // safe
       break;
@@ -1044,7 +1046,7 @@ oms_status_enu_t oms::ComponentFMU3ME::getInteger(const fmi3ValueReference& vr, 
     case oms_signal_numeric_type_INT16:
     {
       int16_t v16;
-      if (fmi3OK != fmi3_getInt16(fmu, &vr, 1, &v16, 1))
+      if (fmi3OK != fmi3_getInt16(instance, &vr, 1, &v16, 1))
         return oms_status_error;
       value = static_cast<int>(v16); // safe
       break;
@@ -1052,7 +1054,7 @@ oms_status_enu_t oms::ComponentFMU3ME::getInteger(const fmi3ValueReference& vr, 
     case oms_signal_numeric_type_INT8:
     {
       int8_t v8;
-      if (fmi3OK != fmi3_getInt8(fmu, &vr, 1, &v8, 1))
+      if (fmi3OK != fmi3_getInt8(instance, &vr, 1, &v8, 1))
         return oms_status_error;
       value = static_cast<int>(v8); // safe
       break;
@@ -1060,7 +1062,7 @@ oms_status_enu_t oms::ComponentFMU3ME::getInteger(const fmi3ValueReference& vr, 
     case oms_signal_numeric_type_UINT64:
     {
       uint64_t vU64;
-      if (fmi3OK != fmi3_getUInt64(fmu, &vr, 1, &vU64, 1))
+      if (fmi3OK != fmi3_getUInt64(instance, &vr, 1, &vU64, 1))
         return oms_status_error;
       if (vU64 > static_cast<uint64_t>(INT_MAX))
         return oms_status_error; // cannot fit in int
@@ -1070,7 +1072,7 @@ oms_status_enu_t oms::ComponentFMU3ME::getInteger(const fmi3ValueReference& vr, 
     case oms_signal_numeric_type_UINT32:
     {
       uint32_t vU32;
-      if (fmi3OK != fmi3_getUInt32(fmu, &vr, 1, &vU32, 1))
+      if (fmi3OK != fmi3_getUInt32(instance, &vr, 1, &vU32, 1))
         return oms_status_error;
       if (vU32 > static_cast<uint32_t>(INT_MAX))
         return oms_status_error; // cannot fit in int
@@ -1080,7 +1082,7 @@ oms_status_enu_t oms::ComponentFMU3ME::getInteger(const fmi3ValueReference& vr, 
     case oms_signal_numeric_type_UINT16:
     {
       uint16_t vU16;
-      if (fmi3OK != fmi3_getUInt16(fmu, &vr, 1, &vU16, 1))
+      if (fmi3OK != fmi3_getUInt16(instance, &vr, 1, &vU16, 1))
         return oms_status_error;
       value = static_cast<int>(vU16); // safe
       break;
@@ -1088,7 +1090,7 @@ oms_status_enu_t oms::ComponentFMU3ME::getInteger(const fmi3ValueReference& vr, 
     case oms_signal_numeric_type_UINT8:
     {
       uint8_t vU8;
-      if (fmi3OK != fmi3_getUInt8(fmu, &vr, 1, &vU8, 1))
+      if (fmi3OK != fmi3_getUInt8(instance, &vr, 1, &vU8, 1))
         return oms_status_error;
       value = static_cast<int>(vU8); // safe
       break;
@@ -1101,7 +1103,7 @@ oms_status_enu_t oms::ComponentFMU3ME::getInteger(const fmi3ValueReference& vr, 
 
 oms_status_enu_t oms::ComponentFMU3ME::setTime(double time)
 {
-  fmi3Status fmistatus = fmi3_setTime(fmu, time);
+  fmi3Status fmistatus = fmi3_setTime(instance, time);
   if (fmi3OK != fmistatus)
     return logError_FMUCall("fmi3_setTime", this);
   return oms_status_ok;
@@ -1206,14 +1208,14 @@ oms_status_enu_t oms::ComponentFMU3ME::getReal(const fmi3ValueReference& vr, dou
   {
     case oms_signal_numeric_type_FLOAT64:
     {
-      if (fmi3OK != fmi3_getFloat64(fmu, &vr, 1, &value, 1))
+      if (fmi3OK != fmi3_getFloat64(instance, &vr, 1, &value, 1))
         return oms_status_error;
       break;
     }
     case oms_signal_numeric_type_FLOAT32:
     {
       float value_;
-      if (fmi3OK != fmi3_getFloat32(fmu, &vr, 1, &value_, 1))
+      if (fmi3OK != fmi3_getFloat32(instance, &vr, 1, &value_, 1))
         return oms_status_error;
       // Convert the float to double and assign to 'value'
       value = static_cast<double>(value_);
@@ -1315,7 +1317,7 @@ oms_status_enu_t oms::ComponentFMU3ME::getString(const fmi3ValueReference& vr, s
 {
   CallClock callClock(clock);
   fmi3String str;
-  if (fmi3OK != fmi3_getString(fmu, &vr, 1, &str, 1))
+  if (fmi3OK != fmi3_getString(instance, &vr, 1, &str, 1))
     return oms_status_error;
 
   value = std::string(str);
@@ -1508,7 +1510,7 @@ oms_status_enu_t oms::ComponentFMU3ME::getDirectionalDerivativeHeper(const int u
   // One unknown → one sensitivity output
   fmi3Float64 sensitivity = 0.0;
 
-  fmi3_getDirectionalDerivative(fmu, &vr_unknown, 1, vr_known, dependencyList.size(), dvknown, dependencyList.size(), &sensitivity, 1);
+  fmi3_getDirectionalDerivative(instance, &vr_unknown, 1, vr_known, dependencyList.size(), dvknown, dependencyList.size(), &sensitivity, 1);
   value = sensitivity;
 
   free(vr_known);
@@ -1561,7 +1563,7 @@ oms_status_enu_t oms::ComponentFMU3ME::setBoolean(const ComRef& cref, bool value
   else
   {
     fmi3ValueReference vr = allVariables[j].getValueReferenceFMI3();
-    if (fmi3OK != fmi3_setBoolean(fmu, &vr, 1, &value, 1))
+    if (fmi3OK != fmi3_setBoolean(instance, &vr, 1, &value, 1))
       return oms_status_error;
   }
 
@@ -1617,56 +1619,56 @@ oms_status_enu_t oms::ComponentFMU3ME::setInteger(const ComRef& cref, int value)
       case oms_signal_numeric_type_INT64:
       {
         int64_t v = static_cast<int64_t>(value);
-        if (fmi3OK != fmi3_setInt64(fmu, &vr, 1, &v, 1))
+        if (fmi3OK != fmi3_setInt64(instance, &vr, 1, &v, 1))
           return oms_status_error;
         break;
       }
       case oms_signal_numeric_type_INT32:
       {
         int32_t v = static_cast<int32_t>(value);
-        if (fmi3OK != fmi3_setInt32(fmu, &vr, 1, &v, 1))
+        if (fmi3OK != fmi3_setInt32(instance, &vr, 1, &v, 1))
           return oms_status_error;
         break;
       }
       case oms_signal_numeric_type_INT16:
       {
         int16_t v = static_cast<int16_t>(value);
-        if (fmi3OK != fmi3_setInt16(fmu, &vr, 1, &v, 1))
+        if (fmi3OK != fmi3_setInt16(instance, &vr, 1, &v, 1))
           return oms_status_error;
         break;
       }
       case oms_signal_numeric_type_INT8:
       {
         int8_t v = static_cast<int8_t>(value);
-        if (fmi3OK != fmi3_setInt8(fmu, &vr, 1, &v, 1))
+        if (fmi3OK != fmi3_setInt8(instance, &vr, 1, &v, 1))
           return oms_status_error;
         break;
       }
       case oms_signal_numeric_type_UINT64:
       {
         uint64_t v = static_cast<uint64_t>(value);
-        if (fmi3OK != fmi3_setUInt64(fmu, &vr, 1, &v, 1))
+        if (fmi3OK != fmi3_setUInt64(instance, &vr, 1, &v, 1))
           return oms_status_error;
         break;
       }
       case oms_signal_numeric_type_UINT32:
       {
         uint32_t v = static_cast<uint32_t>(value);
-        if (fmi3OK != fmi3_setUInt32(fmu, &vr, 1, &v, 1))
+        if (fmi3OK != fmi3_setUInt32(instance, &vr, 1, &v, 1))
           return oms_status_error;
         break;
       }
       case oms_signal_numeric_type_UINT16:
       {
         uint16_t v = static_cast<uint16_t>(value);
-        if (fmi3OK != fmi3_setUInt16(fmu, &vr, 1, &v, 1))
+        if (fmi3OK != fmi3_setUInt16(instance, &vr, 1, &v, 1))
           return oms_status_error;
         break;
       }
       case oms_signal_numeric_type_UINT8:
       {
         uint8_t v = static_cast<uint8_t>(value);
-        if (fmi3OK != fmi3_setUInt8(fmu, &vr, 1, &v, 1))
+        if (fmi3OK != fmi3_setUInt8(instance, &vr, 1, &v, 1))
           return oms_status_error;
         break;
       }
@@ -1797,14 +1799,14 @@ oms_status_enu_t oms::ComponentFMU3ME::setReal(const ComRef& cref, double value)
     {
       case oms_signal_numeric_type_FLOAT64:
       {
-        if (fmi3OK != fmi3_setFloat64(fmu, &vr, 1, &value, 1))
+        if (fmi3OK != fmi3_setFloat64(instance, &vr, 1, &value, 1))
           return oms_status_error;
         break;
       }
       case oms_signal_numeric_type_FLOAT32:
       {
         float value_= static_cast<float>(value);
-        if (fmi3OK != fmi3_setFloat32(fmu, &vr, 1, &value_, 1))
+        if (fmi3OK != fmi3_setFloat32(instance, &vr, 1, &value_, 1))
           return oms_status_error;
         break;
       }
@@ -1865,7 +1867,7 @@ oms_status_enu_t oms::ComponentFMU3ME::setString(const ComRef& cref, const std::
   {
     fmi3ValueReference vr = allVariables[j].getValueReferenceFMI3();
     fmi3String value_ = value.c_str();
-    if (fmi3OK != fmi3_setString(fmu, &vr, 1, &value_, 1))
+    if (fmi3OK != fmi3_setString(instance, &vr, 1, &value_, 1))
       return oms_status_error;
   }
 
@@ -2029,7 +2031,7 @@ oms_status_enu_t oms::ComponentFMU3ME::updateSignals(ResultWriter& resultWriter)
 oms_status_enu_t oms::ComponentFMU3ME::getContinuousStates(double* states)
 {
   CallClock callClock(clock);
-  fmi3Status fmistatus = fmi3_getContinuousStates(fmu, states, getNumberOfContinuousStates());
+  fmi3Status fmistatus = fmi3_getContinuousStates(instance, states, getNumberOfContinuousStates());
   if (fmi3OK != fmistatus)
     return logError_FMUCall("fmi3_getContinuousStates", this);
   return oms_status_ok;
@@ -2038,7 +2040,7 @@ oms_status_enu_t oms::ComponentFMU3ME::getContinuousStates(double* states)
 oms_status_enu_t oms::ComponentFMU3ME::setContinuousStates(double* states)
 {
   CallClock callClock(clock);
-  fmi3Status fmistatus = fmi3_setContinuousStates(fmu, states, getNumberOfContinuousStates());
+  fmi3Status fmistatus = fmi3_setContinuousStates(instance, states, getNumberOfContinuousStates());
   if (fmi3OK != fmistatus)
     return logError_FMUCall("fmi3_setContinuousStates", this);
   return oms_status_ok;
@@ -2047,7 +2049,7 @@ oms_status_enu_t oms::ComponentFMU3ME::setContinuousStates(double* states)
 oms_status_enu_t oms::ComponentFMU3ME::getDerivatives(double* derivatives)
 {
   CallClock callClock(clock);
-  fmi3Status fmistatus = fmi3_getContinuousStateDerivatives(fmu, derivatives, getNumberOfContinuousStates());
+  fmi3Status fmistatus = fmi3_getContinuousStateDerivatives(instance, derivatives, getNumberOfContinuousStates());
   if (fmi3OK != fmistatus)
     return logError_FMUCall("fmi3_getContinuousStateDerivatives", this);
   return oms_status_ok;
@@ -2056,7 +2058,7 @@ oms_status_enu_t oms::ComponentFMU3ME::getDerivatives(double* derivatives)
 oms_status_enu_t oms::ComponentFMU3ME::getNominalsOfContinuousStates(double* nominals)
 {
   CallClock callClock(clock);
-  fmi3Status fmistatus = fmi3_getNominalsOfContinuousStates(fmu, nominals, getNumberOfContinuousStates());
+  fmi3Status fmistatus = fmi3_getNominalsOfContinuousStates(instance, nominals, getNumberOfContinuousStates());
   if (fmi3OK != fmistatus)
     return logError_FMUCall("fmi3_getNominalsOfContinuousStates", this);
   return oms_status_ok;
@@ -2065,7 +2067,7 @@ oms_status_enu_t oms::ComponentFMU3ME::getNominalsOfContinuousStates(double* nom
 oms_status_enu_t oms::ComponentFMU3ME::getEventindicators(double* eventindicators)
 {
   CallClock callClock(clock);
-  fmi3Status fmistatus = fmi3_getEventIndicators(fmu, eventindicators, nEventIndicators);
+  fmi3Status fmistatus = fmi3_getEventIndicators(instance, eventindicators, nEventIndicators);
   if (fmi3OK != fmistatus)
     return logError_FMUCall("fmi3_getEventIndicators", this);
   return oms_status_ok;
@@ -2078,7 +2080,7 @@ oms_status_enu_t oms::ComponentFMU3ME::completedIntegratorStep(bool noSetFMUStat
   fmi3Boolean fmiEnterEventMode = fmi3False;
   fmi3Boolean fmiTerminateSimulation = fmi3False;
 
-  fmi3Status status = fmi3_completedIntegratorStep(fmu,
+  fmi3Status status = fmi3_completedIntegratorStep(instance,
                                                    noSetFMUStatePriorToCurrentPoint ? fmi3True : fmi3False,
                                                    &fmiEnterEventMode,
                                                    &fmiTerminateSimulation);
@@ -2094,7 +2096,7 @@ oms_status_enu_t oms::ComponentFMU3ME::completedIntegratorStep(bool noSetFMUStat
 oms_status_enu_t oms::ComponentFMU3ME::enterEventMode()
 {
   CallClock callClock(clock);
-  fmi3Status status = fmi3_enterEventMode(fmu);
+  fmi3Status status = fmi3_enterEventMode(instance);
   if (status != fmi3OK)
     return logError_FMUCall("fmi3_enterEventMode", this);
   return oms_status_ok;
@@ -2103,7 +2105,7 @@ oms_status_enu_t oms::ComponentFMU3ME::enterEventMode()
 oms_status_enu_t oms::ComponentFMU3ME::enterContinuousTimeMode()
 {
   CallClock callClock(clock);
-  fmi3Status status = fmi3_enterContinuousTimeMode(fmu);
+  fmi3Status status = fmi3_enterContinuousTimeMode(instance);
   if (status != fmi3OK)
     return logError_FMUCall("fmi3_enterContinuousTimeMode", this);
   return oms_status_ok;
@@ -2112,7 +2114,7 @@ oms_status_enu_t oms::ComponentFMU3ME::enterContinuousTimeMode()
 oms_status_enu_t oms::ComponentFMU3ME::getEventindicators(double* eventindicators, size_t size)
 {
   CallClock callClock(clock);
-  fmi3Status fmistatus = fmi3_getEventIndicators(fmu, eventindicators, size);
+  fmi3Status fmistatus = fmi3_getEventIndicators(instance, eventindicators, size);
   if (fmi3OK != fmistatus)
     return logError_FMUCall("fmi3_getEventIndicators", this);
   return oms_status_ok;

--- a/src/OMSimulatorLib/ComponentFMU3ME.h
+++ b/src/OMSimulatorLib/ComponentFMU3ME.h
@@ -121,7 +121,7 @@ namespace oms
     oms_status_enu_t enterEventMode();
     oms_status_enu_t enterContinuousTimeMode();
 
-    fmiHandle* getFMU() {return fmu;}
+    fmuHandle* getFMU() {return fmu;}
 
     bool getCanGetAndSetState() {return getFMUInfo()->getCanGetAndSetFMUstate();}
 
@@ -155,7 +155,8 @@ namespace oms
 
   private:
     fmi3LogMessageCallback omsfmi3logger;
-    fmiHandle *fmu = NULL;
+    fmuHandle *fmu = NULL;
+    fmi3InstanceHandle *instance = NULL;
 
     size_t nEventIndicators;
     size_t nContinuousStates;

--- a/src/OMSimulatorLib/ComponentFMUCS.cpp
+++ b/src/OMSimulatorLib/ComponentFMUCS.cpp
@@ -58,8 +58,8 @@ oms::ComponentFMUCS::ComponentFMUCS(const ComRef& cref, System* parentSystem, co
 
 oms::ComponentFMUCS::~ComponentFMUCS()
 {
-  if (oms_modelState_virgin != getModel().getModelState())
-    fmi2_freeInstance(fmu);
+  if (instance && oms_modelState_virgin != getModel().getModelState())
+    fmi2_freeInstance(instance);
 
   fmi4c_freeFmu(fmu);
 }
@@ -628,7 +628,8 @@ oms_status_enu_t oms::ComponentFMUCS::initializeDependencyGraph_outputs()
 
 oms_status_enu_t oms::ComponentFMUCS::instantiate()
 {
-  if (!fmi2_instantiate(fmu, fmi2CoSimulation, omsfmi2logger, calloc, free, NULL, NULL, fmi2True, fmi2True))
+  instance = fmi2_instantiate(fmu, fmi2CoSimulation, omsfmi2logger, calloc, free, NULL, NULL, fmi2True, fmi2True);
+  if (!instance)
   {
     logInfo("fmi2Instantiate() failed");
     exit(1);
@@ -676,10 +677,10 @@ oms_status_enu_t oms::ComponentFMUCS::instantiate()
   double relativeTolerance = 0.0;
   getParentSystem()->getTolerance(&relativeTolerance);
 
-  fmi2Status status = fmi2_setupExperiment(fmu, fmi2True, relativeTolerance, time, fmi2False, 1.0);
+  fmi2Status status = fmi2_setupExperiment(instance, fmi2True, relativeTolerance, time, fmi2False, 1.0);
   if (fmi2OK != status) return logError_FMUCall("fmi2_setupExperiment", this);
 
-  fmi2Status status_ = fmi2_enterInitializationMode(fmu);
+  fmi2Status status_ = fmi2_enterInitializationMode(instance);
   if (fmi2OK != status_) return logError_FMUCall("fmi2_enterInitializationMode", this);
 
   return oms_status_ok;
@@ -840,7 +841,7 @@ oms_status_enu_t oms::ComponentFMUCS::initialize()
   CallClock callClock(clock);
 
   // exitInitialization
-  fmi2Status status = fmi2_exitInitializationMode(fmu);
+  fmi2Status status = fmi2_exitInitializationMode(instance);
 
   if (fmi2OK != status) return logError_FMUCall("fmi2_exitInitializationMode", this);
 
@@ -850,18 +851,19 @@ oms_status_enu_t oms::ComponentFMUCS::initialize()
 oms_status_enu_t oms::ComponentFMUCS::terminate()
 {
   freeState();
-  fmi2Status fmistatus = fmi2_terminate(fmu);
+  fmi2Status fmistatus = fmi2_terminate(instance);
   if (fmi2OK != fmistatus)
     return logError_Termination(getCref());
 
-  fmi2_freeInstance(fmu);
+  fmi2_freeInstance(instance);
+  instance = NULL;
 
   return oms_status_ok;
 }
 
 oms_status_enu_t oms::ComponentFMUCS::reset()
 {
-  fmi2Status fmistatus = fmi2_reset(fmu);
+  fmi2Status fmistatus = fmi2_reset(instance);
   if (fmi2OK != fmistatus)
     return logError_ResetFailed(getCref());
 
@@ -869,10 +871,10 @@ oms_status_enu_t oms::ComponentFMUCS::reset()
   time = getModel().getStartTime();
   double relativeTolerance = 0.0;
   getParentSystem()->getTolerance(&relativeTolerance);
-  fmistatus = fmi2_setupExperiment(fmu, fmi2True, relativeTolerance, time, fmi2False, 1.0);
+  fmistatus = fmi2_setupExperiment(instance, fmi2True, relativeTolerance, time, fmi2False, 1.0);
   if (fmi2OK != fmistatus) return logError_FMUCall("fmi2_setupExperiment", this);
 
-  fmistatus = fmi2_enterInitializationMode(fmu);
+  fmistatus = fmi2_enterInitializationMode(instance);
   if (fmi2OK != fmistatus) return logError_FMUCall("fmi2_enterInitializationMode", this);
 
   return oms_status_ok;
@@ -887,7 +889,7 @@ oms_status_enu_t oms::ComponentFMUCS::stepUntil(double stopTime)
 
   while (time < stopTime)
   {
-    fmi2Status status = fmi2_doStep(fmu, time, hdef, fmi2True);
+    fmi2Status status = fmi2_doStep(instance, time, hdef, fmi2True);
     time += hdef;
 
     if (status == fmi2Discard)
@@ -908,7 +910,7 @@ oms_status_enu_t oms::ComponentFMUCS::getBoolean(const fmi2ValueReference& vr, b
   CallClock callClock(clock);
 
   int value_;
-  if (fmi2OK != fmi2_getBoolean(fmu, &vr, 1, &value_))
+  if (fmi2OK != fmi2_getBoolean(instance, &vr, 1, &value_))
     return oms_status_error;
 
   value = value_ ? true : false;
@@ -999,7 +1001,7 @@ oms_status_enu_t oms::ComponentFMUCS::getInteger(const fmi2ValueReference& vr, i
 {
   CallClock callClock(clock);
 
-  if (fmi2OK != fmi2_getInteger(fmu, &vr, 1, &value))
+  if (fmi2OK != fmi2_getInteger(instance, &vr, 1, &value))
     return oms_status_error;
 
   return oms_status_ok;
@@ -1100,7 +1102,7 @@ oms_status_enu_t oms::ComponentFMUCS::getReal(const fmi2ValueReference& vr, doub
 {
   CallClock callClock(clock);
 
-  if (fmi2OK != fmi2_getReal(fmu, &vr, 1, &value))
+  if (fmi2OK != fmi2_getReal(instance, &vr, 1, &value))
     return oms_status_error;
 
   if (std::isnan(value))
@@ -1196,7 +1198,7 @@ oms_status_enu_t oms::ComponentFMUCS::getString(const fmi2ValueReference& vr, st
   CallClock callClock(clock);
   fmi2String str;
 
-  if (fmi2OK != fmi2_getString(fmu, &vr, 1, &str))
+  if (fmi2OK != fmi2_getString(instance, &vr, 1, &str))
     return oms_status_error;
 
   value = std::string(str);
@@ -1393,7 +1395,7 @@ oms_status_enu_t oms::ComponentFMUCS::getDirectionalDerivativeHeper(const int un
       dvknown[i] = 0.0;
   }
 
-  fmi2_getDirectionalDerivative(fmu, &vr_unknown, 1, vr_known, dependencyList.size(), dvknown, &value);
+  fmi2_getDirectionalDerivative(instance, &vr_unknown, 1, vr_known, dependencyList.size(), dvknown, &value);
 
   free(vr_known);
   free(dvknown);
@@ -1418,7 +1420,7 @@ oms_status_enu_t oms::ComponentFMUCS::getRealOutputDerivative(const ComRef& cref
   if (!fmu || j < 0)
     return logError_UnknownSignal(getFullCref() + cref);
 
-  der = SignalDerivative(getFMUInfo()->getMaxOutputDerivativeOrder(), fmu, allVariables[j].getValueReference());
+  der = SignalDerivative(getFMUInfo()->getMaxOutputDerivativeOrder(), instance, allVariables[j].getValueReference());
   return oms_status_ok;
 }
 
@@ -1448,7 +1450,7 @@ oms_status_enu_t oms::ComponentFMUCS::setRealInputDerivative(const ComRef& cref,
     return logError_UnknownSignal(getFullCref() + cref);
 
   fmi2ValueReference vr = allVariables[j].getValueReference();
-  return der.setRealInputDerivatives(fmu, vr);
+  return der.setRealInputDerivatives(instance, vr);
 }
 
 oms_status_enu_t oms::ComponentFMUCS::setBoolean(const ComRef& cref, bool value)
@@ -1495,7 +1497,7 @@ oms_status_enu_t oms::ComponentFMUCS::setBoolean(const ComRef& cref, bool value)
   {
     fmi2ValueReference vr = allVariables[j].getValueReference();
     int value_ = value ? 1 : 0;
-    if (fmi2OK != fmi2_setBoolean(fmu, &vr, 1, &value_))
+    if (fmi2OK != fmi2_setBoolean(instance, &vr, 1, &value_))
       return oms_status_error;
   }
 
@@ -1546,7 +1548,7 @@ oms_status_enu_t oms::ComponentFMUCS::setInteger(const ComRef& cref, int value)
   else
   {
     fmi2ValueReference vr = allVariables[j].getValueReference();
-    if (fmi2OK != fmi2_setInteger(fmu, &vr, 1, &value))
+    if (fmi2OK != fmi2_setInteger(instance, &vr, 1, &value))
       return oms_status_error;
   }
 
@@ -1604,7 +1606,7 @@ oms_status_enu_t oms::ComponentFMUCS::setReal(const ComRef& cref, double value)
   else
   {
     fmi2ValueReference vr = allVariables[j].getValueReference();
-    if (fmi2OK != fmi2_setReal(fmu, &vr, 1, &value))
+    if (fmi2OK != fmi2_setReal(instance, &vr, 1, &value))
       return oms_status_error;
   }
 
@@ -1659,7 +1661,7 @@ oms_status_enu_t oms::ComponentFMUCS::setString(const ComRef& cref, const std::s
   {
     fmi2ValueReference vr = allVariables[j].getValueReference();
     fmi2String value_ = value.c_str();
-    if (fmi2OK != fmi2_setString(fmu, &vr, 1, &value_))
+    if (fmi2OK != fmi2_setString(instance, &vr, 1, &value_))
       return oms_status_error;
   }
 
@@ -1939,7 +1941,7 @@ oms_status_enu_t oms::ComponentFMUCS::removeSignalsFromResults(const char* regex
 
 oms_status_enu_t oms::ComponentFMUCS::saveState()
 {
-  fmi2Status fmistatus = fmi2_getFMUstate(fmu, &fmuState);
+  fmi2Status fmistatus = fmi2_getFMUstate(instance, &fmuState);
   if (fmi2OK != fmistatus) return logError_FMUCall("fmi2_getFMUstate", this);
   fmuStateTime = time;
 
@@ -1951,7 +1953,7 @@ oms_status_enu_t oms::ComponentFMUCS::freeState()
   if (!fmuState)
     return oms_status_warning;
 
-  fmi2Status fmistatus = fmi2_freeFMUstate(fmu, &fmuState);
+  fmi2Status fmistatus = fmi2_freeFMUstate(instance, &fmuState);
   fmuState = NULL;
   if (fmi2OK != fmistatus) return logError_FMUCall("fmi2_freeFMUstate", this);
 
@@ -1960,7 +1962,7 @@ oms_status_enu_t oms::ComponentFMUCS::freeState()
 
 oms_status_enu_t oms::ComponentFMUCS::restoreState()
 {
-  fmi2Status fmistatus = fmi2_setFMUstate(fmu, fmuState);
+  fmi2Status fmistatus = fmi2_setFMUstate(instance, fmuState);
   if (fmi2OK != fmistatus) return logError_FMUCall("fmi2_setFMUstate", this);
   time = fmuStateTime;
 

--- a/src/OMSimulatorLib/ComponentFMUCS.h
+++ b/src/OMSimulatorLib/ComponentFMUCS.h
@@ -106,7 +106,7 @@ namespace oms
     oms_status_enu_t updateOrDeleteStartValueInReplacedComponent(std::vector<std::string>& warningList);
 
     oms_status_enu_t setFmuTime(double time) {this->time = time; return oms_status_ok;}
-    fmiHandle* getFMU() {return fmu;}
+    fmuHandle* getFMU() {return fmu;}
     std::vector<Variable> getAllVariables() {return allVariables;}
 
     oms_status_enu_t getRealOutputDerivative(const ComRef& cref, SignalDerivative& der);
@@ -146,7 +146,8 @@ namespace oms
 
   private:
     fmi2CallbackLogger omsfmi2logger;
-    fmiHandle *fmu = NULL;
+    fmuHandle *fmu = NULL;
+    fmi2InstanceHandle *instance = NULL;
     FMUInfo fmuInfo;
 
     std::vector<Variable> allVariables;

--- a/src/OMSimulatorLib/ComponentFMUME.cpp
+++ b/src/OMSimulatorLib/ComponentFMUME.cpp
@@ -56,8 +56,8 @@ oms::ComponentFMUME::ComponentFMUME(const ComRef& cref, System* parentSystem, co
 
 oms::ComponentFMUME::~ComponentFMUME()
 {
-  if (oms_modelState_virgin != getModel().getModelState())
-    fmi2_freeInstance(fmu);
+  if (instance && oms_modelState_virgin != getModel().getModelState())
+    fmi2_freeInstance(instance);
 
   fmi4c_freeFmu(fmu);
 }
@@ -658,7 +658,8 @@ oms_status_enu_t oms::ComponentFMUME::initializeDependencyGraph_outputs()
 
 oms_status_enu_t oms::ComponentFMUME::instantiate()
 {
-  if (!fmi2_instantiate(fmu, fmi2ModelExchange, omsfmi2logger, calloc, free, NULL, NULL, fmi2True, fmi2True))
+  instance = fmi2_instantiate(fmu, fmi2ModelExchange, omsfmi2logger, calloc, free, NULL, NULL, fmi2True, fmi2True);
+  if (!instance)
   {
     logInfo("fmi2Instantiate() failed");
     exit(1);
@@ -706,10 +707,10 @@ oms_status_enu_t oms::ComponentFMUME::instantiate()
   double relativeTolerance = 0.0;
   getParentSystem()->getTolerance(&relativeTolerance);
 
-  fmi2Status status = fmi2_setupExperiment(fmu, fmi2True, relativeTolerance, startTime, fmi2False, 1.0);
+  fmi2Status status = fmi2_setupExperiment(instance, fmi2True, relativeTolerance, startTime, fmi2False, 1.0);
   if (fmi2OK != status) return logError_FMUCall("fmi2_setupExperiment", this);
 
-  fmi2Status status_ = fmi2_enterInitializationMode(fmu);
+  fmi2Status status_ = fmi2_enterInitializationMode(instance);
   if (fmi2OK != status_) return logError_FMUCall("fmi2_enterInitializationMode", this);
 
   eventInfo.newDiscreteStatesNeeded = fmi2False;
@@ -824,7 +825,7 @@ oms_status_enu_t oms::ComponentFMUME::doEventIteration()
   eventInfo.terminateSimulation = fmi2False;
   while (eventInfo.newDiscreteStatesNeeded && !eventInfo.terminateSimulation)
   {
-    fmistatus = fmi2_newDiscreteStates(fmu, &eventInfo);
+    fmistatus = fmi2_newDiscreteStates(instance, &eventInfo);
     if (fmi2OK != fmistatus) return logError_FMUCall("fmi2_import_new_discrete_states", this);
 
     if (++iterations >= maxIterations)
@@ -897,14 +898,14 @@ oms_status_enu_t oms::ComponentFMUME::initialize()
   fmi2Status fmistatus;
 
   // exitInitialization
-  fmistatus = fmi2_exitInitializationMode(fmu);
+  fmistatus = fmi2_exitInitializationMode(instance);
   if (fmi2OK != fmistatus) return logError_FMUCall("fmi2_import_exit_initialization_mode", this);
 
   // fmi2_import_exit_initialization_mode leaves FMU in event mode
   if (oms_status_ok != doEventIteration())
     return oms_status_error;
 
-  fmistatus = fmi2_enterContinuousTimeMode(fmu);
+  fmistatus = fmi2_enterContinuousTimeMode(instance);
   if (fmi2OK != fmistatus) return logError_FMUCall("fmi2_import_enter_continuous_time_mode", this);
 
   return oms_status_ok;
@@ -912,18 +913,19 @@ oms_status_enu_t oms::ComponentFMUME::initialize()
 
 oms_status_enu_t oms::ComponentFMUME::terminate()
 {
-  fmi2Status fmistatus = fmi2_terminate(fmu);
+  fmi2Status fmistatus = fmi2_terminate(instance);
   if (fmi2OK != fmistatus)
     return logError_Termination(getCref());
 
-  fmi2_freeInstance(fmu);
+  fmi2_freeInstance(instance);
+  instance = NULL;
 
   return oms_status_ok;
 }
 
 oms_status_enu_t oms::ComponentFMUME::reset()
 {
-  fmi2Status fmistatus = fmi2_reset(fmu);
+  fmi2Status fmistatus = fmi2_reset(instance);
   if (fmi2OK != fmistatus)
     return logError_ResetFailed(getCref());
 
@@ -931,10 +933,10 @@ oms_status_enu_t oms::ComponentFMUME::reset()
   const double& startTime = getModel().getStartTime();
   double relativeTolerance = 0.0;
   getParentSystem()->getTolerance(&relativeTolerance);
-  fmistatus = fmi2_setupExperiment(fmu, fmi2True, relativeTolerance, startTime, fmi2False, 1.0);
+  fmistatus = fmi2_setupExperiment(instance, fmi2True, relativeTolerance, startTime, fmi2False, 1.0);
   if (fmi2OK != fmistatus) return logError_FMUCall("fmi2_setupExperiment", this);
 
-  fmistatus = fmi2_enterInitializationMode(fmu);
+  fmistatus = fmi2_enterInitializationMode(instance);
   if (fmi2OK != fmistatus) return logError_FMUCall("fmi2_enterInitializationMode", this);
 
   eventInfo.newDiscreteStatesNeeded = fmi2False;
@@ -952,7 +954,7 @@ oms_status_enu_t oms::ComponentFMUME::getBoolean(const fmi2ValueReference& vr, b
   CallClock callClock(clock);
 
   int value_;
-  if (fmi2OK != fmi2_getBoolean(fmu, &vr, 1, &value_))
+  if (fmi2OK != fmi2_getBoolean(instance, &vr, 1, &value_))
     return oms_status_error;
 
   value = value_ ? true : false;
@@ -1043,7 +1045,7 @@ oms_status_enu_t oms::ComponentFMUME::getInteger(const fmi2ValueReference& vr, i
 {
   CallClock callClock(clock);
 
-  if (fmi2OK != fmi2_getInteger(fmu, &vr, 1, &value))
+  if (fmi2OK != fmi2_getInteger(instance, &vr, 1, &value))
     return oms_status_error;
 
   return oms_status_ok;
@@ -1051,7 +1053,7 @@ oms_status_enu_t oms::ComponentFMUME::getInteger(const fmi2ValueReference& vr, i
 
 oms_status_enu_t oms::ComponentFMUME::setTime(double time)
 {
-  fmi2Status fmistatus = fmi2_setTime(fmu, time);
+  fmi2Status fmistatus = fmi2_setTime(instance, time);
   if (fmi2OK != fmistatus)
     return logError_FMUCall("fmi2_setTime", this);
   return oms_status_ok;
@@ -1152,7 +1154,7 @@ oms_status_enu_t oms::ComponentFMUME::getReal(const fmi2ValueReference& vr, doub
 {
   CallClock callClock(clock);
 
-  if (fmi2OK != fmi2_getReal(fmu, &vr, 1, &value))
+  if (fmi2OK != fmi2_getReal(instance, &vr, 1, &value))
     return oms_status_error;
 
   if (std::isnan(value))
@@ -1247,7 +1249,7 @@ oms_status_enu_t oms::ComponentFMUME::getString(const fmi2ValueReference& vr, st
 {
   CallClock callClock(clock);
   fmi2String str;
-  if (fmi2OK != fmi2_getString(fmu, &vr, 1, &str))
+  if (fmi2OK != fmi2_getString(instance, &vr, 1, &str))
     return oms_status_error;
 
   value = std::string(str);
@@ -1437,7 +1439,7 @@ oms_status_enu_t oms::ComponentFMUME::getDirectionalDerivativeHeper(const int un
       dvknown[i] = 0.0;
   }
 
-  fmi2_getDirectionalDerivative(fmu, &vr_unknown, 1, vr_known, dependencyList.size(), dvknown, &value);
+  fmi2_getDirectionalDerivative(instance, &vr_unknown, 1, vr_known, dependencyList.size(), dvknown, &value);
 
   free(vr_known);
   free(dvknown);
@@ -1490,7 +1492,7 @@ oms_status_enu_t oms::ComponentFMUME::setBoolean(const ComRef& cref, bool value)
   {
     fmi2ValueReference vr = allVariables[j].getValueReference();
     int value_ = value ? 1 : 0;
-    if (fmi2OK != fmi2_setBoolean(fmu, &vr, 1, &value_))
+    if (fmi2OK != fmi2_setBoolean(instance, &vr, 1, &value_))
       return oms_status_error;
   }
 
@@ -1541,7 +1543,7 @@ oms_status_enu_t oms::ComponentFMUME::setInteger(const ComRef& cref, int value)
   else
   {
     fmi2ValueReference vr = allVariables[j].getValueReference();
-    if (fmi2OK != fmi2_setInteger(fmu, &vr, 1, &value))
+    if (fmi2OK != fmi2_setInteger(instance, &vr, 1, &value))
       return oms_status_error;
   }
 
@@ -1663,7 +1665,7 @@ oms_status_enu_t oms::ComponentFMUME::setReal(const ComRef& cref, double value)
   else
   {
     fmi2ValueReference vr = allVariables[j].getValueReference();
-    if (fmi2OK != fmi2_setReal(fmu, &vr, 1, &value))
+    if (fmi2OK != fmi2_setReal(instance, &vr, 1, &value))
       return oms_status_error;
   }
 
@@ -1719,7 +1721,7 @@ oms_status_enu_t oms::ComponentFMUME::setString(const ComRef& cref, const std::s
   {
     fmi2ValueReference vr = allVariables[j].getValueReference();
     fmi2String value_ = value.c_str();
-    if (fmi2OK != fmi2_setString(fmu, &vr, 1, &value_))
+    if (fmi2OK != fmi2_setString(instance, &vr, 1, &value_))
       return oms_status_error;
   }
 
@@ -1883,7 +1885,7 @@ oms_status_enu_t oms::ComponentFMUME::updateSignals(ResultWriter& resultWriter)
 oms_status_enu_t oms::ComponentFMUME::getContinuousStates(double* states)
 {
   CallClock callClock(clock);
-  fmi2Status fmistatus = fmi2_getContinuousStates(fmu, states, getNumberOfContinuousStates());
+  fmi2Status fmistatus = fmi2_getContinuousStates(instance, states, getNumberOfContinuousStates());
   if (fmi2OK != fmistatus)
     return logError_FMUCall("fmi2_getContinuousStates", this);
   return oms_status_ok;
@@ -1892,7 +1894,7 @@ oms_status_enu_t oms::ComponentFMUME::getContinuousStates(double* states)
 oms_status_enu_t oms::ComponentFMUME::setContinuousStates(double* states)
 {
   CallClock callClock(clock);
-  fmi2Status fmistatus = fmi2_setContinuousStates(fmu, states, getNumberOfContinuousStates());
+  fmi2Status fmistatus = fmi2_setContinuousStates(instance, states, getNumberOfContinuousStates());
   if (fmi2OK != fmistatus)
     return logError_FMUCall("fmi2_setContinuousStates", this);
   return oms_status_ok;
@@ -1901,7 +1903,7 @@ oms_status_enu_t oms::ComponentFMUME::setContinuousStates(double* states)
 oms_status_enu_t oms::ComponentFMUME::getDerivatives(double* derivatives)
 {
   CallClock callClock(clock);
-  fmi2Status fmistatus = fmi2_getDerivatives(fmu, derivatives, getNumberOfContinuousStates());
+  fmi2Status fmistatus = fmi2_getDerivatives(instance, derivatives, getNumberOfContinuousStates());
   if (fmi2OK != fmistatus)
     return logError_FMUCall("fmi2_getDerivatives", this);
   return oms_status_ok;
@@ -1910,7 +1912,7 @@ oms_status_enu_t oms::ComponentFMUME::getDerivatives(double* derivatives)
 oms_status_enu_t oms::ComponentFMUME::getNominalsOfContinuousStates(double* nominals)
 {
   CallClock callClock(clock);
-  fmi2Status fmistatus = fmi2_getNominalsOfContinuousStates(fmu, nominals, getNumberOfContinuousStates());
+  fmi2Status fmistatus = fmi2_getNominalsOfContinuousStates(instance, nominals, getNumberOfContinuousStates());
   if (fmi2OK != fmistatus)
     return logError_FMUCall("fmi2_getNominalsOfContinuousStates", this);
   return oms_status_ok;
@@ -1919,7 +1921,7 @@ oms_status_enu_t oms::ComponentFMUME::getNominalsOfContinuousStates(double* nomi
 oms_status_enu_t oms::ComponentFMUME::getEventindicators(double* eventindicators)
 {
   CallClock callClock(clock);
-  fmi2Status fmistatus = fmi2_getEventIndicators(fmu, eventindicators, nEventIndicators);
+  fmi2Status fmistatus = fmi2_getEventIndicators(instance, eventindicators, nEventIndicators);
   if (fmi2OK != fmistatus)
     return logError_FMUCall("fmi2_getEventIndicators", this);
   return oms_status_ok;
@@ -1928,7 +1930,7 @@ oms_status_enu_t oms::ComponentFMUME::getEventindicators(double* eventindicators
 oms_status_enu_t oms::ComponentFMUME::getEventindicators(double* eventindicators, size_t size)
 {
   CallClock callClock(clock);
-  fmi2Status fmistatus = fmi2_getEventIndicators(fmu, eventindicators, size);
+  fmi2Status fmistatus = fmi2_getEventIndicators(instance, eventindicators, size);
   if (fmi2OK != fmistatus)
     return logError_FMUCall("fmi2_getEventIndicators", this);
   return oms_status_ok;
@@ -1941,7 +1943,7 @@ oms_status_enu_t oms::ComponentFMUME::completedIntegratorStep(bool noSetFMUState
   fmi2Boolean fmiEnterEventMode = fmi2False;
   fmi2Boolean fmiTerminateSimulation = fmi2False;
 
-  fmi2Status status = fmi2_completedIntegratorStep(fmu,
+  fmi2Status status = fmi2_completedIntegratorStep(instance,
                                                    noSetFMUStatePriorToCurrentPoint ? fmi2True : fmi2False,
                                                    &fmiEnterEventMode,
                                                    &fmiTerminateSimulation);
@@ -1958,7 +1960,7 @@ oms_status_enu_t oms::ComponentFMUME::completedIntegratorStep(bool noSetFMUState
 oms_status_enu_t oms::ComponentFMUME::enterEventMode()
 {
   CallClock callClock(clock);
-  fmi2Status status = fmi2_enterEventMode(fmu);
+  fmi2Status status = fmi2_enterEventMode(instance);
   if (status != fmi2OK)
     return logError_FMUCall("fmi2_enterEventMode", this);
   return oms_status_ok;
@@ -1967,7 +1969,7 @@ oms_status_enu_t oms::ComponentFMUME::enterEventMode()
 oms_status_enu_t oms::ComponentFMUME::enterContinuousTimeMode()
 {
   CallClock callClock(clock);
-  fmi2Status status = fmi2_enterContinuousTimeMode(fmu);
+  fmi2Status status = fmi2_enterContinuousTimeMode(instance);
   if (status != fmi2OK)
     return logError_FMUCall("fmi2_enterContinuousTimeMode", this);
   return oms_status_ok;

--- a/src/OMSimulatorLib/ComponentFMUME.h
+++ b/src/OMSimulatorLib/ComponentFMUME.h
@@ -121,7 +121,7 @@ namespace oms
     oms_status_enu_t enterEventMode();
     oms_status_enu_t enterContinuousTimeMode();
 
-    fmiHandle* getFMU() {return fmu;}
+    fmuHandle* getFMU() {return fmu;}
     fmi2EventInfo* getEventInfo() {return &eventInfo;}
 
     bool getCanGetAndSetState() {return getFMUInfo()->getCanGetAndSetFMUstate();}
@@ -156,7 +156,8 @@ namespace oms
 
   private:
     fmi2CallbackLogger omsfmi2logger;
-    fmiHandle *fmu = NULL;
+    fmuHandle *fmu = NULL;
+    fmi2InstanceHandle *instance = NULL;
 
     fmi2EventInfo eventInfo;
     size_t nEventIndicators;

--- a/src/OMSimulatorLib/FMUInfo.cpp
+++ b/src/OMSimulatorLib/FMUInfo.cpp
@@ -79,7 +79,7 @@ oms::FMUInfo::~FMUInfo()
   if (this->version) delete[] this->version;
 }
 
-void oms::FMUInfo::update(oms_component_enu_t componentType, fmiHandle* fmu)
+void oms::FMUInfo::update(oms_component_enu_t componentType, fmuHandle* fmu)
 {
   // Check the component type
   switch (componentType)
@@ -96,7 +96,7 @@ void oms::FMUInfo::update(oms_component_enu_t componentType, fmiHandle* fmu)
 
 }
 
-void oms::FMUInfo::updateFMI2Info(fmiHandle* fmu)
+void oms::FMUInfo::updateFMI2Info(fmuHandle* fmu)
 {
   if (fmi2_getSupportsCoSimulation(fmu))
     this->fmiKind = oms_fmi_kind_cs;
@@ -142,7 +142,7 @@ void oms::FMUInfo::updateFMI2Info(fmiHandle* fmu)
   }
 }
 
-void oms::FMUInfo::updateFMI3Info(fmiHandle* fmu)
+void oms::FMUInfo::updateFMI3Info(fmuHandle* fmu)
 {
   if (fmi3_supportsCoSimulation(fmu))
     this->fmiKind = oms_fmi_kind_cs;

--- a/src/OMSimulatorLib/FMUInfo.h
+++ b/src/OMSimulatorLib/FMUInfo.h
@@ -51,7 +51,7 @@ namespace oms
     FMUInfo(const std::string& path);
     ~FMUInfo();
 
-    void update(oms_component_enu_t componentType, fmiHandle* fmi4c);
+    void update(oms_component_enu_t componentType, fmuHandle* fmi4c);
 
     std::string getPath() const {return std::string(path);}
     oms_fmi_kind_enu_t getKind() const {return fmiKind;}
@@ -63,8 +63,8 @@ namespace oms
     std::string getGenerationTool() const {return std::string(generationTool);}
 
   private:
-    void updateFMI2Info(fmiHandle *fmi4c);
-    void updateFMI3Info(fmiHandle *fmi4c);
+    void updateFMI2Info(fmuHandle *fmi4c);
+    void updateFMI3Info(fmuHandle *fmi4c);
 
     // methods to copy the object
     FMUInfo(const FMUInfo& rhs);            ///< not implemented

--- a/src/OMSimulatorLib/SignalDerivative.cpp
+++ b/src/OMSimulatorLib/SignalDerivative.cpp
@@ -38,6 +38,7 @@
 #include "Logging.h"
 #include <cmath>
 #include <cstring>
+#include <vector>
 
 oms::SignalDerivative::SignalDerivative()
 {
@@ -52,7 +53,7 @@ oms::SignalDerivative::SignalDerivative(double der)
   values[0] = der;
 }
 
-oms::SignalDerivative::SignalDerivative(unsigned int order, fmiHandle* fmu, fmi2ValueReference vr)
+oms::SignalDerivative::SignalDerivative(unsigned int order, fmi2InstanceHandle* instance, fmi2ValueReference vr)
 {
   this->order = order;
   if (this->order == 0)
@@ -60,7 +61,7 @@ oms::SignalDerivative::SignalDerivative(unsigned int order, fmiHandle* fmu, fmi2
   else
   {
     values = new double[order];
-    if (fmi2OK != fmi2_getRealOutputDerivatives(fmu, &vr, 1, (fmi2Integer*)&this->order, values))
+    if (fmi2OK != fmi2_getRealOutputDerivatives(instance, &vr, 1, (fmi2Integer*)&this->order, values))
       logError("fmi2_getRealOutputDerivatives failed");
     else
     {
@@ -74,6 +75,42 @@ oms::SignalDerivative::SignalDerivative(unsigned int order, fmiHandle* fmu, fmi2
         if (std::isinf(values[i]))
         {
           logWarning("fmi2_getRealOutputDerivatives returned +/-inf");
+          values[i] = 0.0;
+        }
+      }
+    }
+  }
+}
+
+oms::SignalDerivative::SignalDerivative(unsigned int order, fmi3InstanceHandle* instance, fmi3ValueReference vr)
+{
+  this->order = order;
+  if (this->order == 0)
+    values = nullptr;
+  else
+  {
+    values = new double[order];
+    // fmi3GetOutputDerivatives takes one derivative order per value reference,
+    // so the same value reference is requested once for each order 1..order
+    std::vector<fmi3ValueReference> vrs(order, vr);
+    std::vector<fmi3Int32> orders(order);
+    for (unsigned int i=0; i<order; ++i)
+      orders[i] = i+1;
+
+    if (fmi3OK != fmi3_getOutputDerivatives(instance, vrs.data(), order, orders.data(), values, order))
+      logError("fmi3_getOutputDerivatives failed");
+    else
+    {
+      for (unsigned int i=0; i<order; ++i)
+      {
+        if (std::isnan(values[i]))
+        {
+          logWarning("fmi3_getOutputDerivatives returned NAN");
+          values[i] = 0.0;
+        }
+        if (std::isinf(values[i]))
+        {
+          logWarning("fmi3_getOutputDerivatives returned +/-inf");
           values[i] = 0.0;
         }
       }
@@ -123,11 +160,11 @@ oms::SignalDerivative& oms::SignalDerivative::operator=(const oms::SignalDerivat
   return *this;
 }
 
-oms_status_enu_t oms::SignalDerivative::setRealInputDerivatives(fmiHandle* fmu, fmi2ValueReference vr) const
+oms_status_enu_t oms::SignalDerivative::setRealInputDerivatives(fmi2InstanceHandle* instance, fmi2ValueReference vr) const
 {
   if (order > 0 && values)
   {
-    if (fmi2OK != fmi2_setRealInputDerivatives(fmu, &vr, 1, (fmi2Integer*)&order, (fmi2Real*)values))
+    if (fmi2OK != fmi2_setRealInputDerivatives(instance, &vr, 1, (fmi2Integer*)&order, (fmi2Real*)values))
       return oms_status_error;
   }
   return oms_status_ok;

--- a/src/OMSimulatorLib/SignalDerivative.h
+++ b/src/OMSimulatorLib/SignalDerivative.h
@@ -47,7 +47,8 @@ namespace oms
   public:
     SignalDerivative();
     SignalDerivative(double der);
-    SignalDerivative(unsigned int order, fmiHandle* fmu, fmi2ValueReference vr);
+    SignalDerivative(unsigned int order, fmi2InstanceHandle* instance, fmi2ValueReference vr);
+    SignalDerivative(unsigned int order, fmi3InstanceHandle* instance, fmi3ValueReference vr);
     ~SignalDerivative();
 
     // methods to copy the object
@@ -56,7 +57,7 @@ namespace oms
 
     const unsigned int getMaxDerivativeOrder() const {return order;}
     const double* getDerivatives() const {return values;}
-    oms_status_enu_t setRealInputDerivatives(fmiHandle* fmu, fmi2ValueReference vr) const;
+    oms_status_enu_t setRealInputDerivatives(fmi2InstanceHandle* instance, fmi2ValueReference vr) const;
 
     operator std::string() const;
 

--- a/src/OMSimulatorLib/Variable.cpp
+++ b/src/OMSimulatorLib/Variable.cpp
@@ -39,7 +39,7 @@
 #include "Util.h"
 #include <iostream>
 
-oms::Variable::Variable(fmiHandle* fmi4c, int index_, oms_component_enu_t componentType)
+oms::Variable::Variable(fmuHandle* fmi4c, int index_, oms_component_enu_t componentType)
   : der_index(0), state_index(0), is_state(false), is_der(false), is_continuous_time_state(false), is_continuous_time_der(false), index(index_), fmi2(false), fmi3(false), componentType(componentType)
 {
 
@@ -62,7 +62,7 @@ oms::Variable::Variable(fmiHandle* fmi4c, int index_, oms_component_enu_t compon
 }
 
 
-void oms::Variable::configureFMI2Variable(fmiHandle* fmi4c, int index_)
+void oms::Variable::configureFMI2Variable(fmuHandle* fmi4c, int index_)
 {
   // extract the attributes
   fmi2VariableHandle *var = fmi2_getVariableByIndex(fmi4c, index_+1);
@@ -114,7 +114,7 @@ void oms::Variable::configureFMI2Variable(fmiHandle* fmi4c, int index_)
   }
 }
 
-void oms::Variable::configureFMI3Variable(fmiHandle* fmi4c, int index_)
+void oms::Variable::configureFMI3Variable(fmuHandle* fmi4c, int index_)
 {
   // extract the attributes
   fmi3VariableHandle *var = fmi3_getVariableByIndex(fmi4c, index_+1);

--- a/src/OMSimulatorLib/Variable.h
+++ b/src/OMSimulatorLib/Variable.h
@@ -49,7 +49,7 @@ namespace oms
   class Variable
   {
   public:
-    Variable(fmiHandle * fmi4c, int index, oms_component_enu_t componentType);
+    Variable(fmuHandle * fmi4c, int index, oms_component_enu_t componentType);
     ~Variable();
 
     void markAsState(size_t der_index) { is_state = true; this->der_index = der_index; }
@@ -108,8 +108,8 @@ namespace oms
 
   private:
 
-    void configureFMI2Variable(fmiHandle *fmi4c, int index);
-    void configureFMI3Variable(fmiHandle *fmi4c, int index);
+    void configureFMI2Variable(fmuHandle *fmi4c, int index);
+    void configureFMI3Variable(fmuHandle *fmi4c, int index);
 
     ComRef cref;
     std::string description;

--- a/testsuite/tests/CompositeModels/FeedthroughConnections.py
+++ b/testsuite/tests/CompositeModels/FeedthroughConnections.py
@@ -148,8 +148,6 @@ instantiated_model.delete()
 ## warning: Unknown FMI3 base type for var : Binary_output
 ## warning: Unknown FMI3 base type for var : Binary_input
 ## warning: Unknown FMI3 base type for var : Binary_output
-## Loading FMI version 3...
-## Loading FMI version 3...
 ## info:    No result file will be created
 ## info:    Feedthrough1.Float64_continuous_input  : 3.5
 ## info:    Feedthrough1.Float64_continuous_output : 3.5

--- a/testsuite/tests/CompositeModels/FeedthroughSetValue1.py
+++ b/testsuite/tests/CompositeModels/FeedthroughSetValue1.py
@@ -128,7 +128,6 @@ instantiated_model.delete()
 ##
 ## warning: Unknown FMI3 base type for var : Binary_input
 ## warning: Unknown FMI3 base type for var : Binary_output
-## Loading FMI version 3...
 ## info:    No result file will be created
 ## info:    Feedthrough1.Float64_continuous_input : 3.5
 ## info:    Feedthrough1.Int64_input              : 7

--- a/testsuite/tests/CompositeModels/FeedthroughSetValue2.py
+++ b/testsuite/tests/CompositeModels/FeedthroughSetValue2.py
@@ -136,7 +136,6 @@ instantiated_model.delete()
 ##
 ## warning: Unknown FMI3 base type for var : Binary_input
 ## warning: Unknown FMI3 base type for var : Binary_output
-## Loading FMI version 3...
 ## info:    No result file will be created
 ## info:    Feedthrough1.Float64_continuous_input : 3.5
 ## info:    Feedthrough1.Int64_input              : 7

--- a/testsuite/tests/CompositeModels/connectFmi2AndFmi3.py
+++ b/testsuite/tests/CompositeModels/connectFmi2AndFmi3.py
@@ -82,7 +82,6 @@ instantiated_model.delete()
 ## Result:
 ## warning: Unknown FMI3 base type for var : Binary_input
 ## warning: Unknown FMI3 base type for var : Binary_output
-## Loading FMI version 3...
 ## info:    No result file will be created
 ## info:   default.Gain1.u : 15.0
 ## info:   default.Gain1.y : 15.0
@@ -90,7 +89,6 @@ instantiated_model.delete()
 ## info:   default.Feedthrough1.Float64_continuous_output : 15.0
 ## warning: Unknown FMI3 base type for var : Binary_input
 ## warning: Unknown FMI3 base type for var : Binary_output
-## Loading FMI version 3...
 ## info:    model doesn't contain any continuous state
 ## info:    maximum step size for 'model.root': 0.001000
 ## info:    No result file will be created

--- a/testsuite/tests/reference-fmus/3.0/cs/BouncingBall-cs.py
+++ b/testsuite/tests/reference-fmus/3.0/cs/BouncingBall-cs.py
@@ -34,7 +34,6 @@ else:
   print("signal v is not equal", flush=True)
 
 ## Result:
-## Loading FMI version 3...
 ## info:    Result file: BouncingBall-cs3.mat (bufferSize=10)
 ## signal h is equal
 ## signal v is equal

--- a/testsuite/tests/reference-fmus/3.0/cs/Dahlquist-cs.py
+++ b/testsuite/tests/reference-fmus/3.0/cs/Dahlquist-cs.py
@@ -30,7 +30,6 @@ else:
   print("signal x is not equal", flush=True)
 
 ## Result:
-## Loading FMI version 3...
 ## info:    Result file: Dahlquist-cs3.mat (bufferSize=10)
 ## signal x is equal
 ## endResult

--- a/testsuite/tests/reference-fmus/3.0/cs/Feedthrough-cs.py
+++ b/testsuite/tests/reference-fmus/3.0/cs/Feedthrough-cs.py
@@ -57,7 +57,6 @@ instantiated_model.delete()
 ## Result:
 ## warning: Unknown FMI3 base type for var : Binary_input
 ## warning: Unknown FMI3 base type for var : Binary_output
-## Loading FMI version 3...
 ## info:    No result file will be created
 ## info:    Feedthrough.Float32_continuous_input: 3.0999999046325684
 ## info:    Feedthrough.Float64_continuous_input: 3.3

--- a/testsuite/tests/reference-fmus/3.0/cs/Resource-cs.py
+++ b/testsuite/tests/reference-fmus/3.0/cs/Resource-cs.py
@@ -27,7 +27,6 @@ instantiated_model.terminate()
 instantiated_model.delete()
 
 ## Result:
-## Loading FMI version 3...
 ## info:    Result file: Resource-cs3.mat (bufferSize=10)
 ## info:    Resource.y: 97
 ## endResult

--- a/testsuite/tests/reference-fmus/3.0/cs/Stair-cs.py
+++ b/testsuite/tests/reference-fmus/3.0/cs/Stair-cs.py
@@ -31,7 +31,6 @@ else:
   print("signal counter is not equal", flush=True)
 
 ## Result:
-## Loading FMI version 3...
 ## info:    Result file: Stair-cs3.mat (bufferSize=10)
 ## signal counter is equal
 ## endResult

--- a/testsuite/tests/reference-fmus/3.0/cs/VanDerPol-cs.py
+++ b/testsuite/tests/reference-fmus/3.0/cs/VanDerPol-cs.py
@@ -35,7 +35,6 @@ else:
   print("signal x1 is not equal", flush=True)
 
 ## Result:
-## Loading FMI version 3...
 ## info:    Result file: VanDerPol-cs3.mat (bufferSize=10)
 ## signal x0 is equal
 ## signal x1 is equal

--- a/testsuite/tests/reference-fmus/3.0/me/BouncingBall-me.py
+++ b/testsuite/tests/reference-fmus/3.0/me/BouncingBall-me.py
@@ -37,7 +37,6 @@ else:
   print("signal v is not equal")
 
 ## Result:
-## Loading FMI version 3...
 ## info:    maximum step size for 'model.root': 0.001000
 ## info:    Result file: BouncingBall-me3.mat (bufferSize=10)
 ## info:    Final Statistics for 'model.root':

--- a/testsuite/tests/reference-fmus/3.0/me/Dahlquist-me.py
+++ b/testsuite/tests/reference-fmus/3.0/me/Dahlquist-me.py
@@ -34,7 +34,6 @@ else:
   print("signal x is not equal", flush=True)
 
 ## Result:
-## Loading FMI version 3...
 ## info:    maximum step size for 'model.root': 0.001000
 ## info:    Result file: Dahlquist-me3.mat (bufferSize=10)
 ## info:    Final Statistics for 'model.root':

--- a/testsuite/tests/reference-fmus/3.0/me/Feedthrough-me.py
+++ b/testsuite/tests/reference-fmus/3.0/me/Feedthrough-me.py
@@ -60,7 +60,6 @@ instantiated_model.delete()
 ## Result:
 ## warning: Unknown FMI3 base type for var : Binary_input
 ## warning: Unknown FMI3 base type for var : Binary_output
-## Loading FMI version 3...
 ## info:    model doesn't contain any continuous state
 ## info:    maximum step size for 'model.root': 0.001000
 ## info:    No result file will be created

--- a/testsuite/tests/reference-fmus/3.0/me/Resource-me.py
+++ b/testsuite/tests/reference-fmus/3.0/me/Resource-me.py
@@ -31,7 +31,6 @@ instantiated_model.terminate()
 instantiated_model.delete()
 
 ## Result:
-## Loading FMI version 3...
 ## info:    model doesn't contain any continuous state
 ## info:    maximum step size for 'model.root': 0.001000
 ## info:    Result file: Resource-me3.mat (bufferSize=10)

--- a/testsuite/tests/reference-fmus/3.0/me/Stair-me.py
+++ b/testsuite/tests/reference-fmus/3.0/me/Stair-me.py
@@ -35,7 +35,6 @@ else:
   print("signal counter is not equal", flush=True)
 
 ## Result:
-## Loading FMI version 3...
 ## info:    model doesn't contain any continuous state
 ## info:    maximum step size for 'model.root': 0.200000
 ## info:    Result file: Stair-me3.mat (bufferSize=10)

--- a/testsuite/tests/reference-fmus/3.0/me/VanDerPol-me.py
+++ b/testsuite/tests/reference-fmus/3.0/me/VanDerPol-me.py
@@ -39,7 +39,6 @@ else:
   print("signal x1 is not equal", flush=True)
 
 ## Result:
-## Loading FMI version 3...
 ## info:    maximum step size for 'model.root': 0.001000
 ## info:    Result file: VanDerPol-me3.mat (bufferSize=10)
 ## info:    Final Statistics for 'model.root':

--- a/testsuite/tests/simulation/FMI3_SimpleSimulation1.py
+++ b/testsuite/tests/simulation/FMI3_SimpleSimulation1.py
@@ -58,7 +58,6 @@ instantiated_model.delete()
 ## |-- |-- startTime: 0.0
 ## |-- |-- stopTime: 1.0
 ##
-## Loading FMI version 3...
 ## info:    Result file: FMI3_SimpleSimulation1_res.mat (bufferSize=10)
 ## info: After simulation:
 ## info:    default.BouncingBall.g: -9.81

--- a/testsuite/tests/simulation/FMI3_SimpleSimulation2.py
+++ b/testsuite/tests/simulation/FMI3_SimpleSimulation2.py
@@ -70,7 +70,6 @@ instantiated_model.delete()
 ## |-- |-- startTime: 0.0
 ## |-- |-- stopTime: 1.0
 ##
-## Loading FMI version 3...
 ## info:    Result file: FMI3_SimpleSimulation2_res.mat (bufferSize=10)
 ## info: After simulation:
 ## info:    default.BouncingBall.g: 10.81

--- a/testsuite/tests/simulation/FMI3_SimpleSimulation3.py
+++ b/testsuite/tests/simulation/FMI3_SimpleSimulation3.py
@@ -68,7 +68,6 @@ instantiated_model.delete()
 ## |-- |-- startTime: 0.0
 ## |-- |-- stopTime: 1.0
 ##
-## Loading FMI version 3...
 ## info:    Result file: FMI3_SimpleSimulation3_res.mat (bufferSize=10)
 ## info: After simulation:
 ## info:    default.param1: 10.81


### PR DESCRIPTION
### Related Issues

Some users want to compile OMSimulator on macOS. But there are some issues like https://github.com/OpenModelica/OMSimulator-3rdParty/pull/94.
We should update fmi4c to the latest version. Another upside: We get rid of many compiler warnings.

### Purpose

* Update fmi4c to v1.2 (needs https://github.com/OpenModelica/OMSimulator-3rdParty/pull/109)
* Update fmi4c changed calls

### Approach

fmi4c renamed `fmiHandle` to `fmuHandle` and moved all runtime calls to `fmi2InstanceHandle`/`fmi3InstanceHandle` returned by the instantiate functions. Store that instance per component and pass it to every `get`/`set`/`step`/`terminate` call, and reset it after `freeInstance` to avoid a double free in the destructor.

`SignalDerivative` is split into FMI 2 and FMI 3 variants, since the handle types no longer alias; FMI 3 has no `setRealInputDerivatives`.

Drop the `"Loading FMI version 3..."` line from the expected test results, which fmi4c no longer prints.
