### PR TITLE
Move fmi enter initialization mode out of FMU instantiation

### DIFF
--- a/src/OMSimulatorLib/Component.h
+++ b/src/OMSimulatorLib/Component.h
@@ -74,6 +74,7 @@ namespace oms
 
     virtual oms_status_enu_t initialize() = 0;
     virtual oms_status_enu_t instantiate() = 0;
+    virtual oms_status_enu_t enterInitializationMode() { return oms_status_ok; }
     virtual oms_status_enu_t registerSignalsForResultFile(ResultWriter& resultFile) = 0;
     virtual oms_status_enu_t removeSignalsFromResults(const char* regex) = 0;
     virtual oms_status_enu_t reset() = 0;

--- a/src/OMSimulatorLib/ComponentFMU3CS.cpp
+++ b/src/OMSimulatorLib/ComponentFMU3CS.cpp
@@ -684,15 +684,19 @@ oms_status_enu_t oms::ComponentFMU3CS::instantiate()
   {
     setResourcesHelper1(values);
   }
-  // enterInitialization
   time = getModel().getStartTime();
 
+  return oms_status_ok;
+}
+
+oms_status_enu_t oms::ComponentFMU3CS::enterInitializationMode()
+{
   double relativeTolerance = 0.0;
   getParentSystem()->getTolerance(&relativeTolerance);
 
-  fmi3Status status_ = fmi3_enterInitializationMode(fmu, fmi3False, relativeTolerance, time, fmi3False, getModel().getStopTime());
+  fmi3Status status = fmi3_enterInitializationMode(fmu, fmi3False, relativeTolerance, time, fmi3False, getModel().getStopTime());
 
-  if (fmi3OK != status_) return logError_FMUCall("fmi3_enterInitializationMode", this);
+  if (fmi3OK != status) return logError_FMUCall("fmi3_enterInitializationMode", this);
 
   return oms_status_ok;
 }

--- a/src/OMSimulatorLib/ComponentFMU3CS.h
+++ b/src/OMSimulatorLib/ComponentFMU3CS.h
@@ -71,6 +71,7 @@ namespace oms
     oms_status_enu_t exportToSSVTemplate(pugi::xml_node& ssvNode, Snapshot& snapshot);
     oms_status_enu_t exportToSSMTemplate(pugi::xml_node& ssmNode);
     oms_status_enu_t instantiate();
+    oms_status_enu_t enterInitializationMode();
     oms_status_enu_t initialize();
     oms_status_enu_t terminate();
     oms_status_enu_t reset();

--- a/src/OMSimulatorLib/ComponentFMU3ME.cpp
+++ b/src/OMSimulatorLib/ComponentFMU3ME.cpp
@@ -670,15 +670,28 @@ oms_status_enu_t oms::ComponentFMU3ME::instantiate()
     setResourcesHelper1(values);
   }
 
-  // enterInitialization
+  const double& startTime = getModel().getStartTime();
+
+  newDiscreteStatesNeeded = fmi3False;
+  terminateSimulation = fmi3False;
+  nominalsOfContinuousStatesChanged = fmi3False;
+  valuesOfContinuousStatesChanged = fmi3True;
+  nextEventTimeDefined = fmi3False;
+  nextEventTime = -0.0;
+
+  return oms_status_ok;
+}
+
+oms_status_enu_t oms::ComponentFMU3ME::enterInitializationMode()
+{
   const double& startTime = getModel().getStartTime();
 
   double relativeTolerance = 0.0;
   getParentSystem()->getTolerance(&relativeTolerance);
 
-  fmi3Status status_ = fmi3_enterInitializationMode(fmu, fmi3False, relativeTolerance, startTime, fmi3False, getModel().getStopTime());
+  fmi3Status status = fmi3_enterInitializationMode(fmu, fmi3False, relativeTolerance, startTime, fmi3False, getModel().getStopTime());
 
-  if (fmi3OK != status_) return logError_FMUCall("fmi3_enterInitializationMode", this);
+  if (fmi3OK != status) return logError_FMUCall("fmi3_enterInitializationMode", this);
 
   newDiscreteStatesNeeded = fmi3False;
   terminateSimulation = fmi3False;

--- a/src/OMSimulatorLib/ComponentFMU3ME.h
+++ b/src/OMSimulatorLib/ComponentFMU3ME.h
@@ -69,6 +69,7 @@ namespace oms
     oms_status_enu_t exportToSSVTemplate(pugi::xml_node& ssvNode, Snapshot& snapshot);
     oms_status_enu_t exportToSSMTemplate(pugi::xml_node& ssmNode);
     oms_status_enu_t instantiate();
+    oms_status_enu_t enterInitializationMode();
     oms_status_enu_t initialize();
     oms_status_enu_t terminate();
     oms_status_enu_t reset();

--- a/src/OMSimulatorLib/ComponentFMUCS.cpp
+++ b/src/OMSimulatorLib/ComponentFMUCS.cpp
@@ -671,7 +671,7 @@ oms_status_enu_t oms::ComponentFMUCS::instantiate()
     setResourcesHelper1(values);
   }
 
-  // enterInitialization
+  // setup experiment
   time = getModel().getStartTime();
   double relativeTolerance = 0.0;
   getParentSystem()->getTolerance(&relativeTolerance);
@@ -679,8 +679,13 @@ oms_status_enu_t oms::ComponentFMUCS::instantiate()
   fmi2Status status = fmi2_setupExperiment(fmu, fmi2True, relativeTolerance, time, fmi2False, 1.0);
   if (fmi2OK != status) return logError_FMUCall("fmi2_setupExperiment", this);
 
-  fmi2Status status_ = fmi2_enterInitializationMode(fmu);
-  if (fmi2OK != status_) return logError_FMUCall("fmi2_enterInitializationMode", this);
+  return oms_status_ok;
+}
+
+oms_status_enu_t oms::ComponentFMUCS::enterInitializationMode()
+{
+  fmi2Status status = fmi2_enterInitializationMode(fmu);
+  if (fmi2OK != status) return logError_FMUCall("fmi2_enterInitializationMode", this);
 
   return oms_status_ok;
 }

--- a/src/OMSimulatorLib/ComponentFMUCS.h
+++ b/src/OMSimulatorLib/ComponentFMUCS.h
@@ -71,6 +71,7 @@ namespace oms
     oms_status_enu_t exportToSSVTemplate(pugi::xml_node& ssvNode, Snapshot& snapshot);
     oms_status_enu_t exportToSSMTemplate(pugi::xml_node& ssmNode);
     oms_status_enu_t instantiate();
+    oms_status_enu_t enterInitializationMode();
     oms_status_enu_t initialize();
     oms_status_enu_t terminate();
     oms_status_enu_t reset();

--- a/src/OMSimulatorLib/ComponentFMUME.cpp
+++ b/src/OMSimulatorLib/ComponentFMUME.cpp
@@ -701,7 +701,7 @@ oms_status_enu_t oms::ComponentFMUME::instantiate()
     setResourcesHelper1(values);
   }
 
-  // enterInitialization
+  // setup experiment
   const double& startTime = getModel().getStartTime();
   double relativeTolerance = 0.0;
   getParentSystem()->getTolerance(&relativeTolerance);
@@ -709,8 +709,20 @@ oms_status_enu_t oms::ComponentFMUME::instantiate()
   fmi2Status status = fmi2_setupExperiment(fmu, fmi2True, relativeTolerance, startTime, fmi2False, 1.0);
   if (fmi2OK != status) return logError_FMUCall("fmi2_setupExperiment", this);
 
-  fmi2Status status_ = fmi2_enterInitializationMode(fmu);
-  if (fmi2OK != status_) return logError_FMUCall("fmi2_enterInitializationMode", this);
+  eventInfo.newDiscreteStatesNeeded = fmi2False;
+  eventInfo.terminateSimulation = fmi2False;
+  eventInfo.nominalsOfContinuousStatesChanged = fmi2False;
+  eventInfo.valuesOfContinuousStatesChanged = fmi2True;
+  eventInfo.nextEventTimeDefined = fmi2False;
+  eventInfo.nextEventTime = -0.0;
+
+  return oms_status_ok;
+}
+
+oms_status_enu_t oms::ComponentFMUME::enterInitializationMode()
+{
+  fmi2Status status = fmi2_enterInitializationMode(fmu);
+  if (fmi2OK != status) return logError_FMUCall("fmi2_enterInitializationMode", this);
 
   eventInfo.newDiscreteStatesNeeded = fmi2False;
   eventInfo.terminateSimulation = fmi2False;

--- a/src/OMSimulatorLib/ComponentFMUME.h
+++ b/src/OMSimulatorLib/ComponentFMUME.h
@@ -69,6 +69,7 @@ namespace oms
     oms_status_enu_t exportToSSVTemplate(pugi::xml_node& ssvNode, Snapshot& snapshot);
     oms_status_enu_t exportToSSMTemplate(pugi::xml_node& ssmNode);
     oms_status_enu_t instantiate();
+    oms_status_enu_t enterInitializationMode();
     oms_status_enu_t initialize();
     oms_status_enu_t terminate();
     oms_status_enu_t reset();

--- a/src/OMSimulatorLib/System.cpp
+++ b/src/OMSimulatorLib/System.cpp
@@ -1503,6 +1503,19 @@ oms::Model& oms::System::getModel()
   return *parentModel;
 }
 
+oms_status_enu_t oms::System::enterInitializationMode()
+{
+  for (const auto& subsystem : getSubSystems())
+    if (oms_status_ok != subsystem.second->enterInitializationMode())
+      return oms_status_error;
+
+  for (const auto& component : getComponents())
+    if (oms_status_ok != component.second->enterInitializationMode())
+      return oms_status_error;
+
+  return oms_status_ok;
+}
+
 oms_status_enu_t oms::System::deleteAllConectionsTo(const oms::ComRef& cref)
 {
   for (int i=0; i<connections.size(); ++i)

--- a/src/OMSimulatorLib/System.h
+++ b/src/OMSimulatorLib/System.h
@@ -79,6 +79,7 @@ namespace oms
     virtual oms_status_enu_t updateSignals(ResultWriter& resultFile);
     virtual oms_status_enu_t setSolver(oms_solver_enu_t solver) {return oms_status_error;}
     virtual oms_status_enu_t instantiate() = 0;
+    oms_status_enu_t enterInitializationMode();
     virtual oms_status_enu_t initialize() = 0;
     virtual oms_status_enu_t terminate() = 0;
     virtual oms_status_enu_t reset() = 0;

--- a/src/OMSimulatorLib/SystemSC.cpp
+++ b/src/OMSimulatorLib/SystemSC.cpp
@@ -280,6 +280,9 @@ oms_status_enu_t oms::SystemSC::initialize()
   clock.reset();
   CallClock callClock(clock);
 
+  if (oms_status_ok != enterInitializationMode())
+    return oms_status_error;
+
   if (oms_status_ok != updateDependencyGraphs())
     return oms_status_error;
 

--- a/src/OMSimulatorLib/SystemWC.cpp
+++ b/src/OMSimulatorLib/SystemWC.cpp
@@ -233,6 +233,9 @@ oms_status_enu_t oms::SystemWC::initialize()
   clock.reset();
   CallClock callClock(clock);
 
+  if (oms_status_ok != enterInitializationMode())
+    return oms_status_error;
+
   if (oms_status_ok != updateDependencyGraphs())
     return oms_status_error;
 


### PR DESCRIPTION
### Related Issues

https://github.com/OpenModelica/OMSimulator/issues/1550

### Purpose

Move fmi2_enterInitializationMode() from instantiate() to the system initialization phase so that FMUs enter initialization mode only when the system is initialized. This also allows setValues to be properly initialized before entering initialization mode.
