### PR TITLE
fmi-ls-dae: DAE FMUs, IDA for the system, and algebraic loops as rows (#1645)

### DIFF
--- a/include/OMSimulator/Types.h
+++ b/include/OMSimulator/Types.h
@@ -76,6 +76,7 @@ typedef enum {
   oms_solver_sc_min,
   oms_solver_sc_explicit_euler,
   oms_solver_sc_cvode,  ///< default
+  oms_solver_sc_ida,    ///< DAE mode: SUNDIALS IDA over the components' residuals (fmi-ls-dae)
   oms_solver_sc_max,
   oms_solver_wc_min,
   oms_solver_wc_ma,     ///< Fixed stepsize (default)

--- a/src/OMSimulatorLib/CMakeLists.txt
+++ b/src/OMSimulatorLib/CMakeLists.txt
@@ -120,6 +120,7 @@ target_link_libraries(OMSimulatorLib
                           oms::3rd::sundials::kinsol
                           oms::3rd::sundials::cvode
                           oms::3rd::sundials::ida
+                          oms::3rd::sundials::sunlinsolklu
                           oms::3rd::fmi4c
                           oms::3rd::minizip
                           oms::3rd::zlib
@@ -153,6 +154,7 @@ target_link_libraries(OMSimulatorLib_static
                           oms::3rd::sundials::kinsol
                           oms::3rd::sundials::cvode
                           oms::3rd::sundials::ida
+                          oms::3rd::sundials::sunlinsolklu
                           oms::3rd::fmi4c
                           oms::3rd::minizip
                           oms::3rd::zlib

--- a/src/OMSimulatorLib/CMakeLists.txt
+++ b/src/OMSimulatorLib/CMakeLists.txt
@@ -65,6 +65,7 @@ set(OMSIMULATORLIB_SOURCES
       Flags.cpp
       FMUInfo.cpp
       Logging.cpp
+      LsDae.cpp
       MatReader.cpp
       MatVer4.cpp
       MATWriter.cpp

--- a/src/OMSimulatorLib/CMakeLists.txt
+++ b/src/OMSimulatorLib/CMakeLists.txt
@@ -119,6 +119,7 @@ target_link_libraries(OMSimulatorLib
                           oms::public_includes
                           oms::3rd::sundials::kinsol
                           oms::3rd::sundials::cvode
+                          oms::3rd::sundials::ida
                           oms::3rd::fmi4c
                           oms::3rd::minizip
                           oms::3rd::zlib
@@ -151,6 +152,7 @@ target_link_libraries(OMSimulatorLib_static
                           oms::public_includes
                           oms::3rd::sundials::kinsol
                           oms::3rd::sundials::cvode
+                          oms::3rd::sundials::ida
                           oms::3rd::fmi4c
                           oms::3rd::minizip
                           oms::3rd::zlib

--- a/src/OMSimulatorLib/ComponentFMU3CS.cpp
+++ b/src/OMSimulatorLib/ComponentFMU3CS.cpp
@@ -474,6 +474,22 @@ void oms::ComponentFMU3CS::dumpInitialUnknowns()
   logInfo("[" + std::string(getCref()) + ": " + getPath() + "] The FMU contains " + std::to_string(n) + " initial unknowns: " + str);
 }
 
+/**
+ * \\brief The variable a ModelStructure dependency names.
+ *
+ * FMI 3.0 changed this from FMI 2.0: a `dependencies` list holds **value
+ * references**, not one-based indices into the variable list. Reading them as
+ * indices silently wires the dependency graph to the wrong variables, and fails
+ * outright on value reference 0, which is a perfectly ordinary one.
+ */
+const oms::Variable* oms::ComponentFMU3CS::variableByFMI3ValueReference(unsigned int vr) const
+{
+  for (const auto& v : allVariables)
+    if (v.getValueReferenceFMI3() == vr)
+      return &v;
+  return nullptr;
+}
+
 oms_status_enu_t oms::ComponentFMU3CS::initializeDependencyGraph_initialUnknowns()
 {
   if (initialUnknownsGraph.getEdges().connections.size() > 0)
@@ -560,15 +576,16 @@ oms_status_enu_t oms::ComponentFMU3CS::initializeDependencyGraph_initialUnknowns
     else
     {
       //dependency exist
-      for (const auto &index : it.second)
+      for (const auto &vr : it.second)
       {
-        if (index < 1 || index > allVariables.size())
+        const Variable* dependency = variableByFMI3ValueReference(vr);
+        if (!dependency)
         {
-          logWarning("Initial unknown " + std::string(initialUnknownsGraph.getNodes()[i]) + " has bad dependency on variable with index " + std::to_string(index) + " which couldn't be resolved");
+          logWarning("Initial unknown " + std::string(initialUnknownsGraph.getNodes()[i]) + " has a dependency on value reference " + std::to_string(vr) + " which couldn't be resolved");
           return logError(std::string(getCref()) + ": Erroneous initial unknowns detected in modelDescription.xml\nUse flag --ignoreInitialUnknowns=true to ignore all initial unknowns, but this can cause inflated loop size.");
         }
-        logDebug(std::string(getCref()) + ": " + getPath() + " initial unknown " + std::string(initialUnknownsGraph.getNodes()[i]) + " depends on " + std::string(allVariables[index - 1]));
-        initialUnknownsGraph.addEdge(allVariables[index - 1].makeConnector(this->getFullCref()), initialUnknownsGraph.getNodes()[i]);
+        logDebug(std::string(getCref()) + ": " + getPath() + " initial unknown " + std::string(initialUnknownsGraph.getNodes()[i]) + " depends on " + std::string(*dependency));
+        initialUnknownsGraph.addEdge(dependency->makeConnector(this->getFullCref()), initialUnknownsGraph.getNodes()[i]);
       }
     }
     i = i + 1;
@@ -610,15 +627,16 @@ oms_status_enu_t oms::ComponentFMU3CS::initializeDependencyGraph_outputs()
     }
     else
     {
-      for (const auto &index : it.second)
+      for (const auto &vr : it.second)
       {
-        if (index < 1 || index > allVariables.size())
+        const Variable* dependency = variableByFMI3ValueReference(vr);
+        if (!dependency)
         {
-          logWarning("Output " + std::string(output) + " has bad dependency on variable with index " + std::to_string(index) + " which couldn't be resolved");
+          logWarning("Output " + std::string(output) + " has a dependency on value reference " + std::to_string(vr) + " which couldn't be resolved");
           return logError(std::string(getCref()) + ": erroneous dependencies detected in modelDescription.xml");
         }
-        logDebug(std::string(getCref()) + ": " + getPath() + " output " + std::string(output) + " depends on " + std::string(allVariables[index - 1]));
-        outputsGraph.addEdge(allVariables[index - 1].makeConnector(this->getFullCref()), output.makeConnector(this->getFullCref()));
+        logDebug(std::string(getCref()) + ": " + getPath() + " output " + std::string(output) + " depends on " + std::string(*dependency));
+        outputsGraph.addEdge(dependency->makeConnector(this->getFullCref()), output.makeConnector(this->getFullCref()));
       }
     }
     i = i + 1;

--- a/src/OMSimulatorLib/ComponentFMU3CS.h
+++ b/src/OMSimulatorLib/ComponentFMU3CS.h
@@ -77,6 +77,8 @@ namespace oms
 
     oms_status_enu_t stepUntil(double stopTime);
 
+    /// The variable a ModelStructure dependency names (FMI 3.0: a value reference).
+    const Variable* variableByFMI3ValueReference(unsigned int vr) const;
     oms_status_enu_t initializeDependencyGraph_initialUnknowns();
     oms_status_enu_t initializeDependencyGraph_outputs();
 

--- a/src/OMSimulatorLib/ComponentFMU3ME.cpp
+++ b/src/OMSimulatorLib/ComponentFMU3ME.cpp
@@ -651,6 +651,13 @@ oms_status_enu_t oms::ComponentFMU3ME::instantiate()
     exit(1);
   }
 
+  // fmi-ls-dae: the switch is a structural parameter, so Configuration Mode is
+  // where it goes — before the start values and before initialization. An FMU
+  // that declares a DAE formulation is used as one: its residuals are what it
+  // has, and its ODE face need not even be implemented.
+  if (lsDae.isValid() && oms_status_ok != enableDaeMode())
+    return oms_status_error;
+
   // set start values from local resources
   if (values.hasResources())
   {
@@ -898,6 +905,10 @@ oms_status_enu_t oms::ComponentFMU3ME::initialize()
   // get number of event indicators after initialize
   fmistatus = fmi3_getNumberOfEventIndicators(fmu, &nEventIndicators);
   if (fmi3OK != fmistatus) return logError_FMUCall("fmi3_getNumberOfEventIndicators", this);
+
+  // fmi-ls-dae: now that the state count is known, the DAE system can be checked
+  if (oms_status_ok != validateDaeMode())
+    return oms_status_error;
 
   // fmi3_exitInitialization_mode leaves FMU in event mode
   if (oms_status_ok != doEventIteration())
@@ -2092,20 +2103,9 @@ oms_status_enu_t oms::ComponentFMU3ME::enableDaeMode()
     return logError("fmi-ls-dae: FMU \"" + std::string(getFullCref()) +
                     "\" states a semi-explicit DAE, which is not supported yet");
 
-  if (derivativeVrs.size() != getNumberOfContinuousStates())
-    return logError("fmi-ls-dae: FMU \"" + std::string(getFullCref()) + "\" has " +
-                    std::to_string(getNumberOfContinuousStates()) + " continuous states but its <ModelStructure> lists " +
-                    std::to_string(derivativeVrs.size()) + " state derivatives");
-
-  // The implicit form's residuals cover the state rows too, so a square system
-  // wants one residual per state and per algebraic variable.
-  const size_t wanted = getNumberOfContinuousStates() + lsDae.getAlgebraicVariables().size();
-  if (lsDae.getResiduals().size() != wanted)
-    return logError("fmi-ls-dae: FMU \"" + std::string(getFullCref()) + "\" states an implicit DAE with " +
-                    std::to_string(getNumberOfContinuousStates()) + " states and " +
-                    std::to_string(lsDae.getAlgebraicVariables().size()) + " algebraic variables, which wants " +
-                    std::to_string(wanted) + " residuals, but lists " + std::to_string(lsDae.getResiduals().size()) +
-                    "; only a square system can be integrated");
+  // The number of continuous states is only known once the FMU has left
+  // Initialization Mode, which is long after Configuration Mode; the checks that
+  // need it are in validateDaeMode(), called from initialize().
 
   if (fmi3OK != fmi3_enterConfigurationMode(fmu))
     return logError_FMUCall("fmi3_enterConfigurationMode", this);
@@ -2122,6 +2122,33 @@ oms_status_enu_t oms::ComponentFMU3ME::enableDaeMode()
     return logError_FMUCall("fmi3_exitConfigurationMode", this);
 
   daeMode = true;
+  return oms_status_ok;
+}
+
+/**
+ * \brief The fmi-ls-dae checks that need the state count, which the FMU only
+ *        reports once it has left Initialization Mode.
+ */
+oms_status_enu_t oms::ComponentFMU3ME::validateDaeMode()
+{
+  if (!daeMode)
+    return oms_status_ok;
+
+  if (derivativeVrs.size() != getNumberOfContinuousStates())
+    return logError("fmi-ls-dae: FMU \"" + std::string(getFullCref()) + "\" has " +
+                    std::to_string(getNumberOfContinuousStates()) + " continuous states but its <ModelStructure> lists " +
+                    std::to_string(derivativeVrs.size()) + " state derivatives");
+
+  // The implicit form's residuals cover the state rows too, so a square system
+  // wants one residual per state and per algebraic variable.
+  const size_t wanted = getNumberOfContinuousStates() + lsDae.getAlgebraicVariables().size();
+  if (lsDae.getResiduals().size() != wanted)
+    return logError("fmi-ls-dae: FMU \"" + std::string(getFullCref()) + "\" states an implicit DAE with " +
+                    std::to_string(getNumberOfContinuousStates()) + " states and " +
+                    std::to_string(lsDae.getAlgebraicVariables().size()) + " algebraic variables, which wants " +
+                    std::to_string(wanted) + " residuals, but lists " + std::to_string(lsDae.getResiduals().size()) +
+                    "; only a square system can be integrated");
+
   return oms_status_ok;
 }
 

--- a/src/OMSimulatorLib/ComponentFMU3ME.cpp
+++ b/src/OMSimulatorLib/ComponentFMU3ME.cpp
@@ -489,6 +489,22 @@ void oms::ComponentFMU3ME::dumpInitialUnknowns()
   logInfo("[" + std::string(getCref()) + ": " + getPath() + "] The FMU contains " + std::to_string(n) + " initial unknowns: " + str);
 }
 
+/**
+ * \\brief The variable a ModelStructure dependency names.
+ *
+ * FMI 3.0 changed this from FMI 2.0: a `dependencies` list holds **value
+ * references**, not one-based indices into the variable list. Reading them as
+ * indices silently wires the dependency graph to the wrong variables, and fails
+ * outright on value reference 0, which is a perfectly ordinary one.
+ */
+const oms::Variable* oms::ComponentFMU3ME::variableByFMI3ValueReference(unsigned int vr) const
+{
+  for (const auto& v : allVariables)
+    if (v.getValueReferenceFMI3() == vr)
+      return &v;
+  return nullptr;
+}
+
 oms_status_enu_t oms::ComponentFMU3ME::initializeDependencyGraph_initialUnknowns()
 {
   if (initialUnknownsGraph.getEdges().connections.size() > 0)
@@ -575,15 +591,16 @@ oms_status_enu_t oms::ComponentFMU3ME::initializeDependencyGraph_initialUnknowns
     else
     {
       //dependency exist
-      for (const auto &index : it.second)
+      for (const auto &vr : it.second)
       {
-        if (index < 1 || index > allVariables.size())
+        const Variable* dependency = variableByFMI3ValueReference(vr);
+        if (!dependency)
         {
-          logWarning("Initial unknown " + std::string(initialUnknownsGraph.getNodes()[i]) + " has bad dependency on variable with index " + std::to_string(index) + " which couldn't be resolved");
+          logWarning("Initial unknown " + std::string(initialUnknownsGraph.getNodes()[i]) + " has a dependency on value reference " + std::to_string(vr) + " which couldn't be resolved");
           return logError(std::string(getCref()) + ": Erroneous initial unknowns detected in modelDescription.xml\nUse flag --ignoreInitialUnknowns=true to ignore all initial unknowns, but this can cause inflated loop size.");
         }
-        logDebug(std::string(getCref()) + ": " + getPath() + " initial unknown " + std::string(initialUnknownsGraph.getNodes()[i]) + " depends on " + std::string(allVariables[index - 1]));
-        initialUnknownsGraph.addEdge(allVariables[index - 1].makeConnector(this->getFullCref()), initialUnknownsGraph.getNodes()[i]);
+        logDebug(std::string(getCref()) + ": " + getPath() + " initial unknown " + std::string(initialUnknownsGraph.getNodes()[i]) + " depends on " + std::string(*dependency));
+        initialUnknownsGraph.addEdge(dependency->makeConnector(this->getFullCref()), initialUnknownsGraph.getNodes()[i]);
       }
     }
     i = i + 1;
@@ -625,15 +642,16 @@ oms_status_enu_t oms::ComponentFMU3ME::initializeDependencyGraph_outputs()
     }
     else
     {
-      for (const auto &index : it.second)
+      for (const auto &vr : it.second)
       {
-        if (index < 1 || index > allVariables.size())
+        const Variable* dependency = variableByFMI3ValueReference(vr);
+        if (!dependency)
         {
-          logWarning("Output " + std::string(output) + " has bad dependency on variable with index " + std::to_string(index) + " which couldn't be resolved");
+          logWarning("Output " + std::string(output) + " has a dependency on value reference " + std::to_string(vr) + " which couldn't be resolved");
           return logError(std::string(getCref()) + ": erroneous dependencies detected in modelDescription.xml");
         }
-        logDebug(std::string(getCref()) + ": " + getPath() + " output " + std::string(output) + " depends on " + std::string(allVariables[index - 1]));
-        outputsGraph.addEdge(allVariables[index - 1].makeConnector(this->getFullCref()), output.makeConnector(this->getFullCref()));
+        logDebug(std::string(getCref()) + ": " + getPath() + " output " + std::string(output) + " depends on " + std::string(*dependency));
+        outputsGraph.addEdge(dependency->makeConnector(this->getFullCref()), output.makeConnector(this->getFullCref()));
       }
     }
     i = i + 1;

--- a/src/OMSimulatorLib/ComponentFMU3ME.cpp
+++ b/src/OMSimulatorLib/ComponentFMU3ME.cpp
@@ -2152,6 +2152,28 @@ oms_status_enu_t oms::ComponentFMU3ME::validateDaeMode()
   if (!daeMode)
     return oms_status_ok;
 
+  // The state each derivative belongs to: a residual's dependency on a state and
+  // on its derivative are the same column of the Jacobian, because one
+  // difference quotient carries dF/dx + cj*dF/dder(x) together.
+  // The `derivative` attribute is a value reference in FMI 3.0, where FMI 2.0 had
+  // an index — the same change as the ModelStructure dependencies. fmi4c hands
+  // the raw attribute through under its FMI 2.0 name, so what Variable calls the
+  // state index is the state's value reference here.
+  stateVrs.clear();
+  for (const fmi3ValueReference vr : derivativeVrs)
+  {
+    const Variable* der = variableByFMI3ValueReference(vr);
+    const Variable* state = der ? variableByFMI3ValueReference(der->getStateIndex()) : nullptr;
+    if (!state)
+    {
+      logWarning("fmi-ls-dae: FMU \"" + std::string(getFullCref()) + "\" does not say which state the derivative at value reference " +
+                 std::to_string(vr) + " belongs to; the DAE Jacobian will be treated as dense");
+      stateVrs.clear();
+      break;
+    }
+    stateVrs.push_back(state->getValueReferenceFMI3());
+  }
+
   if (derivativeVrs.size() != getNumberOfContinuousStates())
     return logError("fmi-ls-dae: FMU \"" + std::string(getFullCref()) + "\" has " +
                     std::to_string(getNumberOfContinuousStates()) + " continuous states but its <ModelStructure> lists " +

--- a/src/OMSimulatorLib/ComponentFMU3ME.cpp
+++ b/src/OMSimulatorLib/ComponentFMU3ME.cpp
@@ -188,6 +188,23 @@ oms::Component* oms::ComponentFMU3ME::NewComponent(const oms::ComRef& cref, oms:
     return NULL;
   }
 
+  // fmi-ls-dae: a Model Exchange FMU may carry a DAE formulation beside its ODE
+  // face. Nothing changes until the system asks for DAE mode; here we only learn
+  // that the FMU has one, and remember the state derivatives it pairs with its
+  // states (the model description's own <ContinuousStateDerivative> order, which
+  // is the order fmi3GetContinuousStates uses).
+  if (component->lsDae.load(tempDir.generic_string()))
+  {
+    const int n = fmi3_getNumberOfModelStructureContinuousStateDerivatives(component->fmu);
+    for (int i = 0; i < n; ++i)
+      component->derivativeVrs.push_back(
+          fmi3_getModelStructureValueReference(fmi3_getModelStructureContinuousStateDerivative(component->fmu, i)));
+    logInfo("FMU \"" + std::string(cref) + "\" carries a DAE formulation (fmi-ls-dae " +
+            component->lsDae.getVersion() + "): " + std::to_string(component->lsDae.getResiduals().size()) +
+            " residuals over " + std::to_string(component->derivativeVrs.size()) + " states and " +
+            std::to_string(component->lsDae.getAlgebraicVariables().size()) + " algebraic variables");
+  }
+
   // update FMU info
   component->fmuInfo.update(oms_component_fmu3, component->fmu);
   component->omsfmi3logger = oms::fmi3logger;
@@ -2050,6 +2067,109 @@ oms_status_enu_t oms::ComponentFMU3ME::getDerivatives(double* derivatives)
   fmi3Status fmistatus = fmi3_getContinuousStateDerivatives(fmu, derivatives, getNumberOfContinuousStates());
   if (fmi3OK != fmistatus)
     return logError_FMUCall("fmi3_getContinuousStateDerivatives", this);
+  return oms_status_ok;
+}
+
+/**
+ * \brief fmi-ls-dae: switch the FMU into DAE mode.
+ *
+ * The switch is a structural parameter, so Configuration Mode is where it is
+ * set — before initialization, and only once. After this the FMU no longer owes
+ * the derivatives and the algebraic variables: the master sets them and reads
+ * the residuals of F(t, x, x', z) = 0 back.
+ */
+oms_status_enu_t oms::ComponentFMU3ME::enableDaeMode()
+{
+  CallClock callClock(clock);
+
+  if (!lsDae.isValid())
+    return logError("FMU \"" + std::string(getFullCref()) + "\" carries no fmi-ls-dae manifest, so it has no DAE mode");
+
+  if (daeMode)
+    return oms_status_ok;
+
+  if (!lsDae.isFullyImplicit())
+    return logError("fmi-ls-dae: FMU \"" + std::string(getFullCref()) +
+                    "\" states a semi-explicit DAE, which is not supported yet");
+
+  if (derivativeVrs.size() != getNumberOfContinuousStates())
+    return logError("fmi-ls-dae: FMU \"" + std::string(getFullCref()) + "\" has " +
+                    std::to_string(getNumberOfContinuousStates()) + " continuous states but its <ModelStructure> lists " +
+                    std::to_string(derivativeVrs.size()) + " state derivatives");
+
+  // The implicit form's residuals cover the state rows too, so a square system
+  // wants one residual per state and per algebraic variable.
+  const size_t wanted = getNumberOfContinuousStates() + lsDae.getAlgebraicVariables().size();
+  if (lsDae.getResiduals().size() != wanted)
+    return logError("fmi-ls-dae: FMU \"" + std::string(getFullCref()) + "\" states an implicit DAE with " +
+                    std::to_string(getNumberOfContinuousStates()) + " states and " +
+                    std::to_string(lsDae.getAlgebraicVariables().size()) + " algebraic variables, which wants " +
+                    std::to_string(wanted) + " residuals, but lists " + std::to_string(lsDae.getResiduals().size()) +
+                    "; only a square system can be integrated");
+
+  if (fmi3OK != fmi3_enterConfigurationMode(fmu))
+    return logError_FMUCall("fmi3_enterConfigurationMode", this);
+
+  const fmi3ValueReference vr = lsDae.getEnableValueReference();
+  const fmi3Boolean on = fmi3True;
+  if (fmi3OK != fmi3_setBoolean(fmu, &vr, 1, &on, 1))
+  {
+    fmi3_exitConfigurationMode(fmu);
+    return logError_FMUCall("fmi3_setBoolean (the fmi-ls-dae DAE-mode parameter)", this);
+  }
+
+  if (fmi3OK != fmi3_exitConfigurationMode(fmu))
+    return logError_FMUCall("fmi3_exitConfigurationMode", this);
+
+  daeMode = true;
+  return oms_status_ok;
+}
+
+oms_status_enu_t oms::ComponentFMU3ME::getDaeResiduals(double* residuals)
+{
+  CallClock callClock(clock);
+  const std::vector<uint32_t>& vrs = lsDae.getResiduals();
+  if (vrs.empty())
+    return oms_status_ok;
+  fmi3Status fmistatus = fmi3_getFloat64(fmu, vrs.data(), vrs.size(), residuals, vrs.size());
+  if (fmi3OK != fmistatus)
+    return logError_FMUCall("fmi3_getFloat64 (fmi-ls-dae residuals)", this);
+  return oms_status_ok;
+}
+
+oms_status_enu_t oms::ComponentFMU3ME::getAlgebraicVariables(double* values)
+{
+  CallClock callClock(clock);
+  const std::vector<uint32_t>& vrs = lsDae.getAlgebraicVariables();
+  if (vrs.empty())
+    return oms_status_ok;
+  fmi3Status fmistatus = fmi3_getFloat64(fmu, vrs.data(), vrs.size(), values, vrs.size());
+  if (fmi3OK != fmistatus)
+    return logError_FMUCall("fmi3_getFloat64 (fmi-ls-dae algebraic variables)", this);
+  return oms_status_ok;
+}
+
+oms_status_enu_t oms::ComponentFMU3ME::setAlgebraicVariables(const double* values)
+{
+  CallClock callClock(clock);
+  const std::vector<uint32_t>& vrs = lsDae.getAlgebraicVariables();
+  if (vrs.empty())
+    return oms_status_ok;
+  fmi3Status fmistatus = fmi3_setFloat64(fmu, vrs.data(), vrs.size(), values, vrs.size());
+  if (fmi3OK != fmistatus)
+    return logError_FMUCall("fmi3_setFloat64 (fmi-ls-dae algebraic variables)", this);
+  return oms_status_ok;
+}
+
+oms_status_enu_t oms::ComponentFMU3ME::setDerivatives(const double* derivativeValues)
+{
+  CallClock callClock(clock);
+  if (derivativeVrs.empty())
+    return oms_status_ok;
+  fmi3Status fmistatus = fmi3_setFloat64(fmu, derivativeVrs.data(), derivativeVrs.size(),
+                                         derivativeValues, derivativeVrs.size());
+  if (fmi3OK != fmistatus)
+    return logError_FMUCall("fmi3_setFloat64 (state derivatives)", this);
   return oms_status_ok;
 }
 

--- a/src/OMSimulatorLib/ComponentFMU3ME.h
+++ b/src/OMSimulatorLib/ComponentFMU3ME.h
@@ -134,6 +134,11 @@ namespace oms
     size_t getNumberOfDaeResiduals() const {return lsDae.getResiduals().size();}
     size_t getNumberOfAlgebraicVariables() const {return lsDae.getAlgebraicVariables().size();}
     oms_status_enu_t getDaeResiduals(double* residuals);
+    /// The value references of the continuous states, in the order
+    /// fmi3GetContinuousStates uses — that of <ContinuousStateDerivative>.
+    const std::vector<fmi3ValueReference>& getStateValueReferences() const {return stateVrs;}
+    /// The value references of the state derivatives, in the same order.
+    const std::vector<fmi3ValueReference>& getDerivativeValueReferences() const {return derivativeVrs;}
     oms_status_enu_t getAlgebraicVariables(double* values);
     oms_status_enu_t setAlgebraicVariables(const double* values);
     /// The state derivatives, by value reference: the implicit form's knowns.
@@ -193,6 +198,9 @@ namespace oms
     /// The <ContinuousStateDerivative> value references of the model
     /// description, in the order fmi3GetContinuousStates uses for the states.
     std::vector<fmi3ValueReference> derivativeVrs;
+    /// The states those derivatives belong to, resolved from the derivative
+    /// links of the model description; same order.
+    std::vector<fmi3ValueReference> stateVrs;
 
     fmi3Boolean newDiscreteStatesNeeded;
     fmi3Boolean terminateSimulation;

--- a/src/OMSimulatorLib/ComponentFMU3ME.h
+++ b/src/OMSimulatorLib/ComponentFMU3ME.h
@@ -74,6 +74,8 @@ namespace oms
     oms_status_enu_t terminate();
     oms_status_enu_t reset();
 
+    /// The variable a ModelStructure dependency names (FMI 3.0: a value reference).
+    const Variable* variableByFMI3ValueReference(unsigned int vr) const;
     oms_status_enu_t initializeDependencyGraph_initialUnknowns();
     oms_status_enu_t initializeDependencyGraph_outputs();
 

--- a/src/OMSimulatorLib/ComponentFMU3ME.h
+++ b/src/OMSimulatorLib/ComponentFMU3ME.h
@@ -38,6 +38,7 @@
 
 #include "Component.h"
 #include "ComRef.h"
+#include "LsDae.h"
 #include "ResultWriter.h"
 #include "Snapshot.h"
 #include "Values.h"
@@ -111,6 +112,28 @@ namespace oms
 
     size_t getNumberOfContinuousStates() const {return nContinuousStates;}
     size_t getNumberOfEventIndicators() const {return nEventIndicators;}
+
+    /// fmi-ls-dae: what the FMU's layered-standard manifest declares, if any.
+    const LsDaeManifest& getLsDae() const {return lsDae;}
+    bool hasDaeFormulation() const {return lsDae.isValid();}
+    /// Whether this instance was switched into DAE mode.
+    bool isInDaeMode() const {return daeMode;}
+    /**
+     * \brief Switch the FMU into fmi-ls-dae's DAE mode.
+     *
+     * The switch is a structural parameter, so it is set in Configuration Mode,
+     * before initialization. From then on the FMU no longer answers with the
+     * derivatives and the algebraic variables: the importer owns them and reads
+     * the residuals of F(t, x, x', z) = 0 back.
+     */
+    oms_status_enu_t enableDaeMode();
+    size_t getNumberOfDaeResiduals() const {return lsDae.getResiduals().size();}
+    size_t getNumberOfAlgebraicVariables() const {return lsDae.getAlgebraicVariables().size();}
+    oms_status_enu_t getDaeResiduals(double* residuals);
+    oms_status_enu_t getAlgebraicVariables(double* values);
+    oms_status_enu_t setAlgebraicVariables(const double* values);
+    /// The state derivatives, by value reference: the implicit form's knowns.
+    oms_status_enu_t setDerivatives(const double* derivatives);
     oms_status_enu_t getContinuousStates(double* states);
     oms_status_enu_t setContinuousStates(double* states);
     oms_status_enu_t getDerivatives(double* derivatives);
@@ -159,6 +182,13 @@ namespace oms
 
     size_t nEventIndicators;
     size_t nContinuousStates;
+
+    /// fmi-ls-dae: the manifest, and whether this instance runs in DAE mode.
+    LsDaeManifest lsDae;
+    bool daeMode = false;
+    /// The <ContinuousStateDerivative> value references of the model
+    /// description, in the order fmi3GetContinuousStates uses for the states.
+    std::vector<fmi3ValueReference> derivativeVrs;
 
     fmi3Boolean newDiscreteStatesNeeded;
     fmi3Boolean terminateSimulation;

--- a/src/OMSimulatorLib/ComponentFMU3ME.h
+++ b/src/OMSimulatorLib/ComponentFMU3ME.h
@@ -127,6 +127,8 @@ namespace oms
      * the residuals of F(t, x, x', z) = 0 back.
      */
     oms_status_enu_t enableDaeMode();
+    /// The DAE checks that need the state count, which is known after initialization.
+    oms_status_enu_t validateDaeMode();
     size_t getNumberOfDaeResiduals() const {return lsDae.getResiduals().size();}
     size_t getNumberOfAlgebraicVariables() const {return lsDae.getAlgebraicVariables().size();}
     oms_status_enu_t getDaeResiduals(double* residuals);

--- a/src/OMSimulatorLib/LsDae.cpp
+++ b/src/OMSimulatorLib/LsDae.cpp
@@ -1,0 +1,114 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF AGPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.8.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GNU AGPL
+ * VERSION 3, ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+ * Public License (OSMC-PL) are obtained from OSMC, either from the above
+ * address, from the URLs:
+ * http://www.openmodelica.org or
+ * https://github.com/OpenModelica/ or
+ * http://www.ida.liu.se/projects/OpenModelica,
+ * and in the OpenModelica distribution.
+ *
+ * GNU AGPL version 3 is obtained from:
+ * https://www.gnu.org/licenses/licenses.html#GPL
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+#include "LsDae.h"
+
+#include "Logging.h"
+#include "OMSFileSystem.h"
+
+#include <pugixml.hpp>
+#include <sstream>
+
+/**
+ * \brief The value references in a whitespace-separated `dependencies` list.
+ */
+static std::vector<uint32_t> parseValueReferenceList(const char* text)
+{
+  std::vector<uint32_t> vrs;
+  if (!text)
+    return vrs;
+  std::istringstream in(text);
+  unsigned long vr;
+  while (in >> vr)
+    vrs.push_back(static_cast<uint32_t>(vr));
+  return vrs;
+}
+
+bool oms::LsDaeManifest::load(const std::string& unzippedFmuPath)
+{
+  const filesystem::path manifest = filesystem::path(unzippedFmuPath) / filesystem::path(path());
+  if (!filesystem::exists(manifest))
+    return false;   // no DAE formulation, which is the ordinary case
+
+  pugi::xml_document doc;
+  pugi::xml_parse_result result = doc.load_file(manifest.string().c_str());
+  if (!result)
+  {
+    logWarning("fmi-ls-dae: could not read \"" + manifest.string() + "\": " + std::string(result.description()));
+    return false;
+  }
+
+  const pugi::xml_node root = doc.child("fmiDAEManifest");
+  if (!root)
+  {
+    logWarning("fmi-ls-dae: \"" + manifest.string() + "\" has no <fmiDAEManifest> element");
+    return false;
+  }
+
+  version = root.attribute("fmi-ls:fmi-ls-version").as_string();
+
+  const pugi::xml_node enable = root.child("EnableDAEParameter");
+  if (!enable)
+  {
+    logWarning("fmi-ls-dae: the manifest names no <EnableDAEParameter>, so the FMU cannot be switched into DAE mode");
+    return false;
+  }
+  enableVr = enable.attribute("valueReference").as_uint();
+
+  for (const pugi::xml_node& node : root.child("AlgebraicVariables").children("AlgebraicVariable"))
+    algebraicVrs.push_back(node.attribute("valueReference").as_uint());
+
+  // The manifest's <ModelStructure> replaces the model description's: no
+  // <ContinuousStateDerivative> is the fully implicit form, where the residuals
+  // cover the state rows as well.
+  const pugi::xml_node structure = root.child("ModelStructure");
+  for (const pugi::xml_node& node : structure.children("ContinuousStateDerivative"))
+    continuousStateDerivatives.push_back(node.attribute("valueReference").as_uint());
+
+  for (const pugi::xml_node& node : structure.children("Residual"))
+  {
+    residualVrs.push_back(node.attribute("valueReference").as_uint());
+    residualDependencies.push_back(parseValueReferenceList(node.attribute("dependencies").value()));
+  }
+
+  if (residualVrs.empty())
+  {
+    logWarning("fmi-ls-dae: the manifest lists no <Residual>, so there is no DAE system to solve");
+    return false;
+  }
+
+  valid = true;
+  return true;
+}

--- a/src/OMSimulatorLib/LsDae.h
+++ b/src/OMSimulatorLib/LsDae.h
@@ -1,0 +1,114 @@
+/*
+ * This file is part of OpenModelica.
+ *
+ * Copyright (c) 1998-2026, Open Source Modelica Consortium (OSMC),
+ * c/o Linköpings universitet, Department of Computer and Information Science,
+ * SE-58183 Linköping, Sweden.
+ *
+ * All rights reserved.
+ *
+ * THIS PROGRAM IS PROVIDED UNDER THE TERMS OF AGPL VERSION 3 LICENSE OR
+ * THIS OSMC PUBLIC LICENSE (OSMC-PL) VERSION 1.8.
+ * ANY USE, REPRODUCTION OR DISTRIBUTION OF THIS PROGRAM CONSTITUTES
+ * RECIPIENT'S ACCEPTANCE OF THE OSMC PUBLIC LICENSE OR THE GNU AGPL
+ * VERSION 3, ACCORDING TO RECIPIENTS CHOICE.
+ *
+ * The OpenModelica software and the OSMC (Open Source Modelica Consortium)
+ * Public License (OSMC-PL) are obtained from OSMC, either from the above
+ * address, from the URLs:
+ * http://www.openmodelica.org or
+ * https://github.com/OpenModelica/ or
+ * http://www.ida.liu.se/projects/OpenModelica,
+ * and in the OpenModelica distribution.
+ *
+ * GNU AGPL version 3 is obtained from:
+ * https://www.gnu.org/licenses/licenses.html#GPL
+ *
+ * This program is distributed WITHOUT ANY WARRANTY; without
+ * even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE, EXCEPT AS EXPRESSLY SET FORTH
+ * IN THE BY RECIPIENT SELECTED SUBSIDIARY LICENSE CONDITIONS OF OSMC-PL.
+ *
+ * See the full OSMC Public License conditions for more details.
+ *
+ */
+
+#ifndef _OMS_LSDAE_H_
+#define _OMS_LSDAE_H_
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace oms
+{
+  /**
+   * \brief fmi-ls-dae: what an FMU's layered-standard manifest says about its
+   *        DAE formulation.
+   *
+   * A Model Exchange FMU that carries
+   * `extra/org.fmi-standard.fmi-ls-dae/fmi-ls-manifest.xml` is an ordinary ODE
+   * FMU until the importer sets the structural parameter the manifest names,
+   * and a DAE FMU after: it then exposes the residuals of
+   * `F(t, x, x', z) = 0` and lets the importer solve for the algebraic
+   * variables `z` beside the states, instead of iterating on them internally.
+   *
+   * The manifest names the switch, the algebraic variables and the residuals;
+   * the state derivatives are the model description's own
+   * `<ContinuousStateDerivative>` list, which orders them with the states.
+   */
+  class LsDaeManifest
+  {
+  public:
+    /// The layered standard this reader understands.
+    static const char* name() { return "org.fmi-standard.fmi-ls-dae"; }
+    /// Where the manifest sits inside an FMU.
+    static const char* path() { return "extra/org.fmi-standard.fmi-ls-dae/fmi-ls-manifest.xml"; }
+
+    /**
+     * \brief Read the manifest out of an unzipped FMU.
+     *
+     * \param unzippedFmuPath  Directory the FMU was unzipped into.
+     * \return true if a manifest is there and could be read. A missing file is
+     *         not an error: the FMU simply has no DAE formulation.
+     */
+    bool load(const std::string& unzippedFmuPath);
+
+    bool isValid() const { return valid; }
+    /// The version the manifest declares, e.g. "1.0.0-alpha.1".
+    const std::string& getVersion() const { return version; }
+    /// The structural parameter that switches the FMU into DAE mode.
+    uint32_t getEnableValueReference() const { return enableVr; }
+    /// The algebraic variables the importer solves for, beside the states.
+    const std::vector<uint32_t>& getAlgebraicVariables() const { return algebraicVrs; }
+    /// One value reference per residual of F.
+    const std::vector<uint32_t>& getResiduals() const { return residualVrs; }
+    /**
+     * \brief Per residual, the value references it declares a dependency on;
+     *        empty for a residual that named none, which the standard reads as
+     *        a dependency on every known.
+     */
+    const std::vector<std::vector<uint32_t>>& getResidualDependencies() const { return residualDependencies; }
+    /**
+     * \brief The state derivatives the manifest lists.
+     *
+     * Empty for the fully implicit form `F(t, x, x', z) = 0`, where the
+     * residuals cover the state rows too. A non-empty list is the semi-explicit
+     * form: the FMU answers with `der(x)` and the residuals constrain the
+     * algebraic variables alone.
+     */
+    const std::vector<uint32_t>& getContinuousStateDerivatives() const { return continuousStateDerivatives; }
+    bool isFullyImplicit() const { return continuousStateDerivatives.empty(); }
+
+  private:
+    bool valid = false;
+    std::string version;
+    uint32_t enableVr = 0;
+    std::vector<uint32_t> algebraicVrs;
+    std::vector<uint32_t> residualVrs;
+    std::vector<std::vector<uint32_t>> residualDependencies;
+    std::vector<uint32_t> continuousStateDerivatives;
+  };
+}
+
+#endif

--- a/src/OMSimulatorLib/SystemSC.cpp
+++ b/src/OMSimulatorLib/SystemSC.cpp
@@ -166,6 +166,70 @@ int oms::cvode_roots(sunrealtype t, N_Vector y, sunrealtype *gout, void *user_da
  * step.
  * ------------------------------------------------------------------------- */
 
+/**
+ * \brief Which algebraic loops of the simulation graph become rows of the
+ *        global system, and what their unknowns are.
+ *
+ * Every connection of a loop contributes one unknown, the value of the input it
+ * drives, and one row, output - input = 0 — the same system the inner Newton
+ * solved, handed to IDA instead. A loop is only lifted if all of its
+ * connections carry reals: an integer or boolean connection is not something a
+ * continuous unknown can stand for, so such a loop keeps its inner solver.
+ */
+std::vector<bool> oms::SystemSC::allLoopsOf(DirectedGraph& graph) const
+{
+  size_t loops = 0;
+  for (const scc_t& scc : graph.getSortedConnections())
+    if (scc.thisIsALoop)
+      ++loops;
+  return std::vector<bool>(loops, true);
+}
+
+bool oms::SystemSC::anyComponentInDaeMode()
+{
+  for (const auto& component : getComponents())
+  {
+    const ComponentFMU3ME* fmu3 = dynamic_cast<const ComponentFMU3ME*>(component.second);
+    if (fmu3 && fmu3->isInDaeMode())
+      return true;
+  }
+  return false;
+}
+
+void oms::SystemSC::collectLiftedLoops()
+{
+  liftedConnections.clear();
+  liftedLoops.clear();
+
+  const std::vector<scc_t>& sortedConnections = simulationGraph.getSortedConnections();
+  for (const scc_t& scc : sortedConnections)
+  {
+    if (!scc.thisIsALoop)
+      continue;
+
+    bool allReal = true;
+    for (const auto& connection : scc.connections)
+      if (simulationGraph.getNodes()[connection.second].getType() != oms_signal_type_real ||
+          simulationGraph.getNodes()[connection.first].getType() != oms_signal_type_real)
+        allReal = false;
+
+    liftedLoops.push_back(allReal);
+    if (!allReal)
+    {
+      logInfo("system \"" + std::string(getFullCref()) + "\": an algebraic loop over connections that are not all real keeps its own solver");
+      continue;
+    }
+
+    for (const auto& connection : scc.connections)
+      liftedConnections.push_back({connection.first, connection.second});
+  }
+
+  if (!liftedConnections.empty())
+    logInfo("system \"" + std::string(getFullCref()) + "\": " + std::to_string(liftedConnections.size()) +
+            " connection(s) of " + std::to_string(std::count(liftedLoops.begin(), liftedLoops.end(), true)) +
+            " algebraic loop(s) are rows of the DAE system, not an inner solve");
+}
+
 oms_status_enu_t oms::SystemSC::setDaePoint(double t, N_Vector yy, N_Vector yp)
 {
   oms_status_enu_t status;
@@ -205,8 +269,17 @@ oms_status_enu_t oms::SystemSC::setDaePoint(double t, N_Vector yy, N_Vector yp)
     }
   }
 
-  // The coupling, before the rows below are asked for.
-  return updateInputs(simulationGraph);
+  // The loop connections IDA owns: the unknown is the value of the driven input.
+  // Set before the propagation below, which then leaves those loops alone.
+  for (size_t k = 0; k < liftedConnections.size(); ++k)
+  {
+    const double value = NV_Ith_S(yy, nDaeUnknowns - liftedConnections.size() + k);
+    if (oms_status_ok != setReal(simulationGraph.getNodes()[liftedConnections[k].input].getName(), value))
+      return oms_status_error;
+  }
+
+  // The rest of the coupling, before the rows below are asked for.
+  return updateInputsInternal(simulationGraph, &liftedLoops);
 }
 
 oms_status_enu_t oms::SystemSC::getDaePoint(N_Vector yy, N_Vector yp)
@@ -238,6 +311,17 @@ oms_status_enu_t oms::SystemSC::getDaePoint(N_Vector yy, N_Vector yp)
       NV_Ith_S(yy, j) = algebraicVars[i][k];
       NV_Ith_S(yp, j) = 0.0;   // an algebraic unknown has no derivative row
     }
+  }
+
+  // The lifted loop connections, seeded with the values the inputs hold — after
+  // initialization, or after an event, that is the best guess there is.
+  for (size_t k = 0, j = nDaeUnknowns - liftedConnections.size(); k < liftedConnections.size(); ++k, ++j)
+  {
+    double value = 0.0;
+    if (oms_status_ok != getReal(simulationGraph.getNodes()[liftedConnections[k].input].getName(), value))
+      return oms_status_error;
+    NV_Ith_S(yy, j) = value;
+    NV_Ith_S(yp, j) = 0.0;
   }
 
   return oms_status_ok;
@@ -272,6 +356,17 @@ int oms::ida_res(sunrealtype t, N_Vector yy, N_Vector yp, N_Vector rr, void* use
       for (size_t k = 0; k < system->nStates[i]; ++k, ++j)
         NV_Ith_S(rr, j) = NV_Ith_S(yp, j) - system->states_der[i][k];
     }
+  }
+
+  // The lifted loop rows: what the driving output now says, against the value
+  // IDA is carrying for the input it drives.
+  for (size_t k = 0, j = system->nDaeUnknowns - system->liftedConnections.size();
+       k < system->liftedConnections.size(); ++k, ++j)
+  {
+    double value = 0.0;
+    if (oms_status_ok != system->getReal(system->simulationGraph.getNodes()[system->liftedConnections[k].output].getName(), value))
+      return -1;
+    NV_Ith_S(rr, j) = value - NV_Ith_S(yy, j);
   }
 
   return 0;
@@ -434,7 +529,18 @@ oms_status_enu_t oms::SystemSC::initialize()
   if (oms_status_ok != updateDependencyGraphs())
     return oms_status_error;
 
-  if (oms_status_ok != updateInputs(initializationGraph))
+  // fmi-ls-dae: a component in DAE mode does not solve for its own algebraic
+  // outputs — the master does — so a loop through one cannot be closed by the
+  // inner Newton here. Leave every loop of the initialization graph to the
+  // consistent-initial-conditions solve at the end of this function.
+  daeMode = anyComponentInDaeMode();
+  if (daeMode)
+  {
+    std::vector<bool> allLoops = allLoopsOf(initializationGraph);
+    if (oms_status_ok != updateInputsInternal(initializationGraph, &allLoops))
+      return oms_status_error;
+  }
+  else if (oms_status_ok != updateInputs(initializationGraph))
     return oms_status_error;
 
   for (const auto& subsystem : getSubSystems())
@@ -477,9 +583,17 @@ oms_status_enu_t oms::SystemSC::initialize()
     algebraicVars.push_back((double*)calloc(nAlgebraic.back(), sizeof(double)));
     residuals.push_back((double*)calloc(inDaeMode ? fmu3->getNumberOfDaeResiduals() : 0, sizeof(double)));
     if (inDaeMode)
-      daeMode = true;
+      daeMode = true;   // already true from anyComponentInDaeMode(), kept for clarity
     nDaeUnknowns += nStates.back() + nAlgebraic.back();
    }
+
+  // fmi-ls-dae: with IDA driving the system, an algebraic loop over connections
+  // can be rows of it instead of an inner Newton of its own.
+  if (daeMode)
+  {
+    collectLiftedLoops();
+    nDaeUnknowns += liftedConnections.size();
+  }
 
   if (daeMode && oms_solver_sc_ida != solverMethod)
   {
@@ -696,6 +810,12 @@ oms_status_enu_t oms::SystemSC::initialize()
       }
     }
 
+    for (size_t k = 0, j = nDaeUnknowns - liftedConnections.size(); k < liftedConnections.size(); ++k, ++j)
+    {
+      NV_Ith_S(solverData.ida.id, j) = 0.0;
+      NV_Ith_S(solverData.ida.abstol, j) = relativeTolerance;
+    }
+
     solverData.ida.mem = IDACreate(solverData.ida.sunctx);
     if (!solverData.ida.mem) return logError("SUNDIALS_ERROR: IDACreate() failed - returned NULL pointer");
 
@@ -840,6 +960,8 @@ oms_status_enu_t oms::SystemSC::terminate()
   residuals.clear();
   daeMode = false;
   nDaeUnknowns = 0;
+  liftedConnections.clear();
+  liftedLoops.clear();
   states.clear();
   states_der.clear();
   states_nominal.clear();
@@ -943,6 +1065,8 @@ oms_status_enu_t oms::SystemSC::reset()
   residuals.clear();
   daeMode = false;
   nDaeUnknowns = 0;
+  liftedConnections.clear();
+  liftedLoops.clear();
   states.clear();
   states_der.clear();
   states_nominal.clear();
@@ -1467,7 +1591,12 @@ oms_status_enu_t oms::SystemSC::doStepIDA()
         fmus[i]->doEventIteration();
       }
 
-      updateInputs(eventGraph);
+      {
+        // As during initialization: the loops are the integrator's, and
+        // calcConsistentInitialConditions() below closes them.
+        std::vector<bool> allLoops = allLoopsOf(eventGraph);
+        updateInputsInternal(eventGraph, &allLoops);
+      }
 
       for (size_t i = 0; i < fmus.size(); ++i)
       {
@@ -1503,7 +1632,10 @@ oms_status_enu_t oms::SystemSC::doStepIDA()
       if (oms_status_ok != status) return status;
 
       // emit the right limit of the event
-      updateInputs(eventGraph);
+      {
+        std::vector<bool> allLoops = allLoopsOf(eventGraph);
+        updateInputsInternal(eventGraph, &allLoops);
+      }
       if (isTopLevelSystem())
         getModel().emit(time, true);
 
@@ -1545,6 +1677,11 @@ oms_status_enu_t oms::SystemSC::stepUntil(double stopTime)
 }
 
 oms_status_enu_t oms::SystemSC::updateInputs(DirectedGraph& graph)
+{
+  return updateInputsInternal(graph, nullptr);
+}
+
+oms_status_enu_t oms::SystemSC::updateInputsInternal(DirectedGraph& graph, const std::vector<bool>* liftedLoops)
 {
   CallClock callClock(clock);
   oms_status_enu_t status;
@@ -1596,11 +1733,17 @@ oms_status_enu_t oms::SystemSC::updateInputs(DirectedGraph& graph)
     }
     else
     {
-      status = solveAlgLoop(graph, loopNum);
-      if (oms_status_ok != status)
+      // A loop IDA owns is already satisfied by the point it set; solving it
+      // again here would fight the integrator for the same unknowns.
+      const bool lifted = liftedLoops && loopNum < static_cast<int>(liftedLoops->size()) && (*liftedLoops)[loopNum];
+      if (!lifted)
       {
-        forceLoopsToBeUpdated();
-        return status;
+        status = solveAlgLoop(graph, loopNum);
+        if (oms_status_ok != status)
+        {
+          forceLoopsToBeUpdated();
+          return status;
+        }
       }
       loopNum++;
     }

--- a/src/OMSimulatorLib/SystemSC.cpp
+++ b/src/OMSimulatorLib/SystemSC.cpp
@@ -44,6 +44,9 @@
 #include "ssd/Tags.h"
 
 #include <algorithm>
+#include <cmath>
+#include <set>
+#include <map>
 #include <cstring>
 #include <sstream>
 #include <iostream>
@@ -228,6 +231,283 @@ void oms::SystemSC::collectLiftedLoops()
     logInfo("system \"" + std::string(getFullCref()) + "\": " + std::to_string(liftedConnections.size()) +
             " connection(s) of " + std::to_string(std::count(liftedLoops.begin(), liftedLoops.end(), true)) +
             " algebraic loop(s) are rows of the DAE system, not an inner solve");
+}
+
+/**
+ * \brief Does this component own the graph node, i.e. is the node one of its
+ *        own variables?
+ */
+static bool componentOwnsNode(const oms::Component* component, const oms::ComRef& node, std::string& variableName)
+{
+  // The connection graph of a system names its nodes relative to that system
+  // ("A.u"), while a component knows itself by its full path
+  // ("model.root.A"). Try both, so this does not depend on which one a caller
+  // built the graph with.
+  const std::string name = std::string(node);
+  for (const std::string& prefix : {std::string(component->getFullCref()) + ".",
+                                    std::string(component->getCref()) + "."})
+  {
+    if (name.rfind(prefix, 0) == 0 && name.size() > prefix.size())
+    {
+      variableName = name.substr(prefix.size());
+      return true;
+    }
+  }
+  return false;
+}
+
+void oms::SystemSC::buildDaeJacobianSparsity()
+{
+  daeJacRowsByColumn.clear();
+  daeJacColorOfColumn.clear();
+  daeJacColumnsOfColor.clear();
+  daeJacIncrement.clear();
+
+  const size_t n = nDaeUnknowns;
+  if (0 == n)
+    return;
+
+  // Where each component's unknowns sit, and which column a value reference of
+  // it stands for. A state and its derivative share a column: one difference
+  // quotient carries dF/dx + cj*dF/dder(x) together.
+  std::vector<size_t> columnOfComponent(fmus.size(), 0);
+  std::vector<std::map<fmi3ValueReference, int>> columnOfValueReference(fmus.size());
+  const size_t loopBase = n - liftedConnections.size();
+
+  for (size_t i = 0, j = 0; i < fmus.size(); ++i)
+  {
+    columnOfComponent[i] = j;
+    if (daeFmus[i])
+    {
+      const std::vector<fmi3ValueReference>& stateVrs = daeFmus[i]->getStateValueReferences();
+      const std::vector<fmi3ValueReference>& derVrs = daeFmus[i]->getDerivativeValueReferences();
+      if (stateVrs.size() != nStates[i])
+      {
+        // The component could not say which state each derivative belongs to;
+        // without that a residual's dependency on a state cannot be placed.
+        logInfo("system \"" + std::string(getFullCref()) + "\": the DAE Jacobian of \"" +
+                std::string(fmus[i]->getFullCref()) + "\" has no usable structure; differencing it densely");
+        return;
+      }
+      for (size_t k = 0; k < nStates[i]; ++k)
+      {
+        columnOfValueReference[i][stateVrs[k]] = static_cast<int>(j + k);
+        columnOfValueReference[i][derVrs[k]] = static_cast<int>(j + k);
+      }
+      const std::vector<uint32_t>& algVrs = daeFmus[i]->getLsDae().getAlgebraicVariables();
+      for (size_t k = 0; k < algVrs.size(); ++k)
+        columnOfValueReference[i][algVrs[k]] = static_cast<int>(j + nStates[i] + k);
+    }
+    j += nStates[i] + nAlgebraic[i];
+  }
+
+  // A lifted loop's unknown is the value of an input of some component, so a
+  // residual that depends on that input depends on that column.
+  std::vector<int> componentOfLoop(liftedConnections.size(), -1);
+  std::vector<int> componentOfLoopOutput(liftedConnections.size(), -1);
+  for (size_t k = 0; k < liftedConnections.size(); ++k)
+  {
+    for (size_t i = 0; i < fmus.size(); ++i)
+    {
+      std::string variableName;
+      if (componentOwnsNode(fmus[i], simulationGraph.getNodes()[liftedConnections[k].input].getName(), variableName))
+      {
+        componentOfLoop[k] = static_cast<int>(i);
+        if (daeFmus[i])
+        {
+          const Variable* v = daeFmus[i]->getVariable(ComRef(variableName));
+          if (v)
+            columnOfValueReference[i][v->getValueReferenceFMI3()] = static_cast<int>(loopBase + k);
+        }
+      }
+      if (componentOwnsNode(fmus[i], simulationGraph.getNodes()[liftedConnections[k].output].getName(), variableName))
+        componentOfLoopOutput[k] = static_cast<int>(i);
+    }
+  }
+
+  // The loop unknowns that drive a component. A residual of it may depend on any
+  // of them, and the manifest does not say: the dependencies it declares are
+  // those of the FMU's own DAE Jacobian, whose columns are the states and the
+  // algebraic variables — an input is not one of them. It only becomes an
+  // unknown here, where the master carries it, so these columns are added to
+  // every row of the component whether the manifest names them or not.
+  auto incomingLoopColumns = [&](size_t i, std::vector<int>& out) {
+    for (size_t k = 0; k < liftedConnections.size(); ++k)
+      if (componentOfLoop[k] == static_cast<int>(i))
+        out.push_back(static_cast<int>(loopBase + k));
+  };
+
+  // All the columns of one component, plus those: what a row is taken to reach
+  // when nothing more precise is known.
+  auto columnsAround = [&](size_t i, std::vector<int>& out) {
+    for (size_t k = 0; k < nStates[i] + nAlgebraic[i]; ++k)
+      out.push_back(static_cast<int>(columnOfComponent[i] + k));
+    incomingLoopColumns(i, out);
+  };
+
+  std::vector<std::vector<int>> columnsByRow(n);
+  size_t row = 0;
+  for (size_t i = 0; i < fmus.size(); ++i)
+  {
+    if (daeFmus[i])
+    {
+      const std::vector<std::vector<uint32_t>>& dependencies = daeFmus[i]->getLsDae().getResidualDependencies();
+      for (size_t k = 0; k < nStates[i] + nAlgebraic[i]; ++k, ++row)
+      {
+        bool exact = k < dependencies.size() && !dependencies[k].empty();
+        if (exact)
+        {
+          for (const uint32_t vr : dependencies[k])
+          {
+            const auto it = columnOfValueReference[i].find(vr);
+            if (it == columnOfValueReference[i].end())
+            {
+              // A value reference that is not one of the unknowns: a parameter or
+              // time, which contribute nothing, or a variable of the component
+              // that stands for the unknowns behind it. Cannot tell the two
+              // apart here, so take the whole component.
+              exact = false;
+              break;
+            }
+            columnsByRow[row].push_back(it->second);
+          }
+        }
+        if (exact)
+          incomingLoopColumns(i, columnsByRow[row]);
+        else
+        {
+          columnsByRow[row].clear();
+          columnsAround(i, columnsByRow[row]);
+        }
+      }
+    }
+    else
+    {
+      // x' - f(x, u, t): its own states, and whatever drives its inputs.
+      for (size_t k = 0; k < nStates[i]; ++k, ++row)
+        columnsAround(i, columnsByRow[row]);
+    }
+  }
+
+  // A loop row is output - input: the unknown it stands for, and whatever the
+  // component computing that output depends on.
+  for (size_t k = 0; k < liftedConnections.size(); ++k, ++row)
+  {
+    columnsByRow[row].push_back(static_cast<int>(loopBase + k));
+    if (componentOfLoopOutput[k] >= 0)
+      columnsAround(static_cast<size_t>(componentOfLoopOutput[k]), columnsByRow[row]);
+    else
+      for (size_t c = 0; c < n; ++c)
+        columnsByRow[row].push_back(static_cast<int>(c));
+  }
+
+  // Transpose, and drop the duplicates a conservative row may have collected.
+  daeJacRowsByColumn.assign(n, {});
+  size_t nnz = 0;
+  for (size_t r = 0; r < n; ++r)
+  {
+    std::sort(columnsByRow[r].begin(), columnsByRow[r].end());
+    columnsByRow[r].erase(std::unique(columnsByRow[r].begin(), columnsByRow[r].end()), columnsByRow[r].end());
+    for (const int c : columnsByRow[r])
+      daeJacRowsByColumn[c].push_back(static_cast<int>(r));
+    nnz += columnsByRow[r].size();
+  }
+
+  // Greedy distance-1 colouring of the columns: two columns may share a colour
+  // only when no row reaches both, which is what makes their contributions
+  // separable in a single differenced evaluation.
+  daeJacColorOfColumn.assign(n, -1);
+  for (size_t c = 0; c < n; ++c)
+  {
+    std::set<int> forbidden;
+    for (const int r : daeJacRowsByColumn[c])
+      for (const int other : columnsByRow[r])
+        if (other != static_cast<int>(c) && daeJacColorOfColumn[other] >= 0)
+          forbidden.insert(daeJacColorOfColumn[other]);
+
+    int color = 0;
+    while (forbidden.count(color))
+      ++color;
+    daeJacColorOfColumn[c] = color;
+    if (static_cast<size_t>(color) >= daeJacColumnsOfColor.size())
+      daeJacColumnsOfColor.resize(color + 1);
+    daeJacColumnsOfColor[color].push_back(static_cast<int>(c));
+  }
+
+  daeJacIncrement.assign(n, 0.0);
+  logInfo("system \"" + std::string(getFullCref()) + "\": DAE Jacobian " + std::to_string(n) + "x" + std::to_string(n) +
+          ", " + std::to_string(nnz) + " structural nonzeros, " + std::to_string(daeJacColumnsOfColor.size()) +
+          " colour(s) — one residual evaluation per colour instead of one per unknown");
+}
+
+/**
+ * \brief The DAE Jacobian dF/dy + cj*dF/dy', differenced one colour at a time.
+ *
+ * The colouring makes every column of a colour distinguishable in a single
+ * evaluation, because no row reaches two of them, so the whole matrix costs as
+ * many residual evaluations as there are colours. IDA's own difference quotient
+ * would cost one per unknown, and each of those calls into every FMU of the
+ * system.
+ */
+int oms::ida_jac(sunrealtype t, sunrealtype cj, N_Vector yy, N_Vector yp, N_Vector rr,
+                 SUNMatrix Jac, void* user_data, N_Vector tmp1, N_Vector tmp2, N_Vector tmp3)
+{
+  SystemSC* system = (SystemSC*)user_data;
+  const size_t n = system->nDaeUnknowns;
+
+  SUNMatZero(Jac);
+
+  sunrealtype hh = 0.0;
+  if (IDAGetCurrentStep(system->solverData.ida.mem, &hh) != IDA_SUCCESS)
+    return -1;
+  // Its own vector: tmp3 takes the perturbed residual below, which would
+  // otherwise overwrite the weights before the next colour reads them.
+  if (IDAGetErrWeights(system->solverData.ida.mem, system->solverData.ida.ewt) != IDA_SUCCESS)
+    return -1;
+
+  const sunrealtype srur = std::sqrt(SUN_UNIT_ROUNDOFF);
+
+  for (const std::vector<int>& columns : system->daeJacColumnsOfColor)
+  {
+    N_VScale(1.0, yy, tmp1);
+    N_VScale(1.0, yp, tmp2);
+
+    for (const int j : columns)
+    {
+      const sunrealtype yj = NV_Ith_S(yy, j);
+      const sunrealtype ypj = NV_Ith_S(yp, j);
+      const sunrealtype ewtj = NV_Ith_S(system->solverData.ida.ewt, j);
+
+      // IDA's own difference quotient increment (IDADenseDQJac).
+      sunrealtype inc = std::max(srur * std::max(std::fabs(yj), std::fabs(hh * ypj)), 1.0 / ewtj);
+      if (hh * ypj < 0.0)
+        inc = -inc;
+      inc = (yj + inc) - yj;
+      if (0.0 == inc)
+        inc = srur;
+
+      system->daeJacIncrement[j] = inc;
+      NV_Ith_S(tmp1, j) = yj + inc;
+      NV_Ith_S(tmp2, j) = ypj + cj * inc;
+    }
+
+    if (0 != ida_res(t, tmp1, tmp2, tmp3, user_data))
+      return -1;
+
+    for (const int j : columns)
+    {
+      const sunrealtype scale = 1.0 / system->daeJacIncrement[j];
+      for (const int i : system->daeJacRowsByColumn[j])
+        SM_ELEMENT_D(Jac, i, j) = (NV_Ith_S(tmp3, i) - NV_Ith_S(rr, i)) * scale;
+    }
+  }
+
+  // The point the components hold is the perturbed one; put the original back so
+  // whatever reads them next does not see it.
+  if (oms_status_ok != system->setDaePoint(t, yy, yp))
+    return -1;
+
+  return 0;
 }
 
 oms_status_enu_t oms::SystemSC::setDaePoint(double t, N_Vector yy, N_Vector yp)
@@ -785,7 +1065,8 @@ oms_status_enu_t oms::SystemSC::initialize()
     solverData.ida.yp = N_VNew_Serial(n, solverData.ida.sunctx);
     solverData.ida.id = N_VNew_Serial(n, solverData.ida.sunctx);
     solverData.ida.abstol = N_VNew_Serial(n, solverData.ida.sunctx);
-    if (!solverData.ida.y || !solverData.ida.yp || !solverData.ida.id || !solverData.ida.abstol)
+    solverData.ida.ewt = N_VNew_Serial(n, solverData.ida.sunctx);
+    if (!solverData.ida.y || !solverData.ida.yp || !solverData.ida.id || !solverData.ida.abstol || !solverData.ida.ewt)
       return logError("SUNDIALS_ERROR: N_VNew_Serial() failed - returned NULL pointer");
 
     // The point the components hold after their own initialization, and which
@@ -837,15 +1118,24 @@ oms_status_enu_t oms::SystemSC::initialize()
       if (flag < 0) return logError("SUNDIALS_ERROR: IDARootInit() failed with flag = " + std::to_string(flag));
     }
 
-    // A dense Jacobian, differenced by IDA. The manifest's residual dependencies
-    // would give a sparsity pattern for KLU; that is the next step and matters
-    // as soon as the system is more than small.
     solverData.ida.J = SUNDenseMatrix(n, n, solverData.ida.sunctx);
     if (!solverData.ida.J) return logError("SUNDIALS_ERROR: SUNDenseMatrix() failed");
     solverData.ida.linSol = SUNLinSol_Dense(solverData.ida.y, solverData.ida.J, solverData.ida.sunctx);
     if (!solverData.ida.linSol) return logError("SUNDIALS_ERROR: SUNLinSol_Dense() failed");
     flag = IDASetLinearSolver(solverData.ida.mem, solverData.ida.linSol, solverData.ida.J);
     if (flag < 0) return logError("SUNDIALS_ERROR: IDASetLinearSolver() failed with flag = " + std::to_string(flag));
+
+    // The components' manifests say which unknowns each residual reaches. That
+    // structure colours the columns, and the Jacobian is then differenced a
+    // colour at a time instead of a column at a time — the difference between a
+    // handful of residual evaluations and one per unknown, each of which calls
+    // into every FMU. Without a usable structure IDA differences it itself.
+    buildDaeJacobianSparsity();
+    if (!daeJacColumnsOfColor.empty())
+    {
+      flag = IDASetJacFn(solverData.ida.mem, ida_jac);
+      if (flag < 0) return logError("SUNDIALS_ERROR: IDASetJacFn() failed with flag = " + std::to_string(flag));
+    }
 
     flag = IDASetMaxStep(solverData.ida.mem, maximumStepSize);
     if (flag < 0) return logError("SUNDIALS_ERROR: IDASetMaxStep() failed with flag = " + std::to_string(flag));
@@ -900,6 +1190,7 @@ oms_status_enu_t oms::SystemSC::terminate()
     N_VDestroy_Serial(solverData.ida.yp);
     N_VDestroy_Serial(solverData.ida.id);
     N_VDestroy_Serial(solverData.ida.abstol);
+    N_VDestroy_Serial(solverData.ida.ewt);
     IDAFree(&(solverData.ida.mem));
     SUNContext_Free(&(solverData.ida.sunctx));
     solverData.ida.mem = nullptr;
@@ -962,6 +1253,10 @@ oms_status_enu_t oms::SystemSC::terminate()
   nDaeUnknowns = 0;
   liftedConnections.clear();
   liftedLoops.clear();
+  daeJacRowsByColumn.clear();
+  daeJacColorOfColumn.clear();
+  daeJacColumnsOfColor.clear();
+  daeJacIncrement.clear();
   states.clear();
   states_der.clear();
   states_nominal.clear();
@@ -1004,6 +1299,7 @@ oms_status_enu_t oms::SystemSC::reset()
     N_VDestroy_Serial(solverData.ida.yp);
     N_VDestroy_Serial(solverData.ida.id);
     N_VDestroy_Serial(solverData.ida.abstol);
+    N_VDestroy_Serial(solverData.ida.ewt);
     IDAFree(&(solverData.ida.mem));
     SUNContext_Free(&(solverData.ida.sunctx));
     solverData.ida.mem = nullptr;
@@ -1067,6 +1363,10 @@ oms_status_enu_t oms::SystemSC::reset()
   nDaeUnknowns = 0;
   liftedConnections.clear();
   liftedLoops.clear();
+  daeJacRowsByColumn.clear();
+  daeJacColorOfColumn.clear();
+  daeJacColumnsOfColor.clear();
+  daeJacIncrement.clear();
   states.clear();
   states_der.clear();
   states_nominal.clear();

--- a/src/OMSimulatorLib/SystemSC.cpp
+++ b/src/OMSimulatorLib/SystemSC.cpp
@@ -152,6 +152,151 @@ int oms::cvode_roots(sunrealtype t, N_Vector y, sunrealtype *gout, void *user_da
   return 0;
 }
 
+/* ---------------------------------------------------------------------------
+ * fmi-ls-dae: the system as one implicit DAE
+ *
+ * The unknowns are laid out per component, [x_i | z_i], and so are the rows: a
+ * component in DAE mode contributes the residuals it declares, an ODE component
+ * the explicit rows x'_i - f_i(x, u, t). Both blocks are square, so the system
+ * is, and a system may mix the two.
+ *
+ * The coupling is where it was for CVODE: updateInputs() propagates connected
+ * outputs into inputs before the rows are evaluated, so the residuals see a
+ * consistent coupling rather than the value left over from the last accepted
+ * step.
+ * ------------------------------------------------------------------------- */
+
+oms_status_enu_t oms::SystemSC::setDaePoint(double t, N_Vector yy, N_Vector yp)
+{
+  oms_status_enu_t status;
+
+  for (size_t i = 0, j = 0; i < fmus.size(); ++i)
+  {
+    fmus[i]->setTime(t);
+
+    const size_t xoff = j;   // where this component's states sit in y and yp
+    for (size_t k = 0; k < nStates[i]; ++k, ++j)
+      states[i][k] = NV_Ith_S(yy, j);
+    for (size_t k = 0; k < nAlgebraic[i]; ++k, ++j)
+      algebraicVars[i][k] = NV_Ith_S(yy, j);
+
+    if (nStates[i] > 0)
+    {
+      status = fmus[i]->setContinuousStates(states[i]);
+      if (oms_status_ok != status) return status;
+    }
+
+    if (daeFmus[i])
+    {
+      // The implicit form's residuals are a function of (t, x, x', z), so the
+      // derivatives are knowns the master hands over, not something the FMU owes.
+      if (nStates[i] > 0)
+      {
+        for (size_t k = 0; k < nStates[i]; ++k)
+          states_der[i][k] = NV_Ith_S(yp, xoff + k);
+        status = daeFmus[i]->setDerivatives(states_der[i]);
+        if (oms_status_ok != status) return status;
+      }
+      if (nAlgebraic[i] > 0)
+      {
+        status = daeFmus[i]->setAlgebraicVariables(algebraicVars[i]);
+        if (oms_status_ok != status) return status;
+      }
+    }
+  }
+
+  // The coupling, before the rows below are asked for.
+  return updateInputs(simulationGraph);
+}
+
+oms_status_enu_t oms::SystemSC::getDaePoint(N_Vector yy, N_Vector yp)
+{
+  oms_status_enu_t status;
+
+  for (size_t i = 0, j = 0; i < fmus.size(); ++i)
+  {
+    if (nStates[i] > 0)
+    {
+      status = fmus[i]->getContinuousStates(states[i]);
+      if (oms_status_ok != status) return status;
+      status = fmus[i]->getDerivatives(states_der[i]);
+      if (oms_status_ok != status) return status;
+    }
+    if (daeFmus[i] && nAlgebraic[i] > 0)
+    {
+      status = daeFmus[i]->getAlgebraicVariables(algebraicVars[i]);
+      if (oms_status_ok != status) return status;
+    }
+
+    for (size_t k = 0; k < nStates[i]; ++k, ++j)
+    {
+      NV_Ith_S(yy, j) = states[i][k];
+      NV_Ith_S(yp, j) = states_der[i][k];
+    }
+    for (size_t k = 0; k < nAlgebraic[i]; ++k, ++j)
+    {
+      NV_Ith_S(yy, j) = algebraicVars[i][k];
+      NV_Ith_S(yp, j) = 0.0;   // an algebraic unknown has no derivative row
+    }
+  }
+
+  return oms_status_ok;
+}
+
+int oms::ida_res(sunrealtype t, N_Vector yy, N_Vector yp, N_Vector rr, void* user_data)
+{
+  SystemSC* system = (SystemSC*)user_data;
+
+  if (oms_status_ok != system->setDaePoint(t, yy, yp))
+    return -1;
+
+  for (size_t i = 0, j = 0; i < system->fmus.size(); ++i)
+  {
+    if (system->daeFmus[i])
+    {
+      const size_t n = system->nStates[i] + system->nAlgebraic[i];
+      if (n == 0)
+        continue;
+      if (oms_status_ok != system->daeFmus[i]->getDaeResiduals(system->residuals[i]))
+        return -1;
+      for (size_t k = 0; k < n; ++k, ++j)
+        NV_Ith_S(rr, j) = system->residuals[i][k];
+    }
+    else
+    {
+      // An ODE component closes its own rows: x' - f(x, u, t).
+      if (0 == system->nStates[i])
+        continue;
+      if (oms_status_ok != system->fmus[i]->getDerivatives(system->states_der[i]))
+        return -1;
+      for (size_t k = 0; k < system->nStates[i]; ++k, ++j)
+        NV_Ith_S(rr, j) = NV_Ith_S(yp, j) - system->states_der[i][k];
+    }
+  }
+
+  return 0;
+}
+
+int oms::ida_roots(sunrealtype t, N_Vector yy, N_Vector yp, sunrealtype *gout, void* user_data)
+{
+  SystemSC* system = (SystemSC*)user_data;
+
+  if (oms_status_ok != system->setDaePoint(t, yy, yp))
+    return -1;
+
+  for (size_t i = 0, j_gout = 0; i < system->fmus.size(); ++i)
+  {
+    if (0 == system->nEventIndicators[i])
+      continue;
+    if (oms_status_ok != system->fmus[i]->getEventindicators(system->event_indicators[i], system->nEventIndicators[i]))
+      return -1;
+    for (size_t k = 0; k < system->nEventIndicators[i]; ++k, ++j_gout)
+      gout[j_gout] = system->event_indicators[i][k];
+  }
+
+  return 0;
+}
+
 oms::SystemSC::SystemSC(const ComRef& cref, Model* parentModel, System* parentSystem)
   : oms::System(cref, oms_system_sc, parentModel, parentSystem, oms_solver_sc_cvode)
 {
@@ -187,6 +332,8 @@ std::string oms::SystemSC::getSolverName() const
       return std::string("euler");
     case oms_solver_sc_cvode:
       return std::string("cvode");
+    case oms_solver_sc_ida:
+      return std::string("ida");
     default:
       return std::string("unknown");
   }
@@ -198,6 +345,8 @@ oms_status_enu_t oms::SystemSC::setSolverMethod(std::string solver)
     solverMethod = oms_solver_sc_explicit_euler;
   else if (std::string("cvode") == solver)
     solverMethod = oms_solver_sc_cvode;
+  else if (std::string("ida") == solver)
+    solverMethod = oms_solver_sc_ida;
   else
     return oms_status_error;
 
@@ -269,6 +418,8 @@ oms_status_enu_t oms::SystemSC::instantiate()
     ;
   else if (oms_solver_sc_cvode == solverMethod)
     solverData.cvode.mem = nullptr;
+  else if (oms_solver_sc_ida == solverMethod)
+    solverData.ida.mem = nullptr;
   else
     return logError_InternalError;
 
@@ -316,7 +467,32 @@ oms_status_enu_t oms::SystemSC::initialize()
     states_nominal.push_back((double*)calloc(nStates.back(), sizeof(double)));
     event_indicators.push_back((double*)calloc(nEventIndicators.back(), sizeof(double)));
     event_indicators_prev.push_back((double*)calloc(nEventIndicators.back(), sizeof(double)));
+
+    // fmi-ls-dae: a component that was switched into DAE mode carries algebraic
+    // unknowns of its own and answers with residuals instead of derivatives.
+    ComponentFMU3ME* fmu3 = dynamic_cast<ComponentFMU3ME*>(fmu);
+    const bool inDaeMode = fmu3 && fmu3->isInDaeMode();
+    daeFmus.push_back(inDaeMode ? fmu3 : nullptr);
+    nAlgebraic.push_back(inDaeMode ? fmu3->getNumberOfAlgebraicVariables() : 0);
+    algebraicVars.push_back((double*)calloc(nAlgebraic.back(), sizeof(double)));
+    residuals.push_back((double*)calloc(inDaeMode ? fmu3->getNumberOfDaeResiduals() : 0, sizeof(double)));
+    if (inDaeMode)
+      daeMode = true;
+    nDaeUnknowns += nStates.back() + nAlgebraic.back();
    }
+
+  if (daeMode && oms_solver_sc_ida != solverMethod)
+  {
+    // DAE mode is not a choice the user makes: a component that declares a DAE
+    // formulation has no explicit ODE for CVODE to integrate.
+    logInfo("system \"" + std::string(getFullCref()) + "\" contains a component in DAE mode (fmi-ls-dae); integrating with IDA instead of " + getSolverName());
+    solverMethod = oms_solver_sc_ida;
+  }
+  else if (!daeMode && oms_solver_sc_ida == solverMethod)
+  {
+    logInfo("system \"" + std::string(getFullCref()) + "\" contains no component in DAE mode; integrating with CVODE instead of ida");
+    solverMethod = oms_solver_sc_cvode;
+  }
 
   // Now that fmus is filled, the per-FMU flags the integrator steps write to
   // can be sized. make_unique value-initializes them, i.e. all false.
@@ -472,6 +648,100 @@ oms_status_enu_t oms::SystemSC::initialize()
     flag = CVodeSetMaxNumSteps(solverData.cvode.mem, Flags::CVODEMaxSteps());            // MAXIMUM NUMBER OF STEPS
     if (flag < 0) logError("SUNDIALS_ERROR: CVodeSetMaxNumSteps() failed with flag = " + std::to_string(flag));
   }
+  else if (oms_solver_sc_ida == solverMethod)
+  {
+    // fmi-ls-dae: one implicit system over [states | algebraic variables].
+    if (SUNContext_Create(SUN_COMM_NULL, &solverData.ida.sunctx) != SUN_SUCCESS)
+      logError("SUNDIALS_ERROR: SUNContext_Create() failed");
+
+    /* Mute SUNDIALS' own output, use OMSimulator's logger */
+    {
+      SUNLogger logger = NULL;
+      if (SUNContext_GetLogger(solverData.ida.sunctx, &logger) == SUN_SUCCESS && logger != NULL)
+      {
+        SUNLogger_SetErrorFilename(logger, "");
+        SUNLogger_SetWarningFilename(logger, "");
+        SUNLogger_SetInfoFilename(logger, "");
+        SUNLogger_SetDebugFilename(logger, "");
+      }
+    }
+
+    const long n = static_cast<long>(nDaeUnknowns);
+    solverData.ida.y = N_VNew_Serial(n, solverData.ida.sunctx);
+    solverData.ida.yp = N_VNew_Serial(n, solverData.ida.sunctx);
+    solverData.ida.id = N_VNew_Serial(n, solverData.ida.sunctx);
+    solverData.ida.abstol = N_VNew_Serial(n, solverData.ida.sunctx);
+    if (!solverData.ida.y || !solverData.ida.yp || !solverData.ida.id || !solverData.ida.abstol)
+      return logError("SUNDIALS_ERROR: N_VNew_Serial() failed - returned NULL pointer");
+
+    // The point the components hold after their own initialization, and which
+    // of the unknowns are differential: IDACalcIC solves for the algebraic ones
+    // and for the derivatives of the differential ones.
+    if (oms_status_ok != getDaePoint(solverData.ida.y, solverData.ida.yp))
+      return oms_status_error;
+
+    for (size_t i = 0, j = 0; i < fmus.size(); ++i)
+    {
+      for (size_t k = 0; k < nStates[i]; ++k, ++j)
+      {
+        NV_Ith_S(solverData.ida.id, j) = 1.0;
+        NV_Ith_S(solverData.ida.abstol, j) = relativeTolerance * states_nominal[i][k];
+      }
+      for (size_t k = 0; k < nAlgebraic[i]; ++k, ++j)
+      {
+        NV_Ith_S(solverData.ida.id, j) = 0.0;
+        // The FMU gives no nominal for an algebraic unknown of its own, so the
+        // relative tolerance stands in for it.
+        NV_Ith_S(solverData.ida.abstol, j) = relativeTolerance;
+      }
+    }
+
+    solverData.ida.mem = IDACreate(solverData.ida.sunctx);
+    if (!solverData.ida.mem) return logError("SUNDIALS_ERROR: IDACreate() failed - returned NULL pointer");
+
+    int flag = IDASetUserData(solverData.ida.mem, (void*)this);
+    if (flag < 0) return logError("SUNDIALS_ERROR: IDASetUserData() failed with flag = " + std::to_string(flag));
+
+    flag = IDAInit(solverData.ida.mem, ida_res, time, solverData.ida.y, solverData.ida.yp);
+    if (flag < 0) return logError("SUNDIALS_ERROR: IDAInit() failed with flag = " + std::to_string(flag));
+
+    flag = IDASVtolerances(solverData.ida.mem, relativeTolerance, solverData.ida.abstol);
+    if (flag < 0) return logError("SUNDIALS_ERROR: IDASVtolerances() failed with flag = " + std::to_string(flag));
+
+    flag = IDASetId(solverData.ida.mem, solverData.ida.id);
+    if (flag < 0) return logError("SUNDIALS_ERROR: IDASetId() failed with flag = " + std::to_string(flag));
+
+    if (n_event_indicators > 0)
+    {
+      flag = IDARootInit(solverData.ida.mem, static_cast<int>(n_event_indicators), ida_roots);
+      if (flag < 0) return logError("SUNDIALS_ERROR: IDARootInit() failed with flag = " + std::to_string(flag));
+    }
+
+    // A dense Jacobian, differenced by IDA. The manifest's residual dependencies
+    // would give a sparsity pattern for KLU; that is the next step and matters
+    // as soon as the system is more than small.
+    solverData.ida.J = SUNDenseMatrix(n, n, solverData.ida.sunctx);
+    if (!solverData.ida.J) return logError("SUNDIALS_ERROR: SUNDenseMatrix() failed");
+    solverData.ida.linSol = SUNLinSol_Dense(solverData.ida.y, solverData.ida.J, solverData.ida.sunctx);
+    if (!solverData.ida.linSol) return logError("SUNDIALS_ERROR: SUNLinSol_Dense() failed");
+    flag = IDASetLinearSolver(solverData.ida.mem, solverData.ida.linSol, solverData.ida.J);
+    if (flag < 0) return logError("SUNDIALS_ERROR: IDASetLinearSolver() failed with flag = " + std::to_string(flag));
+
+    flag = IDASetMaxStep(solverData.ida.mem, maximumStepSize);
+    if (flag < 0) return logError("SUNDIALS_ERROR: IDASetMaxStep() failed with flag = " + std::to_string(flag));
+    if (initialStepSize > 0.0)
+    {
+      flag = IDASetInitStep(solverData.ida.mem, initialStepSize);
+      if (flag < 0) return logError("SUNDIALS_ERROR: IDASetInitStep() failed with flag = " + std::to_string(flag));
+    }
+    flag = IDASetMaxNumSteps(solverData.ida.mem, Flags::CVODEMaxSteps());
+    if (flag < 0) return logError("SUNDIALS_ERROR: IDASetMaxNumSteps() failed with flag = " + std::to_string(flag));
+
+    // The start point the components initialized to need not satisfy the
+    // coupled system; IDA solves for a consistent one before the first step.
+    if (oms_status_ok != calcConsistentInitialConditions(time + maximumStepSize))
+      return oms_status_error;
+  }
 
   // Mark algebraic loops to be updated on next call
   forceLoopsToBeUpdated();
@@ -488,6 +758,32 @@ oms_status_enu_t oms::SystemSC::terminate()
   for (const auto& component : getComponents())
     if (oms_status_ok != component.second->terminate())
       return oms_status_error;
+
+  if (oms_solver_sc_ida == solverMethod && solverData.ida.mem)
+  {
+    long int nst = 0, nre = 0, nsetups = 0, nni = 0, ncfn = 0, netf = 0;
+    IDAGetNumSteps(solverData.ida.mem, &nst);
+    IDAGetNumResEvals(solverData.ida.mem, &nre);
+    IDAGetNumLinSolvSetups(solverData.ida.mem, &nsetups);
+    IDAGetNumErrTestFails(solverData.ida.mem, &netf);
+    IDAGetNumNonlinSolvIters(solverData.ida.mem, &nni);
+    IDAGetNumNonlinSolvConvFails(solverData.ida.mem, &ncfn);
+
+    std::string msg = "Final Statistics for '" + std::string(getFullCref()) + "':\n";
+    msg += "NumSteps = " + std::to_string(nst) + " NumResEvals  = " + std::to_string(nre) + " NumLinSolvSetups = " + std::to_string(nsetups) + "\n";
+    msg += "NumNonlinSolvIters = " + std::to_string(nni) + " NumNonlinSolvConvFails = " + std::to_string(ncfn) + " NumErrTestFails = " + std::to_string(netf);
+    logInfo(msg);
+
+    SUNMatDestroy(solverData.ida.J);
+    SUNLinSolFree(solverData.ida.linSol);
+    N_VDestroy_Serial(solverData.ida.y);
+    N_VDestroy_Serial(solverData.ida.yp);
+    N_VDestroy_Serial(solverData.ida.id);
+    N_VDestroy_Serial(solverData.ida.abstol);
+    IDAFree(&(solverData.ida.mem));
+    SUNContext_Free(&(solverData.ida.sunctx));
+    solverData.ida.mem = nullptr;
+  }
 
   if (oms_solver_sc_cvode == solverMethod && solverData.cvode.mem)
   {
@@ -529,13 +825,21 @@ oms_status_enu_t oms::SystemSC::terminate()
     free(states_nominal[i]);
     free(event_indicators[i]);
     free(event_indicators_prev[i]);
+    free(algebraicVars[i]);
+    free(residuals[i]);
   }
 
   fmus.clear();
+  daeFmus.clear();
   callEventUpdate.reset();
   terminateSimulation.reset();
   nStates.clear();
   nEventIndicators.clear();
+  nAlgebraic.clear();
+  algebraicVars.clear();
+  residuals.clear();
+  daeMode = false;
+  nDaeUnknowns = 0;
   states.clear();
   states_der.clear();
   states_nominal.clear();
@@ -556,6 +860,32 @@ oms_status_enu_t oms::SystemSC::reset()
       return oms_status_error;
 
   time = getModel().getStartTime();
+
+  if (oms_solver_sc_ida == solverMethod && solverData.ida.mem)
+  {
+    long int nst = 0, nre = 0, nsetups = 0, nni = 0, ncfn = 0, netf = 0;
+    IDAGetNumSteps(solverData.ida.mem, &nst);
+    IDAGetNumResEvals(solverData.ida.mem, &nre);
+    IDAGetNumLinSolvSetups(solverData.ida.mem, &nsetups);
+    IDAGetNumErrTestFails(solverData.ida.mem, &netf);
+    IDAGetNumNonlinSolvIters(solverData.ida.mem, &nni);
+    IDAGetNumNonlinSolvConvFails(solverData.ida.mem, &ncfn);
+
+    std::string msg = "Final Statistics for '" + std::string(getFullCref()) + "':\n";
+    msg += "NumSteps = " + std::to_string(nst) + " NumResEvals  = " + std::to_string(nre) + " NumLinSolvSetups = " + std::to_string(nsetups) + "\n";
+    msg += "NumNonlinSolvIters = " + std::to_string(nni) + " NumNonlinSolvConvFails = " + std::to_string(ncfn) + " NumErrTestFails = " + std::to_string(netf);
+    logInfo(msg);
+
+    SUNMatDestroy(solverData.ida.J);
+    SUNLinSolFree(solverData.ida.linSol);
+    N_VDestroy_Serial(solverData.ida.y);
+    N_VDestroy_Serial(solverData.ida.yp);
+    N_VDestroy_Serial(solverData.ida.id);
+    N_VDestroy_Serial(solverData.ida.abstol);
+    IDAFree(&(solverData.ida.mem));
+    SUNContext_Free(&(solverData.ida.sunctx));
+    solverData.ida.mem = nullptr;
+  }
 
   if (oms_solver_sc_cvode == solverMethod && solverData.cvode.mem)
   {
@@ -595,16 +925,24 @@ oms_status_enu_t oms::SystemSC::reset()
   // instead of appending duplicate entries for every FMU (which corrupts
   // solver setup and causes lifecycle calls like enterContinuousTimeMode()
   // to be issued twice for the same FMU).
+  for (double* ptr : algebraicVars) free(ptr);
+  for (double* ptr : residuals) free(ptr);
   for (double* ptr : states) free(ptr);
   for (double* ptr : states_der) free(ptr);
   for (double* ptr : states_nominal) free(ptr);
   for (double* ptr : event_indicators) free(ptr);
   for (double* ptr : event_indicators_prev) free(ptr);
   fmus.clear();
+  daeFmus.clear();
   callEventUpdate.reset();
   terminateSimulation.reset();
   nStates.clear();
   nEventIndicators.clear();
+  nAlgebraic.clear();
+  algebraicVars.clear();
+  residuals.clear();
+  daeMode = false;
+  nDaeUnknowns = 0;
   states.clear();
   states_der.clear();
   states_nominal.clear();
@@ -623,6 +961,9 @@ oms_status_enu_t oms::SystemSC::doStep()
 
     case oms_solver_sc_cvode:
       return doStepCVODE();
+
+    case oms_solver_sc_ida:
+      return doStepIDA();
 
     default:
       return logError_InternalError;
@@ -1024,6 +1365,157 @@ oms_status_enu_t oms::SystemSC::doStepCVODE()
 
   return oms_status_ok;
 
+}
+
+/**
+ * \brief IDACalcIC over the point the components hold, then read the consistent
+ *        point back into them.
+ *
+ * The components initialize on their own, each consistent with itself but not
+ * necessarily with the coupled system; and after an event the same is true
+ * again. IDA_YA_YDP_INIT solves for the algebraic unknowns and the derivatives
+ * of the differential ones, keeping the states where they are.
+ */
+oms_status_enu_t oms::SystemSC::calcConsistentInitialConditions(double tout)
+{
+  // IDACalcIC wants a time it may integrate towards; anything but the current
+  // one will do, and the step it takes is thrown away.
+  if (tout <= time)
+    tout = time + 1.0;
+
+  int flag = IDACalcIC(solverData.ida.mem, IDA_YA_YDP_INIT, tout);
+  if (flag < 0)
+    return logError("SUNDIALS_ERROR: IDACalcIC() failed with flag = " + std::to_string(flag) +
+                    " at time " + std::to_string(time) +
+                    " (the coupled DAE has no consistent point there, or its Jacobian is singular)");
+
+  flag = IDAGetConsistentIC(solverData.ida.mem, solverData.ida.y, solverData.ida.yp);
+  if (flag < 0)
+    return logError("SUNDIALS_ERROR: IDAGetConsistentIC() failed with flag = " + std::to_string(flag));
+
+  // Leave the components standing at the consistent point, so what is emitted
+  // and what the next step starts from agree with it.
+  return setDaePoint(time, solverData.ida.y, solverData.ida.yp);
+}
+
+oms_status_enu_t oms::SystemSC::doStepIDA()
+{
+  oms_status_enu_t status;
+  int flag;
+
+  double end_time = std::min(time + maximumStepSize, getModel().getStopTime());
+
+  // find next time event
+  double tnext = end_time + 1.0;
+  for (size_t i = 0; i < fmus.size(); ++i)
+  {
+    if (fmus[i]->getNextEventTimeDefined() && (tnext > fmus[i]->getNextEventTime()))
+      tnext = fmus[i]->getNextEventTime();
+
+    if (fmus[i]->getTerminateSimulation())
+    {
+      logInfo("Simulation terminated by FMU " + std::string(fmus[i]->getFullCref()) + " at time " + std::to_string(time));
+      getModel().setStopTime(time);
+      time = end_time;
+    }
+  }
+  snapToEventTime(end_time, tnext);
+
+  while (time < end_time)
+  {
+    const double tout = std::min(tnext, end_time);
+
+    // Nothing left to integrate in an interval IDA cannot tell apart from zero.
+    if (tout - time < 2.0 * SUN_UNIT_ROUNDOFF * std::max(std::fabs(time), std::fabs(tout)))
+    {
+      logDebug("IDA: skipping degenerate interval " + std::to_string(time) + " -> " + std::to_string(tout));
+      time = end_time;
+      break;
+    }
+
+    logDebug("IDA: " + std::to_string(time) + " -> " + std::to_string(tout));
+    flag = IDASolve(solverData.ida.mem, tout, &time, solverData.ida.y, solverData.ida.yp, IDA_NORMAL);
+    if (flag < 0)
+      return logError("IDA failed with flag = " + std::to_string(flag) + " at time " + std::to_string(time));
+
+    // The components stand at the point IDA returned.
+    status = setDaePoint(time, solverData.ida.y, solverData.ida.yp);
+    if (oms_status_ok != status) return status;
+
+    for (const auto& component : getComponents())
+      component.second->setTime(time);
+
+    for (size_t i = 0; i < fmus.size(); ++i)
+    {
+      status = fmus[i]->completedIntegratorStep(true, callEventUpdate[i], terminateSimulation[i]);
+      if (oms_status_ok != status) return status;
+    }
+
+    if (IDA_ROOT_RETURN == flag || time == tnext)
+    {
+      logDebug("event found!!! " + std::to_string(time));
+
+      // emit the left limit of the event
+      if (isTopLevelSystem())
+        getModel().emit(time, false);
+
+      for (size_t i = 0; i < fmus.size(); ++i)
+      {
+        status = fmus[i]->enterEventMode();
+        if (oms_status_ok != status) return status;
+
+        fmus[i]->doEventIteration();
+      }
+
+      updateInputs(eventGraph);
+
+      for (size_t i = 0; i < fmus.size(); ++i)
+      {
+        status = fmus[i]->enterContinuousTimeMode();
+        if (oms_status_ok != status) return status;
+      }
+
+      // find next time event
+      tnext = end_time + 1.0;
+      for (size_t i = 0; i < fmus.size(); ++i)
+      {
+        if (fmus[i]->getNextEventTimeDefined() && (tnext > fmus[i]->getNextEventTime()))
+          tnext = fmus[i]->getNextEventTime();
+
+        if (fmus[i]->getTerminateSimulation())
+        {
+          logInfo("Simulation terminated by FMU " + std::string(fmus[i]->getFullCref()) + " at time " + std::to_string(time));
+          getModel().setStopTime(time);
+          time = end_time;
+        }
+      }
+
+      // The event moved the components; take the point they hold now, restart
+      // IDA there and let it find a consistent one again — the algebraic
+      // unknowns and the derivatives need not have survived the event.
+      status = getDaePoint(solverData.ida.y, solverData.ida.yp);
+      if (oms_status_ok != status) return status;
+
+      flag = IDAReInit(solverData.ida.mem, time, solverData.ida.y, solverData.ida.yp);
+      if (flag < 0) return logError("SUNDIALS_ERROR: IDAReInit() failed with flag = " + std::to_string(flag));
+
+      status = calcConsistentInitialConditions(std::min(tnext, end_time));
+      if (oms_status_ok != status) return status;
+
+      // emit the right limit of the event
+      updateInputs(eventGraph);
+      if (isTopLevelSystem())
+        getModel().emit(time, true);
+
+      continue;
+    }
+
+    updateInputs(simulationGraph);
+    if (isTopLevelSystem())
+      getModel().emit(time, false);
+  }
+
+  return oms_status_ok;
 }
 
 oms_status_enu_t oms::SystemSC::stepUntil(double stopTime)

--- a/src/OMSimulatorLib/SystemSC.cpp
+++ b/src/OMSimulatorLib/SystemSC.cpp
@@ -262,6 +262,7 @@ void oms::SystemSC::buildDaeJacobianSparsity()
   daeJacColorOfColumn.clear();
   daeJacColumnsOfColor.clear();
   daeJacIncrement.clear();
+  daeJacSparse = false;
 
   const size_t n = nDaeUnknowns;
   if (0 == n)
@@ -437,7 +438,7 @@ void oms::SystemSC::buildDaeJacobianSparsity()
   daeJacIncrement.assign(n, 0.0);
   logInfo("system \"" + std::string(getFullCref()) + "\": DAE Jacobian " + std::to_string(n) + "x" + std::to_string(n) +
           ", " + std::to_string(nnz) + " structural nonzeros, " + std::to_string(daeJacColumnsOfColor.size()) +
-          " colour(s) — one residual evaluation per colour instead of one per unknown");
+          " colour(s) — sparse (KLU), one residual evaluation per colour instead of one per unknown");
 }
 
 /**
@@ -455,7 +456,27 @@ int oms::ida_jac(sunrealtype t, sunrealtype cj, N_Vector yy, N_Vector yp, N_Vect
   SystemSC* system = (SystemSC*)user_data;
   const size_t n = system->nDaeUnknowns;
 
-  SUNMatZero(Jac);
+  // A sparse matrix carries its structure in the same arrays as its values, and
+  // SUNMatZero would wipe it; every entry of the pattern is written below
+  // anyway, structure and value together.
+  sunindextype* colptrs = nullptr;
+  sunindextype* rowvals = nullptr;
+  sunrealtype* data = nullptr;
+  if (system->daeJacSparse)
+  {
+    colptrs = SUNSparseMatrix_IndexPointers(Jac);
+    rowvals = SUNSparseMatrix_IndexValues(Jac);
+    data = SUNSparseMatrix_Data(Jac);
+    sunindextype at = 0;
+    for (size_t j = 0; j < n; ++j)
+    {
+      colptrs[j] = at;
+      at += static_cast<sunindextype>(system->daeJacRowsByColumn[j].size());
+    }
+    colptrs[n] = at;
+  }
+  else
+    SUNMatZero(Jac);
 
   sunrealtype hh = 0.0;
   if (IDAGetCurrentStep(system->solverData.ida.mem, &hh) != IDA_SUCCESS)
@@ -497,8 +518,20 @@ int oms::ida_jac(sunrealtype t, sunrealtype cj, N_Vector yy, N_Vector yp, N_Vect
     for (const int j : columns)
     {
       const sunrealtype scale = 1.0 / system->daeJacIncrement[j];
-      for (const int i : system->daeJacRowsByColumn[j])
-        SM_ELEMENT_D(Jac, i, j) = (NV_Ith_S(tmp3, i) - NV_Ith_S(rr, i)) * scale;
+      const std::vector<int>& rows = system->daeJacRowsByColumn[j];
+      for (size_t k = 0; k < rows.size(); ++k)
+      {
+        const int i = rows[k];
+        const sunrealtype value = (NV_Ith_S(tmp3, i) - NV_Ith_S(rr, i)) * scale;
+        if (system->daeJacSparse)
+        {
+          const sunindextype at = colptrs[j] + static_cast<sunindextype>(k);
+          rowvals[at] = i;
+          data[at] = value;
+        }
+        else
+          SM_ELEMENT_D(Jac, i, j) = value;
+      }
     }
   }
 
@@ -1118,20 +1151,39 @@ oms_status_enu_t oms::SystemSC::initialize()
       if (flag < 0) return logError("SUNDIALS_ERROR: IDARootInit() failed with flag = " + std::to_string(flag));
     }
 
-    solverData.ida.J = SUNDenseMatrix(n, n, solverData.ida.sunctx);
-    if (!solverData.ida.J) return logError("SUNDIALS_ERROR: SUNDenseMatrix() failed");
-    solverData.ida.linSol = SUNLinSol_Dense(solverData.ida.y, solverData.ida.J, solverData.ida.sunctx);
-    if (!solverData.ida.linSol) return logError("SUNDIALS_ERROR: SUNLinSol_Dense() failed");
+    // The components' manifests say which unknowns each residual reaches. That
+    // structure does two things: it colours the columns, so the Jacobian is
+    // differenced a colour at a time instead of a column at a time — a handful
+    // of residual evaluations instead of one per unknown, each of which calls
+    // into every FMU — and it lets the matrix be held sparse and factorized by
+    // KLU. Without a usable structure the matrix is dense and IDA differences it
+    // itself.
+    buildDaeJacobianSparsity();
+    daeJacSparse = !daeJacColumnsOfColor.empty();
+
+    if (daeJacSparse)
+    {
+      sunindextype nnz = 0;
+      for (const std::vector<int>& rows : daeJacRowsByColumn)
+        nnz += static_cast<sunindextype>(rows.size());
+
+      solverData.ida.J = SUNSparseMatrix(n, n, nnz, CSC_MAT, solverData.ida.sunctx);
+      if (!solverData.ida.J) return logError("SUNDIALS_ERROR: SUNSparseMatrix() failed");
+      solverData.ida.linSol = SUNLinSol_KLU(solverData.ida.y, solverData.ida.J, solverData.ida.sunctx);
+      if (!solverData.ida.linSol) return logError("SUNDIALS_ERROR: SUNLinSol_KLU() failed");
+    }
+    else
+    {
+      solverData.ida.J = SUNDenseMatrix(n, n, solverData.ida.sunctx);
+      if (!solverData.ida.J) return logError("SUNDIALS_ERROR: SUNDenseMatrix() failed");
+      solverData.ida.linSol = SUNLinSol_Dense(solverData.ida.y, solverData.ida.J, solverData.ida.sunctx);
+      if (!solverData.ida.linSol) return logError("SUNDIALS_ERROR: SUNLinSol_Dense() failed");
+    }
+
     flag = IDASetLinearSolver(solverData.ida.mem, solverData.ida.linSol, solverData.ida.J);
     if (flag < 0) return logError("SUNDIALS_ERROR: IDASetLinearSolver() failed with flag = " + std::to_string(flag));
 
-    // The components' manifests say which unknowns each residual reaches. That
-    // structure colours the columns, and the Jacobian is then differenced a
-    // colour at a time instead of a column at a time — the difference between a
-    // handful of residual evaluations and one per unknown, each of which calls
-    // into every FMU. Without a usable structure IDA differences it itself.
-    buildDaeJacobianSparsity();
-    if (!daeJacColumnsOfColor.empty())
+    if (daeJacSparse)
     {
       flag = IDASetJacFn(solverData.ida.mem, ida_jac);
       if (flag < 0) return logError("SUNDIALS_ERROR: IDASetJacFn() failed with flag = " + std::to_string(flag));
@@ -1257,6 +1309,7 @@ oms_status_enu_t oms::SystemSC::terminate()
   daeJacColorOfColumn.clear();
   daeJacColumnsOfColor.clear();
   daeJacIncrement.clear();
+  daeJacSparse = false;
   states.clear();
   states_der.clear();
   states_nominal.clear();
@@ -1367,6 +1420,7 @@ oms_status_enu_t oms::SystemSC::reset()
   daeJacColorOfColumn.clear();
   daeJacColumnsOfColor.clear();
   daeJacIncrement.clear();
+  daeJacSparse = false;
   states.clear();
   states_der.clear();
   states_nominal.clear();

--- a/src/OMSimulatorLib/SystemSC.h
+++ b/src/OMSimulatorLib/SystemSC.h
@@ -88,6 +88,23 @@ namespace oms
     oms_status_enu_t doStepEuler();
     oms_status_enu_t doStepCVODE();
     oms_status_enu_t doStepIDA();
+    /**
+     * \brief updateInputs, with the algebraic loops IDA owns left alone.
+     *
+     * \param liftedLoops  one flag per loop of the graph, in the order the
+     *                     sorted connections hold them; a loop marked true is
+     *                     skipped, because its connections are rows of the
+     *                     global system and IDA has already set their inputs.
+     *                     nullptr solves every loop, which is what updateInputs
+     *                     itself does.
+     */
+    oms_status_enu_t updateInputsInternal(DirectedGraph& graph, const std::vector<bool>* liftedLoops);
+    /// Which loops of the simulation graph can become rows: every connection real.
+    void collectLiftedLoops();
+    /// A flag per loop of the graph, all true: leave every loop to the integrator.
+    std::vector<bool> allLoopsOf(DirectedGraph& graph) const;
+    /// Whether any component was switched into DAE mode; readable before initialize().
+    bool anyComponentInDaeMode();
     /// Distribute the DAE unknowns y (and the state derivatives yp) into the FMUs.
     oms_status_enu_t setDaePoint(double t, N_Vector yy, N_Vector yp);
     /// Read the point the FMUs hold back into y and yp, after a solve or an event.
@@ -131,7 +148,28 @@ namespace oms
     std::vector<double*> algebraicVars;
     std::vector<double*> residuals;
     bool daeMode = false;              ///< any component runs in DAE mode
-    size_t nDaeUnknowns = 0;           ///< states + algebraic variables, over all components
+    size_t nDaeUnknowns = 0;           ///< states, algebraic variables and lifted loop connections
+
+    /**
+     * An algebraic loop lifted into the global system. The loop's connections
+     * are what the inner Newton solved for; here each becomes one unknown — the
+     * value of the driven input — and one row, output - input = 0. So a loop
+     * spanning components is resolved by the integrator, with its own error
+     * control, instead of being iterated to convergence inside every residual
+     * evaluation on top of whatever each FMU hides internally.
+     *
+     * These unknowns follow the components' in y, and their rows the components'
+     * rows. They are algebraic: their entry in IDASetId's vector is 0.
+     */
+    struct LiftedConnection
+    {
+      int output;   ///< graph node driving the connection
+      int input;    ///< graph node it drives, and the unknown
+    };
+    std::vector<LiftedConnection> liftedConnections;
+    /// Per loop of the simulation graph, whether it was lifted; passed to
+    /// updateInputsInternal so the inner solver leaves those alone.
+    std::vector<bool> liftedLoops;
 
     std::vector<double*> states;
     std::vector<double*> states_der;

--- a/src/OMSimulatorLib/SystemSC.h
+++ b/src/OMSimulatorLib/SystemSC.h
@@ -60,6 +60,8 @@ namespace oms
   int cvode_roots(sunrealtype t, N_Vector y, sunrealtype *gout, void* user_data);
   int ida_res(sunrealtype t, N_Vector yy, N_Vector yp, N_Vector rr, void* user_data);
   int ida_roots(sunrealtype t, N_Vector yy, N_Vector yp, sunrealtype *gout, void* user_data);
+  int ida_jac(sunrealtype t, sunrealtype cj, N_Vector yy, N_Vector yp, N_Vector rr,
+              SUNMatrix Jac, void* user_data, N_Vector tmp1, N_Vector tmp2, N_Vector tmp3);
 
   class SystemSC : public System
   {
@@ -105,6 +107,17 @@ namespace oms
     std::vector<bool> allLoopsOf(DirectedGraph& graph) const;
     /// Whether any component was switched into DAE mode; readable before initialize().
     bool anyComponentInDaeMode();
+    /**
+     * \brief The structure of the DAE Jacobian, out of the components' manifests.
+     *
+     * Which unknowns each row reaches, and a colouring of the columns from it: two
+     * columns share a colour when no row reaches both, so one residual evaluation
+     * differences all of them at once. A dense difference quotient costs one
+     * residual evaluation per unknown — and every one of those calls into every
+     * FMU — where a coloured one costs as many as there are colours, which for a
+     * coupled system is a handful however many unknowns there are.
+     */
+    void buildDaeJacobianSparsity();
     /// Distribute the DAE unknowns y (and the state derivatives yp) into the FMUs.
     oms_status_enu_t setDaePoint(double t, N_Vector yy, N_Vector yp);
     /// Read the point the FMUs hold back into y and yp, after a solve or an event.
@@ -171,6 +184,14 @@ namespace oms
     /// updateInputsInternal so the inner solver leaves those alone.
     std::vector<bool> liftedLoops;
 
+    /// Per unknown, the rows that reach it; empty when the structure is unknown
+    /// and IDA differences the Jacobian itself.
+    std::vector<std::vector<int>> daeJacRowsByColumn;
+    std::vector<int> daeJacColorOfColumn;
+    std::vector<std::vector<int>> daeJacColumnsOfColor;
+    /// The increment each column was perturbed by, kept between the two passes.
+    std::vector<double> daeJacIncrement;
+
     std::vector<double*> states;
     std::vector<double*> states_der;
     std::vector<double*> states_nominal;
@@ -204,6 +225,7 @@ namespace oms
       SUNLinearSolver linSol;
       SUNMatrix J;
       N_Vector abstol;
+      N_Vector ewt;           /* the error weights, for the Jacobian's increments */
     };
 
     union SolverData_t
@@ -218,6 +240,8 @@ namespace oms
     friend int oms::cvode_roots(sunrealtype t, N_Vector y, sunrealtype *gout, void* user_data);
     friend int oms::ida_res(sunrealtype t, N_Vector yy, N_Vector yp, N_Vector rr, void* user_data);
     friend int oms::ida_roots(sunrealtype t, N_Vector yy, N_Vector yp, sunrealtype *gout, void* user_data);
+    friend int oms::ida_jac(sunrealtype t, sunrealtype cj, N_Vector yy, N_Vector yp, N_Vector rr,
+                            SUNMatrix Jac, void* user_data, N_Vector tmp1, N_Vector tmp2, N_Vector tmp3);
   };
 }
 

--- a/src/OMSimulatorLib/SystemSC.h
+++ b/src/OMSimulatorLib/SystemSC.h
@@ -48,6 +48,8 @@
 #include <nvector/nvector_serial.h>     /* serial N_Vector types, fcts., macros */
 #include <ida/ida.h>                    /* prototypes for IDA fcts., consts. */
 #include <sunlinsol/sunlinsol_dense.h>  /* Default dense linear solver */
+#include <sunlinsol/sunlinsol_klu.h>    /* KLU, for the structured DAE Jacobian */
+#include <sunmatrix/sunmatrix_sparse.h>
 
 namespace oms
 {
@@ -191,6 +193,9 @@ namespace oms
     std::vector<std::vector<int>> daeJacColumnsOfColor;
     /// The increment each column was perturbed by, kept between the two passes.
     std::vector<double> daeJacIncrement;
+    /// Whether the Jacobian is held sparse and factorized by KLU, which needs a
+    /// structure; without one it is dense and IDA differences it itself.
+    bool daeJacSparse = false;
 
     std::vector<double*> states;
     std::vector<double*> states_der;

--- a/src/OMSimulatorLib/SystemSC.h
+++ b/src/OMSimulatorLib/SystemSC.h
@@ -46,16 +46,20 @@
 #include <sundials/sundials_logger.h>   /* SUNLogger */
 #include <cvode/cvode.h>                /* prototypes for CVODE fcts., consts. */
 #include <nvector/nvector_serial.h>     /* serial N_Vector types, fcts., macros */
+#include <ida/ida.h>                    /* prototypes for IDA fcts., consts. */
 #include <sunlinsol/sunlinsol_dense.h>  /* Default dense linear solver */
 
 namespace oms
 {
   class Model;
   class ComponentFMUME;
+  class ComponentFMU3ME;
   class Component;
   int cvode_rhs(sunrealtype t, N_Vector y, N_Vector ydot, void* user_data);
   int cvode_rhs_algebraic(sunrealtype t, N_Vector y, N_Vector ydot, void* user_data);
   int cvode_roots(sunrealtype t, N_Vector y, sunrealtype *gout, void* user_data);
+  int ida_res(sunrealtype t, N_Vector yy, N_Vector yp, N_Vector rr, void* user_data);
+  int ida_roots(sunrealtype t, N_Vector yy, N_Vector yp, sunrealtype *gout, void* user_data);
 
   class SystemSC : public System
   {
@@ -83,6 +87,13 @@ namespace oms
   private:
     oms_status_enu_t doStepEuler();
     oms_status_enu_t doStepCVODE();
+    oms_status_enu_t doStepIDA();
+    /// Distribute the DAE unknowns y (and the state derivatives yp) into the FMUs.
+    oms_status_enu_t setDaePoint(double t, N_Vector yy, N_Vector yp);
+    /// Read the point the FMUs hold back into y and yp, after a solve or an event.
+    oms_status_enu_t getDaePoint(N_Vector yy, N_Vector yp);
+    /// IDACalcIC over the current point, then read the consistent point back.
+    oms_status_enu_t calcConsistentInitialConditions(double tout);
 
   protected:
     SystemSC(const ComRef& cref, Model* parentModel, System* parentSystem);
@@ -100,6 +111,27 @@ namespace oms
 
     std::vector<size_t> nStates;
     std::vector<size_t> nEventIndicators;
+
+    /**
+     * fmi-ls-dae. A component that declares a DAE formulation is integrated in
+     * DAE mode: it owns no explicit ODE, so the master carries its algebraic
+     * variables beside the states and drives the residuals of
+     * F(t, x, x', z) = 0 to zero with IDA.
+     *
+     * The unknowns are laid out per component, [x_i | z_i], and so are the
+     * rows: a DAE component contributes its residuals (one per state and per
+     * algebraic variable, checked square when DAE mode is switched on), an ODE
+     * component the explicit rows x'_i - f_i(x, u, t). So a system may mix the
+     * two, and one with no DAE component at all is not affected by any of this.
+     */
+    /// Index-aligned with fmus: the component as an FMI 3.0 ME one when it runs
+    /// in DAE mode, else nullptr.
+    std::vector<ComponentFMU3ME*> daeFmus;
+    std::vector<size_t> nAlgebraic;    ///< per component, 0 unless in DAE mode
+    std::vector<double*> algebraicVars;
+    std::vector<double*> residuals;
+    bool daeMode = false;              ///< any component runs in DAE mode
+    size_t nDaeUnknowns = 0;           ///< states + algebraic variables, over all components
 
     std::vector<double*> states;
     std::vector<double*> states_der;
@@ -124,15 +156,30 @@ namespace oms
       N_Vector abstol;
     };
 
+    struct SolverDataIDA_t
+    {
+      SUNContext sunctx;      /* SUNDIALS simulation context */
+      void *mem;
+      N_Vector y;             /* [states | algebraic variables], per component */
+      N_Vector yp;            /* the state derivatives; unused rows for the algebraic variables */
+      N_Vector id;            /* 1.0 differential, 0.0 algebraic — what IDASetId takes */
+      SUNLinearSolver linSol;
+      SUNMatrix J;
+      N_Vector abstol;
+    };
+
     union SolverData_t
     {
       SolverDataEuler_t euler;
       SolverDataCVODE_t cvode;
+      SolverDataIDA_t ida;
     } solverData;
 
     friend int oms::cvode_rhs(sunrealtype t, N_Vector y, N_Vector ydot, void* user_data);
     friend int oms::cvode_rhs_algebraic(sunrealtype t, N_Vector y, N_Vector ydot, void* user_data);
     friend int oms::cvode_roots(sunrealtype t, N_Vector y, sunrealtype *gout, void* user_data);
+    friend int oms::ida_res(sunrealtype t, N_Vector yy, N_Vector yp, N_Vector rr, void* user_data);
+    friend int oms::ida_roots(sunrealtype t, N_Vector yy, N_Vector yp, sunrealtype *gout, void* user_data);
   };
 }
 

--- a/src/OMSimulatorPython/cli.py
+++ b/src/OMSimulatorPython/cli.py
@@ -213,7 +213,7 @@ def main(argv=None) -> int:
   _addOption(parser, '--realTime', 'false', 'Enable experimental feature for (soft) real-time co-simulation', action=argparse.BooleanOptionalAction)
   _addOption(parser, '--resultFile', "the model name plus '_res.mat'", 'Specify the name of the output result file')
   _addOption(parser, '--skipCSVHeader', 'true', 'Skip the CSV delimiter row in the header of .csv result files', action=argparse.BooleanOptionalAction)
-  _addOption(parser, '--solver', 'cvode', 'Set the ODE solver for model-exchange FMUs (.fmu, mode=me only)', choices=['euler', 'cvode'])
+  _addOption(parser, '--solver', 'cvode', "Set the solver for model-exchange FMUs (.fmu, mode=me only). 'ida' is the DAE mode of fmi-ls-dae and is selected on its own for an FMU that declares a DAE formulation", choices=['euler', 'cvode', 'ida'])
   _addOption(parser, '--solverStats', 'false', 'Add solver stats to the result file, e.g., step size; not supported for all solvers', action=argparse.BooleanOptionalAction)
   _addOption(parser, '--startTime', 'from the model', 'Specify the start time', type=float)
   _addOption(parser, '--stepSize', 'from the model', 'Specify the (maximum) step size (.fmu only)', type=float)

--- a/src/OMSimulatorPython/instantiated_model.py
+++ b/src/OMSimulatorPython/instantiated_model.py
@@ -44,12 +44,18 @@ from enum import Enum
 import warnings
 
 class SolverType(Enum):
-  '''Enumeration for solver method to map with c api.'''
+  '''Enumeration for solver method to map with c api.
+
+  These are the values of oms_solver_enu_t in include/OMSimulator/Types.h and
+  have to be kept in step with it: inserting a solver there renumbers the ones
+  after it, and setSolver() then quietly selects the wrong one.
+  '''
   euler = 2
   cvode = 3
-  oms_ma = 6
-  oms_mav = 7
-  oms_mav2 = 8
+  ida = 4       # DAE mode (fmi-ls-dae)
+  oms_ma = 7
+  oms_mav = 8
+  oms_mav2 = 9
 class SystemType(Enum):
   '''Enumeration for system type to map with c api.'''
   wc = 1

--- a/src/OMSimulatorPython/variable.py
+++ b/src/OMSimulatorPython/variable.py
@@ -45,6 +45,10 @@ class Causality(Enum):
   calculatedParameter = 3
   local = 4
   independent = 5
+  # FMI 3.0: a parameter that changes the structure of the FMU (the number of
+  # states, of variables, of an array's dimensions) and can only be set in
+  # Configuration Mode. fmi-ls-dae's DAE-mode switch is one.
+  structuralParameter = 6
 
 
 class SignalType(Enum):
@@ -135,6 +139,9 @@ class Variable:
 
   def isCalculatedParameter(self):
     return self.causality == Causality.calculatedParameter
+
+  def isStructuralParameter(self):
+    return self.causality == Causality.structuralParameter
 
   def isContinuous(self):
     return self.variability == "continuous"


### PR DESCRIPTION
Towards #1645. OpenModelica/OMSimulator-3rdParty#111 (SUNDIALS' IDA, and SuiteSparse for its KLU) is merged, and the last commit here bumps the submodule to it.

> **The submodule bump needs the `CI/Update Submodules` label**, which is on the PR — without it `submoduleNoChange()` in the Jenkinsfile stops the build with *"Did you intend to change a submodule?"* before anything is compiled. The bump is deliberate: `oms::3rd::sundials::ida` and `::sunlinsolklu` are not targets without it, so the project does not even configure.

Still a draft for the open points at the bottom.

A Model Exchange FMU carrying `extra/org.fmi-standard.fmi-ls-dae/fmi-ls-manifest.xml` exposes the residuals of `F(t, x, x', z) = 0` and lets the importer solve for the algebraic variables `z` beside the states, instead of iterating on them behind its own interface. OpenModelica exports such FMUs (OpenModelica/OpenModelica#16504 for wasm, OpenModelica/OpenModelica#16622 for the C target). This makes OMSimulator read one and integrate it.

## Reading the manifest (commit 1)

- **`LsDae`** reads it: the enable parameter, the algebraic variables, and the residuals with their dependencies — the sparsity a DAE master differences the Jacobian with. A missing manifest is not an error; it is the ordinary FMU.
- **`ComponentFMU3ME`** loads it when the FMU is unpacked, remembers the `<ContinuousStateDerivative>` value references (the model description's own order, which pairs them with the states), switches the FMU into DAE mode at instantiation — that is where Configuration Mode is — and gains the residual, algebraic-variable and derivative accessors. `fmi4c` already binds `fmi3EnterConfigurationMode`, so no 3rdParty change was needed for that.

## Integrating it (commit 2)

The unknowns are laid out per component, `[x_i | z_i]`, and so are the rows: a component in DAE mode contributes the residuals it declares, an ODE component the explicit rows `x'_i - f_i(x, u, t)`. Both blocks are square, so the system is, and **the two mix** — a DAE component next to an ordinary FMU needs nothing special. `IDASetId` says which unknowns are differential; `IDACalcIC` solves for the algebraic ones and for the derivatives at the start and again after every event, because the components initialize consistently with themselves rather than with the coupled system, and an event moves them the same way.

Direct (non-loop) coupling stays where it was for CVODE: `updateInputs()` propagates connected outputs into inputs before the rows are evaluated. Algebraic loops do not — see the next section.

DAE mode is not really a solver choice: a component that declares a DAE formulation has no explicit ODE for CVODE to integrate, so the system switches to IDA on its own and says so in the log. It still has a name (`oms_solver_sc_ida`, `--solver ida`) for the SSD and the CLI.

## Algebraic loops as rows, not an inner solve (commit 4)

An algebraic loop over connections was solved by an inner KINSOL Newton, run to convergence inside **every** residual evaluation, on top of whatever solver each FMU hides behind its own interface. Where IDA drives the system it does not have to be. The translation is direct, because it is the same system the inner solver had: each connection of the loop contributes one unknown — the value of the input it drives — and one row, `output - input = 0`.

A loop is lifted only if all of its connections carry reals; one with an integer or boolean connection keeps its own solver, and so does every loop when the system is not in DAE mode, where none of this applies.

Initialization and events leave every loop to `IDACalcIC` rather than to the inner solver. They have to: a component in DAE mode does not solve for its own algebraic outputs — the master does — so "set the input, read the output back" has nothing behind it and KINSOL fails on a singular Jacobian. The consistent initial conditions are solved for the whole coupled system instead, which is where that belongs.

Tested with a loop across two FMUs, one of them `--daeMode`, against the same two components written as a single Modelica model and simulated by OpenModelica:

| | x(0.5) | x(1.0) | loop equation residual |
|---|---|---|---|
| IDA, loop as rows | 0.817368712680 | 0.701445480172 | **2.7e-14** |
| CVODE + KINSOL inner solve | 0.817433688498 | 0.701528323696 | 8.7e-08 |
| monolithic omc | 0.817368180018 | 0.701445143664 | — |

The lifted rows hold the connection equation to machine precision instead of the inner solver's tolerance, and land two orders of magnitude closer to the monolithic answer. The KINSOL run of that same loop also needs `--directionalDerivatives=false`, because it wants a Jacobian the FMU does not provide — where the lifted rows are simply part of the one IDA differences itself.

## The Jacobian: coloured, and factorized by KLU (commits 5 and 6)

IDA's own difference quotient costs one residual evaluation per unknown, and every one of those calls into every FMU of the system. The manifests say which unknowns each residual reaches, which is enough to colour the columns — two share a colour when no row reaches both — so one evaluation differences all of them at once:

| | unknowns | structural nonzeros | colours |
|---|---|---|---|
| 1 pair of components | 5 | 16 | 5 |
| 4 pairs | 20 | 64 | **5** |
| 8 pairs | 40 | 128 | **5** |

The cost of a Jacobian stays flat as the system grows. The same structure holds the matrix sparse (CSC) and lets KLU factorize it, reusing its symbolic factorization since the pattern never changes. Without a usable structure nothing changes: dense matrix, IDA differences it itself.

Two things about the structure are worth flagging:

- **A residual's dependency on an input is not in the manifest.** The dependencies it declares are those of the FMU's own DAE Jacobian, whose columns are the states and the algebraic variables — an input is not one of them. It only becomes an unknown in a master that carries it for a lifted loop, so those columns are added to every row of the component regardless. Without them the Jacobian is wrong by exactly the `-1` of the input's own row, and a coloured difference quotient then attributes one column's perturbation to another. It may be worth raising with the layered standard: a residual has no way to declare that it depends on an input.
- **The `derivative` attribute is a value reference in FMI 3.0**, where FMI 2.0 had an index — the same change as the ModelStructure dependencies, and fmi4c hands the raw attribute through under its FMI 2.0 name. Read as an index, `derivative="0"` meant "no state" and the structure was discarded.

Validated against a column-at-a-time difference quotient of the same system: the coloured Jacobian agrees to the last bit. KLU and the dense factorization give the same trajectory and the same step counts.

## Two bugs found on the way

1. **FMI 3.0 `ModelStructure` dependencies are value references, not indices.** Both FMI 3.0 components read them the FMI 2.0 way, as one-based indices into the variable list, so the dependency graph was wired to whichever variables sat at those positions — and an FMU whose dependency names value reference 0 was rejected outright (`bad dependency on variable with index 0`). That is what two connected FMI 3.0 FMUs ran into here. Fixed in its own commit; `ComponentFMUME` keeps the index reading, which is correct for FMI 2.0.
2. **`Causality` had no `structuralParameter`**, so `Causality[causality]` raised a `KeyError` while parsing `modelDescription.xml`: OMSimulator could not load *any* FMI 3.0 FMU with a structural parameter, nothing to do with fmi-ls-dae. Happy to split this out.
3. **`SolverType` in `instantiated_model.py` duplicates the C enum's integer values.** Inserting `oms_solver_sc_ida` renumbered `oms_ma`/`oms_mav`/`oms_mav2`, `setSolver()` quietly began selecting the wrong solver, and 37 tests failed with `Failed to set solver` and no hint of why. Fixed, with a comment saying the two have to be kept in step — deriving them from the C API would be better, and I did not want to widen this PR into that.

## Tested

Against a `--daeMode` Model Exchange FMU exported by OpenModelica (OpenModelica/OpenModelica#16622), an index-1 DAE with an algebraic loop, a nonlinear algebraic variable and a state event:

```
$ OMSimulator --mode me --stopTime 1.0 DaeModeMeC.fmu
info:    FMU "DaeModeMe" carries a DAE formulation (fmi-ls-dae 1.0.0-alpha.1): 3 residuals over 1 states and 2 algebraic variables
info:    system "DaeModeMe.root" contains a component in DAE mode (fmi-ls-dae); integrating with IDA instead of cvode
info:    Final Statistics for 'DaeModeMe.root':
         NumSteps = 367 NumResEvals  = 372 NumLinSolvSetups = 13
         NumNonlinSolvIters = 370 NumNonlinSolvConvFails = 0 NumErrTestFails = 0
info:    0 errors
```

The same model was also exported as an ordinary ODE FMU and run through this same master with CVODE. The two agree to ~1e-8, state event included:

| | x(0.25) | event time | x(1.0) |
|---|---|---|---|
| IDA, DAE FMU | 1.4190675494 | 0.2896179339 | 3.4468190259 |
| CVODE, ODE FMU | 1.4190675512 | 0.2896179331 | 3.4468190377 |

(Both differ from OpenModelica's own run of the model by ~1e-5, but identically so — that is OMSimulator's existing behaviour against omc, not something this PR introduces, which is why the comparison above is against the CVODE path rather than against omc.)

`ctest`: **117/117, the same as master.**

## Open points

- **No testsuite test yet.** The resource FMUs in `tests/resources/` carry win64 and linux64 binaries; I can only build linux64 here, so I could not add a proper one. Once OpenModelica/OpenModelica#16622 is merged the FMU can be produced the way the other resources are — tell me how you would like it generated and I will add the test.
- A lifted loop still gets a KINSOL solver instantiated for it that is never used; harmless, but it should not be built.
- The semi-explicit form of the layered standard is rejected with a clear message; only the fully implicit one is handled.
- `fmi-ls-dae` is not a released layered standard yet (1.0.0-alpha.1, draft of 2026-09-02).

---

Generated by Claude Code
